### PR TITLE
Fireman carry mechanic

### DIFF
--- a/Content.Client/Carrying/CarryingSystem.cs
+++ b/Content.Client/Carrying/CarryingSystem.cs
@@ -1,0 +1,65 @@
+using System.Numerics;
+using Content.Shared.Carrying.Components;
+using Content.Shared.Carrying.Systems;
+using Robust.Client.GameObjects;
+using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
+
+namespace Content.Client.Carrying;
+
+internal sealed class CarryingSystem : SharedCarryingSystem
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BeingCarriedComponent, ComponentStartup>(OnBeingCarriedStartup);
+        SubscribeLocalEvent<BeingCarriedComponent, ComponentRemove>(OnBeingCarriedRemove);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        var query = EntityQueryEnumerator<BeingCarriedComponent, CarriableComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var carriable, out var xform))
+        {
+            if (carriable.CarriedBy is not { } carrier)
+                continue;
+
+            if (!TryComp<CarrierComponent>(carrier, out var carrierComp))
+                continue;
+
+            // Local coordinates rotate with the parent, so counter-rotate the offset
+            // to keep the carried entity visually above the carrier in screen space.
+            var carrierXform = Transform(carrier);
+            var worldOffset = new Vector2(0, carrierComp.CarryOffset);
+            var localOffset = (-carrierXform.LocalRotation).RotateVec(worldOffset);
+
+            _xform.SetLocalPosition(uid, localOffset, xform);
+        }
+    }
+
+    private void OnBeingCarriedStartup(EntityUid uid, BeingCarriedComponent component, ComponentStartup args)
+    {
+        if (!TryComp<SpriteComponent>(uid, out var sprite))
+            return;
+
+        component.OriginalDrawDepth ??= sprite.DrawDepth;
+        _sprite.SetDrawDepth((uid, sprite), (int) DrawDepth.OverMobs);
+    }
+
+    private void OnBeingCarriedRemove(EntityUid uid, BeingCarriedComponent component, ComponentRemove args)
+    {
+        if (!component.OriginalDrawDepth.HasValue)
+            return;
+
+        if (!TryComp<SpriteComponent>(uid, out var sprite))
+            return;
+
+        _sprite.SetDrawDepth((uid, sprite), component.OriginalDrawDepth.Value);
+        component.OriginalDrawDepth = null;
+    }
+}

--- a/Content.Client/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Client/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.EscalatedGrab.Systems;
+
+namespace Content.Client.EscalatedGrab;
+
+internal sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Carrying.Systems;
+
+namespace Content.Server.Carrying;
+
+public sealed class CarryingSystem : SharedCarryingSystem;

--- a/Content.Server/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Server/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.EscalatedGrab.Systems;
+
+namespace Content.Server.EscalatedGrab;
+
+public sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Shared/Carrying/Components/ActiveCarrierComponent.cs
+++ b/Content.Shared/Carrying/Components/ActiveCarrierComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Carrying.Components;
+
+/// <summary>
+/// Active marker component on an entity currently carrying another entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActiveCarrierComponent : Component;

--- a/Content.Shared/Carrying/Components/BeingCarriedComponent.cs
+++ b/Content.Shared/Carrying/Components/BeingCarriedComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Carrying.Components;
+
+/// <summary>
+/// Active marker on an entity currently being carried.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BeingCarriedComponent : Component
+{
+    // Saved on ComponentStartup so draw depth can be restored on ComponentRemove (client-side only).
+    [ViewVariables]
+    public int? OriginalDrawDepth;
+}

--- a/Content.Shared/Carrying/Components/CarriableComponent.cs
+++ b/Content.Shared/Carrying/Components/CarriableComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Carrying.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Carrying.Components;
+
+/// <summary>
+/// Indicates this entity can be fireman carried.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedCarryingSystem))]
+public sealed partial class CarriableComponent : Component
+{
+    [AutoNetworkedField, DataField]
+    public EntityUid? CarriedBy;
+}

--- a/Content.Shared/Carrying/Components/CarrierComponent.cs
+++ b/Content.Shared/Carrying/Components/CarrierComponent.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Carrying.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Carrying.Components;
+
+/// <summary>
+/// Indicates this entity can fireman carry another entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedCarryingSystem))]
+public sealed partial class CarrierComponent : Component
+{
+    [AutoNetworkedField, DataField]
+    public EntityUid? Carrying;
+
+    [DataField]
+    public float WalkSpeedModifier = 0.75f;
+
+    [DataField]
+    public float SprintSpeedModifier = 0.6f;
+
+    /// <summary>
+    /// Y offset for the carried entity visual. Overridable per prototype for different species heights.
+    /// </summary>
+    [DataField]
+    public float CarryOffset = 0.2f;
+}

--- a/Content.Shared/Carrying/Events/CarryDoAfterEvent.cs
+++ b/Content.Shared/Carrying/Events/CarryDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Carrying.Events;
+
+/// <summary>
+/// DoAfter event for the carry windup.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class CarryDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Carrying/Events/CarryEvents.cs
+++ b/Content.Shared/Carrying/Events/CarryEvents.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Carrying.Events;
+
+/// <summary>
+/// Raised on both carrier and target before carry starts. Can be cancelled.
+/// </summary>
+[ByRefEvent]
+public record struct CarryAttemptEvent(EntityUid Carrier, EntityUid Target, bool Cancelled = false);
+
+/// <summary>
+/// Raised on both carrier and target after carry starts.
+/// </summary>
+[ByRefEvent]
+public record struct CarryStartedEvent(EntityUid Carrier, EntityUid Target);
+
+/// <summary>
+/// Raised on both carrier and target when carry ends.
+/// </summary>
+[ByRefEvent]
+public record struct CarryStoppedEvent(EntityUid Carrier, EntityUid Target);

