### PR TITLE
Create Account verb on ID cards with account invalidation

### DIFF
--- a/Content.Client/Administration/QuickDialogSystem.cs
+++ b/Content.Client/Administration/QuickDialogSystem.cs
@@ -8,10 +8,17 @@ namespace Content.Client.Administration;
 /// </summary>
 public sealed class QuickDialogSystem : EntitySystem
 {
+    // HONK START - Track windows for server-side close
+    private readonly Dictionary<int, DialogWindow> _openWindows = new();
+    // HONK END
+
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeNetworkEvent<QuickDialogOpenEvent>(OpenDialog);
+        // HONK START
+        SubscribeNetworkEvent<QuickDialogCloseEvent>(OnCloseDialog);
+        // HONK END
     }
 
     private void OpenDialog(QuickDialogOpenEvent ev)
@@ -20,11 +27,18 @@ public sealed class QuickDialogSystem : EntitySystem
         var cancel = (ev.Buttons & QuickDialogButtonFlag.CancelButton) != 0;
         var window = new DialogWindow(ev.Title, ev.Prompts, ok: ok, cancel: cancel);
 
+        // HONK START
+        _openWindows[ev.DialogId] = window;
+        // HONK END
+
         window.OnConfirmed += responses =>
         {
             RaiseNetworkEvent(new QuickDialogResponseEvent(ev.DialogId,
                 responses,
                 QuickDialogButtonFlag.OkButton));
+            // HONK START
+            _openWindows.Remove(ev.DialogId);
+            // HONK END
         };
 
         window.OnCancelled += () =>
@@ -32,6 +46,25 @@ public sealed class QuickDialogSystem : EntitySystem
             RaiseNetworkEvent(new QuickDialogResponseEvent(ev.DialogId,
                 new(),
                 QuickDialogButtonFlag.CancelButton));
+            // HONK START
+            _openWindows.Remove(ev.DialogId);
+            // HONK END
         };
     }
+
+    // HONK START - Server-side dialog close
+    private void OnCloseDialog(QuickDialogCloseEvent ev)
+    {
+        if (!_openWindows.TryGetValue(ev.DialogId, out var window))
+            return;
+
+        _openWindows.Remove(ev.DialogId);
+
+        // Detach handlers so closing doesn't send a cancel response back to the server
+        // (the server already cleaned up this dialog).
+        window.OnConfirmed = null;
+        window.OnCancelled = null;
+        window.Close();
+    }
+    // HONK END
 }

