### PR TITLE
Fix buckled fireman carry bug

### DIFF
--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.ActionBlocker;
+using Content.Shared.Buckle.Components;
 using Content.Shared.RussStation.Carrying.Components;
 using Content.Shared.RussStation.Carrying.Events;
 using Content.Shared.DoAfter;
@@ -67,6 +68,7 @@ public abstract class SharedCarryingSystem : EntitySystem
         // Auto-drop conditions
         SubscribeLocalEvent<BeingCarriedComponent, MobStateChangedEvent>(OnCarriedMobStateChanged);
         SubscribeLocalEvent<BeingCarriedComponent, StoodEvent>(OnCarriedStood);
+        SubscribeLocalEvent<BeingCarriedComponent, BuckledEvent>(OnCarriedBuckled);
         SubscribeLocalEvent<ActiveCarrierComponent, MobStateChangedEvent>(OnCarrierMobStateChanged);
         SubscribeLocalEvent<ActiveCarrierComponent, StunnedEvent>(OnCarrierStunned);
         SubscribeLocalEvent<ActiveCarrierComponent, DownedEvent>(OnCarrierDowned);
@@ -358,6 +360,12 @@ public abstract class SharedCarryingSystem : EntitySystem
     }
 
     private void OnCarriedStood(EntityUid uid, BeingCarriedComponent component, StoodEvent args)
+    {
+        if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier)
+            Drop(carrier);
+    }
+
+    private void OnCarriedBuckled(EntityUid uid, BeingCarriedComponent component, ref BuckledEvent args)
     {
         if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier)
             Drop(carrier);


### PR DESCRIPTION
## About the PR

Drops fireman carry when the carried entity gets buckled. Fixes #26.

## Why / Balance

Buckling a carried entity onto a bed left them both carried and buckled at the same time. Chairs already worked because they call `Stand()`, which fires `StoodEvent` and drops the carry. Beds use `StrapPosition.Down` instead, so nothing told the carry system to let go.

## Technical details

Added a `BuckledEvent` handler on `BeingCarriedComponent` in `SharedCarryingSystem` that drops the carry. Same pattern as the existing `OnCarriedStood` handler, and consistent with how `PullingSystem` stops pulls on buckle.

## Media

Small bug fix, no media needed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Fixed fireman carry not dropping when buckling carried entity onto a bed.