### PR TITLE
Fix organ prototype duplication via proper inheritance

### DIFF
--- a/Content.Shared/Body/GibbableOrganSystem.cs
+++ b/Content.Shared/Body/GibbableOrganSystem.cs
@@ -1,4 +1,7 @@
 using Content.Shared.Gibbing;
+//HONK START
+using Content.Shared.RussStation.Body;
+//HONK END
 
 namespace Content.Shared.Body;
 
@@ -13,6 +16,11 @@ public sealed class GibbableOrganSystem : EntitySystem
 
     private void OnBeingGibbed(Entity<GibbableOrganComponent> ent, ref BodyRelayedEvent<BeingGibbedEvent> args)
     {
+        //HONK START - Cybernetic organs inherit GibbableOrgan from base but shouldn't gib
+        if (HasComp<CyberneticOrganComponent>(ent))
+            return;
+        //HONK END
+
         args.Args.Giblets.Add(ent);
     }
 }

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -1,6 +1,7 @@
 # Cybernetic organ replacements - 6 organs x 3 tiers (Basic, Standard, Advanced)
 # All use human organ sprites as placeholders until cybernetic sprites are made.
-# Parent OrganBase directly (not species-specific bases) to avoid GibbableOrgan inheritance.
+# Parent organ-specific bases (OrganBaseHeart, etc.) to inherit correct components.
+# GibbableOrgan is inherited but suppressed in C# (GibbableOrganSystem skips CyberneticOrgan entities).
 
 # ============================================================
 # Abstract bases for shared cybernetic sprite path
@@ -18,57 +19,37 @@
 # ============================================================
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseHeart, OrganCyberneticInternal]
   id: OrganCyberneticHeartBasic
   name: basic cybernetic heart
   description: A cheap cybernetic heart replacement. Keeps you alive, barely.
   components:
-    - type: Organ
-      category: Heart
-    - type: Sprite
-      layers:
-        - state: heart-on
     - type: Metabolizer
       maxReagents: 1
-      stages: [Bloodstream]
     - type: CyberneticOrgan
       tier: Basic
       empEffect: CardiacArrest
       empVulnerability: 1.5
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseHeart, OrganCyberneticInternal]
   id: OrganCyberneticHeartStandard
   name: cybernetic heart
   description: A reliable cybernetic heart. Performs identically to a biological one.
   components:
-    - type: Organ
-      category: Heart
-    - type: Sprite
-      layers:
-        - state: heart-on
-    - type: Metabolizer
-      maxReagents: 2
-      stages: [Bloodstream]
     - type: CyberneticOrgan
       tier: Standard
       empEffect: CardiacArrest
       empVulnerability: 1.0
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseHeart, OrganCyberneticInternal]
   id: OrganCyberneticHeartAdvanced
   name: advanced cybernetic heart
   description: A state-of-the-art cybernetic heart with enhanced circulatory efficiency.
   components:
-    - type: Organ
-      category: Heart
-    - type: Sprite
-      layers:
-        - state: heart-on
     - type: Metabolizer
       maxReagents: 3
-      stages: [Bloodstream]
     - type: CyberneticOrgan
       tier: Advanced
       empEffect: CardiacArrest
@@ -80,75 +61,43 @@
 # ============================================================
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseLungs, OrganCyberneticInternal]
   id: OrganCyberneticLungsBasic
   name: basic cybernetic lungs
   description: Budget cybernetic lungs. You'll breathe, but don't push it.
   components:
-    - type: Organ
-      category: Lungs
-    - type: Lung
-    - type: Metabolizer
-      stages: [Respiration]
     - type: SolutionContainerManager
       solutions:
         Lung:
           maxVol: 75.0
           canReact: false
-    - type: Sprite
-      layers:
-        - state: lung-l
-        - state: lung-r
     - type: CyberneticOrgan
       tier: Basic
       empEffect: BreathingFailure
       empVulnerability: 1.5
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseLungs, OrganCyberneticInternal]
   id: OrganCyberneticLungsStandard
   name: cybernetic lungs
   description: Reliable cybernetic lungs. Breathe easy.
   components:
