### PR TITLE
Escalated grab system

### DIFF
--- a/Content.Client/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Client/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.EscalatedGrab.Systems;
+
+namespace Content.Client.EscalatedGrab;
+
+internal sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Server/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Server/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.EscalatedGrab.Systems;
+
+namespace Content.Server.EscalatedGrab;
+
+public sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Shared/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/EscalatedGrab/Components/GrabStateComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.EscalatedGrab.Components;
+
+/// <summary>
+/// Added to a puller when their grab escalates beyond a standard pull.
+/// Tracks the current <see cref="GrabStage"/> and target entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class GrabStateComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid Target;
+
+    [DataField, AutoNetworkedField]
+    public GrabStage Stage = GrabStage.Aggressive;
+
+}

--- a/Content.Shared/EscalatedGrab/GrabStage.cs
+++ b/Content.Shared/EscalatedGrab/GrabStage.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.EscalatedGrab;
+
+/// <summary>
+/// Escalation level of a grab. Re-clicking pull advances to the next stage.
+/// </summary>
+[Serializable, NetSerializable]
+public enum GrabStage : byte
+{
+    /// <summary>
+    /// Standard pull. No <see cref="Components.GrabStateComponent"/> exists at this stage.
+    /// </summary>
+    Pull = 0,
+
+    /// <summary>
+    /// Aggressive grab. First escalation from a standard pull.
+    /// </summary>
+    Aggressive = 1,
+}

--- a/Content.Shared/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -1,0 +1,98 @@
+using Content.Shared.EscalatedGrab.Components;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Popups;
+using Content.Shared.Pulling.Events;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.EscalatedGrab.Systems;
+
+/// <summary>
+/// Manages grab escalation. Re-clicking pull on a target escalates the grab
+/// through <see cref="GrabStage"/> tiers instead of releasing.
+/// </summary>
+public abstract class SharedEscalatedGrabSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PullableComponent, PullGrabEscalateAttemptEvent>(OnEscalateAttempt);
+        SubscribeLocalEvent<PullableComponent, AttemptStopPullingEvent>(OnAttemptStopPulling);
+        SubscribeLocalEvent<GrabStateComponent, PullStoppedMessage>(OnPullStopped);
+    }
+
+    private void OnEscalateAttempt(EntityUid uid, PullableComponent component, ref PullGrabEscalateAttemptEvent args)
+    {
+        TryEscalate(args.Puller, args.Pulled);
+    }
+
+    private void OnAttemptStopPulling(EntityUid uid, PullableComponent component, ref AttemptStopPullingEvent args)
+    {
+        if (args.Cancelled || args.User == null)
+            return;
+
+        // Release keybind clears escalation and lets the pull stop.
+        if (args.Force)
+        {
+            ClearEscalation(args.User.Value);
+            return;
+        }
+    }
+
+    private void OnPullStopped(EntityUid uid, GrabStateComponent component, PullStoppedMessage args)
+    {
+        RemComp<GrabStateComponent>(uid);
+    }
+
+    /// <summary>
+    /// Attempts to escalate the grab to the next stage.
+    /// Returns true if the grab was escalated or is already at max stage.
+    /// </summary>
+    public bool TryEscalate(EntityUid puller, EntityUid target)
+    {
+        if (TryComp<GrabStateComponent>(puller, out var existing) && existing.Target == target)
+            return true;
+
+        if (!_timing.IsFirstTimePredicted)
+            return true;
+
+        var state = EnsureComp<GrabStateComponent>(puller);
+        state.Target = target;
+        state.Stage = GrabStage.Aggressive;
+        Dirty(puller, state);
+        _popup.PopupPredicted(Loc.GetString("escalated-grab-aggressive"), target, puller);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the current <see cref="GrabStage"/> for a puller on a target.
+    /// Defaults to <see cref="GrabStage.Pull"/> if no escalation exists.
+    /// </summary>
+    public GrabStage GetStage(EntityUid puller, EntityUid target)
+    {
+        if (TryComp<GrabStateComponent>(puller, out var comp) && comp.Target == target)
+            return comp.Stage;
+
+        return GrabStage.Pull;
+    }
+
+    /// <summary>
+    /// Checks whether the puller has at least the given grab stage on the target.
+    /// </summary>
+    public bool HasStage(EntityUid puller, EntityUid target, GrabStage minimumStage)
+    {
+        return GetStage(puller, target) >= minimumStage;
+    }
+
+    /// <summary>
+    /// Removes grab escalation from a puller.
+    /// </summary>
+    public void ClearEscalation(EntityUid puller)
+    {
+        RemComp<GrabStateComponent>(puller);
+    }
+}

