### PR TITLE
feat: cardiac arrest UI alert and examine text

### DIFF
--- a/Content.Server/RussStation/Body/CardiacArrestSystem.cs
+++ b/Content.Server/RussStation/Body/CardiacArrestSystem.cs
@@ -1,4 +1,6 @@
 using Content.Server.Body.Systems;
+using Content.Shared.Alert;
+using Content.Shared.Examine;
 using Content.Shared.Medical;
 using Content.Shared.RussStation.Body;
 using Content.Shared.StatusEffectNew;
@@ -16,11 +18,13 @@ namespace Content.Server.RussStation.Body;
 /// </summary>
 public sealed class CardiacArrestSystem : EntitySystem
 {
+    [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly RespiratorSystem _respirator = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
 
     private static readonly EntProtoId EffectProto = "StatusEffectCardiacArrest";
+    private static readonly ProtoId<AlertPrototype> CardiacArrestAlert = "CardiacArrest";
 
     /// <summary>
     /// Extra saturation drained per second. Normal drain is ~1/s, so 3/s extra
@@ -35,11 +39,13 @@ public sealed class CardiacArrestSystem : EntitySystem
         SubscribeLocalEvent<CardiacArrestComponent, StatusEffectAppliedEvent>(OnApplied);
         SubscribeLocalEvent<CardiacArrestComponent, StatusEffectRemovedEvent>(OnRemoved);
         SubscribeLocalEvent<ActiveCardiacArrestComponent, TargetDefibrillatedEvent>(OnDefibrillated);
+        SubscribeLocalEvent<ActiveCardiacArrestComponent, ExaminedEvent>(OnExamined);
     }
 
     private void OnApplied(Entity<CardiacArrestComponent> ent, ref StatusEffectAppliedEvent args)
     {
         EnsureComp<ActiveCardiacArrestComponent>(args.Target);
+        _alerts.ShowAlert(args.Target, CardiacArrestAlert);
 
         if (TryComp<StatusEffectComponent>(ent, out var effect))
             _stun.TryAddStunDuration(args.Target, effect.Duration);
@@ -48,11 +54,17 @@ public sealed class CardiacArrestSystem : EntitySystem
     private void OnRemoved(Entity<CardiacArrestComponent> ent, ref StatusEffectRemovedEvent args)
     {
         RemComp<ActiveCardiacArrestComponent>(args.Target);
+        _alerts.ClearAlert(args.Target, CardiacArrestAlert);
     }
 
     private void OnDefibrillated(Entity<ActiveCardiacArrestComponent> ent, ref TargetDefibrillatedEvent args)
     {
         _statusEffects.TryRemoveStatusEffect(ent, EffectProto);
+    }
+
+    private void OnExamined(Entity<ActiveCardiacArrestComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("cardiac-arrest-examine", ("target", ent.Owner)));
     }
 
     public override void Update(float frameTime)

--- a/Resources/Locale/en-US/@RussStation/body/cardiac-arrest.ftl
+++ b/Resources/Locale/en-US/@RussStation/body/cardiac-arrest.ftl
@@ -1,0 +1,4 @@
+alerts-cardiac-arrest-name = [color=red]Cardiac Arrest[/color]
+alerts-cardiac-arrest-desc = Your chest hurts!
+
+cardiac-arrest-examine = [color=red]{CAPITALIZE(THE($target))} is clutching {POSS-ADJ($target)} chest.[/color]

--- a/Resources/Prototypes/@RussStation/Body/alerts.yml
+++ b/Resources/Prototypes/@RussStation/Body/alerts.yml
@@ -1,0 +1,7 @@
+- type: alert
+  id: CardiacArrest
+  icons:
+    - sprite: /Textures/Mobs/Species/Human/organs.rsi
+      state: heart-off
+  name: alerts-cardiac-arrest-name
+  description: alerts-cardiac-arrest-desc


### PR DESCRIPTION
## About the PR

Adds player-facing feedback for cardiac arrest:
- UI alert icon (heart-off sprite from human organs RSI) shown while effect is active
- Examine message: "[Target] is clutching [their] chest." visible to other players

## Why / Balance

Cardiac arrest previously had no visual indicator for the affected player or bystanders. The alert helps the patient understand what's happening, and the examine text gives nearby players a reason to intervene with a defib. Part of #304.

## Technical details

- Added `AlertsSystem` dependency and `ProtoId<AlertPrototype>` constant to `CardiacArrestSystem`
- Alert shown on `StatusEffectAppliedEvent`, cleared on `StatusEffectRemovedEvent`
- `ExaminedEvent` subscription on `ActiveCardiacArrestComponent` for examine text
- New alert prototype in `@RussStation/Body/alerts.yml`
- New locale strings in `@RussStation/body/cardiac-arrest.ftl`

## Media

N/A (alert uses existing heart-off sprite)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Cardiac arrest now shows a heart alert icon and examine text.