-    - type: Organ
-      category: Lungs
-    - type: Lung
-    - type: Metabolizer
-      stages: [Respiration]
-    - type: SolutionContainerManager
-      solutions:
-        Lung:
-          maxVol: 100.0
-          canReact: false
-    - type: Sprite
-      layers:
-        - state: lung-l
-        - state: lung-r
     - type: CyberneticOrgan
       tier: Standard
       empEffect: BreathingFailure
       empVulnerability: 1.0
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseLungs, OrganCyberneticInternal]
   id: OrganCyberneticLungsAdvanced
   name: advanced cybernetic lungs
   description: High-end cybernetic lungs with extended oxygen reserves.
   components:
-    - type: Organ
-      category: Lungs
-    - type: Lung
-    - type: Metabolizer
-      stages: [Respiration]
     - type: SolutionContainerManager
       solutions:
         Lung:
           maxVol: 130.0
           canReact: false
-    - type: Sprite
-      layers:
-        - state: lung-l
-        - state: lung-r
     - type: CyberneticOrgan
       tier: Advanced
       empEffect: BreathingFailure
@@ -160,72 +109,45 @@
 # ============================================================
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseStomach, OrganCyberneticInternal]
   id: OrganCyberneticStomachBasic
   name: basic cybernetic stomach
   description: A bare-bones cybernetic stomach. Digests slowly.
   components:
-    - type: Organ
-      category: Stomach
-    - type: Stomach
     - type: SolutionContainerManager
       solutions:
         stomach:
           maxVol: 35
     - type: Metabolizer
       maxReagents: 2
-      stages: [Digestion]
-    - type: Sprite
-      layers:
-        - state: stomach
     - type: CyberneticOrgan
       tier: Basic
       empEffect: None
       empVulnerability: 1.5
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseStomach, OrganCyberneticInternal]
   id: OrganCyberneticStomachStandard
   name: cybernetic stomach
   description: A dependable cybernetic stomach.
   components:
-    - type: Organ
-      category: Stomach
-    - type: Stomach
-    - type: SolutionContainerManager
-      solutions:
-        stomach:
-          maxVol: 50
-    - type: Metabolizer
-      maxReagents: 3
-      stages: [Digestion]
-    - type: Sprite
-      layers:
-        - state: stomach
     - type: CyberneticOrgan
       tier: Standard
       empEffect: None
       empVulnerability: 1.0
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseStomach, OrganCyberneticInternal]
   id: OrganCyberneticStomachAdvanced
   name: advanced cybernetic stomach
   description: A high-efficiency cybernetic stomach that extracts more nutrients from food.
   components:
-    - type: Organ
-      category: Stomach
-    - type: Stomach
     - type: SolutionContainerManager
       solutions:
         stomach:
           maxVol: 70
     - type: Metabolizer
       maxReagents: 4
-      stages: [Digestion]
-    - type: Sprite
-      layers:
-        - state: stomach
     - type: CyberneticOrgan
       tier: Advanced
       empEffect: None
@@ -237,58 +159,36 @@
 # ============================================================
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseLiver, OrganCyberneticInternal]
   id: OrganCyberneticLiverBasic
   name: basic cybernetic liver
   description: A cheap cybernetic liver. Filters toxins, eventually.
   components:
-    - type: Organ
-      category: Liver
-    - type: Sprite
-      layers:
-        - state: liver
-    - type: Metabolizer
-      maxReagents: 1
-      stages: [Metabolites]
     - type: CyberneticOrgan
       tier: Basic
       empEffect: None
       empVulnerability: 1.5
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseLiver, OrganCyberneticInternal]
   id: OrganCyberneticLiverStandard
   name: cybernetic liver
   description: A reliable cybernetic liver.
   components:
-    - type: Organ
-      category: Liver
-    - type: Sprite
-      layers:
-        - state: liver
-    - type: Metabolizer
-      maxReagents: 1
-      stages: [Metabolites]
     - type: CyberneticOrgan
       tier: Standard
       empEffect: None
       empVulnerability: 1.0
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseLiver, OrganCyberneticInternal]
   id: OrganCyberneticLiverAdvanced
   name: advanced cybernetic liver
   description: A high-performance cybernetic liver with enhanced toxin processing.
   components:
-    - type: Organ
-      category: Liver
-    - type: Sprite
-      layers:
-        - state: liver
     - type: Metabolizer
       maxReagents: 2
       updateIntervalMultiplier: 0.75
