### PR TITLE
Require ID card for wallet app functionality

### DIFF
--- a/Content.Client/RussStation/Economy/BalanceCartridgeUi.cs
+++ b/Content.Client/RussStation/Economy/BalanceCartridgeUi.cs
@@ -30,6 +30,6 @@ public sealed partial class BalanceCartridgeUi : UIFragment
         if (state is not BalanceCartridgeUiState balanceState)
             return;
 
-        _fragment?.UpdateState(balanceState.Balance, balanceState.AccountSuffix, balanceState.PaycheckMuted, balanceState.Transactions);
+        _fragment?.UpdateState(balanceState.Balance, balanceState.AccountSuffix, balanceState.PaycheckMuted, balanceState.Transactions, balanceState.HasId);
     }
 }

--- a/Content.Client/RussStation/Economy/BalanceCartridgeUiFragment.xaml.cs
+++ b/Content.Client/RussStation/Economy/BalanceCartridgeUiFragment.xaml.cs
@@ -63,8 +63,18 @@ public sealed partial class BalanceCartridgeUiFragment : BoxContainer
         content.AddChild(scroll);
     }
 
-    public void UpdateState(int balance, string accountSuffix, bool paycheckMuted, List<TransactionRecord> transactions)
+    public void UpdateState(int balance, string accountSuffix, bool paycheckMuted, List<TransactionRecord> transactions, bool hasId)
     {
+        _muteButton.Visible = hasId;
+
+        if (!hasId)
+        {
+            BalanceLabel.Text = "-";
+            AccountLabel.Text = Loc.GetString("balance-cartridge-no-id");
+            _transactionList.RemoveAllChildren();
+            return;
+        }
+
         BalanceLabel.Text = balance.ToString();
         AccountLabel.Text = string.IsNullOrEmpty(accountSuffix)
             ? ""

--- a/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
+++ b/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
@@ -1,6 +1,8 @@
 using Content.Server.CartridgeLoader;
 using Content.Shared.CartridgeLoader;
+using Content.Shared.Access.Components;
 using Content.Shared.PDA;
+using Robust.Shared.Containers;
 using Content.Shared.RussStation.Economy;
 using Content.Shared.RussStation.Economy.Components;
 
@@ -17,6 +19,15 @@ public sealed class BalanceCartridgeSystem : EntitySystem
         SubscribeLocalEvent<BalanceCartridgeComponent, CartridgeActivatedEvent>(OnActivated);
         SubscribeLocalEvent<BalanceCartridgeComponent, CartridgeMessageEvent>(OnUiMessage);
         SubscribeLocalEvent<PlayerBalanceComponent, BalanceChangedEvent>(OnBalanceChanged);
+        SubscribeLocalEvent<IdCardComponent, EntGotInsertedIntoContainerMessage>(OnIdContainerChanged);
+        SubscribeLocalEvent<IdCardComponent, EntGotRemovedFromContainerMessage>(OnIdContainerChanged);
+    }
+
+    private void OnIdContainerChanged(EntityUid uid, IdCardComponent comp, ContainerModifiedMessage args)
+    {
+        // The container owner is the PDA (if this ID was inserted/removed from one).
+        if (TryComp<PdaComponent>(args.Container.Owner, out _))
+            UpdateUiState(default, args.Container.Owner);
     }
 
     private void OnUiReady(EntityUid uid, BalanceCartridgeComponent component, CartridgeUiReadyEvent args)

--- a/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
+++ b/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.CartridgeLoader;
 using Content.Shared.CartridgeLoader;
+using Content.Shared.PDA;
 using Content.Shared.RussStation.Economy;
 using Content.Shared.RussStation.Economy.Components;
 
@@ -34,6 +35,9 @@ public sealed class BalanceCartridgeSystem : EntitySystem
             return;
 
         var loaderUid = GetEntity(args.LoaderUid);
+        if (!TryComp<PdaComponent>(loaderUid, out var pda) || pda.ContainedId == null)
+            return;
+
         var holder = Transform(loaderUid).ParentUid;
         if (!TryComp<PlayerBalanceComponent>(holder, out var balance))
             return;
@@ -56,7 +60,14 @@ public sealed class BalanceCartridgeSystem : EntitySystem
 
     private void UpdateUiState(EntityUid uid, EntityUid loaderUid)
     {
-        // The loader (PDA) is held by the mob, which is its transform parent.
+        // Require an ID card to be inserted to show wallet data.
+        if (!TryComp<PdaComponent>(loaderUid, out var pda) || pda.ContainedId == null)
+        {
+            var empty = new BalanceCartridgeUiState(0, string.Empty, false, new List<TransactionRecord>(), false);
+            _cartridgeLoader?.UpdateCartridgeUiState(loaderUid, empty);
+            return;
+        }
+
         var holder = Transform(loaderUid).ParentUid;
         var comp = CompOrNull<PlayerBalanceComponent>(holder);
         var balance = comp?.Balance ?? 0;
@@ -67,7 +78,7 @@ public sealed class BalanceCartridgeSystem : EntitySystem
         var muted = comp?.PaycheckMuted ?? false;
         var transactions = comp?.Transactions ?? new List<TransactionRecord>();
 
-        var state = new BalanceCartridgeUiState(balance, suffix, muted, transactions);
+        var state = new BalanceCartridgeUiState(balance, suffix, muted, transactions, true);
         _cartridgeLoader?.UpdateCartridgeUiState(loaderUid, state);
     }
 }

--- a/Content.Server/RussStation/Economy/PayrollSystem.cs
+++ b/Content.Server/RussStation/Economy/PayrollSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.CartridgeLoader;
+using Content.Shared.PDA;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
 using Content.Shared.RussStation.Economy;
@@ -99,17 +100,16 @@ public sealed class PayrollSystem : EntitySystem
 
     private void PlayPdaChime(EntityUid mob)
     {
-        // Find a PDA held by this mob and play the sound from it.
-        var pdaQuery = EntityQueryEnumerator<CartridgeLoaderComponent>();
-        while (pdaQuery.MoveNext(out var loaderUid, out _))
+        // Find a PDA held by this mob with an ID inserted and play the sound from it.
+        var pdaQuery = EntityQueryEnumerator<PdaComponent, CartridgeLoaderComponent>();
+        while (pdaQuery.MoveNext(out var loaderUid, out var pda, out _))
         {
-            if (Transform(loaderUid).ParentUid == mob)
+            if (Transform(loaderUid).ParentUid == mob && pda.ContainedId != null)
             {
                 _audio.PlayPvs(PaycheckSound, loaderUid);
                 return;
             }
         }
-
     }
 
     /// <summary>

--- a/Content.Shared/RussStation/Economy/BalanceCartridgeUiState.cs
+++ b/Content.Shared/RussStation/Economy/BalanceCartridgeUiState.cs
@@ -9,12 +9,14 @@ public sealed class BalanceCartridgeUiState : BoundUserInterfaceState
     public string AccountSuffix;
     public bool PaycheckMuted;
     public List<TransactionRecord> Transactions;
+    public bool HasId;
 
-    public BalanceCartridgeUiState(int balance, string accountSuffix, bool paycheckMuted, List<TransactionRecord> transactions)
+    public BalanceCartridgeUiState(int balance, string accountSuffix, bool paycheckMuted, List<TransactionRecord> transactions, bool hasId)
     {
         Balance = balance;
         AccountSuffix = accountSuffix;
         PaycheckMuted = paycheckMuted;
         Transactions = transactions;
+        HasId = hasId;
     }
 }

--- a/Resources/Locale/en-US/@RussStation/economy/balance-cartridge.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/balance-cartridge.ftl
@@ -2,6 +2,7 @@ balance-cartridge-program-name = Wallet
 balance-cartridge-account-suffix = Account: ****{$suffix}
 balance-cartridge-mute = Mute Notifications
 balance-cartridge-unmute = Unmute Notifications
+balance-cartridge-no-id = Insert ID card
 balance-cartridge-no-transactions = No transactions yet
 balance-cartridge-tx-header = Recent Transactions
 


### PR DESCRIPTION
## About the PR

Wallet app now requires an ID card to function. Shows "Insert ID card" when no ID is present. All functions disabled without ID: balance display, mute toggle, payroll chime notification.

## Why / Balance

Without this, the wallet cartridge could display stale or incorrect data when no ID card is inserted, and payroll notifications would fire even without a linked account.

## Technical details

- `BalanceCartridgeSystem` checks for ID card presence before pushing UI state
- `BalanceCartridgeUiFragment` shows placeholder message when no ID
- `PayrollSystem` skips chime notification when no ID card in PDA
- Added `HasId` field to `BalanceCartridgeUiState`

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**
:cl:
- fix: Wallet app now requires an ID card to display balance and receive payroll notifications