### PR TITLE
Fix: Replace non-functional speed buff with epinephrine auto-inject

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticHeartSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticHeartSystem.cs
@@ -1,0 +1,64 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Timing;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Auto-injects epinephrine into the host's bloodstream when they enter crit,
+/// if they have an advanced cybernetic heart with <see cref="CyberneticHeartComponent"/>.
+/// </summary>
+public sealed class CyberneticHeartSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BodyComponent, MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    private void OnMobStateChanged(EntityUid uid, BodyComponent body, MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Critical)
+            return;
+
+        if (body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!TryComp<CyberneticHeartComponent>(organ, out var heart))
+                continue;
+
+            TryInjectEpinephrine(uid, organ, heart);
+            break;
+        }
+    }
+
+    private void TryInjectEpinephrine(EntityUid body, EntityUid organ, CyberneticHeartComponent heart)
+    {
+        var now = _timing.CurTime;
+
+        if (heart.LastInjection != null && now - heart.LastInjection.Value < heart.Cooldown)
+            return;
+
+        var solution = new Solution(heart.Reagent, heart.InjectAmount);
+        if (!_bloodstream.TryAddToBloodstream(body, solution))
+            return;
+
+        heart.LastInjection = now;
+        Dirty(organ, heart);
+
+        _popup.PopupEntity(
+            Loc.GetString("cybernetic-heart-inject"),
+            body, body, PopupType.MediumCaution);
+    }
+}

--- a/Content.Shared/RussStation/Body/CyberneticHeartComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticHeartComponent.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// When attached to an organ inside a body, auto-injects epinephrine
+/// into the host's bloodstream when they enter crit.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CyberneticHeartComponent : Component
+{
+    [DataField]
+    public ProtoId<ReagentPrototype> Reagent = "Epinephrine";
+
+    [DataField]
+    public FixedPoint2 InjectAmount = FixedPoint2.New(10);
+
+    /// <summary>
+    /// Minimum time between auto-injections.
+    /// </summary>
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// When the last injection occurred. Tracked on the component so it
+    /// survives across system updates.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan? LastInjection;
+}

--- a/Resources/Locale/en-US/@RussStation/medical/cybernetic-heart.ftl
+++ b/Resources/Locale/en-US/@RussStation/medical/cybernetic-heart.ftl
@@ -1,0 +1,1 @@
+cybernetic-heart-inject = You feel a sharp jolt as your cybernetic heart injects emergency epinephrine!

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -73,9 +73,7 @@
       tier: Advanced
       empEffect: CardiacArrest
       empVulnerability: 0.5
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 2.6
-      baseSprintSpeed: 4.6
+    - type: CyberneticHeart
 
 # ============================================================
 # LUNGS - EmpEffect: BreathingFailure


### PR DESCRIPTION
## About the PR

Fixes the advanced cybernetic heart's passive ability. The `MovementSpeedModifier` component doesn't work when attached to an organ entity (it needs to be on the mob). Replaced with an epinephrine auto-inject system inspired by SS13's cybernetic heart.

## Why / Balance

- Advanced heart now auto-injects 10u epinephrine when the host enters crit
- 120 second cooldown prevents abuse
- Gives a meaningful survival edge without being overpowered (epinephrine stabilizes but doesn't heal much)
- Only the advanced tier gets this ability, basic/standard hearts are purely functional replacements

## Technical details

- New `CyberneticHeartComponent` (Shared) stores reagent, amount, cooldown, and last injection time
- New `CyberneticHeartSystem` (Server) listens for `MobStateChangedEvent`, checks organs for the component, injects via `BloodstreamSystem`
- Removed `MovementSpeedModifier` from `OrganCyberneticHeartAdvanced`, added `CyberneticHeart` component instead

## Media

N/A (internal system, no visual changes)

## Requirements

- [x] Builds with 0 errors

## Breaking changes

None

## Changelog

:cl:
- fix: Advanced cybernetic heart now auto-injects epinephrine on crit instead of a non-functional speed buff