### PR TITLE
Clear account index on round restart

### DIFF
--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -46,9 +46,15 @@ public sealed class PlayerBalanceSystem : EntitySystem
 
         Subs.CVar(_cfg, EconomyCCVars.DefaultStartingBalance, v => _defaultStartingBalance = v, true);
 
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawn);
         SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<PlayerBalanceComponent, ComponentRemove>(OnRemove);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        _accountIndex.Clear();
     }
 
     private void OnPlayerSpawn(PlayerSpawnCompleteEvent args)


### PR DESCRIPTION
## About the PR

Adds a `RoundRestartCleanupEvent` handler to `PlayerBalanceSystem` that clears the `_accountIndex` dictionary between rounds.

## Why / Balance

The `_accountIndex` maps account numbers to entity UIDs. While `ComponentRemove` on each `PlayerBalanceComponent` normally cleans entries up when entities are deleted, a belt-and-suspenders explicit clear on round restart prevents stale references if entity cleanup order changes.

## Technical details

Subscribe to `RoundRestartCleanupEvent` and call `_accountIndex.Clear()`. One-liner fix.

## Media

N/A - no in-game visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Bank account lookups no longer risk stale data between rounds