### PR TITLE
Lightweight entity hover tooltip

### DIFF
--- a/Content.Client/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Client/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,5 +1,0 @@
-using Content.Shared.EscalatedGrab.Systems;
-
-namespace Content.Client.EscalatedGrab;
-
-internal sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Client/RussStation/Carrying/CarryingSystem.cs
+++ b/Content.Client/RussStation/Carrying/CarryingSystem.cs
@@ -1,10 +1,10 @@
 using System.Numerics;
-using Content.Shared.Carrying.Components;
-using Content.Shared.Carrying.Systems;
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Systems;
 using Robust.Client.GameObjects;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
-namespace Content.Client.Carrying;
+namespace Content.Client.RussStation.Carrying;
 
 internal sealed class CarryingSystem : SharedCarryingSystem
 {

--- a/Content.Client/RussStation/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Client/RussStation/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.RussStation.EscalatedGrab.Systems;
+
+namespace Content.Client.RussStation.EscalatedGrab;
+
+internal sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Client/RussStation/HoverTooltip/EntityHoverTooltipOverlay.cs
+++ b/Content.Client/RussStation/HoverTooltip/EntityHoverTooltipOverlay.cs
@@ -1,0 +1,47 @@
+using System.Numerics;
+using Content.Client.Resources;
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Shared.Enums;
+
+namespace Content.Client.RussStation.HoverTooltip;
+
+public sealed class EntityHoverTooltipOverlay : Overlay
+{
+    private readonly Font _font;
+
+    public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+
+    public string? TooltipText;
+    public Vector2 ScreenPosition;
+    public bool Visible;
+
+    private const float Padding = 4f;
+    private static readonly Vector2 CursorOffset = new(16f, 16f);
+    private static readonly Color BackgroundColor = Color.Black.WithAlpha(0.65f);
+
+    public EntityHoverTooltipOverlay(IResourceCache resourceCache)
+    {
+        _font = resourceCache.GetFont("/Fonts/NotoSans/NotoSans-Regular.ttf", 12);
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        return Visible && !string.IsNullOrEmpty(TooltipText);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var handle = args.ScreenHandle;
+        handle.SetTransform(Matrix3x2.Identity);
+
+        var pos = ScreenPosition + CursorOffset;
+        var dimensions = handle.GetDimensions(_font, TooltipText!, 1f);
+
+        var bgPos = pos - new Vector2(Padding, Padding);
+        var bgSize = dimensions + new Vector2(Padding * 2, Padding * 2);
+        handle.DrawRect(UIBox2.FromDimensions(bgPos, bgSize), BackgroundColor);
+
+        handle.DrawString(_font, pos, TooltipText!, 1f, Color.White);
+    }
+}

--- a/Content.Client/RussStation/HoverTooltip/EntityHoverTooltipSystem.cs
+++ b/Content.Client/RussStation/HoverTooltip/EntityHoverTooltipSystem.cs
@@ -1,0 +1,109 @@
+using Content.Client.Gameplay;
+using Content.Client.Viewport;
+using Content.Shared.CCVar;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.ResourceManagement;
+using Robust.Client.State;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Configuration;
+
+namespace Content.Client.RussStation.HoverTooltip;
+
+public sealed class EntityHoverTooltipSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly IResourceCache _resourceCache = default!;
+    [Dependency] private readonly IStateManager _stateManager = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+
+    private EntityHoverTooltipOverlay _overlay = default!;
+    private EntityUid? _hoveredEntity;
+    private float _hoverTime;
+    private bool _enabled;
+    private float _delay;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _overlay = new EntityHoverTooltipOverlay(_resourceCache);
+        _overlayManager.AddOverlay(_overlay);
+
+        Subs.CVar(_configManager, CCVars.HoverTooltipEnabled, v => _enabled = v, true);
+        Subs.CVar(_configManager, CCVars.HoverTooltipDelay, v => _delay = v, true);
+
+        UpdatesAfter.Add(typeof(SharedEyeSystem));
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _overlayManager.RemoveOverlay(_overlay);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        if (!_enabled)
+        {
+            _overlay.Visible = false;
+            return;
+        }
+
+        if (_stateManager.CurrentState is not GameplayStateBase screen)
+        {
+            _overlay.Visible = false;
+            return;
+        }
+
+        EntityUid? entityToClick = null;
+
+        if (_uiManager.CurrentlyHovered is IViewportControl vp
+            && _inputManager.MouseScreenPosition.IsValid)
+        {
+            var mousePosWorld = vp.PixelToMap(_inputManager.MouseScreenPosition.Position);
+
+            if (vp is ScalingViewport svp)
+                entityToClick = screen.GetClickedEntity(mousePosWorld, svp.Eye);
+            else
+                entityToClick = screen.GetClickedEntity(mousePosWorld);
+        }
+
+        if (entityToClick != _hoveredEntity)
+        {
+            _hoverTime = 0f;
+            _hoveredEntity = entityToClick;
+        }
+
+        if (_hoveredEntity == null || Deleted(_hoveredEntity))
+        {
+            _hoveredEntity = null;
+            _overlay.Visible = false;
+            return;
+        }
+
+        _hoverTime += frameTime;
+
+        if (_hoverTime < _delay)
+        {
+            _overlay.Visible = false;
+            return;
+        }
+
+        var name = MetaData(_hoveredEntity.Value).EntityName;
+        if (string.IsNullOrEmpty(name))
+        {
+            _overlay.Visible = false;
+            return;
+        }
+
+        _overlay.TooltipText = name;
+        _overlay.ScreenPosition = _inputManager.MouseScreenPosition.Position;
+        _overlay.Visible = true;
+    }
+}

