### PR TITLE
Fix: silent failures in autosurgeon and EMP system

### DIFF
--- a/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
@@ -48,26 +48,19 @@ public sealed class CyberneticEmpSystem : EntitySystem
     {
         var duration = baseDuration * cyber.EmpVulnerability;
 
-        switch (cyber.EmpEffect)
+        var effectId = cyber.EmpEffect switch
         {
-            case CyberneticEmpEffect.CardiacArrest:
-                _statusEffects.TryAddStatusEffectDuration(body, CardiacArrestEffect, duration);
-                break;
+            CyberneticEmpEffect.CardiacArrest => (EntProtoId?) CardiacArrestEffect,
+            CyberneticEmpEffect.BreathingFailure => BreathingSuppressedEffect,
+            CyberneticEmpEffect.Flicker => BlindnessEffect,
+            CyberneticEmpEffect.Deafen => DeafnessEffect,
+            _ => null,
+        };
 
-            case CyberneticEmpEffect.BreathingFailure:
-                _statusEffects.TryAddStatusEffectDuration(body, BreathingSuppressedEffect, duration);
-                break;
+        if (effectId == null)
+            return;
 
-            case CyberneticEmpEffect.Flicker:
-                _statusEffects.TryAddStatusEffectDuration(body, BlindnessEffect, duration);
-                break;
-
-            case CyberneticEmpEffect.Deafen:
-                _statusEffects.TryAddStatusEffectDuration(body, DeafnessEffect, duration);
-                break;
-
-            case CyberneticEmpEffect.None:
-                break;
-        }
+        if (!_statusEffects.TryAddStatusEffectDuration(body, effectId.Value, duration))
+            Log.Debug($"Failed to apply EMP effect {cyber.EmpEffect} to {ToPrettyString(body)}");
     }
 }

--- a/Content.Server/RussStation/Medical/AutosurgeonSystem.cs
+++ b/Content.Server/RussStation/Medical/AutosurgeonSystem.cs
@@ -90,13 +90,17 @@ public sealed class AutosurgeonSystem : EntitySystem
     private void InstallOrgan(EntityUid autosurgeon, AutosurgeonComponent comp, EntityUid user, EntityUid target)
     {
         if (!TryComp<BodyComponent>(target, out var body) || body.Organs == null)
+        {
+            _popup.PopupEntity(Loc.GetString("autosurgeon-no-body"), target, user);
             return;
+        }
 
         // Spawn the organ entity
         var organ = Spawn(comp.OrganPrototype, Transform(target).Coordinates);
 
         if (!TryComp<OrganComponent>(organ, out var organComp))
         {
+            Log.Error($"Autosurgeon organ prototype {comp.OrganPrototype} missing OrganComponent");
             QueueDel(organ);
             return;
         }


### PR DESCRIPTION
## About the PR
- Autosurgeon now shows popup when InstallOrgan fails due to missing body/organs (#333)
- Autosurgeon logs error for misconfigured organ prototypes
- CyberneticEmpSystem checks TryAddStatusEffectDuration return and logs on failure (#336)

## Why / Balance
These were silent failures that gave no feedback to the player or logs to admins.

## Technical details
- AutosurgeonSystem.InstallOrgan early-return now shows "no body" popup
- Missing OrganComponent on spawned organ logs an error
- EMP system refactored from switch to pattern match, checks return value

## Media
N/A - bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

:cl:
- fix: Autosurgeon now shows feedback when installation fails

Closes #333, Closes #336