--- a/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
+++ b/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
@@ -5,8 +5,11 @@ namespace Content.Shared.Pulling.Events;
 /// </summary>
 
 [ByRefEvent]
-public record struct AttemptStopPullingEvent(EntityUid? User = null)
+//HONK START - Escalated grab: added Force parameter
+public record struct AttemptStopPullingEvent(EntityUid? User = null, bool Force = false)
 {
     public readonly EntityUid? User = User;
+    public readonly bool Force = Force;
+    //HONK END
     public bool Cancelled;
 }

--- a/Content.Shared/Movement/Pulling/Events/PullGrabEscalateAttemptEvent.cs
+++ b/Content.Shared/Movement/Pulling/Events/PullGrabEscalateAttemptEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Movement.Pulling.Events;
+
+/// <summary>
+/// Raised on the pulled entity when the puller tries to pull a target
+/// they are already pulling. Subscribers can use this to escalate grabs.
+/// </summary>
+[ByRefEvent]
+public record struct PullGrabEscalateAttemptEvent(EntityUid Puller, EntityUid Pulled);

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -11,6 +11,9 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
+//HONK START - Escalated grab: drop-to-release pull
+using Content.Shared.Interaction.Events;
+//HONK END
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
 using Content.Shared.Mobs;
@@ -75,6 +78,9 @@ public sealed class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullerComponent, EntGotInsertedIntoContainerMessage>(OnPullerContainerInsert);
         SubscribeLocalEvent<PullerComponent, EntityUnpausedEvent>(OnPullerUnpaused);
         SubscribeLocalEvent<PullerComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
+        //HONK START - Drop virtual item releases pull
+        SubscribeLocalEvent<VirtualItemComponent, DroppedEvent>(OnVirtualItemDropped);
+        //HONK END
         SubscribeLocalEvent<PullerComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
         SubscribeLocalEvent<PullerComponent, DropHandItemsEvent>(OnDropHandItems);
         SubscribeLocalEvent<PullerComponent, StopPullingAlertEvent>(OnStopPullingAlert);
@@ -258,6 +264,20 @@ public sealed class PullingSystem : EntitySystem
         }
     }
 
+    //HONK START - Drop virtual item releases pull
+    private void OnVirtualItemDropped(EntityUid uid, VirtualItemComponent component, DroppedEvent args)
+    {
+        if (!TryComp<PullerComponent>(args.User, out var puller))
+            return;
+
+        if (puller.Pulling != component.BlockingEntity)
+            return;
+
+        if (TryComp(component.BlockingEntity, out PullableComponent? pullable))
+            TryStopPull(component.BlockingEntity, pullable, user: args.User, force: true);
+    }
+    //HONK END
+
     private void AddPullVerbs(EntityUid uid, PullableComponent component, GetVerbsEvent<Verb> args)
     {
         if (!args.CanAccess || !args.CanInteract)
@@ -428,7 +448,9 @@ public sealed class PullingSystem : EntitySystem
             return;
         }
 
-        TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player);
+        //HONK START - Force release on keybind
+        TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player, force: true);
+        //HONK END
     }
 
     public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null)
@@ -484,7 +506,11 @@ public sealed class PullingSystem : EntitySystem
 
         if (pullable.Comp.Puller == pullerUid)
         {
-            return TryStopPull(pullable, pullable.Comp);
+            //HONK START - Escalated grab: escalate instead of toggle-off
+            var ev = new PullGrabEscalateAttemptEvent(pullerUid, pullable.Owner);
+            RaiseLocalEvent(pullable.Owner, ref ev);
+            return true;
+            //HONK END
         }
 
         return TryStartPull(pullerUid, pullable, pullableComp: pullable);
@@ -598,14 +624,16 @@ public sealed class PullingSystem : EntitySystem
         return true;
     }
 
-    public bool TryStopPull(EntityUid pullableUid, PullableComponent pullable, EntityUid? user = null)
+    //HONK START - Escalated grab: added force parameter
+    public bool TryStopPull(EntityUid pullableUid, PullableComponent pullable, EntityUid? user = null, bool force = false)
     {
         var pullerUidNull = pullable.Puller;
 
         if (pullerUidNull == null)
             return true;
 
-        var msg = new AttemptStopPullingEvent(user);
+        var msg = new AttemptStopPullingEvent(user, force);
+        //HONK END
         RaiseLocalEvent(pullableUid, ref msg, true);
 
         if (msg.Cancelled)

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -6,6 +6,9 @@ using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
+//HONK START - Escalated grab: skip strip during grab
+using Content.Shared.EscalatedGrab.Components;
+//HONK END
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
@@ -652,6 +655,11 @@ public abstract class SharedStrippableSystem : EntitySystem
         // If the user drags a strippable thing onto themselves.
         if (args.Handled || args.Target != args.User)
             return;
+
+        //HONK START - Skip strip if escalated grab active
+        if (TryComp<GrabStateComponent>(args.User, out var grab) && grab.Target == uid)
+            return;
+        //HONK END
 
         if (TryOpenStrippingUi(args.User, (uid, component)))
             args.Handled = true;

--- a/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
+++ b/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
@@ -1,0 +1,1 @@
+escalated-grab-aggressive = You tighten your grip.

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -64,13 +64,17 @@
   Use [color=yellow][bold][keybind="Drop"][/bold][/color] to [color=cyan]drop[/color] (or place) an item from your hand within arm's reach.
   \n[color=cyan]Throw[/color] items to your cursor with [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color].
 
-  ### Pulling and pushing
-  You can pull movable [bold]entities[/bold] — items, objects, and mobs such as players, as long as you have an empty hand.
+  <!-- HONK START - Escalated grab docs -->
+  ### Pulling, pushing, and grabbing
+  You can pull movable [bold]entities[/bold] (items, objects, and mobs) as long as you have an empty hand.
   - Use [color=yellow][bold][keybind="TryPullObject"][/bold][/color] to start [color=cyan]pulling[/color].
   - [color=cyan]Push[/color] pulled entities to your cursor with [color=yellow][bold][keybind="MovePulledObject"][/bold][/color].
-  - To [color=cyan]release[/color], press [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color] or pull the same entity again.
+  - To [color=cyan]release[/color], press [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color].
+
+  While pulling someone, use [color=yellow][bold][keybind="TryPullObject"][/bold][/color] on them again to escalate to an [color=cyan]aggressive grab[/color]. This holds the target in place and prevents them from being released by toggling pull.
 
   You can also use [color=yellow][bold][keybind="Drop"][/bold][/color] to release pulled entities from your active hand.
+  <!-- HONK END -->
 
   ## Interactions
   The game features [bold]six[/bold] types of context-sensitive interactions, accessible through different methods.

--- a/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
@@ -25,7 +25,9 @@ The following are the controls you'll need for regular gameplay:
 
 - Drop held items with [color=yellow][bold][keybind="Drop"][/bold][/color] or throw them using [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color]
 
-- Pull and release things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]
+<!-- HONK START - Escalated grab mention -->
+- Pull things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and release with [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]. Pull again while holding someone to escalate to an [bold]aggressive grab[/bold]
+<!-- HONK END -->
 
 A more comprehensive list can be found on the [textlink="controls" link="Controls"] page.
 


### PR DESCRIPTION
## About

Adds grab escalation to the pulling system. Re-clicking pull on a target you're already pulling escalates to an aggressive grab instead of releasing. The release keybind still releases normally.

## Why / Balance

Downstream feature for honksquad. Pulling someone and clicking pull again currently just releases them, which feels unintuitive and wastes an interaction. Escalated grabs give pulling more depth and act as a prerequisite for fireman carry (#7). The aggressive grab stage prevents the target from being released by toggling pull, so you have to use the explicit release keybind.

## Technical Details

- New `SharedEscalatedGrabSystem` in `Content.Shared/EscalatedGrab/` with empty client/server overrides
- `GrabStateComponent` tracks the grab target and current `GrabStage` (enum: Pull, Aggressive)
- `PullingSystem.TogglePull` now raises `PullGrabEscalateAttemptEvent` instead of stopping the pull when already pulling a target
- `AttemptStopPullingEvent` gains a `Force` field so the release keybind can bypass escalation
- `OnAttemptStopPulling` clears escalation state when force-released
- `OnVirtualItemDropped` handler stops the pull when the virtual item is dropped (fixes virtual item not cleaning up on drop)
- Guidebook controls section updated for grabbing mechanics

Only upstream file modified: `PullingSystem.cs` (minimal changes to `TogglePull`, `TryStopPull`, and `AttemptStopPullingEvent`).

## Media

Tested in-game on local server. No screenshots attached.

## Breaking Changes

`AttemptStopPullingEvent` has a new `Force` field. Existing subscribers are unaffected (defaults to false).

:cl:
- add: Pulling someone and clicking pull again now escalates to an aggressive grab instead of releasing.
- add: Aggressive grabs hold the target in place. Use the release keybind to let go.
- fix: Dropping a pull virtual item from your hand now properly stops the pull.