### PR TITLE
Fix: overdose threshold scales both min and max

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -306,7 +306,10 @@ public sealed class MetabolizerSystem : EntitySystem
                         var soln = solution.Comp.Solution;
                         var quant = soln.GetTotalPrototypeQuantity(reagentCondition.Reagent);
                         var scaledMin = reagentCondition.Min * overdoseResist.ThresholdMultiplier;
-                        var result = quant >= scaledMin && quant <= reagentCondition.Max;
+                        var scaledMax = reagentCondition.Max > FixedPoint2.Zero
+                            ? reagentCondition.Max * overdoseResist.ThresholdMultiplier
+                            : reagentCondition.Max;
+                        var result = quant >= scaledMin && quant <= scaledMax;
                         if (reagentCondition.Inverted != result)
                             continue;
                         break;


### PR DESCRIPTION
## About the PR
Fixes overdose resistance scaling to shift both Min and Max thresholds, not just Min (#328).

## Why / Balance
Previously, scaling only Min created an impossible condition where Min > Max for some reagents, making overdose effects either never trigger or always trigger incorrectly.

## Technical details
- Upstream file (MetabolizerSystem.cs) modified with HONK markers
- Max is only scaled when it's > 0 to avoid scaling zero/sentinel values

## Media
N/A - bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

:cl:
- fix: Cybernetic liver overdose resistance now correctly scales both minimum and maximum thresholds

Closes #328