### PR TITLE
Add memories guidebook entry

### DIFF
--- a/Resources/Locale/en-US/@RussStation/guidebook/memories.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/memories.ftl
@@ -1,0 +1,1 @@
+guide-entry-memories = Memories

--- a/Resources/Prototypes/@RussStation/Guidebook/memories.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/memories.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: Memories
+  name: guide-entry-memories
+  text: "/ServerInfo/Guidebook/NewPlayer/Memories.xml"

--- a/Resources/Prototypes/Guidebook/newplayer.yml
+++ b/Resources/Prototypes/Guidebook/newplayer.yml
@@ -6,6 +6,9 @@
   children:
   - Controls
   - CharacterCreation
+  # HONK START - Memories guidebook entry (#252)
+  - Memories
+  # HONK END
 
 - type: guideEntry
   id: Controls

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Memories.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Memories.xml
@@ -1,0 +1,15 @@
+<Document>
+# Memories
+
+Your character knows things that you, the player, might forget. The [color=#a4885c]Memories[/color] panel keeps track of private info like bank account numbers, codes, or anything else your character picked up during the round.
+
+## How to check
+
+Press [color=yellow][bold][keybind="OpenCharacterMenu"][/bold][/color] to open your character info. Memories show up as their own section if you have any.
+
+Nobody else can see your memories. If you want someone to know your account number, you have to tell them yourself.
+
+## What shows up here
+
+Memories get added as the round goes on. Your bank account number, for example, gets stored here at spawn so you can look it up later without having to write it down.
+</Document>


### PR DESCRIPTION
## About the PR
Adds a guidebook page for the memories system under the New Player section. Explains what memories are, how to view them via the character info panel, and that they're private to the character.

## Why / Balance
Players need to know how to find their memories (like bank account numbers) after spawning. Without a guidebook entry, the feature is invisible to new players.

Follow-up to #253 (character memories panel).

## Technical details
- New XML guidebook page at `Resources/ServerInfo/Guidebook/NewPlayer/Memories.xml`
- Guide entry prototype in `@RussStation/Guidebook/memories.yml`
- Locale string in `@RussStation/guidebook/memories.ftl`
- Upstream touch: 2-line addition to `newplayer.yml` children list (HONK marked)

## Media
N/A - text-only guidebook page.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.