### PR TITLE
Document sub-branch workflow for feature PR bug fixes

### DIFF
--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -10,19 +10,22 @@ upstream/stable   <- mirrors wizden/stable (read-only)
        v
     release        <- our deployable branch (upstream + tested fork additions)
        |
-       ├── feat/X     <- individual feature/fix branches (PR targets release)
+       ├── feat/X          <- feature branches (PR targets release)
+       │    ├── fix/123-bug-description   <- sub-branches (PR targets feat/X)
+       │    └── fix/124-other-bug
        ├── fix/Y
        └── feat/Z
 ```
 
 ## Remotes
 
-| Remote | URL | Purpose |
-|--------|-----|---------|
-| `origin` | `github.com/HellWatcher/honksquad-ss14` | Our fork |
+| Remote   | URL                                         | Purpose  |
+| -------- | ------------------------------------------- | -------- |
+| `origin` | `github.com/HellWatcher/honksquad-ss14`     | Our fork |
 | `wizden` | `github.com/space-wizards/space-station-14` | Upstream |
 
 To add the wizden remote locally:
+
 ```bash
 git remote add wizden https://github.com/space-wizards/space-station-14.git
 ```
@@ -40,8 +43,8 @@ git remote add wizden https://github.com/space-wizards/space-station-14.git
 
 - **Purpose:** The primary deployable branch. Contains all tested fork additions on top of the upstream base.
 - **Updates:** Receives merges from:
-  1. `upstream/stable` (when syncing to a new Wizden stable)
-  2. Feature/fix PRs (after review and testing)
+    1. `upstream/stable` (when syncing to a new Wizden stable)
+    2. Feature/fix PRs (after review and testing)
 - **Protected:** Yes. PRs required.
 
 ### `staging` (created as needed)
@@ -57,6 +60,17 @@ git remote add wizden https://github.com/space-wizards/space-station-14.git
 - **PRs target:** `release`.
 - **Deleted after merge.**
 
+### Sub-Branches (Bug Fixes Within a Feature)
+
+When a feature PR has bugs or follow-up work tracked as issues, each fix gets its own branch off the feature branch, not off `release`.
+
+- **Naming:** `fix/<issue-number>-<short-description>` (e.g., `fix/305-autosurgeon-access`)
+- **Based on:** The parent feature branch (e.g., `feat/cybernetic-organs`).
+- **PRs target:** The parent feature branch, not `release`.
+- **Deleted after merge into the parent branch.**
+
+This keeps each fix reviewable in isolation while the parent feature PR stays as the rollup into `release`. The parent PR accumulates all merged sub-branch work automatically.
+
 ## Workflows
 
 ### Starting New Work
@@ -68,32 +82,48 @@ git checkout -b feat/my-feature origin/release
 # Open PR targeting release
 ```
 
+### Fixing Bugs in a Feature Branch
+
+When a feature PR has tracked bugs, create a sub-branch per issue:
+
+```bash
+git fetch origin feat/my-feature
+git checkout -b fix/123-bug-description origin/feat/my-feature
+# ... fix the bug, commit, push ...
+# Open PR targeting feat/my-feature (not release)
+gh pr create --base feat/my-feature --repo HellWatcher/honksquad-ss14
+```
+
+After the fix PR merges, the parent feature branch picks up the changes. Repeat for each bug. The parent feature PR into `release` is the final integration point.
+
 ### Syncing Upstream (Wizden Update)
 
 1. **Fetch and update the upstream mirror:**
-   ```bash
-   git fetch wizden stable
-   git checkout upstream/stable
-   git reset --hard wizden/stable
-   # Temporarily disable force-push protection, then:
-   git push --force origin upstream/stable
-   # Re-enable protection
-   ```
+
+    ```bash
+    git fetch wizden stable
+    git checkout upstream/stable
+    git reset --hard wizden/stable
+    # Temporarily disable force-push protection, then:
+    git push --force origin upstream/stable
+    # Re-enable protection
+    ```
 
 2. **Merge upstream into release:**
-   ```bash
-   git checkout release
-   git merge upstream/stable
-   # Resolve conflicts
-   git push origin release
-   ```
+
+    ```bash
+    git checkout release
+    git merge upstream/stable
+    # Resolve conflicts
+    git push origin release
+    ```
 
 3. **Rebase open feature branches** (if needed):
-   ```bash
-   git checkout feat/my-feature
-   git rebase origin/release
-   git push --force-with-lease origin feat/my-feature
-   ```
+    ```bash
+    git checkout feat/my-feature
+    git rebase origin/release
+    git push --force-with-lease origin feat/my-feature
+    ```
 
 ### Handling Upstream Conflicts
 
@@ -104,9 +134,9 @@ git checkout -b feat/my-feature origin/release
 
 ## Branch Protection Rules
 
-| Branch | Direct Push | Force Push | PR Required |
-|--------|------------|------------|-------------|
-| `upstream/stable` | No | Maintainers (during sync) | No |
-| `release` | No | No | Yes |
-| `staging` | Yes | Yes | No |
-| `feat/*` / `fix/*` | Author | Yes (with lease) | N/A |
+| Branch             | Direct Push | Force Push                | PR Required |
+| ------------------ | ----------- | ------------------------- | ----------- |
+| `upstream/stable`  | No          | Maintainers (during sync) | No          |
+| `release`          | No          | No                        | Yes         |
+| `staging`          | Yes         | Yes                       | No          |
+| `feat/*` / `fix/*` | Author      | Yes (with lease)          | N/A         |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,18 @@ Fork-specific files live under `@RussStation` prefixed directories so they never
 - `Resources/Audio/@RussStation/` for sound files
 - `Content.Shared/RussStation/`, `Content.Server/RussStation/`, `Content.Client/RussStation/` for C#
 
+## Bug fixes within feature PRs
+
+When a feature PR has bugs tracked as issues, each fix gets its own branch off the feature branch (not off `release`). The fix PR targets the feature branch, not `release`.
+
+```
+feat/my-feature        <- parent PR targets release
+  ├── fix/123-some-bug   <- PR targets feat/my-feature
+  └── fix/124-other-bug  <- PR targets feat/my-feature
+```
+
+This keeps fixes reviewable in isolation. The parent feature PR rolls everything up into `release`. See [BRANCHING.md](BRANCHING.md) for the full workflow.
+
 ## Pull requests
 
 Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) and fill in all sections. Follow the upstream [PR guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).


### PR DESCRIPTION
## About the PR

Documents the sub-branch workflow pattern where bugs within a feature PR each get their own branch off the feature branch, with fix PRs targeting the feature branch instead of release.

## Why / Balance

We needed a clear, repeatable workflow for fixing bugs in open feature PRs (like #298). This pattern keeps fixes reviewable in isolation while the parent PR stays as the rollup into release.

## Technical details

- **BRANCHING.md**: Added sub-branch diagram, "Sub-Branches" section, and "Fixing Bugs in a Feature Branch" workflow with example commands
- **CONTRIBUTING.md**: Added "Bug fixes within feature PRs" section with the branch pattern and link to BRANCHING.md

## Media

N/A (docs only)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.