### PR TITLE
Update README and commit conventions for fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,7 +310,12 @@ Resources/MapImages
 # Direnv stuff
 .direnv/
 
+# HONK START - Fork-specific ignores
 # AI tooling
 CLAUDE.md
 .serena/
 /docs/
+
+# Deploy
+deploy.sh
+# HONK END

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,40 +1,40 @@
-# Space Station 14 Code of Conduct
+# Honksquad Code of Conduct
 
-Space Station 14's staff and community is made up volunteers from all over the world, working on every aspect of the project - including development, teaching, and hosting integral tools.
+Honksquad is a downstream fork of Space Station 14. Our community is made up of volunteers from all over the world, working on every aspect of the project.
 
 Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to all levels of the project, from commenters to contributors to staff.
 
-This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended, a guide to make it easier to enrich all of us and the technical communities in which we participate.
 
-This code of conduct applies specifically to the Github repositories and its spaces managed by the Space Station 14 project or Space Wizards Federation. Some spaces, such as the Space Station 14 Discord or the official Wizard's Den game servers, have their own rules but are in spirit equal to what may be found in here.
+This code of conduct applies to the Honksquad GitHub repository and its associated spaces, including the [Discord](https://discord.gg/honk).
 
-If you believe someone is violating the code of conduct, we ask that you report it by contacting a Maintainer, Project Manager or Wizard staff member through [Discord](https://discord.ss14.io/), [the forums](https://forum.spacestation14.com/), or emailing [support@spacestation14.com](mailto:support@spacestation14.com).
+If you believe someone is violating the code of conduct, please report it by contacting a maintainer through [Discord](https://discord.gg/honk).
 
 - **Be friendly and patient.**
 - **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 - **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and contributors, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language. We have contributors of all skill levels, some even making their first foray into a new field with this project, so keep that in mind when discussing someone's work.
-- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Space Station 14 community should be respectful when dealing with other members as well as with people outside the Space Station 14 community. Assume contributions to the project, even those that do not end up being included, are made in good faith.
+- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Honksquad community should be respectful when dealing with other members as well as with people outside the community. Assume contributions to the project, even those that do not end up being included, are made in good faith.
 - **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
-  - Violent threats or language directed against another person.
-  - Discriminatory jokes and language.
-  - Posting sexually explicit or violent material.
-  - Posting (or threatening to post) other people's personally identifying information ("doxing").
-  - Personal insults, especially those using racist or sexist terms.
-  - Unwelcome sexual attention.
-  - Advocating for, or encouraging, any of the above behavior.
-  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
-- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Space Station 14 is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of Space Station 14 comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to make mistakes and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+    - Violent threats or language directed against another person.
+    - Discriminatory jokes and language.
+    - Posting sexually explicit or violent material.
+    - Posting (or threatening to post) other people's personally identifying information ("doxing").
+    - Personal insults, especially those using racist or sexist terms.
+    - Unwelcome sexual attention.
+    - Advocating for, or encouraging, any of the above behavior.
+    - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Honksquad is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to make mistakes and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
 Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
 
 ## On Community Moderation
 
-Deviating from the Code of Conduct on the Github repository may result in moderative actions taken by project Maintainers. This can involve your content being edited or deleted, and may result in a temporary or permanent block from the repository.
+Deviating from the Code of Conduct on the GitHub repository may result in moderative actions taken by project maintainers. This can involve your content being edited or deleted, and may result in a temporary or permanent block from the repository.
 
-This is to ensure Space Station 14 is a healthy community in which contributors feel encouraged and empowered to contribute, and to give you as a member of this community a chance to reflect on how you are interacting with it. While outright offensive and bigoted content will *always* be unacceptable on the repository, Maintainers are at liberty to take moderative actions against more ambiguous content that fail to provide constructive criticism, or that provides constructive criticism in a non-constructive manner. Examples of this include using hyperbole, bringing up PRs/changes unrelated to the discussion at hand, hostile tone, off-topic comments, creating PRs/Issues for the sole purpose of causing discussions, skirting the line of acceptable behavior, etc. Disagreeing with content or each other is fine and appreciated, but only as long as it's done with respect and in a constructive manner.
+This is to ensure Honksquad is a healthy community in which contributors feel encouraged and empowered to contribute. While outright offensive and bigoted content will _always_ be unacceptable, maintainers are at liberty to take moderative actions against content that fails to provide constructive criticism, or that provides constructive criticism in a non-constructive manner. Disagreeing with content or each other is fine and appreciated, but only as long as it's done with respect and in a constructive manner.
 
-Maintainers are expected to adhere to the guidelines as listed in the [Github Moderation Guidelines](https://docs.spacestation14.com/en/general-development/github-moderation-guidelines.html), though may deviate should they feel it's in the best interest of the community. If you believe you had an action incorrectly applied against you, you are encouraged to contact staff via [Discord](https://discord.ss14.io/) or [the forums](https://forum.spacestation14.com/), [appeal your Github ban](https://forum.spacestation14.com/c/ban-appeals/appeals-github/38), or make a [staff complaint](https://forum.spacestation14.com/t/staff-complaint-instructions-and-info/31).
+If you believe you had an action incorrectly applied against you, please reach out through [Discord](https://discord.gg/honk).
 
 ## Attribution
 
-This Code of Conduct is an edited version of the [Django Code of Conduct](https://www.djangoproject.com/conduct/), licensed under CC BY 3.0, for the Space Station 14 Github repository.
+This Code of Conduct is an edited version of the [Django Code of Conduct](https://www.djangoproject.com/conduct/), licensed under CC BY 3.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,24 @@
-# Space Station 14 Contributing Guidelines
+# Honksquad Contributing Guidelines
 
-Thanks for contributing to Space Station 14.
-When contributing, be sure to follow our [codebase conventions](https://docs.spacestation14.com/en/general-development/codebase-info/codebase-organization.html) and [PR guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
+Thanks for contributing to Honksquad, a downstream fork of [Space Station 14](https://github.com/space-wizards/space-station-14).
 
-Following these guidelines helps us increase review turnaround time, so be sure to review the linked documents in full.
+## Code Style & PR Guidelines
 
-The last major guidelines update was on **December 6th, 2025**.
+Follow the upstream [codebase conventions](https://docs.spacestation14.com/en/general-development/codebase-info/codebase-organization.html) and [PR guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 
-### Why is this here?
-We put this here so that GitHub will notify you when submitting a pull request that the PR guidelines have changed, if you haven't read the latest version.
+## Fork-Specific Rules
+
+- **Commit prefix:** All fork-specific commits must start with `honksquad:` (e.g., `honksquad: feat: add new feature`).
+- **Avoid modifying upstream files** whenever possible. Add new features in new files using ECS event subscriptions.
+- When upstream files must be touched, wrap changes with `//HONK START` / `//HONK END` marker comments (or `# HONK START` / `# HONK END` for YAML).
+- New files go under `@RussStation` prefixed directories (`Resources/Prototypes/@RussStation/`, etc.).
+
+## AI-Assisted Contributions
+
+AI-assisted contributions to code, YAML, and documentation are accepted, provided the contributor understands and can speak to the changes they submit. Low-effort, unreviewed dumps will be rejected like any other low-quality PR.
+
+AI-generated artwork, sound files, and other creative assets are **not accepted**.
+
+## Getting Help
+
+Join the [Discord](https://discord.gg/honk) if you want to help or have questions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,16 @@
-# Reporting a security vulnerability
-You can report a security vulnerability through Discord or through email.
+# Reporting a Security Vulnerability
 
-If you want to send an email, you can contact us at <support@spacestation14.com>.
-If you want to contact us through Discord, you can join [our server](https://discord.gg/MwDDf6t)
-and then **privately** message anyone with the `@Wizard` or `@SS14 Maintainer` role.
+Honksquad is a downstream fork of [Space Station 14](https://github.com/space-wizards/space-station-14) and shares its engine and core codebase.
 
-In either case, **do not publicly disclose the vulnerability until we explicitly give
-you permission to do so**.
+## Engine / upstream vulnerabilities
+
+Report security issues affecting the SS14 engine or upstream code to the Space Wizards team:
+
+- **Email:** <support@spacestation14.com>
+- **Discord:** Join the [SS14 Discord](https://discord.gg/MwDDf6t) and privately message anyone with the `@Wizard` or `@SS14 Maintainer` role.
+
+## Fork-specific vulnerabilities
+
+For issues that only affect Honksquad-specific code, reach out through the [Honksquad Discord](https://discord.gg/honk).
+
+In either case, **do not publicly disclose the vulnerability until you are explicitly given permission to do so**.


### PR DESCRIPTION
## About

Updates README, gitignore, and clone URL for the honksquad fork. Adds the `honksquad:` commit prefix convention so fork commits are easy to spot when rebasing on upstream.

## Why

Keeps the fork's docs accurate and makes upstream rebases less confusing.