### PR TITLE
Fix fireman carry review findings

### DIFF
--- a/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
@@ -13,15 +13,15 @@ public sealed partial class CarrierComponent : Component
     [AutoNetworkedField, DataField]
     public EntityUid? Carrying;
 
-    [DataField]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float WalkSpeedModifier = 0.75f;
 
-    [DataField]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float SprintSpeedModifier = 0.6f;
 
     /// <summary>
     /// Y offset for the carried entity visual. Overridable per prototype for different species heights.
     /// </summary>
-    [DataField]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float CarryOffset = 0.2f;
 }

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -45,9 +45,10 @@ public abstract class SharedCarryingSystem : EntitySystem
     [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
 
-    // Set during Carry()/Drop() to suppress VirtualItemDeleted cascading into another Drop().
-    // Stopping a pull deletes its virtual item, which would otherwise trigger OnVirtualItemDeleted.
-    private bool _isTransitioning;
+    // Tracks carrier EntityUids currently mid-transition (Carry/Drop/shutdown) to suppress
+    // VirtualItemDeleted cascading into another Drop(). Per-entity instead of a bare bool
+    // so nested or concurrent carries can't interfere with each other.
+    private readonly HashSet<EntityUid> _transitioning = new();
 
     public override void Initialize()
     {
@@ -233,9 +234,9 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (attempt.Cancelled)
             return;
 
-        // Stop pulls before setting carry state. _isTransitioning prevents the pull's
+        // Stop pulls before setting carry state. The _transitioning set prevents the pull's
         // virtual item cleanup from cascading into OnVirtualItemDeleted, which calls Drop().
-        _isTransitioning = true;
+        _transitioning.Add(carrier);
 
         if (TryComp<PullableComponent>(target, out var pullable) && pullable.Puller != null)
             _pulling.TryStopPull(target, pullable);
@@ -244,7 +245,7 @@ public abstract class SharedCarryingSystem : EntitySystem
             && TryComp<PullableComponent>(puller.Pulling.Value, out var pullerPullable))
             _pulling.TryStopPull(puller.Pulling.Value, pullerPullable);
 
-        _isTransitioning = false;
+        _transitioning.Remove(carrier);
 
         carrierComp.Carrying = target;
         carriableComp.CarriedBy = carrier;
@@ -373,7 +374,7 @@ public abstract class SharedCarryingSystem : EntitySystem
         Drop(uid);
     }
 
-    private void OnCarrierDowned(EntityUid uid, ActiveCarrierComponent component, DownedEvent args)
+    private void OnCarrierDowned(EntityUid uid, ActiveCarrierComponent component, ref DownedEvent args)
     {
         Drop(uid);
     }
@@ -400,7 +401,11 @@ public abstract class SharedCarryingSystem : EntitySystem
             carrierComp.Carrying = null;
             Dirty(carrier, carrierComp);
             RemCompDeferred<ActiveCarrierComponent>(carrier);
+
+            _transitioning.Add(carrier);
             _virtualItem.DeleteInHandsMatching(carrier, uid);
+            _transitioning.Remove(carrier);
+
             _movementSpeed.RefreshMovementSpeedModifiers(carrier);
         }
     }
@@ -423,7 +428,7 @@ public abstract class SharedCarryingSystem : EntitySystem
 
     private void OnVirtualItemDeleted(EntityUid uid, CarrierComponent component, VirtualItemDeletedEvent args)
     {
-        if (!_isTransitioning && component.Carrying == args.BlockingEntity)
+        if (!_transitioning.Contains(uid) && component.Carrying == args.BlockingEntity)
             Drop(uid, component);
     }
 


### PR DESCRIPTION
## About the PR

Addresses review findings in the fireman carry system: fixes a concurrency-unsafe transition guard, adds a missing `ref` keyword, and exposes carrier tuning fields to VV.

## Why / Balance

No gameplay changes. These are correctness and debuggability improvements to the carrying system.

## Technical details

- **Per-entity transition tracking**: Replaced the global `bool _isTransitioning` with a `HashSet<EntityUid> _transitioning`. The old boolean meant that if two carries happened to overlap (e.g. during entity shutdown), one could suppress the other's guard. The set tracks per-carrier, so they can't interfere.
- **`ref DownedEvent`**: Added the missing `ref` keyword on `OnCarrierDowned` to match every other `DownedEvent` handler in the codebase.
- **`OnBeingCarriedShutdown` guard**: Wrapped `DeleteInHandsMatching` in the shutdown handler with the `_transitioning` guard, preventing `OnVirtualItemDeleted` from cascading into `Drop()` during component cleanup.
- **`ViewVariables(VVAccess.ReadWrite)`**: Added to `CarrierComponent` speed/offset fields for live tuning.

## Media

N/A (no in-game visual changes)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.