### PR TITLE
feat: deafness system with chat obfuscation

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Players;
 using Content.Shared.Players.RateLimiting;
 using Content.Shared.Radio;
+using Content.Shared.RussStation.Hearing; //HONK
 using Content.Shared.Station.Components;
 using Content.Shared.Whitelist;
 using Robust.Server.Player;
@@ -496,6 +497,14 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
+            //HONK START - Deafness: deaf listeners can't make out whispers at all
+            if (TryComp<DeafableComponent>(listener, out var whisperDeafable) && whisperDeafable.IsDeaf)
+            {
+                _chatManager.ChatMessageToOne(ChatChannel.Whisper, obfuscatedMessage, wrappedUnknownMessage, source, false, session.Channel);
+                continue;
+            }
+            //HONK END
+
             if (data.Range <= WhisperClearRange || data.Observer)
                 _chatManager.ChatMessageToOne(ChatChannel.Whisper, message, wrappedMessage, source, false, session.Channel);
             //If listener is too far, they only hear fragments of the message
@@ -667,12 +676,31 @@ public sealed partial class ChatSystem : SharedChatSystem
     /// </summary>
     private void SendInVoiceRange(ChatChannel channel, string message, string wrappedMessage, EntityUid source, ChatTransmitRange range, NetUserId? author = null)
     {
+        //HONK START - Deafness: obfuscate messages for deaf recipients
+        string? deafMessage = null;
+        string? deafWrapped = null;
+        //HONK END
+
         foreach (var (session, data) in GetRecipients(source, VoiceRange))
         {
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)
                 continue;
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
+
+            //HONK START - Deafness: send obfuscated message to deaf recipients
+            if (session.AttachedEntity is { Valid: true } listener
+                && TryComp<DeafableComponent>(listener, out var deafable)
+                && deafable.IsDeaf)
+            {
+                deafMessage ??= ObfuscateMessageReadability(message, 0.2f);
+                deafWrapped ??= Loc.GetString("chat-manager-entity-deaf-wrap-message",
+                    ("message", FormattedMessage.EscapeText(deafMessage)));
+                _chatManager.ChatMessageToOne(channel, deafMessage, deafWrapped, source, entHideChat, session.Channel, author: author);
+                continue;
+            }
+            //HONK END
+
             _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author);
         }
 

--- a/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
@@ -22,7 +22,7 @@ public sealed class CyberneticEmpSystem : EntitySystem
 
     private static readonly ProtoId<DamageTypePrototype> ShockDamageType = "Shock";
     private static readonly EntProtoId DrowsinessEffect = "StatusEffectDrowsiness";
-    private static readonly EntProtoId SlurredEffect = "StatusEffectSlurred";
+    private static readonly EntProtoId DeafnessEffect = "StatusEffectTemporaryDeafness";
 
     public override void Initialize()
     {
@@ -70,7 +70,7 @@ public sealed class CyberneticEmpSystem : EntitySystem
                 break;
 
             case CyberneticEmpEffect.Deafen:
-                _statusEffects.TryAddStatusEffectDuration(body, SlurredEffect, duration);
+                _statusEffects.TryAddStatusEffectDuration(body, DeafnessEffect, duration);
                 break;
 
             case CyberneticEmpEffect.None:

--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -35,8 +35,8 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         // Eyes: flash protection
         SubscribeLocalEvent<BodyComponent, FlashAttemptEvent>(OnFlashAttempt);
 
-        // Lungs: toxic gas filtering (must run before RespiratorSystem relays to lungs)
-        SubscribeLocalEvent<BodyComponent, InhaledGasEvent>(OnInhaledGas,
+        // Lungs: toxic gas filtering (runs on the organ via relay, before RespiratorSystem processes it)
+        SubscribeLocalEvent<CyberneticLungsComponent, BodyRelayedEvent<InhaledGasEvent>>(OnInhaledGas,
             before: [typeof(RespiratorSystem)]);
 
         // Stomach: nutrient efficiency (reduced hunger decay)
@@ -114,22 +114,9 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
     /// </summary>
     private static readonly Gas[] SafeGases = [Gas.Oxygen, Gas.Nitrogen, Gas.WaterVapor];
 
-    private void OnInhaledGas(EntityUid uid, BodyComponent body, ref InhaledGasEvent args)
+    private void OnInhaledGas(Entity<CyberneticLungsComponent> ent, ref BodyRelayedEvent<InhaledGasEvent> args)
     {
-        if (body.Organs == null)
-            return;
-
-        CyberneticLungsComponent? lungs = null;
-        foreach (var organ in body.Organs.ContainedEntities)
-        {
-            if (TryComp(organ, out lungs))
-                break;
-        }
-
-        if (lungs == null)
-            return;
-
-        var gas = args.Gas;
+        var gas = args.Args.Gas;
         foreach (var gasId in Enum.GetValues<Gas>())
         {
             if (Array.IndexOf(SafeGases, gasId) >= 0)
@@ -139,7 +126,7 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
             if (moles <= 0f)
                 continue;
 
-            gas.SetMoles(gasId, moles * (1f - lungs.FilterFraction));
+            gas.SetMoles(gasId, moles * (1f - ent.Comp.FilterFraction));
         }
     }
 

--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Body;
+using Content.Shared.RussStation.Hearing.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Body;
@@ -41,6 +42,9 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         // Stomach: nutrient efficiency (reduced hunger decay)
         SubscribeLocalEvent<CyberneticStomachComponent, OrganGotInsertedEvent>(OnStomachInserted);
         SubscribeLocalEvent<CyberneticStomachComponent, OrganGotRemovedEvent>(OnStomachRemoved);
+
+        // Ears: deafness resistance
+        SubscribeLocalEvent<BodyComponent, CanHearAttemptEvent>(OnCanHearAttempt);
     }
 
     // ================================================================
@@ -159,5 +163,24 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
             return;
 
         _hunger.SetBaseDecayRate(body, hunger.BaseDecayRate * modifier, hunger);
+    }
+
+    // ================================================================
+    // Ears — deafness resistance
+    // ================================================================
+
+    private void OnCanHearAttempt(EntityUid uid, BodyComponent body, CanHearAttemptEvent args)
+    {
+        if (body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (HasComp<CyberneticEarsComponent>(organ))
+            {
+                args.Uncancel();
+                return;
+            }
+        }
     }
 }

