### PR TITLE
Extract FontFamilyInfo to its own file

### DIFF
--- a/Content.Client/Stylesheets/Fonts/FontCustomizationManager.cs
+++ b/Content.Client/Stylesheets/Fonts/FontCustomizationManager.cs
@@ -325,26 +325,3 @@ public sealed class FontCustomizationManager
         };
     }
 }
-
-/// <summary>
-///     Information about a discovered font family.
-/// </summary>
-public sealed class FontFamilyInfo
-{
-    public string Name { get; }
-
-    /// <summary>
-    ///     Path template with {0} placeholder for font kind (Regular, Bold, etc.)
-    /// </summary>
-    public string PathTemplate { get; }
-
-    public bool IsUserFont { get; }
-    public HashSet<FontKind> AvailableKinds { get; } = new();
-
-    public FontFamilyInfo(string name, string pathTemplate, bool isUserFont)
-    {
-        Name = name;
-        PathTemplate = pathTemplate;
-        IsUserFont = isUserFont;
-    }
-}

--- a/Content.Client/Stylesheets/Fonts/FontFamilyInfo.cs
+++ b/Content.Client/Stylesheets/Fonts/FontFamilyInfo.cs
@@ -1,0 +1,24 @@
+namespace Content.Client.Stylesheets.Fonts;
+
+/// <summary>
+///     Information about a discovered font family.
+/// </summary>
+public sealed class FontFamilyInfo
+{
+    public string Name { get; }
+
+    /// <summary>
+    ///     Path template with {0} placeholder for font kind (Regular, Bold, etc.)
+    /// </summary>
+    public string PathTemplate { get; }
+
+    public bool IsUserFont { get; }
+    public HashSet<FontKind> AvailableKinds { get; } = new();
+
+    public FontFamilyInfo(string name, string pathTemplate, bool isUserFont)
+    {
+        Name = name;
+        PathTemplate = pathTemplate;
+        IsUserFont = isUserFont;
+    }
+}


### PR DESCRIPTION
## About the PR

Moves `FontFamilyInfo` class from the bottom of `FontCustomizationManager.cs` into its own file at `Content.Client/Stylesheets/Fonts/FontFamilyInfo.cs`.

Closes #326

## Why / Balance

One-class-per-file convention. No gameplay changes.

## Technical details

Pure extraction, no logic changes. Same namespace, same visibility.

## Media

No in-game changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.