--- a/Content.Shared/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/Carrying/Systems/SharedCarryingSystem.cs
@@ -1,0 +1,432 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Carrying.Components;
+using Content.Shared.Carrying.Events;
+using Content.Shared.DoAfter;
+using Content.Shared.DragDrop;
+using Content.Shared.EscalatedGrab;
+using Content.Shared.EscalatedGrab.Systems;
+using Content.Shared.Hands;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Events;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using Content.Shared.Verbs;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Carrying.Systems;
+
+public abstract class SharedCarryingSystem : EntitySystem
+{
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SharedEscalatedGrabSystem _grab = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedJointSystem _joints = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
+
+    // Set during Carry()/Drop() to suppress VirtualItemDeleted cascading into another Drop().
+    // Stopping a pull deletes its virtual item, which would otherwise trigger OnVirtualItemDeleted.
+    private bool _isTransitioning;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CarriableComponent, GetVerbsEvent<InteractionVerb>>(AddCarryVerb);
+        SubscribeLocalEvent<BeingCarriedComponent, GetVerbsEvent<InteractionVerb>>(AddDropVerb);
+
+        SubscribeLocalEvent<CarriableComponent, DragDropDraggedEvent>(OnDragDropDragged);
+        SubscribeLocalEvent<CarriableComponent, CanDropDraggedEvent>(OnCanDropDragged);
+        SubscribeLocalEvent<CarrierComponent, CanDropTargetEvent>(OnCanDropTarget);
+        SubscribeLocalEvent<CarrierComponent, CarryDoAfterEvent>(OnCarryDoAfter);
+        SubscribeLocalEvent<ActiveCarrierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
+        SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnCarriedCanMove);
+
+        // Auto-drop conditions
+        SubscribeLocalEvent<BeingCarriedComponent, MobStateChangedEvent>(OnCarriedMobStateChanged);
+        SubscribeLocalEvent<BeingCarriedComponent, StoodEvent>(OnCarriedStood);
+        SubscribeLocalEvent<ActiveCarrierComponent, MobStateChangedEvent>(OnCarrierMobStateChanged);
+        SubscribeLocalEvent<ActiveCarrierComponent, StunnedEvent>(OnCarrierStunned);
+        SubscribeLocalEvent<ActiveCarrierComponent, DownedEvent>(OnCarrierDowned);
+        SubscribeLocalEvent<BeingCarriedComponent, EntGotInsertedIntoContainerMessage>(OnCarriedInserted);
+        SubscribeLocalEvent<ActiveCarrierComponent, EntGotInsertedIntoContainerMessage>(OnCarrierInserted);
+
+        // Cleanup
+        SubscribeLocalEvent<BeingCarriedComponent, ComponentShutdown>(OnBeingCarriedShutdown);
+        SubscribeLocalEvent<ActiveCarrierComponent, ComponentShutdown>(OnActiveCarrierShutdown);
+        SubscribeLocalEvent<ActiveCarrierComponent, DropHandItemsEvent>(OnDropHandItems);
+        SubscribeLocalEvent<CarrierComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
+    }
+
+    #region Verbs
+
+    private void AddCarryVerb(EntityUid uid, CarriableComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (args.User == args.Target)
+            return;
+
+        if (!CanCarry(args.User, args.Target))
+            return;
+
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("carrying-verb-carry"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png")),
+            Act = () =>
+            {
+                if (TryComp<CarrierComponent>(args.User, out var carrier) && CanCarry(args.User, args.Target))
+                    StartCarryDoAfter(args.User, args.Target, carrier);
+            },
+        });
+    }
+
+    private void AddDropVerb(EntityUid uid, BeingCarriedComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!TryComp<CarriableComponent>(uid, out var carriable) || carriable.CarriedBy != args.User)
+            return;
+
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("carrying-verb-drop"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
+            Act = () => Drop(args.User),
+        });
+    }
+
+    #endregion
+
+    #region Drag-Drop
+
+    private void OnCanDropDragged(EntityUid uid, CarriableComponent component, ref CanDropDraggedEvent args)
+    {
+        if (args.Target != args.User)
+            return;
+
+        if (CanCarry(args.User, uid))
+        {
+            args.CanDrop = true;
+            args.Handled = true;
+        }
+    }
+
+    private void OnCanDropTarget(EntityUid uid, CarrierComponent component, ref CanDropTargetEvent args)
+    {
+        args.CanDrop = CanCarry(uid, args.Dragged);
+        args.Handled = true;
+    }
+
+    private void OnDragDropDragged(EntityUid uid, CarriableComponent component, ref DragDropDraggedEvent args)
+    {
+        if (args.Handled || args.Target != args.User)
+            return;
+
+        if (!CanCarry(args.User, uid))
+            return;
+
+        if (!TryComp<CarrierComponent>(args.User, out var carrierComp))
+            return;
+
+        StartCarryDoAfter(args.User, uid, carrierComp);
+        args.Handled = true;
+    }
+
+    #endregion
+
+    #region Carry Logic
+
+    private bool CanCarry(EntityUid carrier, EntityUid target)
+    {
+        if (carrier == target)
+            return false;
+
+        if (!TryComp<CarrierComponent>(carrier, out var carrierComp) || carrierComp.Carrying != null)
+            return false;
+
+        if (!TryComp<CarriableComponent>(target, out var carriableComp) || carriableComp.CarriedBy != null)
+            return false;
+
+        if (_standing.IsDown(carrier) || _mobState.IsIncapacitated(carrier))
+            return false;
+
+        if (!_mobState.IsIncapacitated(target))
+            return false;
+
+        if (!_actionBlocker.CanInteract(carrier, target))
+            return false;
+
+        // Requires an aggressive grab on the target.
+        if (!_grab.HasStage(carrier, target, GrabStage.Aggressive))
+            return false;
+
+        // The pull's virtual item will be freed when the pull stops during Carry(),
+        // so count it as available.
+        var freeHands = _hands.CountFreeHands(carrier);
+        var pullingTarget = TryComp<PullerComponent>(carrier, out var pullerCheck) && pullerCheck.Pulling == target;
+        var effectiveFreeHands = freeHands + (pullingTarget ? 1 : 0);
+        if (effectiveFreeHands < 2)
+            return false;
+
+        return true;
+    }
+
+    private void StartCarryDoAfter(EntityUid carrier, EntityUid target, CarrierComponent component)
+    {
+        var doAfterArgs = new DoAfterArgs(EntityManager, carrier, TimeSpan.FromSeconds(3), new CarryDoAfterEvent(), carrier, target: target)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = true,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnCarryDoAfter(EntityUid uid, CarrierComponent component, CarryDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.Target == null)
+            return;
+
+        args.Handled = true;
+        Carry(uid, args.Target.Value, component);
+    }
+
+    private void Carry(EntityUid carrier, EntityUid target, CarrierComponent? carrierComp = null, CarriableComponent? carriableComp = null)
+    {
+        if (!Resolve(carrier, ref carrierComp) || !Resolve(target, ref carriableComp))
+            return;
+
+        if (carrierComp.Carrying != null || carriableComp.CarriedBy != null)
+            return;
+
+        if (!_standing.IsDown(target) && !_mobState.IsIncapacitated(target))
+            return;
+
+        var attempt = new CarryAttemptEvent(carrier, target);
+        RaiseLocalEvent(carrier, ref attempt);
+        if (attempt.Cancelled)
+            return;
+        RaiseLocalEvent(target, ref attempt);
+        if (attempt.Cancelled)
+            return;
+
+        // Stop pulls before setting carry state. _isTransitioning prevents the pull's
+        // virtual item cleanup from cascading into OnVirtualItemDeleted, which calls Drop().
+        _isTransitioning = true;
+
+        if (TryComp<PullableComponent>(target, out var pullable) && pullable.Puller != null)
+            _pulling.TryStopPull(target, pullable);
+
+        if (TryComp<PullerComponent>(carrier, out var puller) && puller.Pulling != null
+            && TryComp<PullableComponent>(puller.Pulling.Value, out var pullerPullable))
+            _pulling.TryStopPull(puller.Pulling.Value, pullerPullable);
+
+        _isTransitioning = false;
+
+        carrierComp.Carrying = target;
+        carriableComp.CarriedBy = carrier;
+        Dirty(carrier, carrierComp);
+        Dirty(target, carriableComp);
+
+        EnsureComp<ActiveCarrierComponent>(carrier);
+        EnsureComp<BeingCarriedComponent>(target);
+
+        if (!_virtualItem.TrySpawnVirtualItemInHand(target, carrier))
+            Log.Warning($"Failed to spawn first carry virtual item on {ToPrettyString(carrier)}");
+        if (!_virtualItem.TrySpawnVirtualItemInHand(target, carrier))
+            Log.Warning($"Failed to spawn second carry virtual item on {ToPrettyString(carrier)}");
+
+        // Parent to carrier at origin — client FrameUpdate handles the visual offset
+        var xform = Transform(target);
+        var coords = new EntityCoordinates(carrier, System.Numerics.Vector2.Zero);
+        _transform.SetCoordinates(target, xform, coords, rotation: Angle.Zero);
+        _joints.SetRelay(target, carrier);
+
+        _standing.Down(target, playSound: false, dropHeldItems: false, force: true);
+
+        if (TryComp<PhysicsComponent>(target, out var physics))
+            _physics.ResetDynamics(target, physics);
+
+        _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+        _actionBlocker.UpdateCanMove(target);
+
+        _popup.PopupClient(Loc.GetString("carrying-start-carrier", ("target", target)), carrier, carrier);
+        _popup.PopupClient(Loc.GetString("carrying-start-carried", ("carrier", carrier)), target, target);
+
+        var ev = new CarryStartedEvent(carrier, target);
+        RaiseLocalEvent(carrier, ref ev);
+        RaiseLocalEvent(target, ref ev);
+    }
+
+    public void Drop(EntityUid carrier, CarrierComponent? carrierComp = null)
+    {
+        if (!Resolve(carrier, ref carrierComp) || carrierComp.Carrying is not { } target)
+            return;
+
+        if (!TryComp<CarriableComponent>(target, out var carriableComp))
+            return;
+
+        carrierComp.Carrying = null;
+        carriableComp.CarriedBy = null;
+        Dirty(carrier, carrierComp);
+        Dirty(target, carriableComp);
+
+        // Remove immediately (not deferred) so event handlers like OnCarriedCanMove
+        // and OnCarriedStood don't fire after the drop is complete.
+        RemComp<BeingCarriedComponent>(target);
+        RemComp<ActiveCarrierComponent>(carrier);
+
+        _virtualItem.DeleteInHandsMatching(carrier, target);
+
+        if (!Terminating(carrier) && !Terminating(target))
+        {
+            var targetXform = Transform(target);
+            if (targetXform.ParentUid == carrier)
+            {
+                _transform.PlaceNextTo((target, targetXform), (carrier, Transform(carrier)));
+                targetXform.ActivelyLerping = false;
+            }
+        }
+
+        _joints.RefreshRelay(target);
+        _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+        _actionBlocker.UpdateCanMove(target);
+
+        if (!_mobState.IsIncapacitated(target) && !HasComp<KnockedDownComponent>(target))
+            _standing.Stand(target);
+
+        _popup.PopupClient(Loc.GetString("carrying-drop-carrier", ("target", target)), carrier, carrier);
+        _popup.PopupClient(Loc.GetString("carrying-drop-carried", ("carrier", carrier)), target, target);
+
+        var ev = new CarryStoppedEvent(carrier, target);
+        RaiseLocalEvent(carrier, ref ev);
+        RaiseLocalEvent(target, ref ev);
+    }
+
+    #endregion
+
+    #region Speed & Movement
+
+    private void OnRefreshMoveSpeed(EntityUid uid, ActiveCarrierComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (!TryComp<CarrierComponent>(uid, out var carrier) || carrier.Carrying == null)
+            return;
+
+        args.ModifySpeed(carrier.WalkSpeedModifier, carrier.SprintSpeedModifier);
+    }
+
+    private void OnCarriedCanMove(EntityUid uid, BeingCarriedComponent component, UpdateCanMoveEvent args)
+    {
+        args.Cancel();
+    }
+
+    #endregion
+
+    #region Auto-Drop
+
+    private void OnCarriedMobStateChanged(EntityUid uid, BeingCarriedComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Alive)
+        {
+            if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier)
+                Drop(carrier);
+        }
+    }
+
+    private void OnCarriedStood(EntityUid uid, BeingCarriedComponent component, StoodEvent args)
+    {
+        if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier)
+            Drop(carrier);
+    }
+
+    private void OnCarrierMobStateChanged(EntityUid uid, ActiveCarrierComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState is MobState.Critical or MobState.Dead)
+            Drop(uid);
+    }
+
+    private void OnCarrierStunned(EntityUid uid, ActiveCarrierComponent component, ref StunnedEvent args)
+    {
+        Drop(uid);
+    }
+
+    private void OnCarrierDowned(EntityUid uid, ActiveCarrierComponent component, DownedEvent args)
+    {
+        Drop(uid);
+    }
+
+    private void OnCarriedInserted(EntityUid uid, BeingCarriedComponent component, EntGotInsertedIntoContainerMessage args)
+    {
+        if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier)
+            Drop(carrier);
+    }
+
+    private void OnCarrierInserted(EntityUid uid, ActiveCarrierComponent component, EntGotInsertedIntoContainerMessage args)
+    {
+        Drop(uid);
+    }
+
+    #endregion
+
+    #region Cleanup
+
+    private void OnBeingCarriedShutdown(EntityUid uid, BeingCarriedComponent component, ComponentShutdown args)
+    {
+        if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier && TryComp<CarrierComponent>(carrier, out var carrierComp))
+        {
+            carrierComp.Carrying = null;
+            Dirty(carrier, carrierComp);
+            RemCompDeferred<ActiveCarrierComponent>(carrier);
+            _virtualItem.DeleteInHandsMatching(carrier, uid);
+            _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+        }
+    }
+
+    private void OnActiveCarrierShutdown(EntityUid uid, ActiveCarrierComponent component, ComponentShutdown args)
+    {
+        if (TryComp<CarrierComponent>(uid, out var carrier) && carrier.Carrying is { } target && TryComp<CarriableComponent>(target, out var carriable))
+        {
+            carriable.CarriedBy = null;
+            Dirty(target, carriable);
+            RemCompDeferred<BeingCarriedComponent>(target);
+            _actionBlocker.UpdateCanMove(target);
+        }
+    }
+
+    private void OnDropHandItems(EntityUid uid, ActiveCarrierComponent component, DropHandItemsEvent args)
+    {
+        Drop(uid);
+    }
+
+    private void OnVirtualItemDeleted(EntityUid uid, CarrierComponent component, VirtualItemDeletedEvent args)
+    {
+        if (!_isTransitioning && component.Carrying == args.BlockingEntity)
+            Drop(uid, component);
+    }
+
+    #endregion
+}