-      stages: [Metabolites]
     - type: CyberneticOrgan
       tier: Advanced
       empEffect: None
@@ -300,51 +200,33 @@
 # ============================================================
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseEyes, OrganCyberneticInternal]
   id: OrganCyberneticEyesBasic
   name: basic cybernetic eyes
   description: Cheap cybernetic eyes. They work, mostly.
   components:
-    - type: Organ
-      category: Eyes
-    - type: Sprite
-      layers:
-        - state: eyeball-l
-        - state: eyeball-r
     - type: CyberneticOrgan
       tier: Basic
       empEffect: Flicker
       empVulnerability: 1.5
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseEyes, OrganCyberneticInternal]
   id: OrganCyberneticEyesStandard
   name: cybernetic eyes
   description: Standard cybernetic eyes with clear vision.
   components:
-    - type: Organ
-      category: Eyes
-    - type: Sprite
-      layers:
-        - state: eyeball-l
-        - state: eyeball-r
     - type: CyberneticOrgan
       tier: Standard
       empEffect: Flicker
       empVulnerability: 1.0
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseEyes, OrganCyberneticInternal]
   id: OrganCyberneticEyesAdvanced
   name: advanced cybernetic eyes
   description: Top-of-the-line cybernetic eyes with enhanced visual acuity.
   components:
-    - type: Organ
-      category: Eyes
-    - type: Sprite
-      layers:
-        - state: eyeball-l
-        - state: eyeball-r
     - type: CyberneticOrgan
       tier: Advanced
       empEffect: Flicker
@@ -356,48 +238,33 @@
 # ============================================================
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseEars, OrganCyberneticInternal]
   id: OrganCyberneticEarsBasic
   name: basic cybernetic ears
   description: Budget cybernetic ears. You'll hear, sort of.
   components:
-    - type: Organ
-      category: Ears
-    - type: Sprite
-      layers:
-        - state: ears
     - type: CyberneticOrgan
       tier: Basic
       empEffect: Deafen
       empVulnerability: 1.5
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseEars, OrganCyberneticInternal]
   id: OrganCyberneticEarsStandard
   name: cybernetic ears
   description: Reliable cybernetic ears with normal hearing.
   components:
-    - type: Organ
-      category: Ears
-    - type: Sprite
-      layers:
-        - state: ears
     - type: CyberneticOrgan
       tier: Standard
       empEffect: Deafen
       empVulnerability: 1.0
 
 - type: entity
-  parent: [OrganBase, OrganCyberneticInternal]
+  parent: [OrganBaseEars, OrganCyberneticInternal]
   id: OrganCyberneticEarsAdvanced
   name: advanced cybernetic ears
   description: Advanced cybernetic ears with built-in deafness resistance.
   components:
-    - type: Organ
-      category: Ears
-    - type: Sprite
-      layers:
-        - state: ears
     - type: CyberneticOrgan
       tier: Advanced
       empEffect: Deafen


### PR DESCRIPTION
## About the PR

Cybernetic organ prototypes now parent the organ-specific bases (`OrganBaseHeart`, `OrganBaseLungs`, etc.) instead of the generic `OrganBase`, eliminating ~125 lines of duplicated component definitions.

- Gibbing suppressed in C# (`GibbableOrganSystem` skips entities with `CyberneticOrganComponent`) rather than avoided by bypassing inheritance
- Only tier-specific overrides remain in the cybernetic prototypes (different `maxReagents`, `maxVol`, etc.)
- Upstream base organ changes now automatically propagate to cybernetic variants

## Why / Balance

Previously, cybernetic organs parented `OrganBase` directly to avoid inheriting `GibbableOrgan` (cybernetics shouldn't rot/gib). This forced every organ to redeclare all components (`Organ` category, `Metabolizer`, `Stomach`/`Lung`, `SolutionContainerManager`, `Sprite`). If upstream changed a base value, cybernetics wouldn't pick it up.

Closes #303.

## Technical details

- `GibbableOrganSystem.OnBeingGibbed`: early return when entity has `CyberneticOrganComponent` (HONK-wrapped)
- All 18 cybernetic organ prototypes updated from `OrganBase` to their organ-specific base
- Standard-tier organs that match base values exactly now only declare `CyberneticOrgan`

## Media

No visual changes.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Cybernetic organs now properly inherit base organ properties
:cl: