### PR TITLE
Fold sound only on user action

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -92,7 +92,8 @@ public sealed class FoldableSystem : EntitySystem
         _buckle.StrapSetEnabled(uid, !component.IsFolded);
 
         //HONK START - Play buckle sound on fold/unfold
-        _audio.PlayPredicted(new Robust.Shared.Audio.SoundPathSpecifier("/Audio/Effects/buckle.ogg"), uid, user);
+        if (user != null)
+            _audio.PlayPredicted(new Robust.Shared.Audio.SoundPathSpecifier("/Audio/Effects/buckle.ogg"), uid, user);
         //HONK END
 
         var ev = new FoldedEvent(folded, user);


### PR DESCRIPTION
## About the PR

Guard fold/unfold sound so it only plays when a user initiates the action, not on entity spawn, component init, or network state sync.

## Why / Balance

The fold sound was playing on unrelated UI interactions because `SetFolded` is called from `OnFoldableInit` (spawn) and `OnHandleState` (state sync) with no `user` parameter. Now only `TrySetFolded` (user-initiated) passes a user, so the sound is gated on that.

## Technical details

Added a `user != null` guard around the `_audio.PlayPredicted` call in `FoldableSystem.SetFolded`.

## Media

N/A (audio fix, no visual changes)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fold sound no longer plays on unrelated UI actions or entity spawn
:cl: