### PR TITLE
Character memories panel

### DIFF
--- a/Content.Client/RussStation/Memories/MemoriesSystem.cs
+++ b/Content.Client/RussStation/Memories/MemoriesSystem.cs
@@ -1,0 +1,53 @@
+using Content.Client.CharacterInfo;
+using Content.Client.Message;
+using Content.Shared.RussStation.Memories;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.RussStation.Memories;
+
+public sealed class MemoriesSystem : EntitySystem
+{
+    [Dependency] private readonly CharacterInfoSystem _characterInfo = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MemoriesComponent, AfterAutoHandleStateEvent>(OnHandleState);
+        SubscribeLocalEvent<CharacterInfoSystem.GetCharacterInfoControlsEvent>(OnGetCharacterInfoControls);
+    }
+
+    private void OnHandleState(EntityUid uid, MemoriesComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        _characterInfo.RequestCharacterInfo();
+    }
+
+    private void OnGetCharacterInfoControls(ref CharacterInfoSystem.GetCharacterInfoControlsEvent ev)
+    {
+        if (!TryComp<MemoriesComponent>(ev.Entity, out var memories) || memories.Memories.Count == 0)
+            return;
+
+        var box = new BoxContainer
+        {
+            Margin = new Thickness(5),
+            Orientation = BoxContainer.LayoutOrientation.Vertical
+        };
+
+        var title = new RichTextLabel
+        {
+            HorizontalAlignment = Control.HAlignment.Center
+        };
+        title.SetMarkup(Loc.GetString("memories-panel-header"));
+        box.AddChild(title);
+
+        foreach (var (key, value) in memories.Memories)
+        {
+            var entry = new RichTextLabel();
+            entry.SetMarkup(Loc.GetString("memories-panel-entry", ("key", key), ("value", value)));
+            box.AddChild(entry);
+        }
+
+        ev.Controls.Add(box);
+    }
+}

--- a/Content.Server/RussStation/Memories/MemoriesSystem.cs
+++ b/Content.Server/RussStation/Memories/MemoriesSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared.RussStation.Memories;
+
+namespace Content.Server.RussStation.Memories;
+
+public sealed class MemoriesSystem : EntitySystem
+{
+    /// <summary>
+    /// Add a memory to the entity. Creates the component if it doesn't exist.
+    /// </summary>
+    public void AddMemory(EntityUid uid, string key, string value, MemoriesComponent? comp = null)
+    {
+        comp ??= EnsureComp<MemoriesComponent>(uid);
+        comp.Memories[key] = value;
+        Dirty(uid, comp);
+    }
+
+    /// <summary>
+    /// Remove a memory by key. Returns false if the key didn't exist.
+    /// </summary>
+    public bool RemoveMemory(EntityUid uid, string key, MemoriesComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return false;
+
+        if (!comp.Memories.Remove(key))
+            return false;
+
+        Dirty(uid, comp);
+        return true;
+    }
+}

--- a/Content.Shared/RussStation/Memories/MemoriesComponent.cs
+++ b/Content.Shared/RussStation/Memories/MemoriesComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Memories;
+
+/// <summary>
+/// Stores private character memories (key-value pairs) visible only to the owning player.
+/// Added to the player mob on spawn by systems that register memories.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class MemoriesComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, string> Memories = new();
+}

--- a/Resources/Locale/en-US/russstation/memories.ftl
+++ b/Resources/Locale/en-US/russstation/memories.ftl
@@ -1,0 +1,2 @@
+memories-panel-header = [bold]Memories[/bold]
+memories-panel-entry = [bold]{$key}:[/bold] {$value}


### PR DESCRIPTION
## About the PR

Adds a "Memories" section to the character info screen that displays private key-value facts only the owning player can see. This is a general-purpose system -- other features register memories on the player's mob and they show up in the panel automatically.

First consumer will be #163 (bank account numbers and PINs), but it's useful for anything a character "knows" that shouldn't be visible to others (antag codes, safe combos, etc).

Closes #252

## Why / Balance

No gameplay balance impact. This is infrastructure for the economy system and future private-info features.

## Technical details

- `MemoriesComponent` (shared, networked) stores a `Dictionary<string, string>` on the mob
- Server `MemoriesSystem` exposes `AddMemory(uid, key, value)` / `RemoveMemory(uid, key)`
- Client subscribes to `GetCharacterInfoControlsEvent` (same pattern as PointSystem scoreboard) to render memories
- Keys are treated as localization IDs and resolved before display
- 4 new files, 0 upstream touches

## Media

N/A -- character info panel addition, no visual assets.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

:cl:
- add: Character memories panel in the character info screen for private player knowledge.