--- a/Content.Shared/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/EscalatedGrab/Components/GrabStateComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.EscalatedGrab.Components;
+
+/// <summary>
+/// Added to a puller when their grab escalates beyond a standard pull.
+/// Tracks the current <see cref="GrabStage"/> and target entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class GrabStateComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid Target;
+
+    [DataField, AutoNetworkedField]
+    public GrabStage Stage = GrabStage.Aggressive;
+
+}

--- a/Content.Shared/EscalatedGrab/GrabStage.cs
+++ b/Content.Shared/EscalatedGrab/GrabStage.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.EscalatedGrab;
+
+/// <summary>
+/// Escalation level of a grab. Re-clicking pull advances to the next stage.
+/// </summary>
+[Serializable, NetSerializable]
+public enum GrabStage : byte
+{
+    /// <summary>
+    /// Standard pull. No <see cref="Components.GrabStateComponent"/> exists at this stage.
+    /// </summary>
+    Pull = 0,
+
+    /// <summary>
+    /// Aggressive grab. First escalation from a standard pull.
+    /// </summary>
+    Aggressive = 1,
+}

--- a/Content.Shared/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -1,0 +1,98 @@
+using Content.Shared.EscalatedGrab.Components;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Popups;
+using Content.Shared.Pulling.Events;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.EscalatedGrab.Systems;
+
+/// <summary>
+/// Manages grab escalation. Re-clicking pull on a target escalates the grab
+/// through <see cref="GrabStage"/> tiers instead of releasing.
+/// </summary>
+public abstract class SharedEscalatedGrabSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PullableComponent, PullGrabEscalateAttemptEvent>(OnEscalateAttempt);
+        SubscribeLocalEvent<PullableComponent, AttemptStopPullingEvent>(OnAttemptStopPulling);
+        SubscribeLocalEvent<GrabStateComponent, PullStoppedMessage>(OnPullStopped);
+    }
+
+    private void OnEscalateAttempt(EntityUid uid, PullableComponent component, ref PullGrabEscalateAttemptEvent args)
+    {
+        TryEscalate(args.Puller, args.Pulled);
+    }
+
+    private void OnAttemptStopPulling(EntityUid uid, PullableComponent component, ref AttemptStopPullingEvent args)
+    {
+        if (args.Cancelled || args.User == null)
+            return;
+
+        // Release keybind clears escalation and lets the pull stop.
+        if (args.Force)
+        {
+            ClearEscalation(args.User.Value);
+            return;
+        }
+    }
+
+    private void OnPullStopped(EntityUid uid, GrabStateComponent component, PullStoppedMessage args)
+    {
+        RemComp<GrabStateComponent>(uid);
+    }
+
+    /// <summary>
+    /// Attempts to escalate the grab to the next stage.
+    /// Returns true if the grab was escalated or is already at max stage.
+    /// </summary>
+    public bool TryEscalate(EntityUid puller, EntityUid target)
+    {
+        if (TryComp<GrabStateComponent>(puller, out var existing) && existing.Target == target)
+            return true;
+
+        if (!_timing.IsFirstTimePredicted)
+            return true;
+
+        var state = EnsureComp<GrabStateComponent>(puller);
+        state.Target = target;
+        state.Stage = GrabStage.Aggressive;
+        Dirty(puller, state);
+        _popup.PopupPredicted(Loc.GetString("escalated-grab-aggressive"), target, puller);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the current <see cref="GrabStage"/> for a puller on a target.
+    /// Defaults to <see cref="GrabStage.Pull"/> if no escalation exists.
+    /// </summary>
+    public GrabStage GetStage(EntityUid puller, EntityUid target)
+    {
+        if (TryComp<GrabStateComponent>(puller, out var comp) && comp.Target == target)
+            return comp.Stage;
+
+        return GrabStage.Pull;
+    }
+
+    /// <summary>
+    /// Checks whether the puller has at least the given grab stage on the target.
+    /// </summary>
+    public bool HasStage(EntityUid puller, EntityUid target, GrabStage minimumStage)
+    {
+        return GetStage(puller, target) >= minimumStage;
+    }
+
+    /// <summary>
+    /// Removes grab escalation from a puller.
+    /// </summary>
+    public void ClearEscalation(EntityUid puller)
+    {
+        RemComp<GrabStateComponent>(puller);
+    }
+}

--- a/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
+++ b/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
@@ -5,8 +5,11 @@ namespace Content.Shared.Pulling.Events;
 /// </summary>
 
 [ByRefEvent]
-public record struct AttemptStopPullingEvent(EntityUid? User = null)
+//HONK START - Escalated grab: added Force parameter
+public record struct AttemptStopPullingEvent(EntityUid? User = null, bool Force = false)
 {
     public readonly EntityUid? User = User;
+    public readonly bool Force = Force;
+    //HONK END
     public bool Cancelled;
 }

--- a/Content.Shared/Movement/Pulling/Events/PullGrabEscalateAttemptEvent.cs
+++ b/Content.Shared/Movement/Pulling/Events/PullGrabEscalateAttemptEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Movement.Pulling.Events;
+
+/// <summary>
+/// Raised on the pulled entity when the puller tries to pull a target
+/// they are already pulling. Subscribers can use this to escalate grabs.
+/// </summary>
+[ByRefEvent]
+public record struct PullGrabEscalateAttemptEvent(EntityUid Puller, EntityUid Pulled);

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -11,6 +11,9 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
+//HONK START - Escalated grab: drop-to-release pull
+using Content.Shared.Interaction.Events;
+//HONK END
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
 using Content.Shared.Mobs;
@@ -75,6 +78,9 @@ public sealed class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullerComponent, EntGotInsertedIntoContainerMessage>(OnPullerContainerInsert);
         SubscribeLocalEvent<PullerComponent, EntityUnpausedEvent>(OnPullerUnpaused);
         SubscribeLocalEvent<PullerComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
