### PR TITLE
Remove click-to-strip behavior

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -56,6 +56,8 @@ public abstract class SharedStrippableSystem : EntitySystem
         SubscribeLocalEvent<StrippingComponent, CanDropTargetEvent>(OnCanDropOn);
         SubscribeLocalEvent<StrippableComponent, CanDropDraggedEvent>(OnCanDrop);
         SubscribeLocalEvent<StrippableComponent, DragDropDraggedEvent>(OnDragDrop);
+        //HONK START - Removed click-to-strip (OnActivateInWorld subscription removed)
+        //HONK END
     }
 
     private void AddStripVerb(EntityUid uid, StrippableComponent component, GetVerbsEvent<Verb> args)
@@ -624,6 +626,9 @@ public abstract class SharedStrippableSystem : EntitySystem
                 StripRemoveHand((entity.Owner, entity.Comp), ev.Target.Value, ev.Used.Value, ev.SlotOrHandName, ev.Args.Hidden);
         }
     }
+
+    //HONK START - Removed click-to-strip (OnActivateInWorld method removed)
+    //HONK END
 
     /// <summary>
     /// Modify the strip time via events. Raised directed at the item being stripped, the player stripping someone and the player being stripped.


### PR DESCRIPTION
## About

Removes the ability to strip someone by clicking their sprite. You can still strip through the verb menu.

## Why

Click-to-strip was too easy to trigger by accident and too hard to counter. The verb menu is intentional enough that it feels fair. This behavior is also just inconsistent.

:cl:
- remove: Clicking a player's sprite no longer opens the strip menu. Use the strip verb instead.