### PR TITLE
Add per-procedure icons to surgery radial menu

### DIFF
--- a/Content.Client/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Client/RussStation/Surgery/SurgerySystem.cs
@@ -36,15 +36,18 @@ public sealed class SurgerySystem : SharedSurgerySystem
             var target = ev.Target;
             var bedsheet = ev.Bedsheet;
 
+            var icon = proto.Icon != null
+                ? (SpriteSpecifier) new SpriteSpecifier.EntityPrototype(proto.Icon)
+                : new SpriteSpecifier.Rsi(
+                    new ResPath("Objects/Specific/Medical/Surgery/scalpel.rsi"),
+                    "scalpel");
+
             buttons.Add(new RadialMenuActionOption<string>(
                 _ => OnProcedureSelected(target, bedsheet, id),
                 id)
             {
                 ToolTip = Loc.GetString(proto.Name),
-                IconSpecifier = RadialMenuIconSpecifier.With(
-                    new SpriteSpecifier.Rsi(
-                        new ResPath("Objects/Specific/Medical/Surgery/scalpel.rsi"),
-                        "scalpel")),
+                IconSpecifier = RadialMenuIconSpecifier.With(icon),
             });
         }
 

--- a/Content.Shared/RussStation/Surgery/SurgeryProcedurePrototype.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryProcedurePrototype.cs
@@ -93,6 +93,13 @@ public sealed partial class SurgeryProcedurePrototype : IPrototype
     [DataField]
     public string Description = string.Empty;
 
+    /// <summary>
+    /// Entity prototype ID whose sprite is used as the radial menu icon.
+    /// Falls back to a scalpel icon when null.
+    /// </summary>
+    [DataField]
+    public EntProtoId? Icon;
+
     [DataField(required: true)]
     public List<SurgeryStep> Steps = new();
 }

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/organ_manipulation.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/organ_manipulation.yml
@@ -2,6 +2,7 @@
   id: OrganManipulation
   name: surgery-procedure-organ-manipulation
   description: Open the body cavity to remove or insert organs.
+  icon: OrganHumanLungs
   steps:
     - tag: Scalpel
       duration: 2.0

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_brute.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_brute.yml
@@ -2,6 +2,7 @@
   id: TendWoundsBrute
   name: surgery-procedure-tend-wounds-brute
   description: Repair physical damage through surgery.
+  icon: MedkitBrute
   steps:
     - tag: Scalpel
       duration: 2.0

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_burn.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_burn.yml
@@ -2,6 +2,7 @@
   id: TendWoundsBurn
   name: surgery-procedure-tend-wounds-burn
   description: Treat burn damage through surgery.
+  icon: MedkitBurn
   steps:
     - tag: Scalpel
       duration: 2.0


### PR DESCRIPTION
## About the PR

Adds an `Icon` field to `SurgeryProcedurePrototype` so each surgery procedure can display a distinct sprite in the radial menu instead of the default scalpel icon.

These are still placeholder icons (using existing entity sprites), but at least they're visually distinct so players can tell procedures apart at a glance:

- Tend Wounds (Brute): brute treatment kit
- Tend Wounds (Burn): burn treatment kit
- Organ Manipulation: human lungs

## Why / Balance

Previously every procedure showed the same scalpel icon, making the radial menu hard to navigate. Distinct placeholders improve usability until proper icons are made.

## Technical details

- Added optional `EntProtoId? Icon` field to `SurgeryProcedurePrototype`
- Client `SurgerySystem` uses `SpriteSpecifier.EntityPrototype` when icon is set, falls back to scalpel RSI when null
- Set `icon:` in YAML for the three existing procedures

## Media

N/A (radial menu cosmetic change)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Surgery procedures now show distinct placeholder icons in the radial menu instead of all using the same scalpel icon.