### PR TITLE
Fix: deafness desync and entity deletion guard

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -14,7 +14,6 @@ using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Body;
-using Content.Shared.RussStation.Hearing.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -54,8 +53,7 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         SubscribeLocalEvent<CyberneticStomachComponent, OrganGotInsertedEvent>(OnStomachInserted);
         SubscribeLocalEvent<CyberneticStomachComponent, OrganGotRemovedEvent>(OnStomachRemoved);
 
-        // Ears: deafness resistance
-        SubscribeLocalEvent<BodyComponent, CanHearAttemptEvent>(OnCanHearAttempt);
+        // Ears: deafness resistance handled in shared DeafableSystem
 
         // Liver: overdose resistance (applied to body on insert/remove)
         SubscribeLocalEvent<CyberneticLiverComponent, OrganGotInsertedEvent>(OnLiverInserted);
@@ -231,25 +229,6 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
             return;
 
         _hunger.SetBaseDecayRate(body, hunger.BaseDecayRate * modifier, hunger);
-    }
-
-    // ================================================================
-    // Ears — deafness resistance
-    // ================================================================
-
-    private void OnCanHearAttempt(EntityUid uid, BodyComponent body, CanHearAttemptEvent args)
-    {
-        if (body.Organs == null)
-            return;
-
-        foreach (var organ in body.Organs.ContainedEntities)
-        {
-            if (HasComp<CyberneticEarsComponent>(organ))
-            {
-                args.Uncancel();
-                return;
-            }
-        }
     }
 
     // ================================================================

--- a/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
@@ -1,11 +1,13 @@
+using Content.Shared.Body;
 using Content.Shared.Inventory;
 using Content.Shared.Rejuvenate;
+using Content.Shared.RussStation.Body;
 
 namespace Content.Shared.RussStation.Hearing.Systems;
 
 /// <summary>
 /// Manages the IsDeaf state on DeafableComponent by raising CanHearAttemptEvent.
-/// TODO: Integrate with language system so deaf entities lose spoken languages but retain sign language.
+/// Also handles cybernetic ears deafness resistance (shared so client/server agree).
 /// </summary>
 public sealed class DeafableSystem : EntitySystem
 {
@@ -13,6 +15,9 @@ public sealed class DeafableSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<DeafableComponent, RejuvenateEvent>(OnRejuvenate);
+
+        // Cybernetic ears: prevent deafness (shared for client prediction)
+        SubscribeLocalEvent<BodyComponent, CanHearAttemptEvent>(OnCanHearAttempt);
     }
 
     private void OnRejuvenate(Entity<DeafableComponent> ent, ref RejuvenateEvent args)
@@ -23,6 +28,9 @@ public sealed class DeafableSystem : EntitySystem
     public void UpdateIsDeaf(Entity<DeafableComponent?> entity)
     {
         if (!Resolve(entity, ref entity.Comp, false))
+            return;
+
+        if (TerminatingOrDeleted(entity.Owner))
             return;
 
         var old = entity.Comp.IsDeaf;
@@ -37,6 +45,21 @@ public sealed class DeafableSystem : EntitySystem
         var changeEv = new DeafnessChangedEvent(entity.Comp.IsDeaf);
         RaiseLocalEvent(entity.Owner, ref changeEv);
         Dirty(entity);
+    }
+
+    private void OnCanHearAttempt(EntityUid uid, BodyComponent body, CanHearAttemptEvent args)
+    {
+        if (body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (HasComp<CyberneticEarsComponent>(organ))
+            {
+                args.Uncancel();
+                return;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## About the PR
- Move cybernetic ears CanHearAttemptEvent handler from server-only CyberneticOrganEffectsSystem to shared DeafableSystem (#335)
- Add TerminatingOrDeleted guard in UpdateIsDeaf (#337)

## Why / Balance
The server-only handler caused client prediction desync for deafness state. The missing deletion guard could fire events during entity teardown.

## Technical details
- OnCanHearAttempt moved to DeafableSystem (Content.Shared) so client and server agree on deafness state
- Removed duplicate handler and unused Ears section from CyberneticOrganEffectsSystem
- Added TerminatingOrDeleted check before RaiseLocalEvent in UpdateIsDeaf

## Media
N/A - bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

:cl:
- fix: Cybernetic ears deafness resistance no longer desyncs between client and server

Closes #335, Closes #337