--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -1,5 +1,0 @@
-using Content.Shared.Carrying.Systems;
-
-namespace Content.Server.Carrying;
-
-public sealed class CarryingSystem : SharedCarryingSystem;

--- a/Content.Server/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Server/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,5 +1,0 @@
-using Content.Shared.EscalatedGrab.Systems;
-
-namespace Content.Server.EscalatedGrab;
-
-public sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Server/RussStation/Carrying/CarryingSystem.cs
+++ b/Content.Server/RussStation/Carrying/CarryingSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.RussStation.Carrying.Systems;
+
+namespace Content.Server.RussStation.Carrying;
+
+public sealed class CarryingSystem : SharedCarryingSystem;

--- a/Content.Server/RussStation/EscalatedGrab/EscalatedGrabSystem.cs
+++ b/Content.Server/RussStation/EscalatedGrab/EscalatedGrabSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.RussStation.EscalatedGrab.Systems;
+
+namespace Content.Server.RussStation.EscalatedGrab;
+
+public sealed class EscalatedGrabSystem : SharedEscalatedGrabSystem;

--- a/Content.Shared/CCVar/CCVars.HoverTooltip.cs
+++ b/Content.Shared/CCVar/CCVars.HoverTooltip.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     Whether to show entity name tooltip on hover.
+    /// </summary>
+    public static readonly CVarDef<bool> HoverTooltipEnabled =
+        CVarDef.Create("hud.hover_tooltip_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    ///     Delay in seconds before the hover tooltip appears.
+    /// </summary>
+    public static readonly CVarDef<float> HoverTooltipDelay =
+        CVarDef.Create("hud.hover_tooltip_delay", 0.3f, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -21,6 +21,9 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
+//HONK START - Escalated grab event
+using Content.Shared.RussStation.EscalatedGrab.Events;
+//HONK END
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;

--- a/Content.Shared/RussStation/Carrying/Components/ActiveCarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/ActiveCarrierComponent.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Carrying.Components;
+namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
 /// Active marker component on an entity currently carrying another entity.

--- a/Content.Shared/RussStation/Carrying/Components/BeingCarriedComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/BeingCarriedComponent.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Carrying.Components;
+namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
 /// Active marker on an entity currently being carried.

--- a/Content.Shared/RussStation/Carrying/Components/CarriableComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarriableComponent.cs
@@ -1,7 +1,7 @@
-using Content.Shared.Carrying.Systems;
+using Content.Shared.RussStation.Carrying.Systems;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Carrying.Components;
+namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
 /// Indicates this entity can be fireman carried.

--- a/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
@@ -1,7 +1,7 @@
-using Content.Shared.Carrying.Systems;
+using Content.Shared.RussStation.Carrying.Systems;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Carrying.Components;
+namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
 /// Indicates this entity can fireman carry another entity.

--- a/Content.Shared/RussStation/Carrying/Events/CarryDoAfterEvent.cs
+++ b/Content.Shared/RussStation/Carrying/Events/CarryDoAfterEvent.cs
@@ -1,7 +1,7 @@
 using Content.Shared.DoAfter;
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.Carrying.Events;
+namespace Content.Shared.RussStation.Carrying.Events;
 
 /// <summary>
 /// DoAfter event for the carry windup.

--- a/Content.Shared/RussStation/Carrying/Events/CarryEvents.cs
+++ b/Content.Shared/RussStation/Carrying/Events/CarryEvents.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameObjects;
 
-namespace Content.Shared.Carrying.Events;
+namespace Content.Shared.RussStation.Carrying.Events;
 
 /// <summary>
 /// Raised on both carrier and target before carry starts. Can be cancelled.

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -1,10 +1,10 @@
 using Content.Shared.ActionBlocker;
-using Content.Shared.Carrying.Components;
-using Content.Shared.Carrying.Events;
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
-using Content.Shared.EscalatedGrab;
-using Content.Shared.EscalatedGrab.Systems;
+using Content.Shared.RussStation.EscalatedGrab;
+using Content.Shared.RussStation.EscalatedGrab.Systems;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -27,7 +27,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
-namespace Content.Shared.Carrying.Systems;
+namespace Content.Shared.RussStation.Carrying.Systems;
 
 public abstract class SharedCarryingSystem : EntitySystem
 {

--- a/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
@@ -1,7 +1,7 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.EscalatedGrab.Components;
+namespace Content.Shared.RussStation.EscalatedGrab.Components;
 
 /// <summary>
 /// Added to a puller when their grab escalates beyond a standard pull.

--- a/Content.Shared/RussStation/EscalatedGrab/Events/PullGrabEscalateAttemptEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/PullGrabEscalateAttemptEvent.cs
@@ -1,4 +1,4 @@
-namespace Content.Shared.Movement.Pulling.Events;
+namespace Content.Shared.RussStation.EscalatedGrab.Events;
 
 /// <summary>
 /// Raised on the pulled entity when the puller tries to pull a target

--- a/Content.Shared/RussStation/EscalatedGrab/GrabStage.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/GrabStage.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.EscalatedGrab;
+namespace Content.Shared.RussStation.EscalatedGrab;
 
 /// <summary>
 /// Escalation level of a grab. Re-clicking pull advances to the next stage.

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -1,11 +1,12 @@
-using Content.Shared.EscalatedGrab.Components;
+using Content.Shared.RussStation.EscalatedGrab.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.RussStation.EscalatedGrab.Events;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
 using Robust.Shared.Timing;
 
-namespace Content.Shared.EscalatedGrab.Systems;
+namespace Content.Shared.RussStation.EscalatedGrab.Systems;
 
 /// <summary>
 /// Manages grab escalation. Re-clicking pull on a target escalates the grab

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -7,7 +7,7 @@ using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 //HONK START - Escalated grab: skip strip during grab
-using Content.Shared.EscalatedGrab.Components;
+using Content.Shared.RussStation.EscalatedGrab.Components;
 //HONK END
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -1,234 +1,237 @@
 - type: entity
   abstract: true
   parent:
-    - BaseMob
-    - MobCombat
-    - MobDamageable
-    - MobPolymorphable
-    - StripableInventoryBase
-    - BaseSpeciesAppearance
+  - BaseMob
+  - MobCombat
+  - MobDamageable
+  - MobPolymorphable
+  - StripableInventoryBase
+  - BaseSpeciesAppearance
   id: BaseSpeciesMob
   save: false
   components:
-    - type: DamageVisuals
-      thresholds: [10, 20, 30, 50, 70, 100]
-      targetLayers:
-        - "enum.HumanoidVisualLayers.Chest"
-        - "enum.HumanoidVisualLayers.Head"
-        - "enum.HumanoidVisualLayers.LArm"
-        - "enum.HumanoidVisualLayers.LLeg"
-        - "enum.HumanoidVisualLayers.RArm"
-        - "enum.HumanoidVisualLayers.RLeg"
-      damageOverlayGroups:
-        Brute:
-          sprite: Mobs/Effects/brute_damage.rsi
-          color: "#FF0000"
-        Burn:
-          sprite: Mobs/Effects/burn_damage.rsi
-    - type: GenericVisualizer
-      visuals:
-        enum.CreamPiedVisuals.Creamed:
-          clownedon:
-            True: { visible: true }
-            False: { visible: false }
-    - type: StatusIcon
-      bounds: -0.5,-0.5,0.5,0.5
-    - type: JobStatus
-    - type: RotationVisuals
-      defaultRotation: 90
-      horizontalRotation: 90
-    - type: HumanoidProfile
-    - type: TypingIndicator
-    - type: SlowOnDamage
-      speedModifierThresholds:
-        60: 0.7
-        80: 0.5
-    - type: Fixtures
-      fixtures: # TODO: This needs a second fixture just for mob collisions.
-        fix1:
-          shape: !type:PhysShapeCircle
-            radius: 0.35
-          density: 185
-          restitution: 0.0
-          mask:
-            - MobMask
-          layer:
-            - MobLayer
-    - type: FloorOcclusion
-    - type: RangedDamageSound
-      soundGroups:
-        Brute:
-          collection: MeatBulletImpact
-      soundTypes:
-        Heat:
-          collection: MeatLaserImpact
-    - type: Reactive
-      groups:
-        Flammable: [Touch]
-        Extinguish: [Touch]
-        Acidic: [Touch, Ingestion]
-      reactions:
-        - reagents: [Water, SpaceCleaner]
-          methods: [Touch]
-          effects:
-            - !type:WashCreamPie
-    - type: StatusEffects
-      allowed:
-        - Electrocution
-        - RatvarianLanguage
-        - PressureImmunity
-        - Muted
-        - TemporaryBlindness
-        - Pacified
-        - Flashed
-        - RadiationProtection
-        - Adrenaline
-    - type: Identity
-    - type: IdExaminable
-    - type: Internals
-    - type: FloatingVisuals
-    - type: Climbing
-    - type: Cuffable
-    - type: Ensnareable
-      sprite: Objects/Misc/ensnare.rsi
-      state: icon
-    - type: AnimationPlayer
-    - type: Buckle
-    - type: CombatMode
-      canDisarm: true
-    - type: MeleeWeapon
-      soundHit:
-        collection: Punch
-      angle: 30
-      animation: WeaponArcFist
-      attackRate: 1
-      damage:
-        types:
-          Blunt: 5
-    - type: SleepEmitSound
-    - type: SSDIndicator
-    - type: StandingState
-    - type: Crawler
-    - type: Dna
-    - type: MindContainer
-    - type: MindExaminable
-    - type: CanEnterCryostorage
-    - type: InteractionPopup
-      successChance: 1
-      interactSuccessString: hugging-success-generic
-      interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-      messagePerceivedByOthers: hugging-success-generic-others
-    - type: CanHostGuardian
-    - type: NpcFactionMember
-      factions:
-        - NanoTrasen
-    - type: CreamPied
-    - type: ParcelWrapOverride
-      parcelPrototype: WrappedParcelHumanoid
-      wrapDelay: 5
-    - type: Stripping
-    - type: UserInterface
-      interfaces:
-        enum.HumanoidMarkingModifierKey.Key:
-          type: HumanoidMarkingModifierBoundUserInterface
-        enum.StrippingUiKey.Key:
-          type: StrippableBoundUserInterface
-    - type: Puller
-    # HONK START - Fireman carry
-    - type: Carrier
-    - type: Carriable
-    # HONK END
-    - type: Speech
-      speechSounds: Alto
-    - type: DamageForceSay
-    - type: Vocal
-      sounds:
-        Male: MaleHuman
-        Female: FemaleHuman
-        Unsexed: MaleHuman
-    - type: Emoting
-    - type: BodyEmotes
-      soundsId: GeneralBodyEmotes
-    - type: Grammar
-      attributes:
-        proper: true
-    - type: MobPrice
-      price: 1500 # Kidnapping a living person and selling them for cred is a good move.
-      deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
-    - type: Tag
-      tags:
-        - CanPilot
-        - FootstepSound
-        - DoorBumpOpener
-        - AnomalyHost
+  - type: DamageVisuals
+    thresholds: [ 10, 20, 30, 50, 70, 100 ]
+    targetLayers:
+    - "enum.HumanoidVisualLayers.Chest"
+    - "enum.HumanoidVisualLayers.Head"
+    - "enum.HumanoidVisualLayers.LArm"
+    - "enum.HumanoidVisualLayers.LLeg"
+    - "enum.HumanoidVisualLayers.RArm"
+    - "enum.HumanoidVisualLayers.RLeg"
+    damageOverlayGroups:
+      Brute:
+        sprite: Mobs/Effects/brute_damage.rsi
+        color: "#FF0000"
+      Burn:
+        sprite: Mobs/Effects/burn_damage.rsi
+  - type: GenericVisualizer
+    visuals:
+      enum.CreamPiedVisuals.Creamed:
+        clownedon:
+          True: { visible: true }
+          False: { visible: false }
+  - type: StatusIcon
+    bounds: -0.5,-0.5,0.5,0.5
+  - type: JobStatus
+  - type: RotationVisuals
+    defaultRotation: 90
+    horizontalRotation: 90
+  - type: HumanoidProfile
+  - type: TypingIndicator
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      60: 0.7
+      80: 0.5
+  - type: Fixtures
+    fixtures: # TODO: This needs a second fixture just for mob collisions.
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 185
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+  - type: FloorOcclusion
+  - type: RangedDamageSound
+    soundGroups:
+      Brute:
+        collection:
+          MeatBulletImpact
+    soundTypes:
+      Heat:
+        collection:
+          MeatLaserImpact
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion]
+    reactions:
+    - reagents: [Water, SpaceCleaner]
+      methods: [Touch]
+      effects:
+      - !type:WashCreamPie
+  - type: StatusEffects
+    allowed:
+    - Electrocution
+    - RatvarianLanguage
+    - PressureImmunity
+    - Muted
+    - TemporaryBlindness
+    - Pacified
+    - Flashed
+    - RadiationProtection
+    - Adrenaline
+  - type: Identity
+  - type: IdExaminable
+  - type: Internals
+  - type: FloatingVisuals
+  - type: Climbing
+  - type: Cuffable
+  - type: Ensnareable
+    sprite: Objects/Misc/ensnare.rsi
+    state: icon
+  - type: AnimationPlayer
+  - type: Buckle
+  - type: CombatMode
+    canDisarm: true
+  - type: MeleeWeapon
+    soundHit:
+      collection: Punch
+    angle: 30
+    animation: WeaponArcFist
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 5
+  - type: SleepEmitSound
+  - type: SSDIndicator
+  - type: StandingState
+  - type: Crawler
+  - type: Dna
+  - type: MindContainer
+  - type: MindExaminable
+  - type: CanEnterCryostorage
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
+  - type: CanHostGuardian
+  - type: NpcFactionMember
+    factions:
+    - NanoTrasen
+  - type: CreamPied
+  - type: ParcelWrapOverride
+    parcelPrototype: WrappedParcelHumanoid
+    wrapDelay: 5
+  - type: Stripping
+  - type: UserInterface
+    interfaces:
+      enum.HumanoidMarkingModifierKey.Key:
+        type: HumanoidMarkingModifierBoundUserInterface
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
+  - type: Puller
+  # HONK START - Fireman carry
+  - type: Carrier
+  - type: Carriable
+  # HONK END
+  - type: Speech
+    speechSounds: Alto
+  - type: DamageForceSay
+  - type: Vocal
+    sounds:
+      Male: MaleHuman
+      Female: FemaleHuman
+      Unsexed: MaleHuman
+  - type: Emoting
+  - type: BodyEmotes
+    soundsId: GeneralBodyEmotes
+  - type: Grammar
+    attributes:
+      proper: true
+  - type: MobPrice
+    price: 1500 # Kidnapping a living person and selling them for cred is a good move.
+    deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - AnomalyHost
 
 - type: entity
   abstract: true
   parent:
-    - MobBloodstream
-    - MobRespirator
-    - MobAtmosStandard
-    - MobFlammable
-    - BaseSpeciesMob
+  - MobBloodstream
+  - MobRespirator
+  - MobAtmosStandard
+  - MobFlammable
+  - BaseSpeciesMob
   id: BaseSpeciesMobOrganic
   save: false
   components:
-    - type: Hunger
-    - type: Thirst
-    - type: Barotrauma
-      damage:
-        types:
-          Blunt: 0.50
-          Heat: 0.1
-    - type: PassiveDamage
-      allowedStates:
-        - Alive
-      damage:
-        types:
-          Heat: -0.07
-          Blunt: -0.05
-          Piercing: -0.05
-          Slash: -0.05
-    - type: Fingerprint
-    - type: Blindable
-    - type: Temperature
-      currentTemperature: 310.15
-      specificHeat: 42
-    - type: TemperatureDamage
-      heatDamageThreshold: 325
-      coldDamageThreshold: 260
-      coldDamage:
-        types:
-          Cold: 0.1 #per second, scales with temperature & other constants
-      heatDamage:
-        types:
-          Heat: 1.5 #per second, scales with temperature & other constants
-    - type: TemperatureSpeed
-      thresholds:
-        293: 0.9
-        280: 0.8
-        260: 0.7
-    - type: ThermalRegulator
-      metabolismHeat: 800
-      radiatedHeat: 100
-      implicitHeatRegulation: 500
-      sweatHeatRegulation: 2000
-      shiveringHeatRegulation: 2000
-      normalBodyTemperature: 310.15
-      thermalRegulationTemperatureThreshold: 2
-    - type: Perishable
-    - type: Butcherable
-      butcheringType: Spike
-      spawned:
-        - id: FoodMeat
-          amount: 5
-    - type: Respirator
-      damage:
-        types:
-          Asphyxiation: 1.0
-      damageRecovery:
-        types:
-          Asphyxiation: -1.0
-    - type: FireVisuals
-      alternateState: Standing
-    - type: StunVisuals
+  - type: Hunger
+  - type: Thirst
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 0.50
+        Heat: 0.1
+  - type: PassiveDamage
+    allowedStates:
+    - Alive
+    damage:
+      types:
+        Heat: -0.07
+        Blunt: -0.05
+        Piercing: -0.05
+        Slash: -0.05
+  - type: Fingerprint
+  - type: Blindable
+  - type: Temperature
+    currentTemperature: 310.15
+    specificHeat: 42
+  - type: TemperatureDamage
+    heatDamageThreshold: 325
+    coldDamageThreshold: 260
+    coldDamage:
+      types:
+        Cold: 0.1 #per second, scales with temperature & other constants
+    heatDamage:
+      types:
+        Heat: 1.5 #per second, scales with temperature & other constants
+  - type: TemperatureSpeed
+    thresholds:
+      293: 0.9
+      280: 0.8
+      260: 0.7
+  - type: ThermalRegulator
+    metabolismHeat: 800
+    radiatedHeat: 100
+    implicitHeatRegulation: 500
+    sweatHeatRegulation: 2000
+    shiveringHeatRegulation: 2000
+    normalBodyTemperature: 310.15
+    thermalRegulationTemperatureThreshold: 2
+  - type: Perishable
+  - type: Butcherable
+    butcheringType: Spike
+    spawned:
+    - id: FoodMeat
+      amount: 5
+  - type: Respirator
+    damage:
+      types:
+        Asphyxiation: 1.0
+    damageRecovery:
+      types:
+        Asphyxiation: -1.0
+  - type: FireVisuals
+    alternateState: Standing
+  - type: StunVisuals

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -1,134 +1,137 @@
 - type: entity
-  parent: [BaseStructureDynamic, BasePaperLabelableVisualized]
+  parent: [ BaseStructureDynamic, BasePaperLabelableVisualized ]
   id: CrateGeneric
-  categories: [HideSpawnMenu]
+  categories: [ HideSpawnMenu ]
   name: crate
   description: A large container for items.
   components:
-    - type: Animateable
-    - type: Transform
-      noRot: true
-    - type: Icon
-      sprite: Structures/Storage/Crates/generic.rsi
-      state: icon
-    - type: Sprite
-      noRot: true
-      sprite: Structures/Storage/Crates/generic.rsi
-      layers:
-        - state: base
-          map: ["enum.StorageVisualLayers.Base"]
-        - state: closed
-          map: ["enum.StorageVisualLayers.Door"]
-        - state: welded
-          visible: false
-          map: ["enum.WeldableLayers.BaseWelded"]
-        - state: paper
-          sprite: Structures/Storage/Crates/labels.rsi
-          map: ["enum.PaperLabelVisuals.Layer"]
-    - type: InteractionOutline
-    - type: Physics
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape: !type:PhysShapeAabb
-            bounds: "-0.4,-0.4,0.4,0.29"
-          density: 50
-          mask:
-            - CrateMask #this is so they can go under plastic flaps
-          layer:
-            - MachineLayer
-    - type: EntityStorage
-      # HONK START - Crates not airtight by default, welding makes them airtight
-      airtight: false
-      # HONK END
-    - type: PlaceableSurface
-      isPlaceable: false # defaults to closed.
-    - type: Damageable
-      damageContainer: StructuralInorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-        - trigger: !type:DamageTrigger
-            damage: 50
-          behaviors:
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-            - !type:PlaySoundBehavior
-              sound:
-                collection: MetalBreak
-    - type: EntityStorageVisuals
-      stateDoorOpen: open
-      stateDoorClosed: closed
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-        paper_label: !type:ContainerSlot
-    - type: StaticPrice
-      price: 75
-    - type: Construction
-      graph: CrateGenericSteel
-      node: crategenericsteel
-      containers:
-        - entity_storage
-    - type: RequireProjectileTarget
+  - type: Animateable
+  - type: Transform
+    noRot: true
+  - type: Icon
+    sprite: Structures/Storage/Crates/generic.rsi
+    state: icon
+  - type: Sprite
+    noRot: true
+    sprite: Structures/Storage/Crates/generic.rsi
+    layers:
+    - state: base
+      map: ["enum.StorageVisualLayers.Base"]
+    - state: closed
+      map: ["enum.StorageVisualLayers.Door"]
+    - state: welded
+      visible: false
+      map: ["enum.WeldableLayers.BaseWelded"]
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
+  - type: InteractionOutline
+  - type: Physics
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.29"
+        density: 50
+        mask:
+        - CrateMask #this is so they can go under plastic flaps
+        layer:
+        - MachineLayer
+  - type: EntityStorage
+    # HONK START - Crates not airtight by default, welding makes them airtight
+    airtight: false
+    # HONK END
+  - type: PlaceableSurface
+    isPlaceable: false # defaults to closed.
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: EntityStorageVisuals
+    stateDoorOpen: open
+    stateDoorClosed: closed
+  - type: ContainerContainer
+    containers:
+      entity_storage: !type:Container
+      paper_label: !type:ContainerSlot
+  - type: StaticPrice
+    price: 75
+  - type: Construction
+    graph: CrateGenericSteel
+    node: crategenericsteel
+    containers:
+      - entity_storage
+  - type: RequireProjectileTarget
 
 - type: entity
   parent: CrateGeneric
   id: CrateBaseWeldable
-  categories: [HideSpawnMenu]
+  categories: [ HideSpawnMenu ]
   components:
-    - type: Weldable
-    - type: ResistLocker
+  - type: Weldable
+  - type: ResistLocker
 
 - type: entity
   parent: CrateBaseWeldable
   id: CrateBaseSecure
   suffix: Secure
   components:
-    - type: Lock
-    - type: LockVisuals
-    - type: AccessReader
-    - type: Icon
-      sprite: Structures/Storage/Crates/secure.rsi
-      state: icon
-    - type: Sprite
-      sprite: Structures/Storage/Crates/secure.rsi
-      layers:
-        - state: base
-        - state: closed
-          map: ["enum.StorageVisualLayers.Door"]
-        - state: welded
-          visible: false
-          map: ["enum.WeldableLayers.BaseWelded"]
-        - state: locked
-          map: ["enum.LockVisualLayers.Lock"]
-          shader: unshaded
-        - state: paper
-          sprite: Structures/Storage/Crates/labels.rsi
-          offset: "-0.5,0"
-          map: ["enum.PaperLabelVisuals.Layer"]
-    - type: Damageable
-      damageContainer: StructuralInorganic
-      damageModifierSet: StructuralMetallic
-    - type: Destructible
-      thresholds:
-        - trigger: !type:DamageTrigger
-            damage: 75
-          behaviors:
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-            - !type:PlaySoundBehavior
-              sound:
-                collection: MetalBreak
-    - type: Construction
-      graph: CrateSecure
-      node: cratesecure
-      containers:
-        - entity_storage
-    - type: Reflect
-      reflects:
-        - Energy
-      reflectProb: 0.2
-      spread: 90
-    - type: Paintable
-      group: CrateSecure
+  - type: Lock
+  - type: LockVisuals
+  - type: AccessReader
+  - type: Icon
+    sprite: Structures/Storage/Crates/secure.rsi
+    state: icon
+  - type: Sprite
+    sprite: Structures/Storage/Crates/secure.rsi
+    layers:
+    - state: base
+    - state: closed
+      map: ["enum.StorageVisualLayers.Door"]
+    - state: welded
+      visible: false
+      map: ["enum.WeldableLayers.BaseWelded"]
+    - state: locked
+      map: ["enum.LockVisualLayers.Lock"]
+      shader: unshaded
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      offset: "-0.5,0"
+      map: ["enum.PaperLabelVisuals.Layer"]
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: Construction
+    graph: CrateSecure
+    node: cratesecure
+    containers:
+    - entity_storage
+  - type: Reflect
+    reflects:
+    - Energy
+    reflectProb: 0.2
+    spread: 90
+  - type: Paintable
+    group: CrateSecure


### PR DESCRIPTION
## About the PR

Adds a lightweight hover tooltip that shows entity names near the cursor after a short configurable delay. All fork code lives under `Content.Client/RussStation/HoverTooltip/`, zero upstream file modifications.

## Why / Balance

Players currently have no way to quickly identify entities without clicking to examine. This small QoL tooltip improves discoverability, especially for new players. No balance impact.

Closes #14

## Technical details

- `EntityHoverTooltipSystem` resolves the entity under the cursor each frame using the same `GameplayStateBase.GetClickedEntity()` pattern as `InteractionOutlineSystem`
- `EntityHoverTooltipOverlay` draws the name as a screen-space overlay with a semi-transparent background
- Two new CVars: `hud.hover_tooltip_enabled` (bool, default true) and `hud.hover_tooltip_delay` (float, default 0.3s)
- Establishes `Content.Client/RussStation/` as the convention for fork-specific C# code

## Media

Small feature, will add a screenshot after in-game testing.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Entity names now appear as a tooltip when hovering over things in the game world. Can be toggled off in console with `hud.hover_tooltip_enabled`.