### PR TITLE
fix: update payroll wage tier on mid-round job change

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
@@ -5,7 +5,7 @@ using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.RussStation.Economy.Components;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Maths;
+using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.RussStation.Economy;
 

--- a/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
@@ -1,0 +1,89 @@
+using Content.Server.RussStation.Economy;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
+using Content.Shared.RussStation.Economy.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+[TestFixture]
+[TestOf(typeof(PayrollSystem))]
+public sealed class PayrollJobUpdateTest
+{
+    /// <summary>
+    /// Verifies that when a role is added mid-round via RoleAddedEvent,
+    /// the PayrollSystem updates the PlayerBalanceComponent.JobId to the new job.
+    /// This is the fix for #345: without this handler, wage tier was locked
+    /// to whatever job the player spawned with.
+    /// </summary>
+    [Test]
+    public async Task RoleAddedUpdatesJobIdTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mindSystem = entMan.System<SharedMindSystem>();
+            var roleSystem = entMan.System<SharedRoleSystem>();
+
+            // Create mob with balance component, initial job is Passenger.
+            var mob = entMan.SpawnEntity(null, new MapCoordinates());
+            var balance = entMan.AddComponent<PlayerBalanceComponent>(mob);
+            balance.JobId = "Passenger";
+            entMan.AddComponent<MindContainerComponent>(mob);
+
+            // Create a mind and attach it to the mob.
+            var mindId = mindSystem.CreateMind(null).Owner;
+            mindSystem.TransferTo(mindId, mob);
+
+            // Give the mind a job role. MindAddJobRole raises RoleAddedEvent,
+            // which should trigger PayrollSystem.OnRoleAdded to update JobId.
+            roleSystem.MindAddJobRole(mindId, jobPrototype: "StationEngineer");
+
+            Assert.That(balance.JobId, Is.EqualTo("StationEngineer"),
+                "JobId should be updated to the new role after RoleAddedEvent.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Verifies that RoleAddedEvent with no job role component (e.g., antag roles)
+    /// does not clear the existing JobId.
+    /// </summary>
+    [Test]
+    public async Task NonJobRoleDoesNotClearJobIdTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mindSystem = entMan.System<SharedMindSystem>();
+            var roleSystem = entMan.System<SharedRoleSystem>();
+
+            var mob = entMan.SpawnEntity(null, new MapCoordinates());
+            var balance = entMan.AddComponent<PlayerBalanceComponent>(mob);
+            balance.JobId = "StationEngineer";
+            entMan.AddComponent<MindContainerComponent>(mob);
+
+            var mindId = mindSystem.CreateMind(null).Owner;
+            mindSystem.TransferTo(mindId, mob);
+
+            // Add a non-job role (traitor). This should not affect JobId.
+            roleSystem.MindAddRole(mindId, "MindRoleTraitor");
+
+            Assert.That(balance.JobId, Is.EqualTo("StationEngineer"),
+                "JobId should remain unchanged when a non-job role is added.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
@@ -5,6 +5,7 @@ using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.RussStation.Economy.Components;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
 
 namespace Content.IntegrationTests.Tests.RussStation.Economy;
 

--- a/Content.Server/RussStation/Economy/PayrollSystem.cs
+++ b/Content.Server/RussStation/Economy/PayrollSystem.cs
@@ -75,7 +75,7 @@ public sealed class PayrollSystem : EntitySystem
         if (!_jobs.MindTryGetJobId(args.MindId, out var jobId))
             return;
 
-        comp.JobId = jobId.Value;
+        comp.JobId = jobId!.Value;
     }
 
     private void OnBalanceStartup(EntityUid uid, PlayerBalanceComponent comp, ComponentStartup args)

--- a/Content.Server/RussStation/Economy/PayrollSystem.cs
+++ b/Content.Server/RussStation/Economy/PayrollSystem.cs
@@ -1,7 +1,9 @@
 using Content.Shared.CartridgeLoader;
 using Content.Shared.PDA;
 using Content.Shared.Popups;
+using Content.Shared.Mind;
 using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
 using Content.Shared.RussStation.Economy;
 using Content.Shared.RussStation.Economy.Components;
 using Robust.Shared.Audio;
@@ -26,6 +28,7 @@ public sealed class PayrollSystem : EntitySystem
     [Dependency] private readonly PlayerBalanceSystem _balance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedJobSystem _jobs = default!;
 
     private static readonly ProtoId<DepartmentPrototype> CommandDepartment = "Command";
 
@@ -58,6 +61,21 @@ public sealed class PayrollSystem : EntitySystem
         Subs.CVar(_cfg, EconomyCCVars.WageCommand, v => _wageCommand = v, true);
 
         SubscribeLocalEvent<PlayerBalanceComponent, ComponentStartup>(OnBalanceStartup);
+        SubscribeLocalEvent<RoleAddedEvent>(OnRoleAdded);
+    }
+
+    private void OnRoleAdded(RoleAddedEvent args)
+    {
+        if (args.Mind.CurrentEntity is not { } mob)
+            return;
+
+        if (!TryComp<PlayerBalanceComponent>(mob, out var comp))
+            return;
+
+        if (!_jobs.MindTryGetJobId(args.MindId, out var jobId))
+            return;
+
+        comp.JobId = jobId.Value;
     }
 
     private void OnBalanceStartup(EntityUid uid, PlayerBalanceComponent comp, ComponentStartup args)


### PR DESCRIPTION
## About the PR

Payroll wages now update when a player's job changes mid-round, instead of staying locked to their spawn job.

## Why / Balance

A Passenger promoted to a crew role would keep receiving lower-tier wages until round restart. Now their wage tier adjusts immediately on role change.

## Technical details

Added `RoleAddedEvent` subscription in `PayrollSystem`. When a role is added, the system checks if the mob has a `PlayerBalanceComponent` and updates `JobId` from the mind's current job.

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None

**Changelog**

:cl:
- fix: payroll wages now update when job changes mid-round

Closes #345