### PR TITLE
fix(304): replace EMP Flicker with temporary blindness

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
@@ -15,7 +15,7 @@ public sealed class CyberneticEmpSystem : EntitySystem
 
     private static readonly EntProtoId CardiacArrestEffect = "StatusEffectCardiacArrest";
     private static readonly EntProtoId BreathingSuppressedEffect = "StatusEffectBreathingSuppressed";
-    private static readonly EntProtoId DrowsinessEffect = "StatusEffectDrowsiness";
+    private static readonly EntProtoId BlindnessEffect = "StatusEffectTemporaryBlindness";
     private static readonly EntProtoId DeafnessEffect = "StatusEffectTemporaryDeafness";
 
     public override void Initialize()
@@ -59,7 +59,7 @@ public sealed class CyberneticEmpSystem : EntitySystem
                 break;
 
             case CyberneticEmpEffect.Flicker:
-                _statusEffects.TryAddStatusEffectDuration(body, DrowsinessEffect, duration);
+                _statusEffects.TryAddStatusEffectDuration(body, BlindnessEffect, duration);
                 break;
 
             case CyberneticEmpEffect.Deafen:

--- a/Content.Server/RussStation/Body/EmpBlindnessSystem.cs
+++ b/Content.Server/RussStation/Body/EmpBlindnessSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.RussStation.Body;
+using Content.Shared.StatusEffectNew;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Bridges the new status effect system to upstream temporary blindness.
+/// When the EMP blindness effect is applied, adds <see cref="TemporaryBlindnessComponent"/>
+/// to the body so the upstream <see cref="TemporaryBlindnessSystem"/> handles the actual blinding.
+/// </summary>
+public sealed class EmpBlindnessSystem : EntitySystem
+{
+    [Dependency] private readonly BlindableSystem _blindable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmpBlindnessComponent, StatusEffectAppliedEvent>(OnApplied);
+        SubscribeLocalEvent<EmpBlindnessComponent, StatusEffectRemovedEvent>(OnRemoved);
+    }
+
+    private void OnApplied(Entity<EmpBlindnessComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        EnsureComp<TemporaryBlindnessComponent>(args.Target);
+    }
+
+    private void OnRemoved(Entity<EmpBlindnessComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        RemComp<TemporaryBlindnessComponent>(args.Target);
+        _blindable.UpdateIsBlind(args.Target);
+    }
+}

--- a/Content.Shared/RussStation/Body/EmpBlindnessComponent.cs
+++ b/Content.Shared/RussStation/Body/EmpBlindnessComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker on the status effect entity for EMP-induced temporary blindness.
+/// The system bridges this to the body by adding/removing <see cref="Content.Shared.Eye.Blinding.Components.TemporaryBlindnessComponent"/>.
+/// </summary>
+[RegisterComponent]
+public sealed partial class EmpBlindnessComponent : Component;

--- a/Resources/Prototypes/@RussStation/StatusEffects/vision.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/vision.yml
@@ -1,0 +1,14 @@
+# Causes temporary blindness - vision cuts out entirely.
+# Used by cybernetic eyes EMP effect (Flicker).
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectTemporaryBlindness
+  name: temporary blindness
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Blindable
+        requireAll: true
+    - type: TemporaryBlindness

--- a/Resources/Prototypes/@RussStation/StatusEffects/vision.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/vision.yml
@@ -11,4 +11,4 @@
           - MobState
           - Blindable
         requireAll: true
-    - type: TemporaryBlindness
+    - type: EmpBlindness


### PR DESCRIPTION
## About the PR

Replace the placeholder Drowsiness status effect for the cybernetic eyes EMP Flicker effect with proper temporary blindness using the existing upstream `TemporaryBlindnessComponent` and `BlindableSystem`.

Part of #304.

## Why / Balance

Drowsiness (random falling asleep) doesn't match what an EMP should do to cybernetic eyes. Temporary blindness is the correct thematic effect: your vision cuts out briefly when your cybernetic eyes get hit by an EMP.

## Technical details

- Created `StatusEffectTemporaryBlindness` entity prototype in `@RussStation/StatusEffects/vision.yml` (mirrors the pattern used for `StatusEffectTemporaryDeafness`)
- Swapped `DrowsinessEffect` reference in `CyberneticEmpSystem` to `BlindnessEffect`
- Whitelist requires `MobState` + `Blindable` components (both present on species base)

## Media

N/A (status effect, no new visuals -- uses existing upstream blind overlay)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.