### PR TITLE
Cybernetic liver: overdose resistance passive

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -45,6 +45,10 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
         // Ears: deafness resistance
         SubscribeLocalEvent<BodyComponent, CanHearAttemptEvent>(OnCanHearAttempt);
+
+        // Liver: overdose resistance (applied to body on insert/remove)
+        SubscribeLocalEvent<CyberneticLiverComponent, OrganGotInsertedEvent>(OnLiverInserted);
+        SubscribeLocalEvent<CyberneticLiverComponent, OrganGotRemovedEvent>(OnLiverRemoved);
     }
 
     // ================================================================
@@ -169,5 +173,21 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
                 return;
             }
         }
+    }
+
+    // ================================================================
+    // Liver — overdose resistance
+    // ================================================================
+
+    private void OnLiverInserted(EntityUid uid, CyberneticLiverComponent liver, ref OrganGotInsertedEvent args)
+    {
+        var resistance = EnsureComp<OverdoseResistanceComponent>(args.Target);
+        resistance.ThresholdMultiplier = liver.OverdoseThresholdMultiplier;
+        Dirty(args.Target, resistance);
+    }
+
+    private void OnLiverRemoved(EntityUid uid, CyberneticLiverComponent liver, ref OrganGotRemovedEvent args)
+    {
+        RemComp<OverdoseResistanceComponent>(args.Target);
     }
 }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -9,6 +9,9 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.EntityConditions;
 using Content.Shared.EntityConditions.Conditions;
 using Content.Shared.EntityConditions.Conditions.Body;
+//HONK START - cybernetic liver overdose threshold
+using Content.Shared.RussStation.Body;
+//HONK END
 using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.Effects.Body;
 using Content.Shared.EntityEffects.Effects.Solution;
@@ -295,7 +298,20 @@ public sealed class MetabolizerSystem : EntitySystem
                     if (_entityConditions.TryCondition(organ, condition))
                         continue;
                     break;
-                case ReagentCondition:
+                case ReagentCondition reagentCondition:
+                    //HONK START - cybernetic liver overdose threshold
+                    if (TryComp<OverdoseResistanceComponent>(body, out var overdoseResist)
+                        && reagentCondition.Min > FixedPoint2.Zero)
+                    {
+                        var soln = solution.Comp.Solution;
+                        var quant = soln.GetTotalPrototypeQuantity(reagentCondition.Reagent);
+                        var scaledMin = reagentCondition.Min * overdoseResist.ThresholdMultiplier;
+                        var result = quant >= scaledMin && quant <= reagentCondition.Max;
+                        if (reagentCondition.Inverted != result)
+                            continue;
+                        break;
+                    }
+                    //HONK END
                     if (_entityConditions.TryCondition(solution, condition))
                         continue;
                     break;

--- a/Content.Shared/RussStation/Body/CyberneticLiverComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticLiverComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker component for advanced cybernetic liver.
+/// While the organ is implanted, increases overdose thresholds for all reagents,
+/// allowing the body to tolerate higher concentrations before overdose effects trigger.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CyberneticLiverComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to ReagentCondition minimum thresholds during metabolism.
+    /// Values above 1.0 raise the overdose threshold (e.g., 1.5 = 50% higher tolerance).
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float OverdoseThresholdMultiplier = 1.5f;
+}

--- a/Content.Shared/RussStation/Body/OverdoseResistanceComponent.cs
+++ b/Content.Shared/RussStation/Body/OverdoseResistanceComponent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Applied to a body entity when a cybernetic liver with overdose resistance is installed.
+/// Increases the effective minimum threshold for ReagentCondition checks during metabolism,
+/// raising the amount of reagent needed to trigger overdose effects.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class OverdoseResistanceComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to ReagentCondition minimum thresholds.
+    /// Values above 1.0 raise overdose thresholds (e.g., 1.5 = 50% more tolerance).
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ThresholdMultiplier = 1.5f;
+}

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -293,6 +293,7 @@
       tier: Advanced
       empEffect: None
       empVulnerability: 0.5
+    - type: CyberneticLiver
 
 # ============================================================
 # EYES - EmpEffect: Flicker


### PR DESCRIPTION
## About the PR
Adds overdose resistance to the advanced cybernetic liver. While implanted, overdose thresholds are raised by 50%, giving medics a wider safe dosing window.

## Why / Balance
Advanced liver already had faster toxin processing (0.75x update interval), but no qualitative passive like the other organs. The overdose resistance gives it a distinct identity: the liver doesn't just process faster, it tolerates more.

A 1.5x multiplier means a reagent that normally overdoses at 20u won't trigger until 30u. This is meaningful for medical gameplay without being overpowered.

## Technical details
- `CyberneticLiverComponent` (marker on organ) with configurable `OverdoseThresholdMultiplier` (default 1.5)
- `OverdoseResistanceComponent` (applied to body on insert, removed on extraction)
- HONK-marked edit to `MetabolizerSystem.CanMetabolizeEffect`: when `OverdoseResistanceComponent` is present and `ReagentCondition.Min > 0`, scales the min threshold by the multiplier before evaluating
- Organ insert/remove handlers in `CyberneticOrganEffectsSystem`

## Media
N/A (no visual changes)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.