### PR TITLE
Carry state validation and buckle interaction

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
@@ -1,0 +1,219 @@
+using Content.Shared.Buckle.Components;
+using Content.Shared.RussStation.Carrying.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Carrying;
+
+[TestFixture]
+[TestOf(typeof(ActiveCarrierComponent))]
+public sealed class CarryStateValidationTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CarryValidationCarrier
+  components:
+  - type: Carrier
+  - type: Carriable
+  - type: Hands
+  - type: ComplexInteraction
+  - type: InputMover
+  - type: Physics
+    bodyType: KinematicController
+  - type: Puller
+  - type: StandingState
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: Damageable
+    damageContainer: Biological
+  - type: Body
+    prototype: Human
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.35
+
+- type: entity
+  id: CarryValidationTarget
+  components:
+  - type: Carriable
+  - type: Buckle
+  - type: Physics
+    bodyType: KinematicController
+  - type: StandingState
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: Damageable
+    damageContainer: Biological
+  - type: Body
+    prototype: Human
+  - type: Pullable
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.35
+
+- type: entity
+  id: CarryValidationStrap
+  components:
+  - type: Strap
+";
+
+    /// <summary>
+    /// ActiveCarrierComponent with no actual carry target is orphaned state.
+    /// The periodic validation should remove it within a second.
+    /// </summary>
+    [Test]
+    public async Task OrphanedActiveCarrierGetsCleaned()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        EntityUid carrier = default;
+
+        await server.WaitAssertion(() =>
+        {
+            carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+
+            // Add the active marker without setting up a real carry to simulate corruption.
+            entityManager.EnsureComponent<ActiveCarrierComponent>(carrier);
+            var carrierComp = entityManager.GetComponent<CarrierComponent>(carrier);
+            Assert.That(carrierComp.Carrying, Is.Null);
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+        });
+
+        // Wait for the 1-second validation tick to fire.
+        await pair.RunSeconds(2);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "Orphaned ActiveCarrierComponent should be cleaned by validation");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Same as <see cref="OrphanedActiveCarrierGetsCleaned"/> but with a target entity
+    /// spawned alongside, verifying cleanup still works in a populated environment.
+    /// Tests the Carrying=null + ActiveCarrierComponent corruption path, which is the
+    /// most common way carry state gets orphaned (partial cleanup by another system).
+    /// </summary>
+    [Test]
+    public async Task DeletedTargetGetsCleaned()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        EntityUid carrier = default;
+
+        await server.WaitAssertion(() =>
+        {
+            carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+
+            var carrierComp = entityManager.GetComponent<CarrierComponent>(carrier);
+            entityManager.EnsureComponent<ActiveCarrierComponent>(carrier);
+
+            // [Access] prevents writing to Carrying from tests, so we test the
+            // Carrying=null orphan case directly, which is the most common corruption.
+            Assert.That(carrierComp.Carrying, Is.Null);
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+        });
+
+        await pair.RunSeconds(2);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "ActiveCarrierComponent should be removed when Carrying is null");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Buckling a carried entity should be allowed. The carry system drops the
+    /// carry on buckle attempt rather than blocking the buckle.
+    /// </summary>
+    [Test]
+    public async Task BuckleAttemptAllowedWhileCarried()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+            var strap = entityManager.SpawnEntity("CarryValidationStrap", mapData.GridCoords);
+
+            entityManager.EnsureComponent<BeingCarriedComponent>(target);
+
+            var buckleComp = entityManager.GetComponent<BuckleComponent>(target);
+            var strapComp = entityManager.GetComponent<StrapComponent>(strap);
+
+            var ev = new BuckleAttemptEvent(
+                (strap, strapComp),
+                (target, buckleComp),
+                null,
+                false);
+            entityManager.EventBus.RaiseLocalEvent(target, ref ev);
+
+            Assert.That(ev.Cancelled, Is.False,
+                "Buckling should be allowed while carried (carry gets dropped, buckle goes through)");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Buckling an entity that isn't being carried should work normally,
+    /// unaffected by the carry system's buckle handler.
+    /// </summary>
+    [Test]
+    public async Task BuckleAttemptUnaffectedWhenNotCarried()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+            var strap = entityManager.SpawnEntity("CarryValidationStrap", mapData.GridCoords);
+
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False);
+
+            var buckleComp = entityManager.GetComponent<BuckleComponent>(target);
+            var strapComp = entityManager.GetComponent<StrapComponent>(strap);
+
+            var ev = new BuckleAttemptEvent(
+                (strap, strapComp),
+                (target, buckleComp),
+                null,
+                false);
+            entityManager.EventBus.RaiseLocalEvent(target, ref ev);
+
+            Assert.That(ev.Cancelled, Is.False,
+                "BuckleAttemptEvent should not be affected when entity is not being carried");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.ActionBlocker;
+using Content.Shared.Buckle.Components;
 using Content.Shared.RussStation.Carrying.Components;
 using Content.Shared.RussStation.Carrying.Events;
 using Content.Shared.DoAfter;
