### PR TITLE
Client-side audio muffling for deaf entities

### DIFF
--- a/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
+++ b/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
@@ -65,12 +65,16 @@ public sealed class DeafAudioSystem : EntitySystem
 
     private void OnRemove(EntityUid uid, DeafableComponent comp, ComponentRemove args)
     {
-        SetDeaf(false);
+        // Ignore non-local entities so that a distant NPC losing DeafableComponent
+        // does not unhook our override while the local player is still deaf.
+        if (uid == _player.LocalEntity)
+            SetDeaf(false);
     }
 
     private void OnDeafnessChanged(EntityUid uid, DeafableComponent comp, ref DeafnessChangedEvent args)
     {
-        SetDeaf(args.Deaf);
+        if (uid == _player.LocalEntity)
+            SetDeaf(args.Deaf);
     }
 
     private void SetDeaf(bool deaf)

--- a/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
+++ b/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
@@ -1,0 +1,90 @@
+using System.Numerics;
+using Content.Shared.RussStation.Hearing;
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Client.Audio;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Client.RussStation.Hearing;
+
+/// <summary>
+/// Applies an audio low-pass muffling effect when the local player is deaf
+/// by injecting extra occlusion into the engine's audio processing.
+/// </summary>
+public sealed class DeafAudioSystem : EntitySystem
+{
+    [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    /// <summary>
+    /// Extra occlusion added to every audio source when deaf.
+    /// Drives the OpenAL EFX lowpass filter, muffling all sounds.
+    /// </summary>
+    private const float DeafOcclusion = 8f;
+
+    private bool _isDeaf;
+    private float _maxRayLength;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DeafableComponent, LocalPlayerAttachedEvent>(OnAttached);
+        SubscribeLocalEvent<DeafableComponent, LocalPlayerDetachedEvent>(OnDetached);
+        SubscribeLocalEvent<DeafableComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<DeafableComponent, DeafnessChangedEvent>(OnDeafnessChanged);
+
+        Subs.CVar(_cfg, Robust.Shared.CVars.AudioRaycastLength, v => _maxRayLength = v, true);
+    }
+
+    private void OnAttached(EntityUid uid, DeafableComponent comp, LocalPlayerAttachedEvent args)
+    {
+        SetDeaf(comp.IsDeaf);
+    }
+
+    private void OnDetached(EntityUid uid, DeafableComponent comp, LocalPlayerDetachedEvent args)
+    {
+        SetDeaf(false);
+    }
+
+    private void OnRemove(EntityUid uid, DeafableComponent comp, ComponentRemove args)
+    {
+        SetDeaf(false);
+    }
+
+    private void OnDeafnessChanged(EntityUid uid, DeafableComponent comp, ref DeafnessChangedEvent args)
+    {
+        SetDeaf(args.Deaf);
+    }
+
+    private void SetDeaf(bool deaf)
+    {
+        if (_isDeaf == deaf)
+            return;
+
+        _isDeaf = deaf;
+
+        if (deaf)
+            _audio.GetOcclusionOverride += OcclusionOverride;
+        else
+            _audio.GetOcclusionOverride -= OcclusionOverride;
+    }
+
+    private float OcclusionOverride(MapCoordinates listener, Vector2 delta, float distance, EntityUid? ignoredEnt)
+    {
+        float occlusion = 0;
+
+        if (distance > 0.1f)
+        {
+            var rayLength = MathF.Min(distance, _maxRayLength);
+            var ray = new CollisionRay(listener.Position, delta / distance, _audio.OcclusionCollisionMask);
+            occlusion = _physics.IntersectRayPenetration(listener.MapId, ray, rayLength, ignoredEnt);
+        }
+
+        return occlusion + DeafOcclusion;
+    }
+}

--- a/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
+++ b/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared.RussStation.Hearing;
 using Content.Shared.RussStation.Hearing.Systems;
 using Robust.Client.Audio;
+using Robust.Client.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
@@ -19,6 +20,7 @@ public sealed class DeafAudioSystem : EntitySystem
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
 
     /// <summary>
     /// Extra occlusion added to every audio source when deaf.
@@ -33,12 +35,22 @@ public sealed class DeafAudioSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<DeafableComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<DeafableComponent, LocalPlayerAttachedEvent>(OnAttached);
         SubscribeLocalEvent<DeafableComponent, LocalPlayerDetachedEvent>(OnDetached);
         SubscribeLocalEvent<DeafableComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<DeafableComponent, DeafnessChangedEvent>(OnDeafnessChanged);
 
         Subs.CVar(_cfg, Robust.Shared.CVars.AudioRaycastLength, v => _maxRayLength = v, true);
+    }
+
+    private void OnStartup(EntityUid uid, DeafableComponent comp, ComponentStartup args)
+    {
+        // Handle the case where DeafableComponent is added to an entity that is already
+        // the local player (e.g. cloning, mid-round trait toggles, admin verbs).
+        // LocalPlayerAttachedEvent won't fire again for an already-attached entity.
+        if (uid == _player.LocalEntity)
+            SetDeaf(comp.IsDeaf);
     }
 
     private void OnAttached(EntityUid uid, DeafableComponent comp, LocalPlayerAttachedEvent args)
@@ -68,12 +80,19 @@ public sealed class DeafAudioSystem : EntitySystem
 
         _isDeaf = deaf;
 
+        // GetOcclusionOverride is asserted HasSingleTarget inside the engine
+        // (RobustToolbox/Robust.Client/Audio/AudioSystem.cs GetOcclusion), so no
+        // other content system can subscribe at the same time or debug builds crash.
         if (deaf)
             _audio.GetOcclusionOverride += OcclusionOverride;
         else
             _audio.GetOcclusionOverride -= OcclusionOverride;
     }
 
+    // Mirrors the engine's baseline occlusion raycast in
+    // RobustToolbox/Robust.Client/Audio/AudioSystem.cs GetOcclusion, then adds
+    // DeafOcclusion on top so wall muffling still stacks. Keep this in sync
+    // during upstream rebases if the engine's raycast shape changes.
     private float OcclusionOverride(MapCoordinates listener, Vector2 delta, float distance, EntityUid? ignoredEnt)
     {
         float occlusion = 0;


### PR DESCRIPTION
## About the PR

Adds a client-side audio muffling effect when the local player is deaf. All sounds get a lowpass filter applied, simulating impaired hearing.

## Why / Balance

Deafness currently only affects chat (garbled text). This adds the audio dimension, making deafness feel more immersive. Cybernetic ears remain the counter, restoring normal hearing.

## Technical details

Single new system: `DeafAudioSystem` (client-side). Hooks the engine's `GetOcclusionOverride` delegate to inject `DeafOcclusion = 8f` extra occlusion when deaf, which drives the OpenAL EFX lowpass filter. The override replicates the engine's baseline wall-occlusion raycast so wall muffling still stacks on top of the deaf offset.

Lifecycle is managed via `ComponentStartup`, `LocalPlayerAttachedEvent`/`LocalPlayerDetachedEvent`, `ComponentRemove`, and `DeafnessChangedEvent` from the existing `DeafableComponent`. Every handler is guarded on `uid == _player.LocalEntity` so that remote entities flipping their own deafness state cannot toggle the override. `ComponentStartup` specifically covers the case where `DeafableComponent` is added to an already-attached player (cloning, mid-round trait toggles, admin verbs), since `LocalPlayerAttachedEvent` does not re-fire for that path.

`GetOcclusionOverride` is asserted as `HasSingleTarget` by the engine, so only one content system at a time can subscribe. There is a comment in `SetDeaf` flagging that constraint for future contributors. The mirrored raycast body has a comment pointing back at `RobustToolbox/Robust.Client/Audio/AudioSystem.cs GetOcclusion` so upstream rebases flag if the engine's raycast shape drifts.

`DeafOcclusion = 8f` was picked by ear: loud enough that gunfire and alarms still cut through, muffled enough that you notice you cannot hear the scrubbers. Worth revisiting if playtest finds it too subtle or too aggressive; it is a `private const` so the change is one-line.

## Media

Audio effect, no visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Deaf entities now hear all sounds muffled through a lowpass filter.
