### PR TITLE
Fix AutosurgeonSystem [Access] violation on OrganComponent

### DIFF
--- a/Content.Shared/Body/OrganComponent.cs
+++ b/Content.Shared/Body/OrganComponent.cs
@@ -9,8 +9,8 @@ namespace Content.Shared.Body;
 /// </summary>
 /// <seealso cref="BodySystem" />
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-//HONK START - Surgery system needs to read organ Category
-[Access(typeof(BodySystem), typeof(SharedSurgerySystem))]
+//HONK START - Fork systems need to read organ Category
+[Access(typeof(BodySystem), typeof(SharedSurgerySystem), Other = AccessPermissions.ReadExecute)]
 //HONK END
 public sealed partial class OrganComponent : Component
 {


### PR DESCRIPTION
## About the PR

Fixes `AutosurgeonSystem` triggering a debug assertion when reading `OrganComponent.Category` to find the existing organ to replace.

## Why / Balance

The `[Access]` attribute on `OrganComponent` only allowed `BodySystem` and `SharedSurgerySystem`. Any other system reading fields (like `Category`) would hit a runtime assertion in debug builds. Rather than adding each new fork system individually (which requires modifying this upstream file each time), this opens read access broadly while keeping write access restricted.

Closes #305

## Technical details

Changed the HONK marker on `OrganComponent`'s `[Access]` attribute to add `Other = AccessPermissions.ReadExecute`. This allows any system to read organ fields while write access remains locked to `BodySystem` and `SharedSurgerySystem`.

Single line change in `Content.Shared/Body/OrganComponent.cs`.

## Media

N/A, no visual changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.