### PR TITLE
fix(304): replace placeholder breathing failure EMP effect

### DIFF
--- a/Content.Server/RussStation/Body/BreathingSuppressedSystem.cs
+++ b/Content.Server/RussStation/Body/BreathingSuppressedSystem.cs
@@ -1,0 +1,41 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Body;
+using Content.Shared.StatusEffectNew;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Handles the BreathingSuppressed status effect.
+/// When active, intercepts inhaled gas events before lungs can process them,
+/// causing the gas to be returned to the atmosphere and the body to suffocate naturally.
+/// </summary>
+public sealed class BreathingSuppressedSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BreathingSuppressedComponent, StatusEffectAppliedEvent>(OnApplied);
+        SubscribeLocalEvent<BreathingSuppressedComponent, StatusEffectRemovedEvent>(OnRemoved);
+        SubscribeLocalEvent<ActiveBreathingSuppressedComponent, InhaledGasEvent>(OnInhaled,
+            before: [typeof(RespiratorSystem)]);
+    }
+
+    private void OnApplied(Entity<BreathingSuppressedComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        EnsureComp<ActiveBreathingSuppressedComponent>(args.Target);
+    }
+
+    private void OnRemoved(Entity<BreathingSuppressedComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        RemComp<ActiveBreathingSuppressedComponent>(args.Target);
+    }
+
+    private void OnInhaled(Entity<ActiveBreathingSuppressedComponent> ent, ref InhaledGasEvent args)
+    {
+        // Mark as handled so the gas is returned to atmosphere by RespiratorSystem.
+        // Lungs will see Handled=true and skip processing, causing natural suffocation.
+        args.Handled = true;
+    }
+}

--- a/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Body;
 using Content.Shared.Emp;
 using Content.Shared.RussStation.Body;
 using Content.Shared.StatusEffectNew;
-using Content.Shared.Stunnable;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.RussStation.Body;
@@ -12,10 +11,10 @@ namespace Content.Server.RussStation.Body;
 /// </summary>
 public sealed class CyberneticEmpSystem : EntitySystem
 {
-    [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
 
     private static readonly EntProtoId CardiacArrestEffect = "StatusEffectCardiacArrest";
+    private static readonly EntProtoId BreathingSuppressedEffect = "StatusEffectBreathingSuppressed";
     private static readonly EntProtoId DrowsinessEffect = "StatusEffectDrowsiness";
     private static readonly EntProtoId DeafnessEffect = "StatusEffectTemporaryDeafness";
 
@@ -56,7 +55,7 @@ public sealed class CyberneticEmpSystem : EntitySystem
                 break;
 
             case CyberneticEmpEffect.BreathingFailure:
-                _stun.TryAddStunDuration(body, duration);
+                _statusEffects.TryAddStatusEffectDuration(body, BreathingSuppressedEffect, duration);
                 break;
 
             case CyberneticEmpEffect.Flicker:

--- a/Content.Shared/RussStation/Body/BreathingSuppressedComponent.cs
+++ b/Content.Shared/RussStation/Body/BreathingSuppressedComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker placed on a status effect entity to indicate breathing suppression.
+/// When applied, adds <see cref="ActiveBreathingSuppressedComponent"/> to the target body,
+/// preventing lungs from processing inhaled gas and causing natural suffocation.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BreathingSuppressedComponent : Component;
+
+/// <summary>
+/// Marker placed on a body entity whose breathing is currently suppressed.
+/// Managed by <see cref="BreathingSuppressedComponent"/> status effect lifecycle.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ActiveBreathingSuppressedComponent : Component;

--- a/Resources/Prototypes/@RussStation/StatusEffects/breathing.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/breathing.yml
@@ -1,0 +1,14 @@
+# Suppresses breathing - lungs cannot process inhaled gas, causing suffocation.
+# Used by cybernetic lungs EMP effect (BreathingFailure).
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectBreathingSuppressed
+  name: breathing suppressed
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Body
+        requireAll: true
+    - type: BreathingSuppressed


### PR DESCRIPTION
## About the PR

Replaces the placeholder stun-based BreathingFailure EMP effect for cybernetic lungs with a proper breathing suppression status effect. Part of #304.

## Why / Balance

Previously, an EMP hitting cybernetic lungs would just stun the player, which didn't make thematic sense. Now it actually suppresses breathing: lungs can't process inhaled gas, causing natural suffocation until the effect wears off. Duration still scales with `empVulnerability` tier.

## Technical details

- New `BreathingSuppressedComponent` (status effect entity marker) and `ActiveBreathingSuppressedComponent` (body marker)
- `BreathingSuppressedSystem` intercepts `InhaledGasEvent` on the body before `RespiratorSystem` processes it, setting `Handled = true` so lungs skip gas processing
- Two-component pattern needed because `InhaledGasEvent` isn't in the status effect relay list, so lifecycle events on the status effect entity manage the body marker
- New `StatusEffectBreathingSuppressed` prototype with `MobState` + `Body` whitelist
- Removed `SharedStunSystem` dependency from `CyberneticEmpSystem`

## Media

N/A (no visual changes)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: EMP now causes cybernetic lungs to stop processing air instead of stunning the player.