### PR TITLE
Don't play fold sound on map init

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -91,8 +91,9 @@ public sealed class FoldableSystem : EntitySystem
         _appearance.SetData(uid, FoldedVisuals.State, folded);
         _buckle.StrapSetEnabled(uid, !component.IsFolded);
 
-        //HONK START - Play buckle sound on fold/unfold
-        _audio.PlayPredicted(new Robust.Shared.Audio.SoundPathSpecifier("/Audio/Effects/buckle.ogg"), uid, user);
+        //HONK START - Play buckle sound on fold/unfold (only when a user triggers it)
+        if (user != null)
+            _audio.PlayPredicted(new Robust.Shared.Audio.SoundPathSpecifier("/Audio/Effects/buckle.ogg"), uid, user);
         //HONK END
 
         var ev = new FoldedEvent(folded, user);


### PR DESCRIPTION
## About the PR

Prevents the fold/unfold buckle sound from playing during entity initialization on map load.

## Why / Balance

Every foldable entity (beds, chairs, surgical trays) called `SetFolded` during `ComponentInit`, which unconditionally played the buckle sound. Now the sound only plays when a user (non-null) triggers it.

## Technical details

Added `if (user != null)` guard around `_audio.PlayPredicted` in `FoldableSystem.SetFolded`.

## Media

N/A - audio-only fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Foldable objects no longer play sounds during map loading