### PR TITLE
Lower seed vending price to 5 spesos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -22,7 +22,7 @@
     - type: Item
       size: Tiny
     - type: StaticPrice
-      price: 20
+      price: 3 # HONK - lowered so vending price lands at 5 spesos (3 × 1.5 markup, rounded up)
     - type: PhysicalComposition
 
 - type: entity


### PR DESCRIPTION
## About the PR

Lowers SeedBase StaticPrice from 20 to 3 so seed packets vend at 5 spesos instead of 30.

## Why / Balance

30 spesos per seed packet is too expensive for a bulk consumable. Botanists burn through their starting balance just stocking up. At 5 per packet, seeds are affordable without being free.

## Technical details

SeedBase `StaticPrice` 20 → 3. Vending formula: 3 × 1.5 cargo markup = 4.5, ceiling = 5, round-up-to-5 = 5.

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Seed packets now cost 5 spesos at vendors instead of 30
:cl: