### PR TITLE
Extract dialog boilerplate in IdCardAccountSystem

### DIFF
--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -1,4 +1,3 @@
-using Content.Server.Administration;
 using Content.Server.Popups;
 using Content.Server.Stack;
 using Content.Shared.Access.Components;
@@ -12,6 +11,7 @@ using Content.Shared.Popups;
 using Content.Shared.RussStation.Economy.Components;
 using Content.Shared.Stacks;
 using Content.Shared.Verbs;
+using Content.Server.RussStation.UI;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -25,18 +25,12 @@ namespace Content.Server.RussStation.Economy;
 /// </summary>
 public sealed class IdCardAccountSystem : EntitySystem
 {
-    [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
+    [Dependency] private readonly TrackedDialogSystem _trackedDialog = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly PlayerBalanceSystem _balance = default!;
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     private static readonly ProtoId<StackPrototype> CreditStack = "Credit";
-
-    /// <summary>
-    /// Tracks which sessions have an open ID-card dialog.
-    /// Prevents stacking dialogs on repeated alt-click and allows cancel on drop.
-    /// </summary>
-    private readonly HashSet<ICommonSession> _pendingDialogSessions = new();
 
     public override void Initialize()
     {
@@ -55,26 +49,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (!TryComp(args.User, out ActorComponent? actor))
             return;
 
-        if (!_pendingDialogSessions.Remove(actor.PlayerSession))
-            return;
-
-        _quickDialog.CloseAllDialogs(actor.PlayerSession);
-    }
-
-    private void OpenTrackedDialog<T>(ICommonSession session, string titleKey, string promptKey, Action<T> onConfirm)
-    {
-        if (!_pendingDialogSessions.Add(session))
-            return;
-
-        _quickDialog.OpenDialog(session,
-            Loc.GetString(titleKey),
-            Loc.GetString(promptKey),
-            (T value) =>
-            {
-                _pendingDialogSessions.Remove(session);
-                onConfirm(value);
-            },
-            () => _pendingDialogSessions.Remove(session));
+        _trackedDialog.CancelDialog(actor.PlayerSession);
     }
 
     private void OnGetAltVerbs(EntityUid uid, IdCardComponent comp, GetVerbsEvent<AlternativeVerb> args)
@@ -93,9 +68,9 @@ public sealed class IdCardAccountSystem : EntitySystem
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-set-account-verb"),
-                Act = () => OpenTrackedDialog<string>(actor.PlayerSession,
-                    "id-card-set-account-title",
-                    "id-card-set-account-prompt",
+                Act = () => _trackedDialog.OpenDialog<string>(actor.PlayerSession,
+                    Loc.GetString("id-card-set-account-title"),
+                    Loc.GetString("id-card-set-account-prompt"),
                     account => OnAccountEntered(uid, args.User, actor.PlayerSession, account)),
                 Impact = LogImpact.Low,
             });
@@ -105,9 +80,9 @@ public sealed class IdCardAccountSystem : EntitySystem
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-withdraw-verb"),
-                Act = () => OpenTrackedDialog<int>(actor.PlayerSession,
-                    "id-card-withdraw-title",
-                    "id-card-withdraw-prompt",
+                Act = () => _trackedDialog.OpenDialog<int>(actor.PlayerSession,
+                    Loc.GetString("id-card-withdraw-title"),
+                    Loc.GetString("id-card-withdraw-prompt"),
                     amount => OnWithdraw(uid, args.User, actor.PlayerSession, amount)),
                 Impact = LogImpact.Low,
             });
@@ -131,9 +106,9 @@ public sealed class IdCardAccountSystem : EntitySystem
         args.Verbs.Add(new ActivationVerb
         {
             Text = Loc.GetString("id-card-create-account-verb"),
-            Act = () => OpenTrackedDialog<string>(actor.PlayerSession,
-                "id-card-create-account-title",
-                "id-card-create-account-confirm",
+            Act = () => _trackedDialog.OpenDialog<string>(actor.PlayerSession,
+                Loc.GetString("id-card-create-account-title"),
+                Loc.GetString("id-card-create-account-confirm"),
                 confirmation =>
                 {
                     if (confirmation.Trim().Equals("YES", StringComparison.OrdinalIgnoreCase))

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -61,6 +61,22 @@ public sealed class IdCardAccountSystem : EntitySystem
         _quickDialog.CloseAllDialogs(actor.PlayerSession);
     }
 
+    private void OpenTrackedDialog<T>(ICommonSession session, string titleKey, string promptKey, Action<T> onConfirm)
+    {
+        if (!_pendingDialogSessions.Add(session))
+            return;
+
+        _quickDialog.OpenDialog(session,
+            Loc.GetString(titleKey),
+            Loc.GetString(promptKey),
+            (T value) =>
+            {
+                _pendingDialogSessions.Remove(session);
+                onConfirm(value);
+            },
+            () => _pendingDialogSessions.Remove(session));
+    }
+
     private void OnGetAltVerbs(EntityUid uid, IdCardComponent comp, GetVerbsEvent<AlternativeVerb> args)
     {
         if (!TryComp(args.User, out ActorComponent? actor))
@@ -77,21 +93,10 @@ public sealed class IdCardAccountSystem : EntitySystem
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-set-account-verb"),
-                Act = () =>
-                {
-                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
-                        return;
-
-                    _quickDialog.OpenDialog(actor.PlayerSession,
-                        Loc.GetString("id-card-set-account-title"),
-                        Loc.GetString("id-card-set-account-prompt"),
-                        (string accountNumber) =>
-                        {
-                            _pendingDialogSessions.Remove(actor.PlayerSession);
-                            OnAccountEntered(uid, args.User, actor.PlayerSession, accountNumber);
-                        },
-                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
-                },
+                Act = () => OpenTrackedDialog<string>(actor.PlayerSession,
+                    "id-card-set-account-title",
+                    "id-card-set-account-prompt",
+                    account => OnAccountEntered(uid, args.User, actor.PlayerSession, account)),
                 Impact = LogImpact.Low,
             });
         }
@@ -100,21 +105,10 @@ public sealed class IdCardAccountSystem : EntitySystem
             args.Verbs.Add(new AlternativeVerb
             {
                 Text = Loc.GetString("id-card-withdraw-verb"),
-                Act = () =>
-                {
-                    if (!_pendingDialogSessions.Add(actor.PlayerSession))
-                        return;
-
-                    _quickDialog.OpenDialog(actor.PlayerSession,
-                        Loc.GetString("id-card-withdraw-title"),
-                        Loc.GetString("id-card-withdraw-prompt"),
-                        (int amount) =>
-                        {
-                            _pendingDialogSessions.Remove(actor.PlayerSession);
-                            OnWithdraw(uid, args.User, actor.PlayerSession, amount);
-                        },
-                        () => _pendingDialogSessions.Remove(actor.PlayerSession));
-                },
+                Act = () => OpenTrackedDialog<int>(actor.PlayerSession,
+                    "id-card-withdraw-title",
+                    "id-card-withdraw-prompt",
+                    amount => OnWithdraw(uid, args.User, actor.PlayerSession, amount)),
                 Impact = LogImpact.Low,
             });
         }
@@ -137,22 +131,14 @@ public sealed class IdCardAccountSystem : EntitySystem
         args.Verbs.Add(new ActivationVerb
         {
             Text = Loc.GetString("id-card-create-account-verb"),
-            Act = () =>
-            {
-                if (!_pendingDialogSessions.Add(actor.PlayerSession))
-                    return;
-
-                _quickDialog.OpenDialog(actor.PlayerSession,
-                    Loc.GetString("id-card-create-account-title"),
-                    Loc.GetString("id-card-create-account-confirm"),
-                    (string confirmation) =>
-                    {
-                        _pendingDialogSessions.Remove(actor.PlayerSession);
-                        if (confirmation.Trim().Equals("YES", StringComparison.OrdinalIgnoreCase))
-                            OnCreateAccount(uid, args.User, actor.PlayerSession);
-                    },
-                    () => _pendingDialogSessions.Remove(actor.PlayerSession));
-            },
+            Act = () => OpenTrackedDialog<string>(actor.PlayerSession,
+                "id-card-create-account-title",
+                "id-card-create-account-confirm",
+                confirmation =>
+                {
+                    if (confirmation.Trim().Equals("YES", StringComparison.OrdinalIgnoreCase))
+                        OnCreateAccount(uid, args.User, actor.PlayerSession);
+                }),
             Impact = LogImpact.Low,
         });
     }

--- a/Content.Server/RussStation/UI/TrackedDialogSystem.cs
+++ b/Content.Server/RussStation/UI/TrackedDialogSystem.cs
@@ -1,0 +1,54 @@
+using Content.Server.Administration;
+using Robust.Shared.Player;
+
+namespace Content.Server.RussStation.UI;
+
+/// <summary>
+/// Wraps <see cref="QuickDialogSystem"/> with per-session tracking to prevent
+/// stacking dialogs on repeated interactions. Systems inject this instead of
+/// managing their own HashSet of pending sessions.
+/// </summary>
+public sealed class TrackedDialogSystem : EntitySystem
+{
+    [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
+
+    private readonly HashSet<ICommonSession> _pending = new();
+
+    /// <summary>
+    /// Opens a single-field tracked dialog. If the session already has a dialog
+    /// open through this system, the call is silently ignored.
+    /// </summary>
+    public void OpenDialog<T>(ICommonSession session, string title, string prompt, Action<T> onConfirm)
+    {
+        if (!_pending.Add(session))
+            return;
+
+        _quickDialog.OpenDialog(session, title, prompt,
+            (T value) =>
+            {
+                _pending.Remove(session);
+                onConfirm(value);
+            },
+            () => _pending.Remove(session));
+    }
+
+    /// <summary>
+    /// Returns true if the given session has a tracked dialog open.
+    /// </summary>
+    public bool HasPendingDialog(ICommonSession session)
+    {
+        return _pending.Contains(session);
+    }
+
+    /// <summary>
+    /// Closes any tracked dialog for the session and cleans up tracking state.
+    /// Call this when the item is dropped or the interaction is otherwise interrupted.
+    /// </summary>
+    public void CancelDialog(ICommonSession session)
+    {
+        if (!_pending.Remove(session))
+            return;
+
+        _quickDialog.CloseAllDialogs(session);
+    }
+}


### PR DESCRIPTION
## About the PR

Extracts dialog session-tracking boilerplate into a reusable `TrackedDialogSystem` and migrates `IdCardAccountSystem` as the first consumer.

Closes #327

## Why / Balance

Any fork system that opens a `QuickDialog` needs the same scaffolding: prevent stacking on repeated clicks, clean up on item drop/disconnect. This centralizes that pattern so future systems get it for free with a single dependency injection.

## Technical details

- New `TrackedDialogSystem` in `Content.Server/RussStation/UI/` wraps `QuickDialogSystem` with a `HashSet<ICommonSession>` for tracking
- Exposes `OpenDialog<T>`, `CancelDialog`, and `HasPendingDialog`
- `IdCardAccountSystem` drops its private tracking set, private helper method, and `QuickDialogSystem` dependency in favor of `TrackedDialogSystem`
- Upstream QuickDialog consumers (Fax, Prayer, Admin, CritMob) are not touched per upstream file policy

## Media

No in-game changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.