### PR TITLE
Make holopad non-blocking for movement and pulling

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -6,6 +6,13 @@
   components:
   - type: Transform
     anchored: true
+  # HONK START - Fix holopad blocking pulled entities (issue #30)
+  # Upstream bug: PR #34300 added Impassable+hard:true to fix wall clipping,
+  # PR #36341 partially cleaned up but left Impassable+hard:true intact.
+  # A floor-mounted device should not block movement or pulling.
+  # fix1: Impassable mask prevents clipping through walls; hard:false lets
+  #        mobs/objects walk and be pulled over it.
+  # fix2: MachineLayer so projectiles and interactions can still hit it.
   - type: Fixtures
     fixtures:
       fix1:
@@ -14,6 +21,15 @@
           radius: 0.25
         mask:
         - Impassable
+        hard: false
+      fix2:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        layer:
+        - MachineLayer
+        hard: false
+  # HONK END
   - type: ApcPowerReceiver
     powerLoad: 5
   - type: PowerState


### PR DESCRIPTION
## About the PR

Fixes holopads acting as impassable obstacles that block entities from being pulled over them.

- Adds `hard: false` to the existing fixture so mobs and objects can walk/be pulled over the holopad
- Adds a second fixture with `MachineLayer` so projectiles can still hit it
- HONK markers document the upstream bug history for rebase clarity

Closes #30

## Why / Balance

Holopads are floor-mounted devices and should not block movement or pulling. The current `Impassable` + `hard: true` fixture config is an upstream bug introduced across PRs #34300 and #36341. Upstream's "fix" (PR #36527) only changed tank fixtures to avoid the collision, but didn't address the root cause on the holopad itself. Other pulled entities (mobs, crates, etc.) still get stuck.

## Technical details

**History:**
- Originally holopad had `SubfloorMask` + `LowImpassable` + `hard: false` (non-blocking)
- PR #34300 changed to `Impassable` + `HighImpassable` + `MidImpassable` to fix wall clipping
- PR #36341 "bugfix" stripped extra masks but left `Impassable` + `hard: true`
- PR #36527 worked around the issue by changing tank fixtures instead of fixing the holopad

**Fix:** Two fixtures, both `hard: false`:
- `fix1`: `Impassable` mask prevents the holopad from clipping through walls
- `fix2`: `MachineLayer` layer allows projectiles and interactions to hit it

## Media

N/A - prototype-only change

## Requirements

- [x] Entities can be pulled over holopads without getting stuck
- [x] Holopads don't clip through walls
- [x] Holopads can still be hit by projectiles

## Breaking changes

None

## Changelog

:cl:
- fix: holopads no longer block entities from being pulled over them