+        //HONK START - Drop virtual item releases pull
+        SubscribeLocalEvent<VirtualItemComponent, DroppedEvent>(OnVirtualItemDropped);
+        //HONK END
         SubscribeLocalEvent<PullerComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
         SubscribeLocalEvent<PullerComponent, DropHandItemsEvent>(OnDropHandItems);
         SubscribeLocalEvent<PullerComponent, StopPullingAlertEvent>(OnStopPullingAlert);
@@ -258,6 +264,20 @@ public sealed class PullingSystem : EntitySystem
         }
     }
 
+    //HONK START - Drop virtual item releases pull
+    private void OnVirtualItemDropped(EntityUid uid, VirtualItemComponent component, DroppedEvent args)
+    {
+        if (!TryComp<PullerComponent>(args.User, out var puller))
+            return;
+
+        if (puller.Pulling != component.BlockingEntity)
+            return;
+
+        if (TryComp(component.BlockingEntity, out PullableComponent? pullable))
+            TryStopPull(component.BlockingEntity, pullable, user: args.User, force: true);
+    }
+    //HONK END
+
     private void AddPullVerbs(EntityUid uid, PullableComponent component, GetVerbsEvent<Verb> args)
     {
         if (!args.CanAccess || !args.CanInteract)
@@ -428,7 +448,9 @@ public sealed class PullingSystem : EntitySystem
             return;
         }
 
-        TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player);
+        //HONK START - Force release on keybind
+        TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player, force: true);
+        //HONK END
     }
 
     public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null)
@@ -484,7 +506,11 @@ public sealed class PullingSystem : EntitySystem
 
         if (pullable.Comp.Puller == pullerUid)
         {
-            return TryStopPull(pullable, pullable.Comp);
+            //HONK START - Escalated grab: escalate instead of toggle-off
+            var ev = new PullGrabEscalateAttemptEvent(pullerUid, pullable.Owner);
+            RaiseLocalEvent(pullable.Owner, ref ev);
+            return true;
+            //HONK END
         }
 
         return TryStartPull(pullerUid, pullable, pullableComp: pullable);
@@ -598,14 +624,16 @@ public sealed class PullingSystem : EntitySystem
         return true;
     }
 
-    public bool TryStopPull(EntityUid pullableUid, PullableComponent pullable, EntityUid? user = null)
+    //HONK START - Escalated grab: added force parameter
+    public bool TryStopPull(EntityUid pullableUid, PullableComponent pullable, EntityUid? user = null, bool force = false)
     {
         var pullerUidNull = pullable.Puller;
 
         if (pullerUidNull == null)
             return true;
 
-        var msg = new AttemptStopPullingEvent(user);
+        var msg = new AttemptStopPullingEvent(user, force);
+        //HONK END
         RaiseLocalEvent(pullableUid, ref msg, true);
 
         if (msg.Cancelled)

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -6,6 +6,9 @@ using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
+//HONK START - Escalated grab: skip strip during grab
+using Content.Shared.EscalatedGrab.Components;
+//HONK END
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
@@ -652,6 +655,11 @@ public abstract class SharedStrippableSystem : EntitySystem
         // If the user drags a strippable thing onto themselves.
         if (args.Handled || args.Target != args.User)
             return;
+
+        //HONK START - Skip strip if escalated grab active
+        if (TryComp<GrabStateComponent>(args.User, out var grab) && grab.Target == uid)
+            return;
+        //HONK END
 
         if (TryOpenStrippingUi(args.User, (uid, component)))
             args.Handled = true;

--- a/Resources/Locale/en-US/@RussStation/carrying/carrying.ftl
+++ b/Resources/Locale/en-US/@RussStation/carrying/carrying.ftl
@@ -1,0 +1,6 @@
+carrying-verb-carry = Fireman carry
+carrying-verb-drop = Drop
+carrying-start-carrier = You hoist {$target} over your shoulder.
+carrying-start-carried = {$carrier} hoists you over their shoulder!
+carrying-drop-carrier = You drop {$target}.
+carrying-drop-carried = {$carrier} drops you!

--- a/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
+++ b/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
@@ -1,0 +1,1 @@
+escalated-grab-aggressive = You tighten your grip.

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -1,233 +1,234 @@
 - type: entity
   abstract: true
   parent:
-  - BaseMob
-  - MobCombat
-  - MobDamageable
-  - MobPolymorphable
-  - StripableInventoryBase
-  - BaseSpeciesAppearance
+    - BaseMob
+    - MobCombat
+    - MobDamageable
+    - MobPolymorphable
+    - StripableInventoryBase
+    - BaseSpeciesAppearance
   id: BaseSpeciesMob
   save: false
   components:
-  - type: DamageVisuals
-    thresholds: [ 10, 20, 30, 50, 70, 100 ]
-    targetLayers:
-    - "enum.HumanoidVisualLayers.Chest"
-    - "enum.HumanoidVisualLayers.Head"
-    - "enum.HumanoidVisualLayers.LArm"
-    - "enum.HumanoidVisualLayers.LLeg"
-    - "enum.HumanoidVisualLayers.RArm"
-    - "enum.HumanoidVisualLayers.RLeg"
-    damageOverlayGroups:
-      Brute:
-        sprite: Mobs/Effects/brute_damage.rsi
-        color: "#FF0000"
-      Burn:
-        sprite: Mobs/Effects/burn_damage.rsi
-  - type: GenericVisualizer
-    visuals:
-      enum.CreamPiedVisuals.Creamed:
-        clownedon:
-          True: { visible: true }
-          False: { visible: false }
-  - type: StatusIcon
-    bounds: -0.5,-0.5,0.5,0.5
-  - type: JobStatus
-  - type: RotationVisuals
-    defaultRotation: 90
-    horizontalRotation: 90
-  - type: HumanoidProfile
-  - type: TypingIndicator
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      60: 0.7
-      80: 0.5
-  - type: Fixtures
-    fixtures: # TODO: This needs a second fixture just for mob collisions.
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 185
-        restitution: 0.0
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: FloorOcclusion
-  - type: RangedDamageSound
-    soundGroups:
-      Brute:
-        collection:
-          MeatBulletImpact
-    soundTypes:
-      Heat:
-        collection:
-          MeatLaserImpact
-  - type: Reactive
-    groups:
-      Flammable: [ Touch ]
-      Extinguish: [ Touch ]
-      Acidic: [Touch, Ingestion]
-    reactions:
-    - reagents: [Water, SpaceCleaner]
-      methods: [Touch]
-      effects:
-      - !type:WashCreamPie
-  - type: StatusEffects
-    allowed:
-    - Electrocution
-    - RatvarianLanguage
-    - PressureImmunity
-    - Muted
-    - TemporaryBlindness
-    - Pacified
-    - Flashed
-    - RadiationProtection
-    - Adrenaline
-  - type: Identity
-  - type: IdExaminable
-  - type: Internals
-  - type: FloatingVisuals
-  - type: Climbing
-  - type: Cuffable
-  - type: Ensnareable
-    sprite: Objects/Misc/ensnare.rsi
-    state: icon
-  - type: AnimationPlayer
-  - type: Buckle
-  - type: CombatMode
-    canDisarm: true
-  - type: MeleeWeapon
-    soundHit:
-      collection: Punch
-    angle: 30
-    animation: WeaponArcFist
-    attackRate: 1
-    damage:
-      types:
-        Blunt: 5
-  - type: SleepEmitSound
-  - type: SSDIndicator
-  - type: StandingState
-  - type: Crawler
-  - type: Dna
-  - type: MindContainer
-  - type: MindExaminable
-  - type: CanEnterCryostorage
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
-  - type: CanHostGuardian
-  - type: NpcFactionMember
-    factions:
-    - NanoTrasen
-  - type: CreamPied
-  - type: ParcelWrapOverride
-    parcelPrototype: WrappedParcelHumanoid
-    wrapDelay: 5
-  - type: Stripping
-  - type: UserInterface
-    interfaces:
-      enum.HumanoidMarkingModifierKey.Key:
-        type: HumanoidMarkingModifierBoundUserInterface
-      enum.StrippingUiKey.Key:
-        type: StrippableBoundUserInterface
-  - type: Puller
-  - type: Speech
-    speechSounds: Alto
-  - type: DamageForceSay
-  - type: Vocal
-    sounds:
-      Male: MaleHuman
-      Female: FemaleHuman
-      Unsexed: MaleHuman
-  - type: Emoting
-  - type: BodyEmotes
-    soundsId: GeneralBodyEmotes
-  - type: Grammar
-    attributes:
-      proper: true
-  - type: MobPrice
-    price: 1500 # Kidnapping a living person and selling them for cred is a good move.
-    deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
-  - type: Tag
-    tags:
-    - CanPilot
-    - FootstepSound
-    - DoorBumpOpener
-    - AnomalyHost
+    - type: DamageVisuals
+      thresholds: [10, 20, 30, 50, 70, 100]
+      targetLayers:
+        - "enum.HumanoidVisualLayers.Chest"
+        - "enum.HumanoidVisualLayers.Head"
+        - "enum.HumanoidVisualLayers.LArm"
+        - "enum.HumanoidVisualLayers.LLeg"
+        - "enum.HumanoidVisualLayers.RArm"
+        - "enum.HumanoidVisualLayers.RLeg"
+      damageOverlayGroups:
+        Brute:
+          sprite: Mobs/Effects/brute_damage.rsi
+          color: "#FF0000"
+        Burn:
+          sprite: Mobs/Effects/burn_damage.rsi
+    - type: GenericVisualizer
+      visuals:
+        enum.CreamPiedVisuals.Creamed:
+          clownedon:
+            True: { visible: true }
+            False: { visible: false }
+    - type: StatusIcon
+      bounds: -0.5,-0.5,0.5,0.5
+    - type: JobStatus
+    - type: RotationVisuals
+      defaultRotation: 90
+      horizontalRotation: 90
+    - type: HumanoidProfile
+    - type: TypingIndicator
+    - type: SlowOnDamage
+      speedModifierThresholds:
+        60: 0.7
+        80: 0.5
+    - type: Fixtures
+      fixtures: # TODO: This needs a second fixture just for mob collisions.
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 185
+          restitution: 0.0
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: FloorOcclusion
+    - type: RangedDamageSound
+      soundGroups:
+        Brute:
+          collection: MeatBulletImpact
+      soundTypes:
+        Heat:
+          collection: MeatLaserImpact
+    - type: Reactive
+      groups:
+        Flammable: [Touch]
+        Extinguish: [Touch]
+        Acidic: [Touch, Ingestion]
+      reactions:
+        - reagents: [Water, SpaceCleaner]
+          methods: [Touch]
+          effects:
+            - !type:WashCreamPie
+    - type: StatusEffects
+      allowed:
+        - Electrocution
+        - RatvarianLanguage
+        - PressureImmunity
+        - Muted
+        - TemporaryBlindness
+        - Pacified
+        - Flashed
+        - RadiationProtection
+        - Adrenaline
+    - type: Identity
+    - type: IdExaminable
+    - type: Internals
+    - type: FloatingVisuals
+    - type: Climbing
+    - type: Cuffable
+    - type: Ensnareable
+      sprite: Objects/Misc/ensnare.rsi
+      state: icon
+    - type: AnimationPlayer
+    - type: Buckle
+    - type: CombatMode
+      canDisarm: true
+    - type: MeleeWeapon
+      soundHit:
+        collection: Punch
+      angle: 30
+      animation: WeaponArcFist
+      attackRate: 1
+      damage:
+        types:
+          Blunt: 5
+    - type: SleepEmitSound
+    - type: SSDIndicator
+    - type: StandingState
+    - type: Crawler
+    - type: Dna
+    - type: MindContainer
+    - type: MindExaminable
+    - type: CanEnterCryostorage
+    - type: InteractionPopup
+      successChance: 1
+      interactSuccessString: hugging-success-generic
+      interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+      messagePerceivedByOthers: hugging-success-generic-others
+    - type: CanHostGuardian
+    - type: NpcFactionMember
+      factions:
+        - NanoTrasen
+    - type: CreamPied
+    - type: ParcelWrapOverride
+      parcelPrototype: WrappedParcelHumanoid
+      wrapDelay: 5
+    - type: Stripping
+    - type: UserInterface
+      interfaces:
+        enum.HumanoidMarkingModifierKey.Key:
+          type: HumanoidMarkingModifierBoundUserInterface
+        enum.StrippingUiKey.Key:
+          type: StrippableBoundUserInterface
+    - type: Puller
+    # HONK START - Fireman carry
+    - type: Carrier
+    - type: Carriable
+    # HONK END
+    - type: Speech
+      speechSounds: Alto
+    - type: DamageForceSay
+    - type: Vocal
+      sounds:
+        Male: MaleHuman
+        Female: FemaleHuman
+        Unsexed: MaleHuman
+    - type: Emoting
+    - type: BodyEmotes
+      soundsId: GeneralBodyEmotes
+    - type: Grammar
+      attributes:
+        proper: true
+    - type: MobPrice
+      price: 1500 # Kidnapping a living person and selling them for cred is a good move.
+      deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
+    - type: Tag
+      tags:
+        - CanPilot
+        - FootstepSound
+        - DoorBumpOpener
+        - AnomalyHost
 
 - type: entity
   abstract: true
   parent:
-  - MobBloodstream
-  - MobRespirator
-  - MobAtmosStandard
-  - MobFlammable
-  - BaseSpeciesMob
+    - MobBloodstream
+    - MobRespirator
+    - MobAtmosStandard
+    - MobFlammable
+    - BaseSpeciesMob
   id: BaseSpeciesMobOrganic
   save: false
   components:
-  - type: Hunger
-  - type: Thirst
-  - type: Barotrauma
-    damage:
-      types:
-        Blunt: 0.50
-        Heat: 0.1
-  - type: PassiveDamage
-    allowedStates:
-    - Alive
-    damage:
-      types:
-        Heat: -0.07
-        Blunt: -0.05
-        Piercing: -0.05
-        Slash: -0.05
-  - type: Fingerprint
-  - type: Blindable
-  - type: Temperature
-    currentTemperature: 310.15
-    specificHeat: 42
-  - type: TemperatureDamage
-    heatDamageThreshold: 325
-    coldDamageThreshold: 260
-    coldDamage:
-      types:
-        Cold: 0.1 #per second, scales with temperature & other constants
-    heatDamage:
-      types:
-        Heat: 1.5 #per second, scales with temperature & other constants
-  - type: TemperatureSpeed
-    thresholds:
-      293: 0.9
-      280: 0.8
-      260: 0.7
-  - type: ThermalRegulator
-    metabolismHeat: 800
-    radiatedHeat: 100
-    implicitHeatRegulation: 500
-    sweatHeatRegulation: 2000
-    shiveringHeatRegulation: 2000
-    normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 2
-  - type: Perishable
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 5
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 1.0
-    damageRecovery:
-      types:
-        Asphyxiation: -1.0
-  - type: FireVisuals
-    alternateState: Standing
-  - type: StunVisuals
+    - type: Hunger
+    - type: Thirst
+    - type: Barotrauma
+      damage:
+        types:
+          Blunt: 0.50
+          Heat: 0.1
+    - type: PassiveDamage
+      allowedStates:
+        - Alive
+      damage:
+        types:
+          Heat: -0.07
+          Blunt: -0.05
+          Piercing: -0.05
+          Slash: -0.05
+    - type: Fingerprint
+    - type: Blindable
+    - type: Temperature
+      currentTemperature: 310.15
+      specificHeat: 42
+    - type: TemperatureDamage
+      heatDamageThreshold: 325
+      coldDamageThreshold: 260
+      coldDamage:
+        types:
+          Cold: 0.1 #per second, scales with temperature & other constants
+      heatDamage:
+        types:
+          Heat: 1.5 #per second, scales with temperature & other constants
+    - type: TemperatureSpeed
+      thresholds:
+        293: 0.9
+        280: 0.8
+        260: 0.7
+    - type: ThermalRegulator
+      metabolismHeat: 800
+      radiatedHeat: 100
+      implicitHeatRegulation: 500
+      sweatHeatRegulation: 2000
+      shiveringHeatRegulation: 2000
+      normalBodyTemperature: 310.15
+      thermalRegulationTemperatureThreshold: 2
+    - type: Perishable
+    - type: Butcherable
+      butcheringType: Spike
+      spawned:
+        - id: FoodMeat
+          amount: 5
+    - type: Respirator
+      damage:
+        types:
+          Asphyxiation: 1.0
+      damageRecovery:
+        types:
+          Asphyxiation: -1.0
+    - type: FireVisuals
+      alternateState: Standing
+    - type: StunVisuals

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -76,6 +76,16 @@
   You can also use [color=yellow][bold][keybind="Drop"][/bold][/color] to release pulled entities from your active hand.
   <!-- HONK END -->
 
+  <!-- HONK START - Fireman carry docs -->
+  ### Carrying
+  You can [color=cyan]fireman carry[/color] a [color=cyan]downed[/color] or incapacitated mob over your shoulder.
+  - [color=cyan]Pull[/color] a downed mob, then [color=cyan]pull again[/color] to pick them up.
+  - You can also right-click a downed mob and select [bold]Fireman carry[/bold].
+  - Carrying takes [bold]both hands[/bold] and slows you down.
+  - To drop them, use [color=yellow][bold][keybind="Drop"][/bold][/color] or right-click and select [bold]Drop[/bold].
+  - You drop them automatically if you get stunned, downed, or go critical. They also get dropped if they recover.
+  <!-- HONK END -->
+
   ## Interactions
   The game features [bold]six[/bold] types of context-sensitive interactions, accessible through different methods.
 

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -64,13 +64,17 @@
   Use [color=yellow][bold][keybind="Drop"][/bold][/color] to [color=cyan]drop[/color] (or place) an item from your hand within arm's reach.
   \n[color=cyan]Throw[/color] items to your cursor with [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color].
 
-  ### Pulling and pushing
-  You can pull movable [bold]entities[/bold] — items, objects, and mobs such as players, as long as you have an empty hand.
+  <!-- HONK START - Escalated grab docs -->
+  ### Pulling, pushing, and grabbing
+  You can pull movable [bold]entities[/bold] (items, objects, and mobs) as long as you have an empty hand.
   - Use [color=yellow][bold][keybind="TryPullObject"][/bold][/color] to start [color=cyan]pulling[/color].
   - [color=cyan]Push[/color] pulled entities to your cursor with [color=yellow][bold][keybind="MovePulledObject"][/bold][/color].
-  - To [color=cyan]release[/color], press [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color] or pull the same entity again.
+  - To [color=cyan]release[/color], press [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color].
+
+  While pulling someone, use [color=yellow][bold][keybind="TryPullObject"][/bold][/color] on them again to escalate to an [color=cyan]aggressive grab[/color]. This holds the target in place and prevents them from being released by toggling pull.
 
   You can also use [color=yellow][bold][keybind="Drop"][/bold][/color] to release pulled entities from your active hand.
+  <!-- HONK END -->
 
   ## Interactions
   The game features [bold]six[/bold] types of context-sensitive interactions, accessible through different methods.

--- a/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
@@ -25,7 +25,9 @@ The following are the controls you'll need for regular gameplay:
 
 - Drop held items with [color=yellow][bold][keybind="Drop"][/bold][/color] or throw them using [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color]
 
-- Pull and release things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]
+<!-- HONK START - Escalated grab mention -->
+- Pull things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and release with [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]. Pull again while holding someone to escalate to an [bold]aggressive grab[/bold]
+<!-- HONK END -->
 
 A more comprehensive list can be found on the [textlink="controls" link="Controls"] page.
 


### PR DESCRIPTION
## About

Adds fireman carry. Players can hoist downed or incapacitated mobs over their shoulder. Requires an aggressive grab and two free hands. The carrier is slowed while carrying.

## Why / Balance

Downstream feature for honksquad. Gives players a way to move incapacitated crew faster than pulling, at the cost of both hands and an escalated grab. The speed penalty (75% walk, 60% sprint) keeps it from being a free upgrade over pulling.

## Technical Details

- New ECS feature in `Content.Shared/Carrying/` with client/server overrides
- Components: `CarrierComponent`, `CarriableComponent`, `ActiveCarrierComponent`, `BeingCarriedComponent`
- `SharedCarryingSystem` handles carry logic: initiation via verb or drag-drop, do-after windup, parenting the carried entity to the carrier, speed modifiers, auto-drop on stun/down/crit/container insertion
- Client system handles visual offset (carried entity rendered above carrier) and draw depth
- Integrates with `SharedEscalatedGrabSystem` (requires aggressive grab stage)
- Fixes `GrabStateComponent` networking: added `[AutoGenerateComponentState]` and `[DataField, AutoNetworkedField]` to `Target` and `Stage` so grab state replicates to clients
- Adds strip-menu conflict guard: drag-dropping with an escalated grab no longer opens the strip UI
- Added `Carrier` and `Carriable` components to `species_base.yml`
- Locale strings and guidebook entry for controls

## Media

Tested in-game on local server. No screenshots attached.

## Breaking Changes

None. All new files. The only upstream files touched are `species_base.yml` (two component additions) and `SharedStrippableSystem.cs` (3-line guard clause).

:cl:
- add: You can now fireman carry downed or incapacitated mobs over your shoulder. Requires an aggressive grab and both hands free.
- add: Carrying slows you down but moves the carried person with you.
- fix: Drag-dropping a mob you have an escalated grab on no longer opens the strip menu.