--- a/Content.Shared/RussStation/Body/CyberneticEarsComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticEarsComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker component for advanced cybernetic ears.
+/// While the organ is implanted, cancels deafness attempts (deafness resistance).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CyberneticEarsComponent : Component
+{
+}

--- a/Content.Shared/RussStation/Hearing/DeafableComponent.cs
+++ b/Content.Shared/RussStation/Hearing/DeafableComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Component for entities that can be deafened.
+/// Analogous to <see cref="Content.Shared.Eye.Blinding.Components.BlindableComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(DeafableSystem))]
+public sealed partial class DeafableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool IsDeaf;
+}

--- a/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Inventory;
+using Content.Shared.Rejuvenate;
+
+namespace Content.Shared.RussStation.Hearing.Systems;
+
+/// <summary>
+/// Manages the IsDeaf state on DeafableComponent by raising CanHearAttemptEvent.
+/// TODO: Integrate with language system so deaf entities lose spoken languages but retain sign language.
+/// </summary>
+public sealed class DeafableSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<DeafableComponent, RejuvenateEvent>(OnRejuvenate);
+    }
+
+    private void OnRejuvenate(Entity<DeafableComponent> ent, ref RejuvenateEvent args)
+    {
+        UpdateIsDeaf((ent.Owner, (DeafableComponent?) ent.Comp));
+    }
+
+    public void UpdateIsDeaf(Entity<DeafableComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp, false))
+            return;
+
+        var old = entity.Comp.IsDeaf;
+
+        var ev = new CanHearAttemptEvent();
+        RaiseLocalEvent(entity.Owner, ev);
+        entity.Comp.IsDeaf = ev.Deaf;
+
+        if (old == entity.Comp.IsDeaf)
+            return;
+
+        var changeEv = new DeafnessChangedEvent(entity.Comp.IsDeaf);
+        RaiseLocalEvent(entity.Owner, ref changeEv);
+        Dirty(entity);
+    }
+}
+
+[ByRefEvent]
+public record struct DeafnessChangedEvent(bool Deaf);
+
+/// <summary>
+/// Raised directed at an entity to check whether it can currently hear.
+/// Cancel to make the entity deaf.
+/// </summary>
+public sealed class CanHearAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
+{
+    public bool Deaf => Cancelled;
+    public SlotFlags TargetSlots => SlotFlags.EARS | SlotFlags.HEAD | SlotFlags.MASK;
+}

--- a/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
@@ -1,12 +1,7 @@
-using Content.Shared.StatusEffect;
-using Robust.Shared.Prototypes;
-
 namespace Content.Shared.RussStation.Hearing.Systems;
 
 public sealed class TemporaryDeafnessSystem : EntitySystem
 {
-    public static readonly ProtoId<StatusEffectPrototype> DeafnessStatusEffect = "TemporaryDeafness";
-
     [Dependency] private readonly DeafableSystem _deafable = default!;
 
     public override void Initialize()

--- a/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
@@ -1,0 +1,36 @@
+using Content.Shared.StatusEffect;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Hearing.Systems;
+
+public sealed class TemporaryDeafnessSystem : EntitySystem
+{
+    public static readonly ProtoId<StatusEffectPrototype> DeafnessStatusEffect = "TemporaryDeafness";
+
+    [Dependency] private readonly DeafableSystem _deafable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TemporaryDeafnessComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<TemporaryDeafnessComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<TemporaryDeafnessComponent, CanHearAttemptEvent>(OnTryHear);
+    }
+
+    private void OnStartup(EntityUid uid, TemporaryDeafnessComponent component, ComponentStartup args)
+    {
+        _deafable.UpdateIsDeaf(uid);
+    }
+
+    private void OnShutdown(EntityUid uid, TemporaryDeafnessComponent component, ComponentShutdown args)
+    {
+        _deafable.UpdateIsDeaf(uid);
+    }
+
+    private void OnTryHear(EntityUid uid, TemporaryDeafnessComponent component, CanHearAttemptEvent args)
+    {
+        if (component.LifeStage <= ComponentLifeStage.Running)
+            args.Cancel();
+    }
+}

--- a/Content.Shared/RussStation/Hearing/TemporaryDeafnessComponent.cs
+++ b/Content.Shared/RussStation/Hearing/TemporaryDeafnessComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Component applied by the TemporaryDeafness status effect.
+/// While present, the entity cannot hear.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TemporaryDeafnessComponent : Component
+{
+}

--- a/Resources/Locale/en-US/@RussStation/hearing/deafness.ftl
+++ b/Resources/Locale/en-US/@RussStation/hearing/deafness.ftl
@@ -1,0 +1,1 @@
+chat-manager-entity-deaf-wrap-message = [italic][font size=10]You can barely make out: "[BubbleContent]{$message}[/BubbleContent]"[/font][/italic]

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -390,7 +390,7 @@
   parent: [OrganBase, OrganCyberneticInternal]
   id: OrganCyberneticEarsAdvanced
   name: advanced cybernetic ears
-  description: Premium cybernetic ears with sound filtering capabilities.
+  description: Advanced cybernetic ears with built-in deafness resistance.
   components:
     - type: Organ
       category: Ears
@@ -401,3 +401,4 @@
       tier: Advanced
       empEffect: Deafen
       empVulnerability: 0.5
+    - type: CyberneticEars

--- a/Resources/Prototypes/@RussStation/StatusEffects/hearing.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/hearing.yml
@@ -1,0 +1,13 @@
+# Causes temporary deafness - muffles/obfuscates incoming chat messages.
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectTemporaryDeafness
+  name: temporary deafness
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Deafable
+        requireAll: true
+    - type: TemporaryDeafness

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -194,6 +194,9 @@
         Slash: -0.05
   - type: Fingerprint
   - type: Blindable
+  # HONK START - Deafness system
+  - type: Deafable
+  # HONK END
   - type: Temperature
     currentTemperature: 310.15
     specificHeat: 42


### PR DESCRIPTION
## About the PR

Adds a deafness mechanic mirroring the existing blindness pattern. Deaf entities receive obfuscated chat messages (say and whisper). Advanced cybernetic ears provide deafness resistance. The EMP deafen effect now applies real temporary deafness instead of slurred speech.

Sub-branch of #314.

## Why / Balance

Previously there was no deafness mechanic in the engine, which meant cybernetic ears had no meaningful passive (noted in #308). This provides the foundation for hearing-related gameplay (flashbangs, explosions, EMP) and gives advanced cybernetic ears their passive: deafness resistance.

## Technical details

**New shared components and systems (Content.Shared/RussStation/Hearing/):**
- `DeafableComponent` - tracks `IsDeaf` state, networked, analogous to `BlindableComponent`
- `DeafableSystem` - raises `CanHearAttemptEvent` to determine deafness, fires `DeafnessChangedEvent` on state change. Supports `IInventoryRelayEvent` for equipment-based hearing protection
- `TemporaryDeafnessComponent` - marker component applied by status effect
- `TemporaryDeafnessSystem` - cancels `CanHearAttemptEvent` while active, manages `DeafableComponent` updates

**Chat obfuscation (ChatSystem.cs, HONK markers):**
- `SendInVoiceRange`: deaf recipients get `ObfuscateMessageReadability(message, 0.2f)` with a deaf-specific wrap message
- `SendEntityWhisper`: deaf recipients always get the fully obfuscated unknown-speaker message

**Cybernetic ears passive (CyberneticOrganEffectsSystem):**
- `CyberneticEarsComponent` marker on advanced ears prototype
- `CanHearAttemptEvent` handler on `BodyComponent` scans organs for the marker and uncancels deafness

**EMP fix (CyberneticEmpSystem):**
- `CyberneticEmpEffect.Deafen` now applies `StatusEffectTemporaryDeafness` instead of `StatusEffectSlurred`

**YAML/Prototypes:**
- `DeafableComponent` added to `species_base.yml` (HONK markers)
- `StatusEffectTemporaryDeafness` entity prototype in `@RussStation/StatusEffects/hearing.yml`
- `CyberneticEars` component added to `OrganCyberneticEarsAdvanced`

**Future work:** Language system integration, so deaf entities lose spoken languages but retain sign language (TODO in DeafableSystem). Client-side audio muffling for deaf players.

## Media

N/A (chat text changes only, no visual assets)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Deafness system. Deaf entities receive garbled chat messages and can't make out whispers.
- add: Advanced cybernetic ears now provide deafness resistance.
- fix: EMP deafen effect on cybernetic ears now causes actual deafness instead of slurred speech.
:cl: