### PR TITLE
fix: prevent account number broadcast and add withdraw ownership check

### DIFF
--- a/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
+++ b/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
@@ -54,7 +54,6 @@ public sealed class BalanceCartridgeSystem : EntitySystem
             return;
 
         balance.PaycheckMuted = !balance.PaycheckMuted;
-        Dirty(holder, balance);
         UpdateUiState(uid, loaderUid);
     }
 

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -297,6 +297,13 @@ public sealed class IdCardAccountSystem : EntitySystem
             return;
         }
 
+        // Only the account owner can withdraw
+        if (owner != user)
+        {
+            _popup.PopupEntity(Loc.GetString("id-card-withdraw-not-owner"), idCard, session, PopupType.MediumCaution);
+            return;
+        }
+
         if (!_balance.TryDeduct(owner, amount, description: Loc.GetString("transaction-withdraw")))
         {
             _popup.PopupEntity(Loc.GetString("id-card-withdraw-insufficient"), idCard, session, PopupType.MediumCaution);

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -70,8 +70,6 @@ public sealed class PlayerBalanceSystem : EntitySystem
         comp.AccountNumber = GenerateAccountNumber();
         _accountIndex[comp.AccountNumber] = args.Mob;
 
-        Dirty(args.Mob, comp);
-
         // Stamp account number onto the player's ID card.
         if (_idCard.TryFindIdCard(args.Mob, out var idCard))
         {
@@ -132,7 +130,6 @@ public sealed class PlayerBalanceSystem : EntitySystem
 
         comp.Balance -= amount;
         RecordTransaction(comp, -amount, description ?? "Debit");
-        Dirty(uid, comp);
         RaiseLocalEvent(uid, new BalanceChangedEvent(uid));
         return true;
     }
@@ -147,7 +144,6 @@ public sealed class PlayerBalanceSystem : EntitySystem
 
         comp.Balance += amount;
         RecordTransaction(comp, amount, description ?? "Credit");
-        Dirty(uid, comp);
         RaiseLocalEvent(uid, new BalanceChangedEvent(uid));
     }
 
@@ -185,7 +181,6 @@ public sealed class PlayerBalanceSystem : EntitySystem
         comp.Balance = startingBalance;
         comp.AccountNumber = GenerateAccountNumber();
         _accountIndex[comp.AccountNumber] = uid;
-        Dirty(uid, comp);
 
         _memories.AddMemory(uid, "memories-key-account-number", comp.AccountNumber);
         RaiseLocalEvent(uid, new BalanceChangedEvent(uid));

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -172,7 +172,8 @@ public sealed class PlayerBalanceSystem : EntitySystem
 
     /// <summary>
     /// Create a new bank account for an entity, invalidating any previous account.
-    /// Balance defaults to 0 unless overridden.
+    /// Intentionally resets balance to startingBalance (default 0) -- creating a new account
+    /// means the old one and its funds are gone. This is the intended penalty for account replacement.
     /// </summary>
     public string CreateAccount(EntityUid uid, int startingBalance = 0)
     {

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -70,7 +70,6 @@ public sealed partial class IdCardComponent : Component
     /// Bank account number linked to the player's balance. Set at spawn, can be manually set on new IDs.
     /// </summary>
     [DataField]
-    [AutoNetworkedField]
     public string? AccountNumber;
     //HONK END
 }

--- a/Content.Shared/RussStation/Economy/Components/PlayerBalanceComponent.cs
+++ b/Content.Shared/RussStation/Economy/Components/PlayerBalanceComponent.cs
@@ -1,5 +1,4 @@
 using Robust.Shared.GameObjects;
-using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Economy.Components;
 
@@ -7,16 +6,16 @@ namespace Content.Shared.RussStation.Economy.Components;
 /// Tracks a player's speso balance for the current round.
 /// Added to the player mob on spawn.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent]
 public sealed partial class PlayerBalanceComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public int Balance;
 
     /// <summary>
     /// Unique hex account number assigned at spawn. Used by ID cards to reference this balance.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public string AccountNumber = string.Empty;
 
     /// <summary>
@@ -35,7 +34,7 @@ public sealed partial class PlayerBalanceComponent : Component
     /// <summary>
     /// Whether paycheck notification sounds are muted. Toggled via the wallet cartridge UI.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public bool PaycheckMuted;
 
     /// <summary>

--- a/Content.Shared/RussStation/Memories/MemoriesComponent.cs
+++ b/Content.Shared/RussStation/Memories/MemoriesComponent.cs
@@ -9,6 +9,8 @@ namespace Content.Shared.RussStation.Memories;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class MemoriesComponent : Component
 {
+    public override bool SendOnlyToOwner => true;
+
     [DataField, AutoNetworkedField]
     public Dictionary<string, string> Memories = new();
 }

--- a/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
+++ b/Resources/Locale/en-US/@RussStation/economy/id-card-account.ftl
@@ -8,6 +8,7 @@ id-card-withdraw-verb = Withdraw
 id-card-withdraw-title = Withdraw Spesos
 id-card-withdraw-prompt = Amount to withdraw:
 id-card-withdraw-insufficient = Insufficient funds.
+id-card-withdraw-not-owner = This isn't your account.
 id-card-withdraw-success = Withdrew {$amount} spesos.
 
 id-card-deposit-success = Deposited {$amount} spesos.


### PR DESCRIPTION
## About the PR

- Remove `[AutoNetworkedField]` from `IdCardComponent.AccountNumber` and all fields on `PlayerBalanceComponent` (no client code reads these directly, wallet UI uses BUI state)
- Remove `NetworkedComponent`/`AutoGenerateComponentState` from `PlayerBalanceComponent` entirely
- Add `SendOnlyToOwner` to `MemoriesComponent` so memories only sync to the owning player
- Add ownership check to withdraw verb (only account owner can withdraw)
- Add clarifying doc comment to `CreateAccount` noting balance wipe is intentional

## Why / Balance

Account numbers were broadcast via component state to all nearby clients, enabling balance theft without physical interaction. Memories dict (containing account number) was also broadcast to everyone in PVS range. Withdraw had no ownership check, so anyone holding someone else's ID could drain their account.

## Technical details

`PlayerBalanceComponent` fields are only needed server-side (balance, account number, mute state). The wallet cartridge already sends this data through `BalanceCartridgeUiState` BUI messages, which only go to the player with the UI open.

`MemoriesComponent` still needs networking (client displays memories in character info panel) but now uses `SendOnlyToOwner => true` so only the owning player receives the state.

## Media

N/A (no visual changes)

## Requirements

- [x] Account number no longer in component state for nearby players
- [x] Memories only sync to owner
- [x] Withdraw requires account ownership
- [x] Wallet cartridge UI still works (uses BUI state, unaffected)

## Breaking changes

None.

## Changelog

:cl:
- fix: Bank account numbers are no longer leaked to nearby players
- fix: Only the account owner can withdraw from their account