### PR TITLE
fix: exclude emag/contraband items from vending pricing

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Economy/VendingContrabandPricingTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/VendingContrabandPricingTest.cs
@@ -1,0 +1,84 @@
+using Content.Server.RussStation.Economy;
+using Content.Shared.RussStation.Economy.Components;
+using Content.Shared.VendingMachines;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+/// <summary>
+/// Verifies that emag and contraband vending items are not priced.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(VendingPaymentSystem))]
+public sealed class VendingContrabandPricingTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  parent: BaseItem
+  id: ContrabandTestRegularItem
+  name: ContrabandTestRegularItem
+
+- type: entity
+  parent: BaseItem
+  id: ContrabandTestEmagItem
+  name: ContrabandTestEmagItem
+
+- type: entity
+  parent: BaseItem
+  id: ContrabandTestContrabandItem
+  name: ContrabandTestContrabandItem
+
+- type: vendingMachineInventory
+  id: ContrabandTestInventory
+  startingInventory:
+    ContrabandTestRegularItem: 5
+  emaggedInventory:
+    ContrabandTestEmagItem: 3
+  contrabandInventory:
+    ContrabandTestContrabandItem: 3
+
+- type: entity
+  id: ContrabandTestVendor
+  parent: VendingMachine
+  components:
+  - type: VendingMachine
+    pack: ContrabandTestInventory
+    ejectDelay: 0
+  - type: Sprite
+    sprite: error.rsi
+";
+
+    [Test]
+    public async Task EmagAndContrabandItemsHaveNoPriceTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+
+        await server.WaitAssertion(() =>
+        {
+            var vendor = entMan.Spawn("ContrabandTestVendor");
+            var paymentSystem = entMan.System<VendingPaymentSystem>();
+
+            paymentSystem.UpdatePrices(vendor);
+
+            var prices = entMan.GetComponent<VendingPricesComponent>(vendor);
+
+            // Regular items should have a price.
+            Assert.That(prices.Prices.ContainsKey("ContrabandTestRegularItem"), Is.True,
+                "Regular item should be priced.");
+
+            // Emag items should NOT have a price.
+            Assert.That(prices.Prices.ContainsKey("ContrabandTestEmagItem"), Is.False,
+                "Emag item should not be priced.");
+
+            // Contraband items should NOT have a price.
+            Assert.That(prices.Prices.ContainsKey("ContrabandTestContrabandItem"), Is.False,
+                "Contraband item should not be priced.");
+
+            entMan.DeleteEntity(vendor);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
+++ b/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
@@ -112,11 +112,7 @@ public sealed class VendingPaymentSystem : EntitySystem
         foreach (var itemId in comp.Inventory.Keys)
             prices.Prices[itemId] = GetRawItemPrice(itemId);
 
-        foreach (var itemId in comp.EmaggedInventory.Keys)
-            prices.Prices.TryAdd(itemId, GetRawItemPrice(itemId));
-
-        foreach (var itemId in comp.ContrabandInventory.Keys)
-            prices.Prices.TryAdd(itemId, GetRawItemPrice(itemId));
+        // Emag and contraband items are not priced -- they vend free once unlocked.
 
         // Pass 2: find cheapest non-zero price as vendor minimum.
         var vendorMin = int.MaxValue;


### PR DESCRIPTION
## About the PR

Emag and contraband vending items were being priced at material/cargo cost because the pricing system didn't account for these inventory types separately. They now vend free once unlocked.

## Why / Balance

Emagging a vendor is the cost of accessing its hidden inventory. Charging spesos on top of that undermines the black-market design and wasn't intentional -- emag/contraband was simply overlooked when building the pricing system.

## Technical details

Removed the `EmaggedInventory` and `ContrabandInventory` pricing loops from `VendingPaymentSystem.UpdatePrices`. Items without a price entry in `VendingPricesComponent` pass through `OnBeforeVend` without payment.

## Media

N/A

## Requirements

- [x] Emagged items vend without payment
- [x] Contraband items vend without payment
- [x] Regular inventory pricing unaffected

## Breaking changes

None

## Changelog

:cl:
- fix: emag and contraband vending items no longer cost spesos

Closes #343
Closes #357