### PR TITLE
Lowpop game ruleset for small servers

### DIFF
--- a/Resources/Prototypes/@RussStation/GameRules/lowpop_events.yml
+++ b/Resources/Prototypes/@RussStation/GameRules/lowpop_events.yml
@@ -1,0 +1,381 @@
+# Lowpop midround event overrides for ~10-15 player servers.
+# These inherit from upstream events and only lower minimumPlayers thresholds.
+
+# === Calm events ===
+
+- type: entity
+  parent: AnomalySpawn
+  id: LowpopAnomalySpawn
+  components:
+    - type: StationEvent
+      startAnnouncementColor: "#18abf5"
+      startAudio:
+        path: /Audio/Announcements/announce.ogg
+      weight: 8
+      duration: 35
+      reoccurrenceDelay: 20
+
+- type: entity
+  parent: BluespaceArtifact
+  id: LowpopBluespaceArtifact
+  components:
+    - type: StationEvent
+      startAnnouncementColor: "#18abf5"
+      startAudio:
+        path: /Audio/Announcements/announce.ogg
+      weight: 8
+      duration: 35
+      reoccurrenceDelay: 20
+
+- type: entity
+  parent: GasLeak
+  id: LowpopGasLeak
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-gas-leak-start-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      endAnnouncement: station-event-gas-leak-end-announcement
+      weight: 8
+      reoccurrenceDelay: 20
+
+- type: entity
+  parent: SolarFlare
+  id: LowpopSolarFlare
+  components:
+    - type: StationEvent
+      weight: 8
+      startAnnouncement: station-event-solar-flare-start-announcement
+      endAnnouncement: station-event-solar-flare-end-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      duration: 120
+      maxDuration: 240
+      reoccurrenceDelay: 20
+
+- type: entity
+  parent: PowerGridCheck
+  id: LowpopPowerGridCheck
+  components:
+    - type: StationEvent
+      weight: 5
+      startAnnouncement: station-event-power-grid-check-start-announcement
+      endAnnouncement: station-event-power-grid-check-end-announcement
+      startAudio:
+        path: /Audio/Announcements/power_off.ogg
+        params:
+          volume: -4
+      duration: 60
+      maxDuration: 120
+      reoccurrenceDelay: 20
+
+- type: entity
+  parent: BreakerFlip
+  id: LowpopBreakerFlip
+  components:
+    - type: StationEvent
+      weight: 7
+      duration: 1
+      minimumPlayers: 10
+
+- type: entity
+  parent: BureaucraticError
+  id: LowpopBureaucraticError
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-bureaucratic-error-announcement
+      minimumPlayers: 15
+      earliestStart: 20
+      weight: 6
+      duration: 1
+
+- type: entity
+  parent: ClericalError
+  id: LowpopClericalError
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-clerical-error-announcement
+      minimumPlayers: 10
+      earliestStart: 20
+      weight: 6
+      duration: 1
+
+- type: entity
+  parent: KudzuGrowth
+  id: LowpopKudzuGrowth
+  components:
+    - type: StationEvent
+      earliestStart: 15
+      minimumPlayers: 10
+
+- type: entity
+  parent: BluespaceLocker
+  id: LowpopBluespaceLocker
+  components:
+    - type: StationEvent
+      weight: 2
+      reoccurrenceDelay: 20
+      earliestStart: 15
+      duration: 1
+
+- type: entity
+  parent: MimicVendorRule
+  id: LowpopMimicVendorRule
+  components:
+    - type: StationEvent
+      earliestStart: 0
+      minimumPlayers: 10
+
+- type: entity
+  parent: VentClog
+  id: LowpopVentClog
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-vent-clog-start-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      earliestStart: 15
+      minimumPlayers: 10
+
+# === Critter hordes ===
+
+- type: entity
+  parent: SlimesSpawnHorde
+  id: LowpopSlimesSpawnHorde
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-vent-creatures-start-horde-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      earliestStart: 20
+      minimumPlayers: 10
+
+- type: entity
+  parent: SnakeSpawnHorde
+  id: LowpopSnakeSpawnHorde
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-vent-creatures-start-horde-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      earliestStart: 20
+      minimumPlayers: 10
+
+- type: entity
+  parent: SpiderSpawnHorde
+  id: LowpopSpiderSpawnHorde
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-vent-creatures-start-horde-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      earliestStart: 20
+      minimumPlayers: 10
+
+- type: entity
+  parent: SpiderClownSpawnHorde
+  id: LowpopSpiderClownSpawnHorde
+  components:
+    - type: StationEvent
+      startAnnouncement: station-event-vent-creatures-start-horde-announcement
+      startAudio:
+        path: /Audio/Announcements/attention.ogg
+      earliestStart: 20
+      minimumPlayers: 10
+
+# === Basic antag events ===
+
+- type: entity
+  parent: RevenantSpawn
+  id: LowpopRevenantSpawn
+  components:
+    - type: StationEvent
+      weight: 7.5
+      duration: 1
+      earliestStart: 45
+      minimumPlayers: 10
+
+- type: entity
+  parent: DerelictSyndicateAssaultCyborgSpawn
+  id: LowpopDerelictSyndicateAssaultCyborgSpawn
+  components:
+    - type: StationEvent
+      weight: 2.5
+      earliestStart: 25
+      reoccurrenceDelay: 20
+      minimumPlayers: 10
+      duration: null
+
+# === Moderate antag events ===
+
+- type: entity
+  parent: DragonSpawn
+  id: LowpopDragonSpawn
+  components:
+    - type: StationEvent
+      weight: 6.5
+      earliestStart: 40
+      reoccurrenceDelay: 20
+      minimumPlayers: 12
+
+- type: entity
+  parent: NinjaSpawn
+  id: LowpopNinjaSpawn
+  components:
+    - type: StationEvent
+      weight: 6
+      duration: null
+      earliestStart: 30
+      reoccurrenceDelay: 20
+      minimumPlayers: 15
+
+- type: entity
+  parent: ParadoxCloneSpawn
+  id: LowpopParadoxCloneSpawn
+  components:
+    - type: StationEvent
+      weight: 5
+      duration: null
+      earliestStart: 20
+      reoccurrenceDelay: 20
+      minimumPlayers: 10
+
+- type: entity
+  parent: SleeperAgents
+  id: LowpopSleeperAgents
+  components:
+    - type: StationEvent
+      earliestStart: 30
+      weight: 8
+      minimumPlayers: 10
+
+- type: entity
+  parent: LoneOpsSpawn
+  id: LowpopLoneOpsSpawn
+  components:
+    - type: StationEvent
+      earliestStart: 35
+      weight: 5.5
+      minimumPlayers: 12
+
+# === Pest events ===
+
+- type: entity
+  parent: KingRatMigration
+  id: LowpopKingRatMigration
+  components:
+    - type: StationEvent
+      earliestStart: 15
+      weight: 6
+      duration: 50
+      minimumPlayers: 15
+
+- type: entity
+  parent: SnailMigration
+  id: LowpopSnailMigration
+  components:
+    - type: StationEvent
+      earliestStart: 15
+      weight: 6
+      duration: 50
+      minimumPlayers: 15
+
+# === Lowpop event tables ===
+
+- type: entityTable
+  id: LowpopCalmEventsTable
+  table: !type:AllSelector
+    children:
+      - id: LowpopAnomalySpawn
+      - id: LowpopBluespaceArtifact
+      - id: LowpopBluespaceLocker
+      - id: LowpopBreakerFlip
+      - id: LowpopBureaucraticError
+      - id: LowpopClericalError
+      - id: CockroachMigration
+      - id: LowpopGasLeak
+      - id: IonStorm
+      - id: LowpopKudzuGrowth
+      - id: MassHallucinations
+      - id: LowpopMimicVendorRule
+      - id: MouseMigration
+      - id: LowpopPowerGridCheck
+      - id: RandomSentience
+      - id: LowpopSlimesSpawnHorde
+      - id: LowpopSolarFlare
+      - id: LowpopSnakeSpawnHorde
+      - id: LowpopSpiderClownSpawnHorde
+      - id: LowpopSpiderSpawnHorde
+      - id: LowpopVentClog
+
+- type: entityTable
+  id: LowpopAntagEventsTable
+  table: !type:AllSelector
+    children:
+      - id: ClosetSkeleton
+      - id: LowpopRevenantSpawn
+      - !type:NestedSelector
+        tableId: LowpopDerelictBorgEventTable
+
+- type: entityTable
+  id: LowpopDerelictBorgEventTable
+  table: !type:GroupSelector
+    children:
+      - !type:GroupSelector
+        weight: 85
+        children:
+          - id: DerelictEngineerCyborgSpawn
+          - id: DerelictGenericCyborgSpawn
+          - id: DerelictJanitorCyborgSpawn
+          - id: DerelictMedicalCyborgSpawn
+          - id: DerelictMiningCyborgSpawn
+      - !type:GroupSelector
+        weight: 15
+        children:
+          - id: LowpopDerelictSyndicateAssaultCyborgSpawn
+
+- type: entityTable
+  id: LowpopModerateAntagEventsTable
+  table: !type:AllSelector
+    children:
+      - id: LowpopDragonSpawn
+      - id: LowpopNinjaSpawn
+      - id: LowpopParadoxCloneSpawn
+      - id: LowpopSleeperAgents
+      - id: LowpopLoneOpsSpawn
+      - !type:NestedSelector
+        tableId: LowpopDerelictBorgEventTable
+
+- type: entityTable
+  id: LowpopPestEventsTable
+  table: !type:AllSelector
+    children:
+      - id: LowpopKingRatMigration
+      - id: LowpopSnailMigration
+
+- type: entityTable
+  id: LowpopGameRulesTable
+  table: !type:AllSelector
+    children:
+      - !type:NestedSelector
+        tableId: LowpopCalmEventsTable
+      - !type:NestedSelector
+        tableId: LowpopAntagEventsTable
+      - !type:NestedSelector
+        tableId: LowpopModerateAntagEventsTable
+      - !type:NestedSelector
+        tableId: CargoGiftsTable
+      - !type:NestedSelector
+        tableId: CalmPestEventsTable
+      - !type:NestedSelector
+        tableId: LowpopPestEventsTable
+
+# === Lowpop scheduler ===
+
+- type: entity
+  id: LowpopBasicStationEventScheduler
+  parent: BaseGameRule
+  components:
+    - type: BasicStationEventScheduler
+      scheduledGameRules: !type:NestedSelector
+        tableId: LowpopGameRulesTable

