### PR TITLE
Fix: cybernetic organ passive effect bugs

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -34,6 +34,8 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
     [Dependency] private readonly SharedAtmosphereSystem _atmos = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
+    private static readonly Gas[] AllGases = Enum.GetValues<Gas>();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -90,7 +92,10 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
         var solution = new Solution(heart.Reagent, heart.InjectAmount);
         if (!_bloodstream.TryAddToBloodstream(body, solution))
+        {
+            Log.Warning($"Cybernetic heart failed to inject into {ToPrettyString(body)}");
             return;
+        }
 
         heart.LastInjection = now;
         Dirty(organ, heart);
@@ -196,9 +201,14 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
     private void OnInhaledGas(Entity<CyberneticLungsComponent> ent, ref BodyRelayedEvent<InhaledGasEvent> args)
     {
+        // If no oxygenating gases were resolved, skip filtering entirely
+        // to avoid suffocating the patient by removing all gas.
+        if (ent.Comp.OxygenatingGases.Count == 0)
+            return;
+
         var gas = args.Args.Gas;
 
-        foreach (var gasId in Enum.GetValues<Gas>())
+        foreach (var gasId in AllGases)
         {
             if (ent.Comp.OxygenatingGases.Contains(gasId))
                 continue;
@@ -217,20 +227,20 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
     private void OnStomachInserted(EntityUid uid, CyberneticStomachComponent stomach, ref OrganGotInsertedEvent args)
     {
-        ApplyHungerDecayModifier(args.Target, stomach.DecayMultiplier);
+        if (!TryComp<HungerComponent>(args.Target, out var hunger))
+            return;
+
+        stomach.OriginalDecayRate = hunger.BaseDecayRate;
+        _hunger.SetBaseDecayRate(args.Target, hunger.BaseDecayRate * stomach.DecayMultiplier, hunger);
     }
 
     private void OnStomachRemoved(EntityUid uid, CyberneticStomachComponent stomach, ref OrganGotRemovedEvent args)
     {
-        ApplyHungerDecayModifier(args.Target, 1f / stomach.DecayMultiplier);
-    }
-
-    private void ApplyHungerDecayModifier(EntityUid body, float modifier)
-    {
-        if (!TryComp<HungerComponent>(body, out var hunger))
+        if (stomach.OriginalDecayRate == null || !TryComp<HungerComponent>(args.Target, out var hunger))
             return;
 
-        _hunger.SetBaseDecayRate(body, hunger.BaseDecayRate * modifier, hunger);
+        _hunger.SetBaseDecayRate(args.Target, stomach.OriginalDecayRate.Value, hunger);
+        stomach.OriginalDecayRate = null;
     }
 
     // ================================================================
@@ -265,6 +275,16 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
     private void OnLiverRemoved(EntityUid uid, CyberneticLiverComponent liver, ref OrganGotRemovedEvent args)
     {
+        // Check if any other cybernetic liver remains in the body
+        if (TryComp<BodyComponent>(args.Target, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                if (organ != uid && HasComp<CyberneticLiverComponent>(organ))
+                    return;
+            }
+        }
+
         RemComp<OverdoseResistanceComponent>(args.Target);
     }
 }

--- a/Content.Shared/RussStation/Body/CyberneticStomachComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticStomachComponent.cs
@@ -14,4 +14,11 @@ public sealed partial class CyberneticStomachComponent : Component
     /// </summary>
     [DataField]
     public float DecayMultiplier = 0.5f;
+
+    /// <summary>
+    /// Original BaseDecayRate stored on insert, restored on remove.
+    /// Avoids float drift from multiply/divide roundtrips.
+    /// </summary>
+    [ViewVariables]
+    public float? OriginalDecayRate;
 }


### PR DESCRIPTION
## About the PR
Fixes five bugs in CyberneticOrganEffectsSystem:
- Cache `Enum.GetValues<Gas>()` to avoid per-call allocation (#340)
- Guard OnInhaledGas when OxygenatingGases is empty (#339)
- Log warning on heart injection failure (#338)
- Store/restore original decay rate for stomach instead of multiply/divide roundtrip (#332)
- Check for remaining cybernetic livers before removing OverdoseResistanceComponent (#341)

## Why / Balance
Fixes float drift from repeated stomach insert/remove cycles and prevents silent failures in heart/liver edge cases.

## Technical details
- Static `Gas[]` cache replaces per-event `Enum.GetValues` allocation
- Stomach now stores `OriginalDecayRate` on insert and restores it on remove (no more divide-by-multiplier)
- Liver removal scans remaining organs before removing the resistance component

## Media
N/A - bugfixes only

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

:cl:
- fix: Cybernetic stomach no longer drifts hunger decay rate after repeated insert/remove cycles
- fix: Cybernetic liver overdose resistance is no longer removed when a second cybernetic liver exists

Closes #332, Closes #338, Closes #339, Closes #340, Closes #341