### PR TITLE
Fix crates being airtight before welding

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -1,134 +1,134 @@
 - type: entity
-  parent: [ BaseStructureDynamic, BasePaperLabelableVisualized ]
+  parent: [BaseStructureDynamic, BasePaperLabelableVisualized]
   id: CrateGeneric
-  categories: [ HideSpawnMenu ]
+  categories: [HideSpawnMenu]
   name: crate
   description: A large container for items.
   components:
-  - type: Animateable
-  - type: Transform
-    noRot: true
-  - type: Icon
-    sprite: Structures/Storage/Crates/generic.rsi
-    state: icon
-  - type: Sprite
-    noRot: true
-    sprite: Structures/Storage/Crates/generic.rsi
-    layers:
-    - state: base
-      map: ["enum.StorageVisualLayers.Base"]
-    - state: closed
-      map: ["enum.StorageVisualLayers.Door"]
-    - state: welded
-      visible: false
-      map: ["enum.WeldableLayers.BaseWelded"]
-    - state: paper
-      sprite: Structures/Storage/Crates/labels.rsi
-      map: ["enum.PaperLabelVisuals.Layer"]
-  - type: InteractionOutline
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.4,-0.4,0.4,0.29"
-        density: 50
-        mask:
-        - CrateMask #this is so they can go under plastic flaps
-        layer:
-        - MachineLayer
-  - type: EntityStorage
-  - type: PlaceableSurface
-    isPlaceable: false # defaults to closed.
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
-  - type: EntityStorageVisuals
-    stateDoorOpen: open
-    stateDoorClosed: closed
-  - type: ContainerContainer
-    containers:
-      entity_storage: !type:Container
-      paper_label: !type:ContainerSlot
-  - type: StaticPrice
-    price: 75
-  - type: Construction
-    graph: CrateGenericSteel
-    node: crategenericsteel
-    containers:
-      - entity_storage
-  - type: RequireProjectileTarget
+    - type: Animateable
+    - type: Transform
+      noRot: true
+    - type: Icon
+      sprite: Structures/Storage/Crates/generic.rsi
+      state: icon
+    - type: Sprite
+      noRot: true
+      sprite: Structures/Storage/Crates/generic.rsi
+      layers:
+        - state: base
+          map: ["enum.StorageVisualLayers.Base"]
+        - state: closed
+          map: ["enum.StorageVisualLayers.Door"]
+        - state: welded
+          visible: false
+          map: ["enum.WeldableLayers.BaseWelded"]
+        - state: paper
+          sprite: Structures/Storage/Crates/labels.rsi
+          map: ["enum.PaperLabelVisuals.Layer"]
+    - type: InteractionOutline
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeAabb
+            bounds: "-0.4,-0.4,0.4,0.29"
+          density: 50
+          mask:
+            - CrateMask #this is so they can go under plastic flaps
+          layer:
+            - MachineLayer
+    - type: EntityStorage
+      # HONK START - Crates not airtight by default, welding makes them airtight
+      airtight: false
+      # HONK END
+    - type: PlaceableSurface
+      isPlaceable: false # defaults to closed.
+    - type: Damageable
+      damageContainer: StructuralInorganic
+      damageModifierSet: Metallic
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTrigger
+            damage: 50
+          behaviors:
+            - !type:DoActsBehavior
+              acts: ["Destruction"]
+            - !type:PlaySoundBehavior
+              sound:
+                collection: MetalBreak
+    - type: EntityStorageVisuals
+      stateDoorOpen: open
+      stateDoorClosed: closed
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+        paper_label: !type:ContainerSlot
+    - type: StaticPrice
+      price: 75
+    - type: Construction
+      graph: CrateGenericSteel
+      node: crategenericsteel
+      containers:
+        - entity_storage
+    - type: RequireProjectileTarget
 
 - type: entity
   parent: CrateGeneric
   id: CrateBaseWeldable
-  categories: [ HideSpawnMenu ]
+  categories: [HideSpawnMenu]
   components:
-  - type: Weldable
-  - type: ResistLocker
+    - type: Weldable
+    - type: ResistLocker
 
 - type: entity
   parent: CrateBaseWeldable
   id: CrateBaseSecure
   suffix: Secure
   components:
-  - type: Lock
-  - type: LockVisuals
-  - type: AccessReader
-  - type: Icon
-    sprite: Structures/Storage/Crates/secure.rsi
-    state: icon
-  - type: Sprite
-    sprite: Structures/Storage/Crates/secure.rsi
-    layers:
-    - state: base
-    - state: closed
-      map: ["enum.StorageVisualLayers.Door"]
-    - state: welded
-      visible: false
-      map: ["enum.WeldableLayers.BaseWelded"]
-    - state: locked
-      map: ["enum.LockVisualLayers.Lock"]
-      shader: unshaded
-    - state: paper
-      sprite: Structures/Storage/Crates/labels.rsi
-      offset: "-0.5,0"
-      map: ["enum.PaperLabelVisuals.Layer"]
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 75
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
-    containers:
-    - entity_storage
-  - type: Reflect
-    reflects:
-    - Energy
-    reflectProb: 0.2
-    spread: 90
-  - type: Paintable
-    group: CrateSecure
+    - type: Lock
+    - type: LockVisuals
+    - type: AccessReader
+    - type: Icon
+      sprite: Structures/Storage/Crates/secure.rsi
+      state: icon
+    - type: Sprite
+      sprite: Structures/Storage/Crates/secure.rsi
+      layers:
+        - state: base
+        - state: closed
+          map: ["enum.StorageVisualLayers.Door"]
+        - state: welded
+          visible: false
+          map: ["enum.WeldableLayers.BaseWelded"]
+        - state: locked
+          map: ["enum.LockVisualLayers.Lock"]
+          shader: unshaded
+        - state: paper
+          sprite: Structures/Storage/Crates/labels.rsi
+          offset: "-0.5,0"
+          map: ["enum.PaperLabelVisuals.Layer"]
+    - type: Damageable
+      damageContainer: StructuralInorganic
+      damageModifierSet: StructuralMetallic
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTrigger
+            damage: 75
+          behaviors:
+            - !type:DoActsBehavior
+              acts: ["Destruction"]
+            - !type:PlaySoundBehavior
+              sound:
+                collection: MetalBreak
+    - type: Construction
+      graph: CrateSecure
+      node: cratesecure
+      containers:
+        - entity_storage
+    - type: Reflect
+      reflects:
+        - Energy
+      reflectProb: 0.2
+      spread: 90
+    - type: Paintable
+      group: CrateSecure


### PR DESCRIPTION
## About the PR
Sets `airtight: false` on CrateGeneric's EntityStorage component. Without this, crates inherited the C# default of `airtight: true`, so they were airtight on spawn before any welding.

## Why / Balance
The airtight-lockers feature makes lockers/crates airtight only when welded shut. Crates skipped this because their base prototype never set `airtight: false`, so they spawned already sealed.

## Technical details
`CrateGeneric` in `base_structurecrates.yml` had a bare `- type: EntityStorage` with no fields. The C# default for `EntityStorageComponent.Airtight` is `true`. Added explicit `airtight: false` with HONK markers since this is an upstream file.

## Media
N/A, no visual changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Crates are no longer airtight by default; they only become airtight when welded shut.