### PR TITLE
Tooltip delay slider shows correct value

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -39,7 +39,7 @@ public sealed partial class AccessibilityTab : Control
             0f,
             20f,
             0.1f,
-            (_, value) => $"{value * 0.1f:F1}s"));
+            (_, value) => $"{value:F1}s"));
 
         // Font customization
         var cfg = IoCManager.Resolve<IConfigurationManager>();


### PR DESCRIPTION
## About the PR

Fixes the hover tooltip delay slider label showing 10x less than the actual delay.

## Why / Balance

The slider display format was `value * 0.1f`, so a 3.0 second delay showed as "0.3s" in the settings UI. Players thought they were setting sub-second delays but were actually getting multi-second ones.

## Technical details

Removed the `* 0.1f` multiplier from the slider label format string in `AccessibilityTab.xaml.cs`.

## Media

N/A - settings UI text fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Hover tooltip delay slider now shows the correct delay value