### PR TITLE
Fix vending prices preferring recipe cost over cargo markup

### DIFF
--- a/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
+++ b/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
@@ -230,25 +230,26 @@ public sealed class VendingPaymentSystem : EntitySystem
 
     /// <summary>
     /// Calculate the raw vending price for an item (before per-vendor minimum).
-    /// Uses max of: recipe material cost × material markup, cargo value × cargo markup.
+    /// Prefers recipe material cost when a recipe exists; falls back to cargo value.
     /// Result is rounded up to nearest 5.
     /// </summary>
     private int GetRawItemPrice(string itemId)
     {
-        var materialPrice = 0.0;
-        var cargoPrice = 0.0;
-
         // Primary: recipe material cost.
         if (_recipeMaterialCosts.TryGetValue(itemId, out var materialCost))
-            materialPrice = materialCost * _vendMaterialMarkup;
+        {
+            var materialPrice = materialCost * _vendMaterialMarkup;
+            return RoundUpTo5((int) Math.Ceiling(materialPrice));
+        }
 
-        // Secondary: cargo estimated value.
+        // Fallback: cargo estimated value.
         if (_proto.TryIndex<EntityPrototype>(itemId, out var proto))
-            cargoPrice = _pricing.GetEstimatedPrice(proto) * _vendCargoMarkup;
+        {
+            var cargoPrice = _pricing.GetEstimatedPrice(proto) * _vendCargoMarkup;
+            return RoundUpTo5((int) Math.Ceiling(cargoPrice));
+        }
 
-        var rawPrice = Math.Max(materialPrice, cargoPrice);
-
-        return RoundUpTo5((int) Math.Ceiling(rawPrice));
+        return 0;
     }
 
     private static int RoundUpTo5(int value)


### PR DESCRIPTION
## About the PR

Vending price calculation now prefers recipe material cost when a lathe recipe exists for the item, falling back to cargo estimated value only for items without recipes.

## Why / Balance

Empty chemistry jugs were costing 90 spesos from the ChemVend because the old logic took the max of recipe cost and cargo value. The jug has `StaticPrice: 60` (for cargo selling), which got multiplied by the 1.5x cargo markup to 90, beating the recipe-based price of 40 (400 Plastic * 0.20 * 0.5 markup).

Recipe material cost is the better signal for "what should this cost to buy" since it reflects what players would actually spend to craft the item. Cargo value reflects what the station can sell it for, which includes margins that shouldn't stack with vending markup.

Most vended items are unaffected since they either have no recipe (filled bottles, food) or their recipe cost already exceeded cargo value (glassware, beverage jugs).

## Technical details

Changed `GetRawItemPrice` in `VendingPaymentSystem.cs` from `Math.Max(materialPrice, cargoPrice)` to an early-return pattern: if a recipe exists, use material cost; otherwise fall back to cargo value.

## Media

N/A, price-only change.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Vending prices now prefer recipe material cost over cargo value markup, making empty containers like chemistry jugs cheaper.
:cl: