### PR TITLE
Remove empty HONK markers and duplicate airtight lines

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -56,8 +56,6 @@ public abstract class SharedStrippableSystem : EntitySystem
         SubscribeLocalEvent<StrippingComponent, CanDropTargetEvent>(OnCanDropOn);
         SubscribeLocalEvent<StrippableComponent, CanDropDraggedEvent>(OnCanDrop);
         SubscribeLocalEvent<StrippableComponent, DragDropDraggedEvent>(OnDragDrop);
-        //HONK START - Removed click-to-strip (OnActivateInWorld subscription removed)
-        //HONK END
     }
 
     private void AddStripVerb(EntityUid uid, StrippableComponent component, GetVerbsEvent<Verb> args)
@@ -626,9 +624,6 @@ public abstract class SharedStrippableSystem : EntitySystem
                 StripRemoveHand((entity.Owner, entity.Comp), ev.Target.Value, ev.Used.Value, ev.SlotOrHandName, ev.Args.Hidden);
         }
     }
-
-    //HONK START - Removed click-to-strip (OnActivateInWorld method removed)
-    //HONK END
 
     /// <summary>
     /// Modify the strip time via events. Raised directed at the item being stripped, the player stripping someone and the player being stripped.

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -45,9 +45,6 @@
             - MachineLayer
     - type: EntityStorage
       airtight: false
-      # HONK START - Lockers not airtight unless welded
-      airtight: false
-      # HONK END
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -143,9 +140,6 @@
           map: ["enum.WeldableLayers.BaseWelded"]
     - type: EntityStorage
       airtight: false
-      # HONK START - Wall closets not airtight unless welded
-      airtight: false
-      # HONK END
       isCollidableWhenOpen: true
       enteringOffset: 0, -0.6
       enteringRange: 0.03


### PR DESCRIPTION
## Summary
- Remove two empty HONK marker pairs in SharedStrippableSystem.cs (dead "removed code" comments)
- Remove duplicate `airtight: false` lines with redundant HONK markers in base_structureclosets.yml

Cleanup from PR merge order — these were leftovers that didn't serve a purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)