@@ -44,11 +45,14 @@ public abstract class SharedCarryingSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
-    // Tracks carrier EntityUids currently mid-transition (Carry/Drop/shutdown) to suppress
-    // VirtualItemDeleted cascading into another Drop(). Per-entity instead of a bare bool
-    // so nested or concurrent carries can't interfere with each other.
+    // Carriers currently setting up or tearing down a carry. While in this set,
+    // OnVirtualItemDeleted won't call Drop(), preventing double-drop cascades.
     private readonly HashSet<EntityUid> _transitioning = new();
+
+    private TimeSpan _nextValidation;
+    private static readonly TimeSpan ValidationInterval = TimeSpan.FromSeconds(1);
 
     public override void Initialize()
     {
@@ -72,6 +76,9 @@ public abstract class SharedCarryingSystem : EntitySystem
         SubscribeLocalEvent<ActiveCarrierComponent, DownedEvent>(OnCarrierDowned);
         SubscribeLocalEvent<BeingCarriedComponent, EntGotInsertedIntoContainerMessage>(OnCarriedInserted);
         SubscribeLocalEvent<ActiveCarrierComponent, EntGotInsertedIntoContainerMessage>(OnCarrierInserted);
+
+        // Drop carry when the carried entity gets buckled
+        SubscribeLocalEvent<BeingCarriedComponent, BuckleAttemptEvent>(OnCarriedBuckleAttempt);
 
         // Cleanup
         SubscribeLocalEvent<BeingCarriedComponent, ComponentShutdown>(OnBeingCarriedShutdown);
@@ -176,6 +183,9 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (!_mobState.IsIncapacitated(target))
             return false;
 
+        if (TryComp<BuckleComponent>(target, out var buckle) && buckle.Buckled)
+            return false;
+
         if (!_actionBlocker.CanInteract(carrier, target))
             return false;
 
@@ -234,8 +244,9 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (attempt.Cancelled)
             return;
 
-        // Stop pulls before setting carry state. The _transitioning set prevents the pull's
-        // virtual item cleanup from cascading into OnVirtualItemDeleted, which calls Drop().
+        // Mark as transitioning for the full setup. The reparent below can trigger
+        // other systems (like buckle) which may delete virtual items. Without this
+        // guard, those deletions would call Drop() while we're still setting up.
         _transitioning.Add(carrier);
 
         if (TryComp<PullableComponent>(target, out var pullable) && pullable.Puller != null)
@@ -244,8 +255,6 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (TryComp<PullerComponent>(carrier, out var puller) && puller.Pulling != null
             && TryComp<PullableComponent>(puller.Pulling.Value, out var pullerPullable))
             _pulling.TryStopPull(puller.Pulling.Value, pullerPullable);
-
-        _transitioning.Remove(carrier);
 
         carrierComp.Carrying = target;
         carriableComp.CarriedBy = carrier;
@@ -260,10 +269,23 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (!_virtualItem.TrySpawnVirtualItemInHand(target, carrier))
             Log.Warning($"Failed to spawn second carry virtual item on {ToPrettyString(carrier)}");
 
-        // Parent to carrier at origin — client FrameUpdate handles the visual offset
+        // Parent target to carrier. The client's FrameUpdate handles the visual offset.
         var xform = Transform(target);
         var coords = new EntityCoordinates(carrier, System.Numerics.Vector2.Zero);
         _transform.SetCoordinates(target, xform, coords, rotation: Angle.Zero);
+
+        _transitioning.Remove(carrier);
+
+        // The reparent above can cause other systems to move the target back (e.g.
+        // buckle detecting a parent change and unbuckling). If that happened, clean
+        // up instead of continuing with a half-built carry.
+        if (carrierComp.Carrying != target || Transform(target).ParentUid != carrier)
+        {
+            Log.Warning($"Carry disrupted during setup: {ToPrettyString(carrier)} -> {ToPrettyString(target)}");
+            CleanOrphanedCarryState(carrier, carrierComp);
+            return;
+        }
+
         _joints.SetRelay(target, carrier);
 
         _standing.Down(target, playSound: false, dropHeldItems: false, force: true);
@@ -295,8 +317,8 @@ public abstract class SharedCarryingSystem : EntitySystem
         Dirty(carrier, carrierComp);
         Dirty(target, carriableComp);
 
-        // Remove immediately (not deferred) so event handlers like OnCarriedCanMove
-        // and OnCarriedStood don't fire after the drop is complete.
+        // Remove immediately so carried-entity event handlers (like OnCarriedCanMove
+        // and OnCarriedStood) don't fire after the drop.
         RemComp<BeingCarriedComponent>(target);
         RemComp<ActiveCarrierComponent>(carrier);
 
@@ -430,6 +452,96 @@ public abstract class SharedCarryingSystem : EntitySystem
     {
         if (!_transitioning.Contains(uid) && component.Carrying == args.BlockingEntity)
             Drop(uid, component);
+    }
+
+    private void OnCarriedBuckleAttempt(EntityUid uid, BeingCarriedComponent component, ref BuckleAttemptEvent args)
+    {
+        if (TryComp<CarriableComponent>(uid, out var carriable) && carriable.CarriedBy is { } carrier)
+            Drop(carrier);
+    }
+
+    #endregion
+
+    #region State Validation
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_timing.CurTime < _nextValidation)
+            return;
+        _nextValidation = _timing.CurTime + ValidationInterval;
+
+        var query = EntityQueryEnumerator<ActiveCarrierComponent, CarrierComponent>();
+        while (query.MoveNext(out var uid, out _, out var carrier))
+        {
+            if (_transitioning.Contains(uid))
+                continue;
+
+            if (carrier.Carrying is not { } target || !Exists(target) || Terminating(target))
+            {
+                CleanOrphanedCarryState(uid, carrier);
+                continue;
+            }
+
+            if (Transform(target).ParentUid != uid)
+            {
+                // Target escaped the carrier. Try a normal Drop first, then
+                // fall back to orphan cleanup if Drop couldn't fully resolve it.
+                Drop(uid, carrier);
+                if (HasComp<ActiveCarrierComponent>(uid))
+                    CleanOrphanedCarryState(uid, carrier);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fallback cleanup for when <see cref="Drop"/> can't fully resolve a broken carry,
+    /// such as when the target no longer exists or Carrying was already nulled but
+    /// marker components and virtual items are still hanging around.
+    /// </summary>
+    private void CleanOrphanedCarryState(EntityUid uid, CarrierComponent carrier)
+    {
+        var target = carrier.Carrying;
+
+        carrier.Carrying = null;
+        Dirty(uid, carrier);
+
+        if (target != null && Exists(target.Value) && !Terminating(target.Value))
+        {
+            if (TryComp<CarriableComponent>(target.Value, out var carriable))
+            {
+                carriable.CarriedBy = null;
+                Dirty(target.Value, carriable);
+            }
+
+            RemCompDeferred<BeingCarriedComponent>(target.Value);
+
+            _transitioning.Add(uid);
+            _virtualItem.DeleteInHandsMatching(uid, target.Value);
+            _transitioning.Remove(uid);
+
+            if (!Terminating(uid))
+            {
+                var xform = Transform(target.Value);
+                if (xform.ParentUid == uid)
+                {
+                    _transform.PlaceNextTo((target.Value, xform), (uid, Transform(uid)));
+                    xform.ActivelyLerping = false;
+                }
+            }
+
+            _joints.RefreshRelay(target.Value);
+            _actionBlocker.UpdateCanMove(target.Value);
+
+            if (!_mobState.IsIncapacitated(target.Value) && !HasComp<KnockedDownComponent>(target.Value))
+                _standing.Stand(target.Value);
+        }
+
+        RemComp<ActiveCarrierComponent>(uid);
+        _movementSpeed.RefreshMovementSpeedModifiers(uid);
+
+        Log.Warning($"Cleaned orphaned carry state on {ToPrettyString(uid)}");
     }
 
     #endregion


### PR DESCRIPTION
## About the PR

Fixes carry state getting permanently stuck when something goes wrong mid-carry. The bug in #21 was that carrying a buckled person could corrupt everything, leaving the carrier unable to use their hands for the rest of the round.

What changed:
- Buckled entities can't be picked up anymore (prevents the original bug)
- Buckling a carried entity drops them first instead of blocking the buckle
- A once-per-second check catches corrupted carry state and cleans it up, so even if we missed another edge case the player won't be stuck forever

## Why / Balance

Bugfix. The carry and buckle systems had zero awareness of each other. Carrying a buckled person triggered a reparent cascade that orphaned virtual items in the carrier's hands permanently. Past carry bugs kept hitting the same end result (permanently broken virtual items), so the periodic validation should catch future edge cases too.

## Technical details

- Buckle check in `CanCarry()` rejects buckled targets
- `BuckleAttemptEvent` handler on `BeingCarriedComponent` drops the carry and lets the buckle go through
- `_transitioning` guard now covers the full `Carry()` setup including the reparent, with a post-reparent integrity check that bails cleanly if something moved the target out from under us
- `Update()` runs every second, queries `ActiveCarrierComponent` entities, validates the carry is still intact (target exists, parented to carrier)
- `CleanOrphanedCarryState()` handles partial state corruption when the normal `Drop()` path can't
- 4 new integration tests for orphan cleanup and buckle interaction

## Media

N/A, bugfix only.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Fixed carry state getting permanently stuck when carrying a buckled person or when other edge cases corrupted the carry mid-setup
- fix: Buckled entities can no longer be picked up via fireman carry
- tweak: Buckling a carried entity now drops them instead of blocking the buckle
: