### PR TITLE
Fix: tighten OrganComponent access and null category guard

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
@@ -21,6 +21,12 @@ public sealed partial class SurgerySystem
         if (!TryComp<OrganComponent>(organ, out var organComp))
             return;
 
+        if (organComp.Category == null)
+        {
+            Log.Warning($"Attempted to insert organ {ToPrettyString(organ)} with no category");
+            return;
+        }
+
         if (!TryComp<BodyComponent>(patient, out var body) || body.Organs == null)
         {
             _popup.PopupEntity(Loc.GetString("surgery-organ-insert-failed"), patient, surgeon);
@@ -28,18 +34,15 @@ public sealed partial class SurgerySystem
         }
 
         // Block if the patient already has an organ of the same category
-        if (organComp.Category != null)
+        foreach (var existing in body.Organs.ContainedEntities)
         {
-            foreach (var existing in body.Organs.ContainedEntities)
+            if (TryComp<OrganComponent>(existing, out var existingOrgan) &&
+                existingOrgan.Category == organComp.Category)
             {
-                if (TryComp<OrganComponent>(existing, out var existingOrgan) &&
-                    existingOrgan.Category == organComp.Category)
-                {
-                    _popup.PopupEntity(
-                        Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(organ).EntityName)),
-                        patient, surgeon);
-                    return;
-                }
+                _popup.PopupEntity(
+                    Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(organ).EntityName)),
+                    patient, surgeon);
+                return;
             }
         }
 

--- a/Content.Shared/Body/OrganComponent.cs
+++ b/Content.Shared/Body/OrganComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Body;
 /// <seealso cref="BodySystem" />
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 //HONK START - Fork systems need to read organ Category
-[Access(typeof(BodySystem), typeof(SharedSurgerySystem), Other = AccessPermissions.ReadExecute)]
+[Access(typeof(BodySystem), typeof(SharedSurgerySystem), Other = AccessPermissions.Read)]
 //HONK END
 public sealed partial class OrganComponent : Component
 {


### PR DESCRIPTION
## About the PR
- Narrow OrganComponent Access from ReadExecute to Read for non-listed systems (#342)
- Add null-category guard in SurgerySystem.TryInsertOrgan (#344)

## Why / Balance
ReadExecute was overly permissive. Organs without categories could bypass duplicate checking during surgery.

## Technical details
- OrganComponent Access changed from `Other = ReadExecute` to `Other = Read`
- TryInsertOrgan now rejects organs with null category early with a log warning
- Removed now-unnecessary null check around duplicate category scan

## Media
N/A - bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

Closes #342, Closes #344