### PR TITLE
Make lockers airtight only when welded

### DIFF
--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -4,7 +4,9 @@ using Content.Server.Construction;
 using Content.Server.Construction.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
+//HONK START - Airtight lockers when welded
 using Content.Shared.Tools.Systems;
+//HONK END
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 
@@ -23,7 +25,9 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
 
         SubscribeLocalEvent<EntityStorageComponent, MapInitEvent>(OnMapInit);
 
+        //HONK START - Airtight lockers when welded
         SubscribeLocalEvent<EntityStorageComponent, WeldableChangedEvent>(OnWeldChanged);
+        //HONK END
 
         SubscribeLocalEvent<InsideEntityStorageComponent, InhaleLocationEvent>(OnInsideInhale);
         SubscribeLocalEvent<InsideEntityStorageComponent, ExhaleLocationEvent>(OnInsideExhale);
@@ -87,6 +91,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         return null;
     }
 
+    //HONK START - Airtight lockers when welded
     // NOTE: This only fires on state change, so lockers placed pre-welded in maps
     // won't become airtight until unwelded and re-welded.
     private void OnWeldChanged(EntityUid uid, EntityStorageComponent component, ref WeldableChangedEvent args)
@@ -102,6 +107,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
             component.Airtight = false;
         }
     }
+    //HONK END
 
     #region Gas mix event handlers
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -45,6 +45,9 @@
             - MachineLayer
     - type: EntityStorage
       airtight: false
+      # HONK START - Lockers not airtight unless welded
+      airtight: false
+      # HONK END
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -140,6 +143,9 @@
           map: ["enum.WeldableLayers.BaseWelded"]
     - type: EntityStorage
       airtight: false
+      # HONK START - Wall closets not airtight unless welded
+      airtight: false
+      # HONK END
       isCollidableWhenOpen: true
       enteringOffset: 0, -0.6
       enteringRange: 0.03


### PR DESCRIPTION
## About

Lockers are only airtight when welded shut. Closing a locker no longer seals it from atmosphere.

## Why

A closed locker blocking atmos never made much sense. Welding it shut does.

:cl:
- tweak: Lockers no longer block atmosphere unless welded shut.