### PR TITLE
ID card create account verb and account invalidation

### DIFF
--- a/Content.Client/Administration/QuickDialogSystem.cs
+++ b/Content.Client/Administration/QuickDialogSystem.cs
@@ -8,10 +8,17 @@ namespace Content.Client.Administration;
 /// </summary>
 public sealed class QuickDialogSystem : EntitySystem
 {
+    // HONK START - Track open windows for server-initiated close (#163)
+    private readonly Dictionary<int, DialogWindow> _openWindows = new();
+    // HONK END
+
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeNetworkEvent<QuickDialogOpenEvent>(OpenDialog);
+        // HONK START
+        SubscribeNetworkEvent<QuickDialogCloseEvent>(OnCloseDialog);
+        // HONK END
     }
 
     private void OpenDialog(QuickDialogOpenEvent ev)
@@ -20,8 +27,15 @@ public sealed class QuickDialogSystem : EntitySystem
         var cancel = (ev.Buttons & QuickDialogButtonFlag.CancelButton) != 0;
         var window = new DialogWindow(ev.Title, ev.Prompts, ok: ok, cancel: cancel);
 
+        // HONK START
+        _openWindows[ev.DialogId] = window;
+        // HONK END
+
         window.OnConfirmed += responses =>
         {
+            // HONK START
+            _openWindows.Remove(ev.DialogId);
+            // HONK END
             RaiseNetworkEvent(new QuickDialogResponseEvent(ev.DialogId,
                 responses,
                 QuickDialogButtonFlag.OkButton));
@@ -29,9 +43,20 @@ public sealed class QuickDialogSystem : EntitySystem
 
         window.OnCancelled += () =>
         {
+            // HONK START
+            _openWindows.Remove(ev.DialogId);
+            // HONK END
             RaiseNetworkEvent(new QuickDialogResponseEvent(ev.DialogId,
                 new(),
                 QuickDialogButtonFlag.CancelButton));
         };
     }
+
+    // HONK START
+    private void OnCloseDialog(QuickDialogCloseEvent ev)
+    {
+        if (_openWindows.Remove(ev.DialogId, out var window))
+            window.Close();
+    }
+    // HONK END
 }

--- a/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
@@ -130,8 +130,8 @@ public sealed class CreateAccountTest : InteractionTest
     }
 
     /// <summary>
-    /// An ID card that already has an account number set should be locked.
-    /// The account number cannot be overwritten.
+    /// An ID card that already has an account number set should not be overwritten
+    /// by creating a new account. The old account number persists on the ID.
     /// </summary>
     [Test]
     public async Task LockedIdCannotBeOverwrittenTest()
@@ -141,15 +141,25 @@ public sealed class CreateAccountTest : InteractionTest
 
         await Server.WaitPost(() =>
         {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
             var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
 
-            // Set an account number on the ID.
-            idComp.AccountNumber = "DEADBEEF";
+            // Create an account and stamp it on the ID (simulates normal spawn).
+            var firstAccount = balanceSys.CreateAccount(SPlayer);
+            idComp.AccountNumber = firstAccount;
 
-            // The ID is now locked. Verify the account number persists.
-            Assert.That(idComp.AccountNumber, Is.EqualTo("DEADBEEF"));
-            Assert.That(string.IsNullOrEmpty(idComp.AccountNumber), Is.False,
-                "ID with account set should be considered locked.");
+            // Create a second account (simulates "Create Account" verb).
+            // The mob gets a new account, but the ID should still have the old number.
+            var secondAccount = balanceSys.CreateAccount(SPlayer);
+            Assert.That(secondAccount, Is.Not.EqualTo(firstAccount));
+
+            // ID still has the first account number (locked).
+            Assert.That(idComp.AccountNumber, Is.EqualTo(firstAccount),
+                "ID with account set should not be overwritten by creating a new account.");
+
+            // The old account on the ID is now invalid (invalidated by second create).
+            Assert.That(balanceSys.TryGetByAccount(firstAccount, out _), Is.False,
+                "Old account should be invalidated after creating a new one.");
         });
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
@@ -1,0 +1,155 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.RussStation.Economy;
+using Content.Shared.Access.Components;
+using Content.Shared.RussStation.Economy.Components;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+public sealed class CreateAccountTest : InteractionTest
+{
+    /// <summary>
+    /// Creating an account on a mob without one should generate a new account
+    /// and stamp it on the ID card.
+    /// </summary>
+    [Test]
+    public async Task CreateAccountOnBlankIdTest()
+    {
+        // Spawn an ID card as the target.
+        await SpawnTarget("PassengerIDCard");
+        var idEnt = SEntMan.GetEntity(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Player should not have an account yet.
+            Assert.That(SEntMan.HasComponent<PlayerBalanceComponent>(SPlayer), Is.False);
+
+            // ID should be blank.
+            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+            Assert.That(string.IsNullOrEmpty(idComp.AccountNumber), Is.True);
+
+            // Create account.
+            var accountNumber = balanceSys.CreateAccount(SPlayer);
+            Assert.That(accountNumber, Is.Not.Null.And.Not.Empty);
+
+            // Player should now have a balance component with the account.
+            var balanceComp = SEntMan.GetComponent<PlayerBalanceComponent>(SPlayer);
+            Assert.That(balanceComp.AccountNumber, Is.EqualTo(accountNumber));
+            Assert.That(balanceComp.Balance, Is.EqualTo(0), "New account should start with zero balance.");
+        });
+    }
+
+    /// <summary>
+    /// Creating a new account should invalidate the old one.
+    /// The old account number should no longer resolve.
+    /// </summary>
+    [Test]
+    public async Task CreateAccountInvalidatesOldTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Create the first account.
+            var oldAccount = balanceSys.CreateAccount(SPlayer);
+            Assert.That(oldAccount, Is.Not.Null);
+
+            // Old account should resolve.
+            Assert.That(balanceSys.TryGetByAccount(oldAccount, out _), Is.True);
+
+            // Create a second account (simulating stolen ID replacement).
+            var newAccount = balanceSys.CreateAccount(SPlayer);
+            Assert.That(newAccount, Is.Not.Null);
+            Assert.That(newAccount, Is.Not.EqualTo(oldAccount));
+
+            // Old account should no longer resolve.
+            Assert.That(balanceSys.TryGetByAccount(oldAccount, out _), Is.False,
+                "Old account should be invalidated after creating a new one.");
+
+            // New account should resolve.
+            Assert.That(balanceSys.TryGetByAccount(newAccount, out _), Is.True);
+        });
+    }
+
+    /// <summary>
+    /// Creating a new account should wipe the old balance to zero.
+    /// </summary>
+    [Test]
+    public async Task CreateAccountWipesBalanceTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Create account and add extra funds.
+            balanceSys.CreateAccount(SPlayer);
+            balanceSys.AddBalance(SPlayer, 5000);
+            var balanceComp = SEntMan.GetComponent<PlayerBalanceComponent>(SPlayer);
+            Assert.That(balanceComp.Balance, Is.EqualTo(5000));
+
+            // Create new account, balance should reset to zero.
+            balanceSys.CreateAccount(SPlayer);
+            Assert.That(balanceComp.Balance, Is.EqualTo(0),
+                "New account should wipe balance to zero.");
+        });
+    }
+
+    /// <summary>
+    /// An ID card with an invalidated account number should fail lookups.
+    /// </summary>
+    [Test]
+    public async Task InvalidatedIdFailsLookupTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+        var idEnt = SEntMan.GetEntity(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var balanceSys = SEntMan.System<PlayerBalanceSystem>();
+
+            // Create account and stamp it on the ID.
+            var oldAccount = balanceSys.CreateAccount(SPlayer);
+            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+            idComp.AccountNumber = oldAccount;
+
+            // Verify it resolves.
+            Assert.That(balanceSys.TryGetByAccount(idComp.AccountNumber, out _), Is.True);
+
+            // Create a new account (invalidates old).
+            balanceSys.CreateAccount(SPlayer);
+
+            // The ID still has the old account number, which should no longer resolve.
+            Assert.That(balanceSys.TryGetByAccount(idComp.AccountNumber, out _), Is.False,
+                "ID with old account number should fail lookup after invalidation.");
+        });
+    }
+
+    /// <summary>
+    /// An ID card that already has an account number set should be locked.
+    /// The account number cannot be overwritten.
+    /// </summary>
+    [Test]
+    public async Task LockedIdCannotBeOverwrittenTest()
+    {
+        await SpawnTarget("PassengerIDCard");
+        var idEnt = SEntMan.GetEntity(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+
+            // Set an account number on the ID.
+            idComp.AccountNumber = "DEADBEEF";
+
+            // The ID is now locked. Verify the account number persists.
+            Assert.That(idComp.AccountNumber, Is.EqualTo("DEADBEEF"));
+            Assert.That(string.IsNullOrEmpty(idComp.AccountNumber), Is.False,
+                "ID with account set should be considered locked.");
+        });
+    }
+}

--- a/Content.Server/Administration/QuickDialogSystem.cs
+++ b/Content.Server/Administration/QuickDialogSystem.cs
@@ -65,6 +65,28 @@ public sealed partial class QuickDialogSystem : EntitySystem
         return _nextDialogId++;
     }
 
+    // HONK START - Close all dialogs for a session (#163)
+    /// <summary>
+    /// Close all open quick dialogs for the given session, invoking cancel callbacks.
+    /// </summary>
+    public void CloseAllDialogs(ICommonSession session)
+    {
+        if (!_openDialogsByUser.TryGetValue(session.UserId, out var dialogIds))
+            return;
+
+        foreach (var dialogId in dialogIds)
+        {
+            if (_openDialogs.Remove(dialogId, out var actions))
+            {
+                actions.cancelAction.Invoke();
+                RaiseNetworkEvent(new QuickDialogCloseEvent(dialogId), session);
+            }
+        }
+
+        _openDialogsByUser.Remove(session.UserId);
+    }
+    // HONK END
+
     private void PlayerManagerOnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
     {
         if (e.NewStatus != SessionStatus.Disconnected && e.NewStatus != SessionStatus.Zombie)

--- a/Content.Server/Administration/QuickDialogSystem.cs
+++ b/Content.Server/Administration/QuickDialogSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class QuickDialogSystem : EntitySystem
         if (!_openDialogsByUser.TryGetValue(session.UserId, out var dialogIds))
             return;
 
-        foreach (var dialogId in dialogIds)
+        foreach (var dialogId in new List<int>(dialogIds))
         {
             if (_openDialogs.Remove(dialogId, out var actions))
             {

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.PDA;
 using Content.Shared.Popups;
@@ -17,8 +18,9 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.RussStation.Economy;
 
 /// <summary>
-/// Handles bank account interactions on ID cards: set account, withdraw spesos, deposit spesos.
+/// Handles bank account interactions on ID cards: set account, create account, withdraw, deposit.
 /// Alt-click on an ID: prompts to set account (if none) or withdraw (if linked).
+/// Right-click on an ID: create a new account (if none linked).
 /// Use spesos on an ID or PDA (with ID inside) to deposit.
 /// </summary>
 public sealed class IdCardAccountSystem : EntitySystem
@@ -31,18 +33,32 @@ public sealed class IdCardAccountSystem : EntitySystem
     private static readonly ProtoId<StackPrototype> CreditStack = "Credit";
 
     /// <summary>
-    /// Sessions that currently have a dialog open. Prevents stacking dialogs on repeated alt-click.
+    /// Tracks which sessions have an open ID-card dialog.
+    /// Prevents stacking dialogs on repeated alt-click and allows cancel on drop.
     /// </summary>
-    private readonly HashSet<ICommonSession> _pendingDialogs = new();
+    private readonly HashSet<ICommonSession> _pendingDialogSessions = new();
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<IdCardComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
+        SubscribeLocalEvent<IdCardComponent, GetVerbsEvent<ActivationVerb>>(OnGetActivationVerbs);
         SubscribeLocalEvent<IdCardComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<IdCardComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<PdaComponent, InteractUsingEvent>(OnPdaInteractUsing);
+        SubscribeLocalEvent<IdCardComponent, GotUnequippedHandEvent>(OnIdDropped);
+    }
+
+    private void OnIdDropped(EntityUid uid, IdCardComponent comp, GotUnequippedHandEvent args)
+    {
+        if (!TryComp(args.User, out ActorComponent? actor))
+            return;
+
+        if (!_pendingDialogSessions.Remove(actor.PlayerSession))
+            return;
+
+        _quickDialog.CloseAllDialogs(actor.PlayerSession);
     }
 
     private void OnGetAltVerbs(EntityUid uid, IdCardComponent comp, GetVerbsEvent<AlternativeVerb> args)
@@ -53,19 +69,17 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (!args.CanInteract || !args.CanAccess)
             return;
 
-        // ID must be in the user's hand.
         if (!_hands.IsHolding(args.User, uid))
             return;
 
         if (string.IsNullOrEmpty(comp.AccountNumber))
         {
-            // No account linked: offer to set one.
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-set-account-verb"),
                 Act = () =>
                 {
-                    if (!_pendingDialogs.Add(actor.PlayerSession))
+                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
                         return;
 
                     _quickDialog.OpenDialog(actor.PlayerSession,
@@ -73,23 +87,22 @@ public sealed class IdCardAccountSystem : EntitySystem
                         Loc.GetString("id-card-set-account-prompt"),
                         (string accountNumber) =>
                         {
-                            _pendingDialogs.Remove(actor.PlayerSession);
+                            _pendingDialogSessions.Remove(actor.PlayerSession);
                             OnAccountEntered(uid, args.User, actor.PlayerSession, accountNumber);
                         },
-                        () => _pendingDialogs.Remove(actor.PlayerSession));
+                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
                 },
                 Impact = LogImpact.Low,
             });
         }
-        else
+        else if (_balance.TryGetByAccount(comp.AccountNumber, out _))
         {
-            // Account linked: offer to withdraw.
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-withdraw-verb"),
                 Act = () =>
                 {
-                    if (!_pendingDialogs.Add(actor.PlayerSession))
+                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
                         return;
 
                     _quickDialog.OpenDialog(actor.PlayerSession,
@@ -97,14 +110,51 @@ public sealed class IdCardAccountSystem : EntitySystem
                         Loc.GetString("id-card-withdraw-prompt"),
                         (int amount) =>
                         {
-                            _pendingDialogs.Remove(actor.PlayerSession);
+                            _pendingDialogSessions.Remove(actor.PlayerSession);
                             OnWithdraw(uid, args.User, actor.PlayerSession, amount);
                         },
-                        () => _pendingDialogs.Remove(actor.PlayerSession));
+                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
                 },
                 Impact = LogImpact.Low,
             });
         }
+    }
+
+    private void OnGetActivationVerbs(EntityUid uid, IdCardComponent comp, GetVerbsEvent<ActivationVerb> args)
+    {
+        if (!TryComp(args.User, out ActorComponent? actor))
+            return;
+
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        if (!_hands.IsHolding(args.User, uid))
+            return;
+
+        if (!string.IsNullOrEmpty(comp.AccountNumber))
+            return;
+
+        args.Verbs.Add(new ActivationVerb
+        {
+            Text = Loc.GetString("id-card-create-account-verb"),
+            Act = () =>
+            {
+                if (!_pendingDialogSessions.Add(actor.PlayerSession))
+                    return;
+
+                _quickDialog.OpenDialog(actor.PlayerSession,
+                    Loc.GetString("id-card-create-account-title"),
+                    Loc.GetString("id-card-create-account-confirm"),
+                    (string confirmation) =>
+                    {
+                        _pendingDialogSessions.Remove(actor.PlayerSession);
+                        if (confirmation.Trim().Equals("YES", StringComparison.OrdinalIgnoreCase))
+                            OnCreateAccount(uid, args.User, actor.PlayerSession);
+                    },
+                    () => _pendingDialogSessions.Remove(actor.PlayerSession));
+            },
+            Impact = LogImpact.Low,
+        });
     }
 
     private void OnExamine(EntityUid uid, IdCardComponent comp, ExaminedEvent args)
@@ -112,14 +162,15 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (string.IsNullOrEmpty(comp.AccountNumber))
             return;
 
-        if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
-            return;
-
-        if (!TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
-            return;
-
         using (args.PushGroup(nameof(IdCardAccountSystem)))
         {
+            if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner)
+                || !TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
+            {
+                args.PushMarkup(Loc.GetString("id-card-account-invalid-examine"));
+                return;
+            }
+
             args.PushMarkup(Loc.GetString("id-card-examine-balance", ("balance", balanceComp.Balance)));
         }
     }
@@ -162,7 +213,10 @@ public sealed class IdCardAccountSystem : EntitySystem
             return false;
 
         if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
-            return false;
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, user, PopupType.MediumCaution);
+            return true;
+        }
 
         var amount = stack.Count;
         if (amount <= 0)
@@ -179,12 +233,30 @@ public sealed class IdCardAccountSystem : EntitySystem
         return true;
     }
 
+    private void OnCreateAccount(EntityUid idCard, EntityUid user, ICommonSession session)
+    {
+        if (!TryComp<IdCardComponent>(idCard, out var comp))
+            return;
+
+        if (!string.IsNullOrEmpty(comp.AccountNumber))
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-account-locked"), idCard, session, PopupType.MediumCaution);
+            return;
+        }
+
+        var accountNumber = _balance.CreateAccount(user);
+
+        comp.AccountNumber = accountNumber;
+        Dirty(idCard, comp);
+
+        _popup.PopupEntity(Loc.GetString("id-card-create-account-success"), idCard, session, PopupType.Medium);
+    }
+
     private void OnAccountEntered(EntityUid idCard, EntityUid user, ICommonSession session, string accountNumber)
     {
         if (!TryComp<IdCardComponent>(idCard, out var comp))
             return;
 
-        // Account is locked once set.
         if (!string.IsNullOrEmpty(comp.AccountNumber))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-locked"), idCard, session, PopupType.MediumCaution);
@@ -220,7 +292,10 @@ public sealed class IdCardAccountSystem : EntitySystem
             return;
 
         if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, session, PopupType.MediumCaution);
             return;
+        }
 
         if (!_balance.TryDeduct(owner, amount, description: Loc.GetString("transaction-withdraw")))
         {

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.RussStation.Economy;
 using Content.Shared.RussStation.Economy.Components;
 using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -46,6 +47,7 @@ public sealed class PlayerBalanceSystem : EntitySystem
         Subs.CVar(_cfg, EconomyCCVars.DefaultStartingBalance, v => _defaultStartingBalance = v, true);
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawn);
+        SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<PlayerBalanceComponent, ComponentRemove>(OnRemove);
     }
 
@@ -74,6 +76,27 @@ public sealed class PlayerBalanceSystem : EntitySystem
 
         // Register account number in the player's memories.
         _memories.AddMemory(args.Mob, "memories-key-account-number", comp.AccountNumber);
+    }
+
+    /// <summary>
+    /// When a player takes over a mob that has no account and is holding a blank ID, auto-create one.
+    /// Skips if the mob already has any account (even with a blank ID in hand).
+    /// </summary>
+    private void OnPlayerAttached(PlayerAttachedEvent args)
+    {
+        if (HasComp<PlayerBalanceComponent>(args.Entity))
+            return;
+
+        if (!_idCard.TryFindIdCard(args.Entity, out var idCard))
+            return;
+
+        var idComp = Comp<IdCardComponent>(idCard);
+        if (!string.IsNullOrEmpty(idComp.AccountNumber))
+            return;
+
+        var accountNumber = CreateAccount(args.Entity);
+        idComp.AccountNumber = accountNumber;
+        Dirty(idCard, idComp);
     }
 
     private void OnRemove(EntityUid uid, PlayerBalanceComponent comp, ComponentRemove args)

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -95,6 +95,10 @@ public sealed class PlayerBalanceSystem : EntitySystem
             return;
 
         var accountNumber = CreateAccount(args.Entity);
+        var balanceComp = Comp<PlayerBalanceComponent>(args.Entity);
+        balanceComp.Balance = _defaultStartingBalance;
+        Dirty(args.Entity, balanceComp);
+
         idComp.AccountNumber = accountNumber;
         Dirty(idCard, idComp);
     }

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -142,6 +142,27 @@ public sealed class PlayerBalanceSystem : EntitySystem
     }
 
     /// <summary>
+    /// Create a new bank account for an entity, invalidating any previous account.
+    /// </summary>
+    public string CreateAccount(EntityUid uid)
+    {
+        var comp = EnsureComp<PlayerBalanceComponent>(uid);
+
+        if (!string.IsNullOrEmpty(comp.AccountNumber))
+            _accountIndex.Remove(comp.AccountNumber);
+
+        comp.Balance = 0;
+        comp.AccountNumber = GenerateAccountNumber();
+        _accountIndex[comp.AccountNumber] = uid;
+        Dirty(uid, comp);
+
+        _memories.AddMemory(uid, "memories-key-account-number", comp.AccountNumber);
+        RaiseLocalEvent(uid, new BalanceChangedEvent(uid));
+
+        return comp.AccountNumber;
+    }
+
+    /// <summary>
     /// Generate an 8-character hex account number, ensuring uniqueness within the round.
     /// </summary>
     private string GenerateAccountNumber()

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -94,11 +94,7 @@ public sealed class PlayerBalanceSystem : EntitySystem
         if (!string.IsNullOrEmpty(idComp.AccountNumber))
             return;
 
-        var accountNumber = CreateAccount(args.Entity);
-        var balanceComp = Comp<PlayerBalanceComponent>(args.Entity);
-        balanceComp.Balance = _defaultStartingBalance;
-        Dirty(args.Entity, balanceComp);
-
+        var accountNumber = CreateAccount(args.Entity, _defaultStartingBalance);
         idComp.AccountNumber = accountNumber;
         Dirty(idCard, idComp);
     }
@@ -170,15 +166,16 @@ public sealed class PlayerBalanceSystem : EntitySystem
 
     /// <summary>
     /// Create a new bank account for an entity, invalidating any previous account.
+    /// Balance defaults to 0 unless overridden.
     /// </summary>
-    public string CreateAccount(EntityUid uid)
+    public string CreateAccount(EntityUid uid, int startingBalance = 0)
     {
         var comp = EnsureComp<PlayerBalanceComponent>(uid);
 
         if (!string.IsNullOrEmpty(comp.AccountNumber))
             _accountIndex.Remove(comp.AccountNumber);
 
-        comp.Balance = 0;
+        comp.Balance = startingBalance;
         comp.AccountNumber = GenerateAccountNumber();
         _accountIndex[comp.AccountNumber] = uid;
         Dirty(uid, comp);

--- a/Content.Shared/Administration/QuickDialogOpenEvent.cs
+++ b/Content.Shared/Administration/QuickDialogOpenEvent.cs
@@ -101,6 +101,22 @@ public sealed class QuickDialogEntry
     }
 }
 
+// HONK START - Server-initiated dialog close (#163)
+/// <summary>
+/// A networked event raised when the server wants to close an open quick dialog.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class QuickDialogCloseEvent : EntityEventArgs
+{
+    public int DialogId;
+
+    public QuickDialogCloseEvent(int dialogId)
+    {
+        DialogId = dialogId;
+    }
+}
+// HONK END
+
 /// <summary>
 /// The buttons available in a quick dialog.
 /// </summary>

--- a/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
@@ -12,5 +12,13 @@ id-card-withdraw-success = Withdrew {$amount} spesos.
 
 id-card-deposit-success = Deposited {$amount} spesos.
 
+id-card-create-account-verb = Create Account
+id-card-create-account-title = Old account will be lost!
+id-card-create-account-confirm = Type YES:
+id-card-create-account-success = New bank account created and linked.
+
+id-card-account-invalid = Error: account invalid.
+id-card-account-invalid-examine = [color=red]Error: account invalid.[/color]
+
 id-card-account-locked = This ID's account is already set.
 id-card-examine-balance = It has [color=green]{$balance} spesos[/color] linked.


### PR DESCRIPTION
## About the PR

Ports the lost PR #260 feature set to release and adds auto-account creation on ghost role takeover.

- **Create Account** verb in the right-click menu on blank IDs with YES confirmation dialog (starts at 0 balance)
- Old accounts are invalidated when a new one is created (stolen IDs stop working)
- `CloseAllDialogs` added to `QuickDialogSystem` so dropping an ID card dismisses open dialogs
- Invalid account error handling on examine, deposit, and withdraw
- Auto-create bank account when a player takes over a mob with a blank ID but no account (ghost roles, starts with default balance)
- 5 integration tests covering account creation, invalidation, balance wipe, and locked IDs

## Why / Balance

Ghost role visitors and late joiners who pick up blank IDs had no way to create a bank account. This gives them a path to participate in the economy. Account invalidation means stolen IDs become useless after the victim creates a new account, adding a security layer. Ghost roles with IDs now get accounts automatically on takeover with starting balance so they can immediately participate.

Manual account creation from the right-click menu starts at 0 balance to prevent abuse (creating throwaway accounts to farm starting funds).

## Technical details

- `PlayerBalanceSystem.CreateAccount()` replaces old account, sets balance to 0, updates memories
- `PlayerAttachedEvent` handler auto-creates account if mob has no `PlayerBalanceComponent` and is holding a blank ID, then sets starting balance
- `QuickDialogCloseEvent` network event + client window tracking for server-initiated dialog close
- Upstream QuickDialog changes wrapped in HONK markers
- Create Account uses `ActivationVerb` (right-click), Set Account stays on `AlternativeVerb` (alt-click)

## Media

N/A - no visual changes

## Requirements

- [x] Build passes
- [x] Integration tests pass

## Breaking changes

None

## Changelog

:cl:
- add: Right-click "Create Account" verb on blank ID cards (0 balance)
- add: Creating a new account invalidates the old one (stolen IDs stop working)
- add: Dropping an ID card auto-closes any open account dialog
- add: Error messages when using an ID with an invalidated account
- add: Ghost role mobs with blank IDs auto-get a bank account with starting balance on takeover