--- a/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
@@ -1,0 +1,158 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.RussStation.Economy;
+using Content.Shared.Access.Components;
+using Content.Shared.RussStation.Economy.Components;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+public sealed class CreateAccountTest : InteractionTest
+{
+    /// <summary>
+    /// Creating an account on a mob without one should generate a new account
+    /// and stamp it on the ID card.
+    /// </summary>
+    [Test]
+    public async Task CreateAccountOnBlankIdTest()
+    {
+        // Spawn an ID card as the target.
+        await SpawnTarget("PassengerIDCard");
+        var idEnt = SEntMan.GetEntity(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Player should not have an account yet.
+            Assert.That(SEntMan.HasComponent<PlayerBalanceComponent>(SPlayer), Is.False);
+
+            // ID should be blank.
+            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+            Assert.That(string.IsNullOrEmpty(idComp.AccountNumber), Is.True);
+
+            // Create account.
+            var accountNumber = balanceSys.CreateAccount(SPlayer);
+            Assert.That(accountNumber, Is.Not.Null.And.Not.Empty);
+
+            // Player should now have a balance component with the account.
+            var balanceComp = SEntMan.GetComponent<PlayerBalanceComponent>(SPlayer);
+            Assert.That(balanceComp.AccountNumber, Is.EqualTo(accountNumber));
+            Assert.That(balanceComp.Balance, Is.GreaterThan(0), "New account should have starting balance.");
+        });
+    }
+
+    /// <summary>
+    /// Creating a new account should invalidate the old one.
+    /// The old account number should no longer resolve.
+    /// </summary>
+    [Test]
+    public async Task CreateAccountInvalidatesOldTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Create the first account.
+            var oldAccount = balanceSys.CreateAccount(SPlayer);
+            Assert.That(oldAccount, Is.Not.Null);
+
+            // Old account should resolve.
+            Assert.That(balanceSys.TryGetByAccount(oldAccount, out _), Is.True);
+
+            // Create a second account (simulating stolen ID replacement).
+            var newAccount = balanceSys.CreateAccount(SPlayer);
+            Assert.That(newAccount, Is.Not.Null);
+            Assert.That(newAccount, Is.Not.EqualTo(oldAccount));
+
+            // Old account should no longer resolve.
+            Assert.That(balanceSys.TryGetByAccount(oldAccount, out _), Is.False,
+                "Old account should be invalidated after creating a new one.");
+
+            // New account should resolve.
+            Assert.That(balanceSys.TryGetByAccount(newAccount, out _), Is.True);
+        });
+    }
+
+    /// <summary>
+    /// Creating a new account should wipe the old balance.
+    /// The player gets a fresh starting balance.
+    /// </summary>
+    [Test]
+    public async Task CreateAccountWipesBalanceTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Create account and add extra funds.
+            balanceSys.CreateAccount(SPlayer);
+            balanceSys.AddBalance(SPlayer, 5000);
+            var balanceComp = SEntMan.GetComponent<PlayerBalanceComponent>(SPlayer);
+            var oldBalance = balanceComp.Balance;
+            Assert.That(oldBalance, Is.GreaterThan(5000));
+
+            // Create new account, balance should reset to starting amount.
+            balanceSys.CreateAccount(SPlayer);
+            var newBalance = balanceComp.Balance;
+            Assert.That(newBalance, Is.LessThan(oldBalance),
+                "New account should reset balance, wiping old funds.");
+        });
+    }
+
+    /// <summary>
+    /// An ID card with an invalidated account number should fail lookups.
+    /// </summary>
+    [Test]
+    public async Task InvalidatedIdFailsLookupTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+        var idEnt = SEntMan.GetEntity(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Create account and stamp it on the ID.
+            var oldAccount = balanceSys.CreateAccount(SPlayer);
+            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+            idComp.AccountNumber = oldAccount;
+
+            // Verify it resolves.
+            Assert.That(balanceSys.TryGetByAccount(idComp.AccountNumber, out _), Is.True);
+
+            // Create a new account (invalidates old).
+            balanceSys.CreateAccount(SPlayer);
+
+            // The ID still has the old account number, which should no longer resolve.
+            Assert.That(balanceSys.TryGetByAccount(idComp.AccountNumber, out _), Is.False,
+                "ID with old account number should fail lookup after invalidation.");
+        });
+    }
+
+    /// <summary>
+    /// An ID card that already has an account number set should be locked.
+    /// The account number cannot be overwritten.
+    /// </summary>
+    [Test]
+    public async Task LockedIdCannotBeOverwrittenTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+        var idEnt = SEntMan.GetEntity(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+
+            // Set an account number on the ID.
+            idComp.AccountNumber = "DEADBEEF";
+
+            // The ID is now locked. Verify the account number persists.
+            Assert.That(idComp.AccountNumber, Is.EqualTo("DEADBEEF"));
+            Assert.That(string.IsNullOrEmpty(idComp.AccountNumber), Is.False,
+                "ID with account set should be considered locked.");
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
@@ -36,7 +36,7 @@ public sealed class CreateAccountTest : InteractionTest
             // Player should now have a balance component with the account.
             var balanceComp = SEntMan.GetComponent<PlayerBalanceComponent>(SPlayer);
             Assert.That(balanceComp.AccountNumber, Is.EqualTo(accountNumber));
-            Assert.That(balanceComp.Balance, Is.GreaterThan(0), "New account should have starting balance.");
+            Assert.That(balanceComp.Balance, Is.EqualTo(0), "New account should start with zero balance.");
         });
     }
 
@@ -75,8 +75,7 @@ public sealed class CreateAccountTest : InteractionTest
     }
 
     /// <summary>
-    /// Creating a new account should wipe the old balance.
-    /// The player gets a fresh starting balance.
+    /// Creating a new account should wipe the old balance to zero.
     /// </summary>
     [Test]
     public async Task CreateAccountWipesBalanceTest()
@@ -91,14 +90,12 @@ public sealed class CreateAccountTest : InteractionTest
             balanceSys.CreateAccount(SPlayer);
             balanceSys.AddBalance(SPlayer, 5000);
             var balanceComp = SEntMan.GetComponent<PlayerBalanceComponent>(SPlayer);
-            var oldBalance = balanceComp.Balance;
-            Assert.That(oldBalance, Is.GreaterThan(5000));
+            Assert.That(balanceComp.Balance, Is.EqualTo(5000));
 
-            // Create new account, balance should reset to starting amount.
+            // Create new account, balance should reset to zero.
             balanceSys.CreateAccount(SPlayer);
-            var newBalance = balanceComp.Balance;
-            Assert.That(newBalance, Is.LessThan(oldBalance),
-                "New account should reset balance, wiping old funds.");
+            Assert.That(balanceComp.Balance, Is.EqualTo(0),
+                "New account should wipe balance to zero.");
         });
     }
 

--- a/Content.Server/Administration/QuickDialogSystem.cs
+++ b/Content.Server/Administration/QuickDialogSystem.cs
@@ -84,7 +84,29 @@ public sealed partial class QuickDialogSystem : EntitySystem
         _openDialogsByUser.Remove(user);
     }
 
-    private void OpenDialogInternal(ICommonSession session, string title, List<QuickDialogEntry> entries, QuickDialogButtonFlag buttons, Action<QuickDialogResponseEvent> okAction, Action cancelAction)
+    // HONK START - Server-side dialog close
+    /// <summary>
+    /// Close all open dialogs for a session from the server side.
+    /// Invokes each dialog's cancel action and tells the client to close the windows.
+    /// </summary>
+    public void CloseAllDialogs(ICommonSession session)
+    {
+        if (!_openDialogsByUser.TryGetValue(session.UserId, out var list))
+            return;
+
+        foreach (var dialogId in list)
+        {
+            _openDialogs[dialogId].cancelAction.Invoke();
+            _openDialogs.Remove(dialogId);
+            RaiseNetworkEvent(new QuickDialogCloseEvent(dialogId), session);
+        }
+
+        list.Clear();
+    }
+    // HONK END
+
+    // HONK - changed return type from void to int for dialog ID tracking
+    private int OpenDialogInternal(ICommonSession session, string title, List<QuickDialogEntry> entries, QuickDialogButtonFlag buttons, Action<QuickDialogResponseEvent> okAction, Action cancelAction)
     {
         var did = GetDialogId();
         RaiseNetworkEvent(
@@ -101,6 +123,8 @@ public sealed partial class QuickDialogSystem : EntitySystem
             _openDialogsByUser.Add(session.UserId, new List<int>());
 
         _openDialogsByUser[session.UserId].Add(did);
+
+        return did; // HONK
     }
 
     private bool TryParseQuickDialog<T>(QuickDialogEntryType entryType, string input, [NotNullWhen(true)] out T? output)

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.PDA;
 using Content.Shared.Popups;
@@ -31,9 +32,10 @@ public sealed class IdCardAccountSystem : EntitySystem
     private static readonly ProtoId<StackPrototype> CreditStack = "Credit";
 
     /// <summary>
-    /// Sessions that currently have a dialog open. Prevents stacking dialogs on repeated alt-click.
+    /// Tracks which sessions have an open ID-card dialog.
+    /// Prevents stacking dialogs on repeated alt-click and allows cancel on drop.
     /// </summary>
-    private readonly HashSet<ICommonSession> _pendingDialogs = new();
+    private readonly HashSet<ICommonSession> _pendingDialogSessions = new();
 
     public override void Initialize()
     {
@@ -43,6 +45,18 @@ public sealed class IdCardAccountSystem : EntitySystem
         SubscribeLocalEvent<IdCardComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<IdCardComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<PdaComponent, InteractUsingEvent>(OnPdaInteractUsing);
+        SubscribeLocalEvent<IdCardComponent, GotUnequippedHandEvent>(OnIdDropped);
+    }
+
+    private void OnIdDropped(EntityUid uid, IdCardComponent comp, GotUnequippedHandEvent args)
+    {
+        if (!TryComp(args.User, out ActorComponent? actor))
+            return;
+
+        if (!_pendingDialogSessions.Remove(actor.PlayerSession))
+            return;
+
+        _quickDialog.CloseAllDialogs(actor.PlayerSession);
     }
 
     private void OnGetAltVerbs(EntityUid uid, IdCardComponent comp, GetVerbsEvent<AlternativeVerb> args)
@@ -65,7 +79,7 @@ public sealed class IdCardAccountSystem : EntitySystem
                 Text = Loc.GetString("id-card-set-account-verb"),
                 Act = () =>
                 {
-                    if (!_pendingDialogs.Add(actor.PlayerSession))
+                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
                         return;
 
                     _quickDialog.OpenDialog(actor.PlayerSession,
@@ -73,10 +87,10 @@ public sealed class IdCardAccountSystem : EntitySystem
                         Loc.GetString("id-card-set-account-prompt"),
                         (string accountNumber) =>
                         {
-                            _pendingDialogs.Remove(actor.PlayerSession);
+                            _pendingDialogSessions.Remove(actor.PlayerSession);
                             OnAccountEntered(uid, args.User, actor.PlayerSession, accountNumber);
                         },
-                        () => _pendingDialogs.Remove(actor.PlayerSession));
+                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
                 },
                 Impact = LogImpact.Low,
             });
@@ -87,14 +101,19 @@ public sealed class IdCardAccountSystem : EntitySystem
                 Text = Loc.GetString("id-card-create-account-verb"),
                 Act = () =>
                 {
+                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
+                        return;
+
                     _quickDialog.OpenDialog(actor.PlayerSession,
                         Loc.GetString("id-card-create-account-title"),
                         Loc.GetString("id-card-create-account-confirm"),
                         (string confirmation) =>
                         {
+                            _pendingDialogSessions.Remove(actor.PlayerSession);
                             if (confirmation.Trim().Equals("YES", StringComparison.OrdinalIgnoreCase))
                                 OnCreateAccount(uid, args.User, actor.PlayerSession);
-                        });
+                        },
+                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
                 },
                 Impact = LogImpact.Low,
             });
@@ -107,7 +126,7 @@ public sealed class IdCardAccountSystem : EntitySystem
                 Text = Loc.GetString("id-card-withdraw-verb"),
                 Act = () =>
                 {
-                    if (!_pendingDialogs.Add(actor.PlayerSession))
+                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
                         return;
 
                     _quickDialog.OpenDialog(actor.PlayerSession,
@@ -115,10 +134,10 @@ public sealed class IdCardAccountSystem : EntitySystem
                         Loc.GetString("id-card-withdraw-prompt"),
                         (int amount) =>
                         {
-                            _pendingDialogs.Remove(actor.PlayerSession);
+                            _pendingDialogSessions.Remove(actor.PlayerSession);
                             OnWithdraw(uid, args.User, actor.PlayerSession, amount);
                         },
-                        () => _pendingDialogs.Remove(actor.PlayerSession));
+                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
                 },
                 Impact = LogImpact.Low,
             });

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -80,6 +80,14 @@ public sealed class IdCardAccountSystem : EntitySystem
                 },
                 Impact = LogImpact.Low,
             });
+
+            // Offer to create a brand new account.
+            args.Verbs.Add(new AlternativeVerb
+            {
+                Text = Loc.GetString("id-card-create-account-verb"),
+                Act = () => OnCreateAccount(uid, args.User, actor.PlayerSession),
+                Impact = LogImpact.Low,
+            });
         }
         else
         {
@@ -112,14 +120,15 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (string.IsNullOrEmpty(comp.AccountNumber))
             return;
 
-        if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
-            return;
-
-        if (!TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
-            return;
-
         using (args.PushGroup(nameof(IdCardAccountSystem)))
         {
+            if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner)
+                || !TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
+            {
+                args.PushMarkup(Loc.GetString("id-card-account-invalid"));
+                return;
+            }
+
             args.PushMarkup(Loc.GetString("id-card-examine-balance", ("balance", balanceComp.Balance)));
         }
     }
@@ -162,7 +171,10 @@ public sealed class IdCardAccountSystem : EntitySystem
             return false;
 
         if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
-            return false;
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, user);
+            return true; // handled, just rejected
+        }
 
         var amount = stack.Count;
         if (amount <= 0)
@@ -177,6 +189,26 @@ public sealed class IdCardAccountSystem : EntitySystem
             user);
 
         return true;
+    }
+
+    private void OnCreateAccount(EntityUid idCard, EntityUid user, ICommonSession session)
+    {
+        if (!TryComp<IdCardComponent>(idCard, out var comp))
+            return;
+
+        if (!string.IsNullOrEmpty(comp.AccountNumber))
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-account-locked"), idCard, session, PopupType.MediumCaution);
+            return;
+        }
+
+        // Creates a new account (or replaces the old one, invalidating any stolen IDs).
+        var accountNumber = _balance.CreateAccount(user);
+
+        comp.AccountNumber = accountNumber;
+        Dirty(idCard, comp);
+
+        _popup.PopupEntity(Loc.GetString("id-card-create-account-success"), idCard, session, PopupType.Medium);
     }
 
     private void OnAccountEntered(EntityUid idCard, EntityUid user, ICommonSession session, string accountNumber)
@@ -220,7 +252,10 @@ public sealed class IdCardAccountSystem : EntitySystem
             return;
 
         if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, session, PopupType.MediumCaution);
             return;
+        }
 
         if (!_balance.TryDeduct(owner, amount))
         {

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -85,13 +85,23 @@ public sealed class IdCardAccountSystem : EntitySystem
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-create-account-verb"),
-                Act = () => OnCreateAccount(uid, args.User, actor.PlayerSession),
+                Act = () =>
+                {
+                    _quickDialog.OpenDialog(actor.PlayerSession,
+                        Loc.GetString("id-card-create-account-title"),
+                        Loc.GetString("id-card-create-account-confirm"),
+                        (string confirmation) =>
+                        {
+                            if (confirmation.Trim().Equals("YES", StringComparison.OrdinalIgnoreCase))
+                                OnCreateAccount(uid, args.User, actor.PlayerSession);
+                        });
+                },
                 Impact = LogImpact.Low,
             });
         }
-        else
+        else if (_balance.TryGetByAccount(comp.AccountNumber, out _))
         {
-            // Account linked: offer to withdraw.
+            // Account linked and valid: offer to withdraw.
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-withdraw-verb"),
@@ -125,7 +135,7 @@ public sealed class IdCardAccountSystem : EntitySystem
             if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner)
                 || !TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
             {
-                args.PushMarkup(Loc.GetString("id-card-account-invalid"));
+                args.PushMarkup(Loc.GetString("id-card-account-invalid-examine"));
                 return;
             }
 
@@ -172,7 +182,7 @@ public sealed class IdCardAccountSystem : EntitySystem
 
         if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
         {
-            _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, user);
+            _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, user, PopupType.MediumCaution);
             return true; // handled, just rejected
         }
 

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -130,6 +130,31 @@ public sealed class PlayerBalanceSystem : EntitySystem
     }
 
     /// <summary>
+    /// Create a new bank account for a mob. If the mob already has an account,
+    /// the old account is invalidated (removed from the index, balance wiped).
+    /// Any ID cards with the old account number become dead cards.
+    /// Returns the new account number.
+    /// </summary>
+    public string CreateAccount(EntityUid uid)
+    {
+        var comp = EnsureComp<PlayerBalanceComponent>(uid);
+
+        // Invalidate old account if one exists.
+        if (!string.IsNullOrEmpty(comp.AccountNumber))
+            _accountIndex.Remove(comp.AccountNumber);
+
+        comp.Balance = _defaultStartingBalance;
+        comp.AccountNumber = GenerateAccountNumber();
+        _accountIndex[comp.AccountNumber] = uid;
+        Dirty(uid, comp);
+
+        _memories.AddMemory(uid, "memories-key-account-number", comp.AccountNumber);
+        RaiseLocalEvent(uid, new BalanceChangedEvent(uid));
+
+        return comp.AccountNumber;
+    }
+
+    /// <summary>
     /// Generate an 8-character hex account number, ensuring uniqueness within the round.
     /// </summary>
     private string GenerateAccountNumber()

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -133,6 +133,7 @@ public sealed class PlayerBalanceSystem : EntitySystem
     /// Create a new bank account for a mob. If the mob already has an account,
     /// the old account is invalidated (removed from the index, balance wiped).
     /// Any ID cards with the old account number become dead cards.
+    /// New accounts start with zero balance.
     /// Returns the new account number.
     /// </summary>
     public string CreateAccount(EntityUid uid)
@@ -143,7 +144,7 @@ public sealed class PlayerBalanceSystem : EntitySystem
         if (!string.IsNullOrEmpty(comp.AccountNumber))
             _accountIndex.Remove(comp.AccountNumber);
 
-        comp.Balance = _defaultStartingBalance;
+        comp.Balance = 0;
         comp.AccountNumber = GenerateAccountNumber();
         _accountIndex[comp.AccountNumber] = uid;
         Dirty(uid, comp);

--- a/Content.Shared/Administration/QuickDialogOpenEvent.cs
+++ b/Content.Shared/Administration/QuickDialogOpenEvent.cs
@@ -111,6 +111,22 @@ public enum QuickDialogButtonFlag
     CancelButton = 2,
 }
 
+// HONK START - Server-side dialog close support
+/// <summary>
+/// Sent from the server to tell the client to close a specific dialog.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class QuickDialogCloseEvent : EntityEventArgs
+{
+    public int DialogId;
+
+    public QuickDialogCloseEvent(int dialogId)
+    {
+        DialogId = dialogId;
+    }
+}
+// HONK END
+
 /// <summary>
 /// The entry types for a quick dialog.
 /// </summary>

--- a/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
@@ -12,5 +12,10 @@ id-card-withdraw-success = Withdrew {$amount} spesos.
 
 id-card-deposit-success = Deposited {$amount} spesos.
 
+id-card-create-account-verb = Create Account
+id-card-create-account-success = New bank account created and linked.
+
+id-card-account-invalid = [color=red]Error: account invalid.[/color]
+
 id-card-account-locked = This ID's account is already set.
 id-card-examine-balance = It has [color=green]{$balance} spesos[/color] linked.

--- a/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
@@ -13,8 +13,8 @@ id-card-withdraw-success = Withdrew {$amount} spesos.
 id-card-deposit-success = Deposited {$amount} spesos.
 
 id-card-create-account-verb = Create Account
-id-card-create-account-title = WARNING: Old account will be lost!
-id-card-create-account-confirm = Type YES to create a new account:
+id-card-create-account-title = Old account will be lost!
+id-card-create-account-confirm = Type YES:
 id-card-create-account-success = New bank account created and linked.
 
 id-card-account-invalid = Error: account invalid.

--- a/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
@@ -13,9 +13,12 @@ id-card-withdraw-success = Withdrew {$amount} spesos.
 id-card-deposit-success = Deposited {$amount} spesos.
 
 id-card-create-account-verb = Create Account
+id-card-create-account-title = Create Bank Account
+id-card-create-account-confirm = This will create a new bank account. If you already have one, your old account and its balance will be permanently lost. Are you sure? Type YES to confirm:
 id-card-create-account-success = New bank account created and linked.
 
-id-card-account-invalid = [color=red]Error: account invalid.[/color]
+id-card-account-invalid = Error: account invalid.
+id-card-account-invalid-examine = [color=red]Error: account invalid.[/color]
 
 id-card-account-locked = This ID's account is already set.
 id-card-examine-balance = It has [color=green]{$balance} spesos[/color] linked.

--- a/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
@@ -13,8 +13,8 @@ id-card-withdraw-success = Withdrew {$amount} spesos.
 id-card-deposit-success = Deposited {$amount} spesos.
 
 id-card-create-account-verb = Create Account
-id-card-create-account-title = Create Bank Account
-id-card-create-account-confirm = This will create a new bank account. If you already have one, your old account and its balance will be permanently lost. Are you sure? Type YES to confirm:
+id-card-create-account-title = WARNING: Old account will be lost!
+id-card-create-account-confirm = Type YES to create a new account:
 id-card-create-account-success = New bank account created and linked.
 
 id-card-account-invalid = Error: account invalid.


### PR DESCRIPTION
## About the PR

Adds a "Create Account" alt-click verb on blank ID cards. Creates a new bank account for the holder and stamps the account number on the ID. If the holder already had an account, the old one is invalidated (removed from the lookup index, balance wiped). Any ID cards with the old account number become dead cards that show "Error: account invalid" on examine, withdraw, and deposit.

Also adds auto-cancel for ID card dialogs when the card is dropped, and idempotent dialog tracking to prevent stacking on repeated alt-click.

Replaces #259 which couldn't be reopened after base branch deletion.

## Why / Balance

Players whose IDs get stolen currently have no recourse. The thief can drain their account indefinitely. This gives victims a way to cut off the stolen ID at the cost of losing their current balance. The tradeoff (lose your money to protect yourself) keeps theft gameplay meaningful while giving victims an out.

Spawned mobs and ghost roles that lack economy setup can now self-service into the economy system.

## Technical details

- `PlayerBalanceSystem.CreateAccount()` public method handles account creation and old account invalidation
- Old account number removed from `_accountIndex` dictionary, making it unresolvable
- `IdCardAccountSystem` adds "Create Account" verb alongside existing "Set Account" on blank IDs
- `_pendingDialogSessions` HashSet prevents dialog stacking and enables cancel-on-drop
- `QuickDialogCloseEvent` and `CloseAllDialogs()` for server-side dialog close support
- Invalid account error messages on examine, withdraw, and deposit for dead account numbers
- 5 integration tests covering creation, invalidation, balance wipe, failed lookup, and ID locking
- Zero upstream files touched

## Media

N/A, text-only interactions (popups, examine text).

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

:cl:
- add: Alt-click a blank ID card to create a new bank account.
- add: Creating a new account invalidates your old one, making stolen IDs useless.
- add: ID cards with invalid accounts now show an error on examine and block transactions.
- fix: ID card dialogs auto-cancel when the card is dropped from hand.