### PR TITLE
Clean up SurgeryDrapedComponent on failed bedsheet insert

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -201,6 +201,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         if (!_container.Insert(bedsheet.Value, drapeContainer))
         {
             Log.Warning($"Failed to insert bedsheet {ToPrettyString(bedsheet.Value)} into surgery drape container on {ToPrettyString(target.Value)}");
+            RemComp<SurgeryDrapedComponent>(target.Value);
             return;
         }
 


### PR DESCRIPTION
## About the PR

Fixes orphaned `SurgeryDrapedComponent` when bedsheet container insertion fails during surgery setup.

## Why / Balance

In `OnProcedureSelected`, the `SurgeryDrapedComponent` is added before attempting to insert the bedsheet into the drape container. If that insert fails, the method returned early without removing the component, leaving the patient in a "draped" state with no actual bedsheet. This could block further surgery attempts on that patient.

## Technical details

Added `RemComp<SurgeryDrapedComponent>` to the early-return path in `SurgerySystem.OnProcedureSelected` when `_container.Insert` fails.

## Media

N/A - no in-game visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Surgery drape no longer gets stuck on patient if bedsheet insertion fails