### PR TITLE
Cybernetic lungs: species-aware gas filtering

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -1,14 +1,21 @@
+using System.Linq;
 using Content.Server.Body.Systems;
 using Content.Shared.Atmos;
+using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Body;
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityConditions.Conditions.Body;
+using Content.Shared.EntityEffects.Effects.Body;
 using Content.Shared.Flash;
+using Content.Shared.Metabolism;
 using Content.Shared.Mobs;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Body;
 using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Body;
@@ -21,8 +28,10 @@ namespace Content.Server.RussStation.Body;
 public sealed class CyberneticOrganEffectsSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
     [Dependency] private readonly HungerSystem _hunger = default!;
+    [Dependency] private readonly SharedAtmosphereSystem _atmos = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
@@ -36,6 +45,8 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         SubscribeLocalEvent<BodyComponent, FlashAttemptEvent>(OnFlashAttempt);
 
         // Lungs: toxic gas filtering (runs on the organ via relay, before RespiratorSystem processes it)
+        SubscribeLocalEvent<CyberneticLungsComponent, OrganGotInsertedEvent>(OnLungsInserted);
+        SubscribeLocalEvent<CyberneticLungsComponent, OrganGotRemovedEvent>(OnLungsRemoved);
         SubscribeLocalEvent<CyberneticLungsComponent, BodyRelayedEvent<InhaledGasEvent>>(OnInhaledGas,
             before: [typeof(RespiratorSystem)]);
 
@@ -108,18 +119,84 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
     // Lungs — toxic gas filtering
     // ================================================================
 
-    /// <summary>
-    /// Safe gases that cybernetic lungs should NOT filter.
-    /// Everything else (plasma, tritium, ammonia, etc.) gets reduced.
-    /// </summary>
-    private static readonly Gas[] SafeGases = [Gas.Oxygen, Gas.Nitrogen, Gas.WaterVapor];
+    private void OnLungsInserted(EntityUid uid, CyberneticLungsComponent lungs, ref OrganGotInsertedEvent args)
+    {
+        lungs.OxygenatingGases.Clear();
+
+        // Find the host body's metabolizer types from any organ that has them.
+        var metabolizerTypes = new HashSet<ProtoId<MetabolizerTypePrototype>>();
+        if (TryComp<BodyComponent>(args.Target, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                if (TryComp<MetabolizerComponent>(organ, out var met) && met.MetabolizerTypes != null)
+                {
+                    metabolizerTypes.UnionWith(met.MetabolizerTypes);
+                }
+            }
+        }
+
+        if (metabolizerTypes.Count == 0)
+            return;
+
+        // Scan gas reagent prototypes for Oxygenate effects matching the host's types.
+        for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+        {
+            var reagentId = _atmos.GasReagents[i];
+            if (reagentId == null || !_proto.TryIndex<ReagentPrototype>(reagentId, out var reagent))
+                continue;
+
+            if (IsOxygenatingForTypes(reagent, metabolizerTypes))
+                lungs.OxygenatingGases.Add((Gas) i);
+        }
+    }
+
+    private void OnLungsRemoved(EntityUid uid, CyberneticLungsComponent lungs, ref OrganGotRemovedEvent args)
+    {
+        lungs.OxygenatingGases.Clear();
+    }
+
+    private bool IsOxygenatingForTypes(
+        ReagentPrototype reagent,
+        HashSet<ProtoId<MetabolizerTypePrototype>> types)
+    {
+        if (reagent.Metabolisms == null)
+            return false;
+
+        // Check both Respiration and Bloodstream stages (gases use both).
+        foreach (var (_, entry) in reagent.Metabolisms.Metabolisms)
+        {
+            foreach (var effect in entry.Effects)
+            {
+                if (effect is not Oxygenate oxy || oxy.Factor <= 0f)
+                    continue;
+
+                if (effect.Conditions == null)
+                    return true;
+
+                foreach (var condition in effect.Conditions)
+                {
+                    if (condition is not MetabolizerTypeCondition metCond)
+                        continue;
+
+                    var matchesAny = metCond.Type.Any(t => types.Contains(t));
+                    // Inverted means "NOT these types", so invert the result.
+                    if (matchesAny != metCond.Inverted)
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     private void OnInhaledGas(Entity<CyberneticLungsComponent> ent, ref BodyRelayedEvent<InhaledGasEvent> args)
     {
         var gas = args.Args.Gas;
+
         foreach (var gasId in Enum.GetValues<Gas>())
         {
-            if (Array.IndexOf(SafeGases, gasId) >= 0)
+            if (ent.Comp.OxygenatingGases.Contains(gasId))
                 continue;
 
             var moles = gas[(int) gasId];

--- a/Content.Shared/RussStation/Body/CyberneticLungsComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticLungsComponent.cs
@@ -1,9 +1,12 @@
+using Content.Shared.Atmos;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Body;
 
 /// <summary>
 /// Marker component for advanced cybernetic lungs that filter toxic gases.
+/// Filters all inhaled gases except those that oxygenate the host species.
+/// The oxygenating gases are resolved from reagent prototypes on organ insertion.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class CyberneticLungsComponent : Component
@@ -14,4 +17,11 @@ public sealed partial class CyberneticLungsComponent : Component
     /// </summary>
     [DataField]
     public float FilterFraction = 0.5f;
+
+    /// <summary>
+    /// Gases that oxygenate the host species; excluded from filtering.
+    /// Populated at runtime when the organ is inserted into a body.
+    /// </summary>
+    [ViewVariables]
+    public HashSet<Gas> OxygenatingGases = new();
 }


### PR DESCRIPTION
## About the PR
Cybernetic lungs now dynamically resolve which gases oxygenate the host species and exclude them from filtering. Previously used a hardcoded `SafeGases` array (oxygen, nitrogen, water vapor) that didn't adapt to different species.

## Why / Balance
A Vox with cybernetic lungs should keep breathing nitrogen (their oxygenating gas) while filtering plasma, tritium, etc. The old approach filtered the same gases regardless of species. This also means cross-species organ transplants automatically adapt to the recipient's biology.

## Technical details
- On `OrganGotInsertedEvent`, scans the host body's `MetabolizerTypes` from all organs with `MetabolizerComponent`
- Iterates gas reagent prototypes via `SharedAtmosphereSystem.GasReagents`, checks for `Oxygenate` effects with positive factor and matching `MetabolizerTypeCondition`
- Populates `CyberneticLungsComponent.OxygenatingGases` HashSet (runtime cache, not serialized)
- On `OrganGotRemovedEvent`, clears the cache
- `OnInhaledGas` skips gases in `OxygenatingGases`, filters the rest by `FilterFraction`
- No YAML config needed per species, new species just need standard `MetabolizerType` + `Oxygenate` entries in `gases.yml`

## Media
N/A (no visual changes)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.