### PR TITLE
Add fork-specific CI workflows and improve local CI

### DIFF
--- a/.github/workflows/honk-marker-audit.yml
+++ b/.github/workflows/honk-marker-audit.yml
@@ -1,0 +1,20 @@
+name: "HONK Marker Audit"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [release]
+
+jobs:
+  audit:
+    name: HONK Marker Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Audit upstream files for HONK markers
+        run: |
+          chmod +x Tools/honk_marker_audit.sh
+          Tools/honk_marker_audit.sh "origin/${{ github.base_ref }}"

--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -1,0 +1,71 @@
+name: "PR Body Check"
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review]
+    branches: [release]
+
+jobs:
+  check:
+    name: PR Body Check
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          WARNINGS=0
+          ERRORS=0
+
+          warn() { echo "::warning::$1"; ((WARNINGS++)) || true; }
+          err()  { echo "::error::$1";   ((ERRORS++))   || true; }
+
+          if [ -z "$PR_BODY" ]; then
+            err "PR body is empty. Please use the PR template."
+            exit 1
+          fi
+
+          # Check required sections exist and aren't just the template placeholder
+          check_section() {
+            local heading="$1"
+            local placeholder="$2"
+
+            if ! echo "$PR_BODY" | grep -q "## ${heading}"; then
+              err "Missing section: ## ${heading}"
+              return
+            fi
+
+            # Extract content between this heading and the next heading (or EOF)
+            local content
+            content=$(echo "$PR_BODY" | sed -n "/## ${heading}/,/^## /p" | tail -n +2 | sed '/^## /d')
+
+            # Strip HTML comments and whitespace
+            local stripped
+            stripped=$(echo "$content" | sed 's/<!--.*-->//g' | tr -d '[:space:]')
+
+            if [ -z "$stripped" ]; then
+              warn "Section '## ${heading}' appears empty (only template comments)"
+            fi
+          }
+
+          check_section "About the PR" "What did you change"
+          check_section "Why / Balance" "Discuss how this would affect"
+
+          # Check for changelog - :cl: should be outside comment block
+          # Template has :cl: inside <!-- --> comments; a filled-in PR moves it outside
+          CL_UNCOMMENTED=$(echo "$PR_BODY" | grep -v '^\s*<!--' | grep -c ':cl:' || true)
+          CL_COMMENTED=$(echo "$PR_BODY" | sed -n '/<!--/,/-->/p' | grep -c ':cl:' || true)
+
+          if [ "$CL_UNCOMMENTED" -eq 0 ] && [ "$CL_COMMENTED" -gt 0 ]; then
+            warn "Changelog (:cl:) is still inside a comment block. Uncomment it if this PR has player-facing changes."
+          elif [ "$CL_UNCOMMENTED" -eq 0 ] && [ "$CL_COMMENTED" -eq 0 ]; then
+            warn "No :cl: changelog found. Add one if this PR has player-facing changes."
+          fi
+
+          echo ""
+          echo "PR body check: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+
+          if [ "$ERRORS" -gt 0 ]; then
+            exit 1
+          fi

--- a/.github/workflows/prototype-id-check.yml
+++ b/.github/workflows/prototype-id-check.yml
@@ -1,0 +1,21 @@
+name: "Prototype ID Check"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [release]
+    paths:
+      - "Resources/Prototypes/@RussStation/**/*.yml"
+      - "Resources/Prototypes/@RussStation/**/*.yaml"
+
+jobs:
+  check:
+    name: Prototype ID Collision Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: Check for prototype ID collisions
+        run: |
+          chmod +x Tools/prototype_id_check.sh
+          Tools/prototype_id_check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -315,7 +315,6 @@ Resources/MapImages
 CLAUDE.md
 .serena/
 .prettierignore
-ci-local.sh
 /docs/
 
 # Deploy

--- a/Tools/honk_marker_audit.sh
+++ b/Tools/honk_marker_audit.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Audits modified upstream files for HONK marker comments.
+# Helps catch unmarked fork changes that will be hard to find during rebase.
+#
+# Usage: Tools/honk_marker_audit.sh [base_ref]
+#   base_ref: git ref to diff against (default: origin/release)
+#
+# In GitHub Actions, emits ::warning annotations.
+# Locally, prints plain warnings.
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/release}"
+
+# Fork-specific path patterns (never need HONK markers)
+FORK_PATTERNS=(
+    "@RussStation"
+    "RussStation/"
+    ".github/workflows/honk-"
+    ".github/workflows/pr-body"
+    ".github/workflows/prototype-id"
+    ".github/workflows/check-upstream"
+    ".github/workflows/labeler-size"
+    ".github/labeler.yml"
+    "ci-local.sh"
+    "deploy.sh"
+    "CLAUDE.md"
+    "BRANCHING.md"
+    "CONTRIBUTING.md"
+    ".claude/"
+)
+
+is_fork_file() {
+    local file="$1"
+    for pattern in "${FORK_PATTERNS[@]}"; do
+        if [[ "$file" == *"$pattern"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+warn() {
+    local file="$1"
+    local msg="$2"
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+        echo "::warning file=${file}::${msg}"
+    else
+        echo "  WARN: ${file} -- ${msg}"
+    fi
+}
+
+# Resolve base ref
+if ! git rev-parse "${BASE_REF}" >/dev/null 2>&1; then
+    echo "Cannot resolve base ref: ${BASE_REF}"
+    exit 1
+fi
+
+MODIFIED_FILES=$(git diff --name-only --diff-filter=d "${BASE_REF}"...HEAD 2>/dev/null \
+    || git diff --name-only --diff-filter=d "${BASE_REF}" HEAD)
+
+if [ -z "$MODIFIED_FILES" ]; then
+    echo "No modified files found."
+    exit 0
+fi
+
+WARNINGS=0
+CHECKED=0
+
+echo "Checking upstream files for HONK markers (base: ${BASE_REF})..."
+echo ""
+
+while IFS= read -r file; do
+    # Skip fork-specific files
+    if is_fork_file "$file"; then
+        continue
+    fi
+
+    # Skip files that no longer exist
+    if [ ! -f "$file" ]; then
+        continue
+    fi
+
+    case "$file" in
+        *.cs)
+            ((CHECKED++)) || true
+            if ! grep -q "HONK START\|HONK END" "$file" 2>/dev/null; then
+                warn "$file" "Upstream C# file modified without HONK markers"
+                ((WARNINGS++)) || true
+            fi
+            ;;
+        *.yml|*.yaml)
+            ((CHECKED++)) || true
+            if ! grep -q "HONK START\|HONK END" "$file" 2>/dev/null; then
+                warn "$file" "Upstream YAML file modified without HONK markers"
+                ((WARNINGS++)) || true
+            fi
+            ;;
+    esac
+done <<< "$MODIFIED_FILES"
+
+echo ""
+echo "Checked ${CHECKED} upstream file(s), found ${WARNINGS} without HONK markers."
+
+if [ "$WARNINGS" -gt 0 ]; then
+    echo ""
+    echo "Wrap fork changes with marker comments for easier rebase tracking:"
+    echo "  C#:   //HONK START ... //HONK END"
+    echo "  YAML: # HONK START ... # HONK END"
+fi

--- a/Tools/prototype_id_check.sh
+++ b/Tools/prototype_id_check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Checks for prototype ID collisions between fork (@RussStation) and upstream prototypes.
+# Intentional overrides are valid but should be documented.
+#
+# Usage: Tools/prototype_id_check.sh
+#
+# In GitHub Actions, emits ::warning annotations.
+# Locally, prints plain warnings.
+
+set -euo pipefail
+
+FORK_DIR="Resources/Prototypes/@RussStation"
+UPSTREAM_DIR="Resources/Prototypes"
+
+warn() {
+    local msg="$1"
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+        echo "::warning::${msg}"
+    else
+        echo "  WARN: ${msg}"
+    fi
+}
+
+if [ ! -d "$FORK_DIR" ]; then
+    echo "No fork prototypes directory found at ${FORK_DIR}"
+    exit 0
+fi
+
+# Extract prototype IDs from fork YAML files
+# Matches lines like:  id: SomeThing  or  id: "SomeThing"
+FORK_IDS=$(grep -rh '^\s*id:\s*' "$FORK_DIR" --include='*.yml' --include='*.yaml' 2>/dev/null \
+    | sed "s/.*id:\s*['\"]*//" | sed "s/['\"].*$//" | sed 's/\s*$//' | sort -u)
+
+if [ -z "$FORK_IDS" ]; then
+    echo "No prototype IDs found in ${FORK_DIR}"
+    exit 0
+fi
+
+TOTAL=$(echo "$FORK_IDS" | wc -l)
+COLLISIONS=0
+
+echo "Checking ${TOTAL} fork prototype IDs for upstream collisions..."
+echo ""
+
+while IFS= read -r id; do
+    [ -z "$id" ] && continue
+
+    # Search upstream prototypes (exclude fork directory)
+    UPSTREAM_MATCH=$(grep -rl "^\s*id:\s*['\"]*${id}['\"]* *$" "$UPSTREAM_DIR" \
+        --include='*.yml' --include='*.yaml' --exclude-dir='@RussStation' 2>/dev/null | head -1 || true)
+
+    if [ -n "$UPSTREAM_MATCH" ]; then
+        FORK_MATCH=$(grep -rl "^\s*id:\s*['\"]*${id}['\"]* *$" "$FORK_DIR" \
+            --include='*.yml' --include='*.yaml' 2>/dev/null | head -1 || true)
+        warn "ID collision: '${id}' in ${FORK_MATCH} shadows ${UPSTREAM_MATCH}"
+        ((COLLISIONS++)) || true
+    fi
+done <<< "$FORK_IDS"
+
+echo ""
+echo "Checked ${TOTAL} fork prototype ID(s), found ${COLLISIONS} collision(s) with upstream."
+
+if [ "$COLLISIONS" -gt 0 ]; then
+    echo ""
+    echo "Collisions may be intentional overrides. If so, add a comment in the fork YAML:"
+    echo "  # Intentional override: <reason>"
+fi

--- a/ci-local.sh
+++ b/ci-local.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Local CI - replicates the GitHub Actions checks for PR validation.
+# Usage: ./ci-local.sh [flags]
+#
+# Flags:
+#   --skip-build    Skip the build step
+#   --skip-tests    Skip both test suites
+#   --skip-lint     Skip the YAML linter
+#   --only-build    Run only the build step
+#   --only-tests    Run only the test suites
+#   --only-lint     Run only the YAML linter
+set -euo pipefail
+
+SKIP_BUILD=false
+SKIP_TESTS=false
+SKIP_LINT=false
+ONLY_BUILD=false
+ONLY_TESTS=false
+ONLY_LINT=false
+
+for arg in "$@"; do
+    case $arg in
+        --skip-build)  SKIP_BUILD=true ;;
+        --skip-tests)  SKIP_TESTS=true ;;
+        --skip-lint)   SKIP_LINT=true ;;
+        --only-build)  ONLY_BUILD=true ;;
+        --only-tests)  ONLY_TESTS=true ;;
+        --only-lint)   ONLY_LINT=true ;;
+        --help|-h)
+            echo "Usage: ./ci-local.sh [--skip-build] [--skip-tests] [--skip-lint]"
+            echo "                     [--only-build] [--only-tests] [--only-lint]"
+            exit 0
+            ;;
+    esac
+done
+
+# --only flags override --skip flags: run only the specified step(s)
+if $ONLY_BUILD || $ONLY_TESTS || $ONLY_LINT; then
+    $ONLY_BUILD || SKIP_BUILD=true
+    $ONLY_TESTS || SKIP_TESTS=true
+    $ONLY_LINT  || SKIP_LINT=true
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Timing helpers
+declare -A STEP_TIMES
+TOTAL_START=$SECONDS
+
+step_start() { STEP_START=$SECONDS; }
+step_end() {
+    local name="$1"
+    local elapsed=$(( SECONDS - STEP_START ))
+    STEP_TIMES["$name"]=$elapsed
+}
+
+pass() { echo -e "${GREEN}PASS${NC}: $1 ${DIM}(${2}s)${NC}"; }
+fail() { echo -e "${RED}FAIL${NC}: $1 ${DIM}(${2}s)${NC}"; FAILED=true; }
+skip() { echo -e "${YELLOW}SKIP${NC}: $1"; }
+
+FAILED=false
+
+echo "========================================"
+echo "  Local CI - honksquad-ss14"
+echo "========================================"
+echo ""
+
+# --- CRLF Check ---
+echo "--- CRLF Check ---"
+step_start
+if git grep -rlI $'\r' -- '*.cs' '*.yml' '*.yaml' '*.csproj' > /dev/null 2>&1; then
+    step_end "CRLF Check"
+    fail "CRLF Check" "${STEP_TIMES["CRLF Check"]}"
+    git grep -rlI $'\r' -- '*.cs' '*.yml' '*.yaml' '*.csproj' | head -10
+else
+    step_end "CRLF Check"
+    pass "CRLF Check" "${STEP_TIMES["CRLF Check"]}"
+fi
+echo ""
+
+# --- Build (DebugOpt) ---
+if [ "$SKIP_BUILD" = false ]; then
+    echo "--- Build (DebugOpt) ---"
+    step_start
+    if dotnet build --configuration DebugOpt --no-restore /m 2>&1 | tee /dev/stderr | grep -q "0 Error(s)"; then
+        step_end "Build"
+        pass "Build (DebugOpt)" "${STEP_TIMES["Build"]}"
+    else
+        step_end "Build"
+        fail "Build (DebugOpt)" "${STEP_TIMES["Build"]}"
+        exit 1
+    fi
+    echo ""
+else
+    skip "Build (DebugOpt)"
+    echo ""
+fi
+
+# --- Unit Tests ---
+if [ "$SKIP_TESTS" = false ]; then
+    echo "--- Content.Tests ---"
+    step_start
+    if dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 2>&1 | tee /dev/stderr | grep -q "Passed!"; then
+        step_end "Unit Tests"
+        pass "Content.Tests" "${STEP_TIMES["Unit Tests"]}"
+    else
+        step_end "Unit Tests"
+        fail "Content.Tests" "${STEP_TIMES["Unit Tests"]}"
+    fi
+    echo ""
+
+    echo "--- Content.IntegrationTests ---"
+    step_start
+    DOTNET_gcServer=1 dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed 2>&1 | tee /dev/stderr
+    if [ "${PIPESTATUS[0]}" -eq 0 ]; then
+        step_end "Integration Tests"
+        pass "Content.IntegrationTests" "${STEP_TIMES["Integration Tests"]}"
+    else
+        step_end "Integration Tests"
+        fail "Content.IntegrationTests" "${STEP_TIMES["Integration Tests"]}"
+    fi
+    echo ""
+else
+    skip "Content.Tests"
+    skip "Content.IntegrationTests"
+    echo ""
+fi
+
+# --- YAML Linter ---
+if [ "$SKIP_LINT" = false ]; then
+    echo "--- YAML Linter ---"
+    step_start
+    if dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj --no-build 2>&1 | tee /dev/stderr | grep -q "0 errors"; then
+        step_end "YAML Linter"
+        pass "YAML Linter" "${STEP_TIMES["YAML Linter"]}"
+    else
+        step_end "YAML Linter"
+        fail "YAML Linter" "${STEP_TIMES["YAML Linter"]}"
+    fi
+    echo ""
+else
+    skip "YAML Linter"
+    echo ""
+fi
+
+# --- Summary ---
+TOTAL_ELAPSED=$(( SECONDS - TOTAL_START ))
+
+echo "========================================"
+if [ "$FAILED" = true ]; then
+    echo -e "  ${RED}CI FAILED${NC}  (${TOTAL_ELAPSED}s total)"
+else
+    echo -e "  ${GREEN}CI PASSED${NC}  (${TOTAL_ELAPSED}s total)"
+fi
+echo ""
+
+# Print timing breakdown
+if [ ${#STEP_TIMES[@]} -gt 0 ]; then
+    echo "  Timing:"
+    for step in "CRLF Check" "Build" "Unit Tests" "Integration Tests" "YAML Linter"; do
+        if [ -n "${STEP_TIMES[$step]+x}" ]; then
+            printf "    %-25s %4ss\n" "$step" "${STEP_TIMES[$step]}"
+        fi
+    done
+    echo ""
+fi
+
+if [ "$FAILED" = true ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
## About the PR

Adds three new advisory CI workflows that only run on fork content, plus improvements to the local CI script. Also disables four upstream workflows that don't apply to this fork.

**New workflows (all advisory, not blocking):**
- **HONK Marker Audit** -- flags upstream files modified without `//HONK START`/`//HONK END` markers, catching unmarked changes before they become rebase pain
- **PR Body Check** -- validates PR template sections are filled in and `:cl:` changelog is uncommented
- **Prototype ID Check** -- detects `@RussStation` prototype IDs that shadow upstream IDs (only runs when fork prototypes change)

**ci-local.sh improvements:**
- `--only-build`, `--only-tests`, `--only-lint` flags for faster iteration
- Per-step timing with a summary table at the end

**Disabled upstream workflows** (via `gh workflow disable`, no file changes):
- Close PRs on master (we don't use master)
- Update credits (upstream patron/contributor list)
- Publish + Publish Testing (upstream deployment pipeline)

## Why / Balance

All new files are fork-only, so zero rebase conflict risk with upstream. The disabled workflows were burning CI minutes on things that don't apply to a downstream fork.

## Technical details

New scripts in `Tools/` (`honk_marker_audit.sh`, `prototype_id_check.sh`) work both locally and in GitHub Actions, using `::warning` annotations in CI and plain text locally. ci-local.sh was previously gitignored as a personal helper but is now tracked for all contributors.

## Media

N/A -- CI/tooling only.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

No player-facing changes.