### PR TITLE
Prevent infinite loop on repeatable surgery steps

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -330,6 +330,9 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
         var step = proto.Steps[active.CurrentStep];
 
+        // Snapshot damage before healing so we can detect zero-effect iterations.
+        var damageBefore = _damageable.GetTotalDamage((patient, null));
+
         // Apply side effects
         ApplyStepEffects(patient, step);
 
@@ -351,8 +354,11 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
         else if (step.Effect == null)
         {
-            // Auto-repeat if the step can still heal something
-            args.Repeat = StepCanStillHeal(patient, step);
+            var damageAfter = _damageable.GetTotalDamage((patient, null));
+            var healedSomething = damageAfter < damageBefore;
+
+            // Auto-repeat only if healing actually reduced damage.
+            args.Repeat = healedSomething && StepCanStillHeal(patient, step);
 
             if (!args.Repeat)
                 _popup.PopupEntity(Loc.GetString("surgery-step-repeat-done"), patient);


### PR DESCRIPTION
## About the PR

Fixes a potential infinite DoAfter loop when repeatable surgery healing steps hit FixedPoint2 precision limits.

## Why / Balance

When a repeatable healing step's calculated heal amount is smaller than FixedPoint2 precision (0.01), the heal rounds to zero. `StepCanStillHeal` still returns true because the patient has remaining damage of matching types, so the DoAfter repeats forever with zero healing.

## Technical details

Compare total damage before and after `ApplyStepEffects`. Only set `args.Repeat = true` if damage actually decreased. This catches the edge case where FixedPoint2 rounding makes the heal amount zero.

Affected code: `SurgerySystem.OnStepDoAfter` in `Content.Server/RussStation/Surgery/SurgerySystem.cs`.

## Media

N/A - edge case fix, no visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Surgery healing steps no longer loop infinitely when remaining damage is too small to heal