--- a/Resources/Prototypes/@RussStation/GameRules/lowpop_presets.yml
+++ b/Resources/Prototypes/@RussStation/GameRules/lowpop_presets.yml
@@ -1,0 +1,73 @@
+# Lowpop game presets for ~10-15 player servers.
+# Use by setting the CVar: game.secret_weight_prototype = LowpopSecret
+
+- type: gamePreset
+  id: LowpopTraitor
+  alias:
+    - lowpoptraitor
+  name: traitor-title
+  description: traitor-description
+  showInVote: false
+  rules:
+    - DummyNonAntagChance
+    - LowpopTraitor
+    - SubGamemodesRuleNoWizard
+    - LowpopBasicStationEventScheduler
+    - MeteorSwarmMildScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: LowpopRevolutionary
+  alias:
+    - lowpoprev
+  name: rev-title
+  description: rev-description
+  showInVote: false
+  rules:
+    - DummyNonAntagChance
+    - LowpopRevolutionary
+    - SubGamemodesRuleNoWizard
+    - LowpopBasicStationEventScheduler
+    - MeteorSwarmMildScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: LowpopChangeling
+  alias:
+    - lowpopchangeling
+  name: changeling-title
+  description: changeling-description
+  showInVote: false
+  rules:
+    - DummyNonAntagChance
+    - LowpopChangeling
+    - SubGamemodesRuleNoWizard
+    - LowpopBasicStationEventScheduler
+    - MeteorSwarmMildScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: LowpopZombie
+  alias:
+    - lowpopzombie
+  name: zombie-title
+  description: zombie-description
+  showInVote: false
+  rules:
+    - LowpopZombie
+    - LowpopBasicStationEventScheduler
+    - MeteorSwarmMildScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: weightedRandom
+  id: LowpopSecret
+  weights:
+    LowpopTraitor: 0.55
+    LowpopRevolutionary: 0.15
+    LowpopChangeling: 0.10
+    LowpopZombie: 0.10
+    Survival: 0.10

--- a/Resources/Prototypes/@RussStation/GameRules/lowpop_roundstart.yml
+++ b/Resources/Prototypes/@RussStation/GameRules/lowpop_roundstart.yml
@@ -1,0 +1,113 @@
+# Lowpop antag rules for ~10-15 player servers.
+# These inherit from upstream rules and only override minPlayers + antag ratios.
+
+- type: entity
+  parent: Traitor
+  id: LowpopTraitor
+  components:
+    - type: GameRule
+      minPlayers: 5
+    - type: AntagSelection
+      selectionTime: IntraPlayerSpawn
+      definitions:
+        - prefRoles: [Traitor]
+          max: 5
+          playerRatio: 4
+          blacklist:
+            components:
+              - AntagImmune
+          lateJoinAdditional: false
+          mindRoles:
+            - MindRoleTraitor
+
+- type: entity
+  parent: Revolutionary
+  id: LowpopRevolutionary
+  components:
+    - type: GameRule
+      minPlayers: 8
+    - type: AntagSelection
+      selectionTime: IntraPlayerSpawn
+      definitions:
+        - prefRoles: [HeadRev]
+          max: 2
+          playerRatio: 10
+          briefing:
+            text: head-rev-role-greeting
+            color: CornflowerBlue
+            sound: "/Audio/Ambience/Antag/headrev_start.ogg"
+          startingGear: HeadRevGear
+          components:
+            - type: Revolutionary
+            - type: HeadRevolutionary
+          mindRoles:
+            - MindRoleHeadRevolutionary
+
+- type: entity
+  parent: Changeling
+  id: LowpopChangeling
+  components:
+    - type: GameRule
+      minPlayers: 10
+    - type: AntagSelection
+      agentName: changeling-round-end-agent-name
+      selectionTime: IntraPlayerSpawn
+      definitions:
+        - prefRoles: [Changeling]
+          max: 2
+          playerRatio: 10
+          briefing:
+            text: changeling-role-greeting
+            color: Red
+            sound: /Audio/Ambience/Antag/changeling_start.ogg
+          components:
+            - type: ChangelingDevour
+            - type: ChangelingIdentity
+            - type: ChangelingTransform
+            - type: ActionGrant
+              actions:
+                - ActionChangelingStore
+            - type: Store
+              name: store-preset-name-changeling
+              categories:
+                - ChangelingAbilities
+              currencyWhitelist:
+                - ChangelingDNA
+              balance:
+                ChangelingDNA: 50
+            - type: UserInterface
+              interfaces:
+                enum.StoreUiKey.Key:
+                  type: StoreBoundUserInterface
+                  requireInputValidation: false
+          mindRoles:
+            - MindRoleChangeling
+
+- type: entity
+  parent: Zombie
+  id: LowpopZombie
+  components:
+    - type: GameRule
+      minPlayers: 10
+    - type: AntagSelection
+      agentName: zombie-round-end-agent-name
+      selectionTime: IntraPlayerSpawn
+      definitions:
+        - prefRoles: [InitialInfected]
+          max: 3
+          playerRatio: 10
+          blacklist:
+            components:
+              - ZombieImmune
+              - AntagImmune
+          briefing:
+            text: zombie-patientzero-role-greeting
+            color: Plum
+            sound: "/Audio/Ambience/Antag/zombie_start.ogg"
+          components:
+            - type: PendingZombie
+            - type: ZombifyOnDeath
+            - type: IncurableZombie
+            - type: InitialInfected
+          mindRoles:
+            - MindRoleInitialInfected

--- a/Resources/Prototypes/@RussStation/GameRules/lowpop_roundstart.yml
+++ b/Resources/Prototypes/@RussStation/GameRules/lowpop_roundstart.yml
@@ -90,7 +90,6 @@
     - type: GameRule
       minPlayers: 10
     - type: AntagSelection
-      agentName: zombie-round-end-agent-name
       selectionTime: IntraPlayerSpawn
       definitions:
         - prefRoles: [InitialInfected]


### PR DESCRIPTION
## About the PR

Adds a complete lowpop game ruleset designed for servers with ~10-15 average players. Activated via CVar without requiring any upstream file changes.

## Why / Balance

On a low-population server, most midround events are blocked by high `minimumPlayers` thresholds, causing the few eligible events (BluespaceLocker, PowerGridCheck, meteors) to fire disproportionately often. This creates repetitive, frustrating rounds.

This PR fixes that by:
- Lowering `minimumPlayers` on most events to expand the pool
- Adding 20-minute `reoccurrenceDelay` to events that lacked one (prevents spam in 90-min rounds)
- Swapping to mild meteor scheduler (dust + small swarms only, no rods)
- Tightening roundstart antag ratios (Traitor 1:4, others 1:10) so lowpop rounds still get antags
- Excluding overly disruptive events: GreytideVirus, ZombieOutbreak, WizardSpawn

## Technical details

Three new files under `Resources/Prototypes/@RussStation/GameRules/`:

- **lowpop_roundstart.yml** - Roundstart antag rules (LowpopTraitor, LowpopRevolutionary, LowpopChangeling, LowpopZombie) inheriting upstream rules with lower minPlayers and adjusted ratios
- **lowpop_events.yml** - ~20 midround event overrides with lowered minimumPlayers, reoccurrence delays, and adjusted weights. Includes all event tables and the LowpopBasicStationEventScheduler
- **lowpop_presets.yml** - Four game presets using lowpop schedulers/rules, plus `LowpopSecret` weighted random (55% Traitor, 15% Rev, 10% Changeling, 10% Zombie, 10% Survival)

Activation: set `game.secret_weight_prototype = LowpopSecret` in server config alongside `game.defaultpreset = "secret"`.

No upstream files modified.

## Media

N/A (prototype-only changes, no visual changes)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Lowpop game ruleset for small servers (~10-15 players). Activate with game.secret_weight_prototype = LowpopSecret.
: