### PR TITLE
Atmospheric radiation pulse system

### DIFF
--- a/Content.Server/RussStation/Atmos/AtmosRadiationPulseEvent.cs
+++ b/Content.Server/RussStation/Atmos/AtmosRadiationPulseEvent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Map;
+
+namespace Content.Server.RussStation.Atmos;
+
+/// <summary>
+///     Raised as a broadcast event by gas reactions that should emit a radiation pulse.
+///     Collected and batched by <see cref="Systems.AtmosRadiationPulseSystem"/>.
+/// </summary>
+[ByRefEvent]
+public record struct AtmosRadiationPulseEvent(EntityUid GridUid, Vector2i Tile, float Rads);

--- a/Content.Server/RussStation/Atmos/RadiationPulseHelper.cs
+++ b/Content.Server/RussStation/Atmos/RadiationPulseHelper.cs
@@ -1,0 +1,26 @@
+using Content.Server.Atmos;
+using Content.Shared.Atmos;
+using Robust.Shared.IoC;
+
+namespace Content.Server.RussStation.Atmos;
+
+/// <summary>
+///     Helper for gas reactions to emit radiation pulses.
+///     Reactions are data definitions without access to EntityManager,
+///     so this resolves it via IoC and raises the broadcast event.
+/// </summary>
+public static class RadiationPulseHelper
+{
+    public static void EmitRadiation(IGasMixtureHolder? holder, float rads)
+    {
+        if (holder is not TileAtmosphere tile)
+            return;
+
+        if (rads <= 0f)
+            return;
+
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var ev = new AtmosRadiationPulseEvent(tile.GridIndex, tile.GridIndices, rads);
+        entMan.EventBus.RaiseEvent(EventSource.Local, ref ev);
+    }
+}

--- a/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
+++ b/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
@@ -196,7 +196,7 @@ public sealed class AtmosRadiationPulseSystem : EntitySystem
         var uid = Spawn(null, coords);
 
         var source = EnsureComp<RadiationSourceComponent>(uid);
-        source.Intensity = totalRads;
+        source.Intensity = totalRads / tiles.Count;
         source.Enabled = true;
 
         var despawn = EnsureComp<TimedDespawnComponent>(uid);

--- a/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
+++ b/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
@@ -1,0 +1,239 @@
+using Content.Shared.Radiation.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Spawners;
+
+namespace Content.Server.RussStation.Atmos.Systems;
+
+/// <summary>
+///     Collects <see cref="AtmosRadiationPulseEvent"/>s raised by gas reactions and spawns
+///     short-lived radiation source entities so the existing gridcast system handles
+///     wall occlusion, resistance, etc.
+/// </summary>
+/// <remarks>
+///     Pulses on the same tile within one tick are flood-filled into connected blobs.
+///     Non-square blobs are recursively subdivided along their longer axis so the
+///     radiation field follows the shape of the reacting gas cloud.
+///     Each source lives for one radiation gridcast cycle (~1 s) then despawns.
+/// </remarks>
+public sealed class AtmosRadiationPulseSystem : EntitySystem
+{
+    [Dependency] private readonly SharedMapSystem _map = default!;
+
+    private readonly Dictionary<(EntityUid Grid, Vector2i Tile), float> _pending = new();
+
+    private const float PulseLifetime = 1.5f;
+    private const float MinIntensity = 0.5f;
+
+    /// <summary>
+    ///     Aspect ratio threshold. A blob with max(w,h)/min(w,h) above this gets split.
+    /// </summary>
+    private const float AspectThreshold = 1.5f;
+
+    /// <summary>
+    ///     Blobs at or below this tile count are never subdivided.
+    /// </summary>
+    private const int MinSplitSize = 4;
+
+    // Reusable collections to avoid per-tick allocation.
+    private readonly HashSet<(EntityUid, Vector2i)> _visited = new();
+    private readonly Queue<(EntityUid, Vector2i)> _queue = new();
+    private readonly List<(Vector2i Tile, float Rads)> _blob = new();
+    private readonly List<(Vector2i Tile, float Rads)> _splitA = new();
+    private readonly List<(Vector2i Tile, float Rads)> _splitB = new();
+
+    private static readonly Vector2i[] Neighbors =
+    {
+        new(1, 0), new(-1, 0), new(0, 1), new(0, -1),
+    };
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AtmosRadiationPulseEvent>(OnPulse);
+    }
+
+    private void OnPulse(ref AtmosRadiationPulseEvent ev)
+    {
+        var key = (ev.GridUid, ev.Tile);
+        if (_pending.TryGetValue(key, out var existing))
+            _pending[key] = existing + ev.Rads;
+        else
+            _pending[key] = ev.Rads;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_pending.Count == 0)
+            return;
+
+        _visited.Clear();
+
+        foreach (var (key, rads) in _pending)
+        {
+            if (_visited.Contains(key))
+                continue;
+
+            if (rads < MinIntensity)
+            {
+                _visited.Add(key);
+                continue;
+            }
+
+            FloodFill(key.Grid, key.Tile);
+
+            if (_blob.Count == 0)
+                continue;
+
+            if (!TryComp<MapGridComponent>(key.Grid, out var grid))
+                continue;
+
+            SpawnSubdivided(key.Grid, grid, _blob);
+        }
+
+        _pending.Clear();
+    }
+
+    /// <summary>
+    ///     Recursively subdivides a blob along its longer bounding-box axis
+    ///     until each chunk is roughly square, then spawns a source per chunk.
+    /// </summary>
+    private void SpawnSubdivided(
+        EntityUid gridUid,
+        MapGridComponent grid,
+        List<(Vector2i Tile, float Rads)> tiles)
+    {
+        if (tiles.Count == 0)
+            return;
+
+        // Compute bounding box.
+        var minX = int.MaxValue;
+        var minY = int.MaxValue;
+        var maxX = int.MinValue;
+        var maxY = int.MinValue;
+        foreach (var (tile, _) in tiles)
+        {
+            if (tile.X < minX) minX = tile.X;
+            if (tile.Y < minY) minY = tile.Y;
+            if (tile.X > maxX) maxX = tile.X;
+            if (tile.Y > maxY) maxY = tile.Y;
+        }
+
+        var width = maxX - minX + 1;
+        var height = maxY - minY + 1;
+        var longer = Math.Max(width, height);
+        var shorter = Math.Max(1, Math.Min(width, height));
+
+        // If roughly square or too small to split, spawn a single source.
+        if (tiles.Count <= MinSplitSize || (float) longer / shorter <= AspectThreshold)
+        {
+            SpawnSource(gridUid, grid, tiles);
+            return;
+        }
+
+        // Split along the longer axis at the midpoint.
+        _splitA.Clear();
+        _splitB.Clear();
+
+        if (width >= height)
+        {
+            var midX = minX + width / 2;
+            foreach (var entry in tiles)
+            {
+                if (entry.Tile.X <= midX)
+                    _splitA.Add(entry);
+                else
+                    _splitB.Add(entry);
+            }
+        }
+        else
+        {
+            var midY = minY + height / 2;
+            foreach (var entry in tiles)
+            {
+                if (entry.Tile.Y <= midY)
+                    _splitA.Add(entry);
+                else
+                    _splitB.Add(entry);
+            }
+        }
+
+        // Copy to avoid aliasing since recursion reuses _splitA/_splitB.
+        var halfA = new List<(Vector2i, float)>(_splitA);
+        var halfB = new List<(Vector2i, float)>(_splitB);
+
+        SpawnSubdivided(gridUid, grid, halfA);
+        SpawnSubdivided(gridUid, grid, halfB);
+    }
+
+    private void SpawnSource(
+        EntityUid gridUid,
+        MapGridComponent grid,
+        List<(Vector2i Tile, float Rads)> tiles)
+    {
+        var cx = 0f;
+        var cy = 0f;
+        var totalRads = 0f;
+        foreach (var (tile, rads) in tiles)
+        {
+            cx += (tile.X + 0.5f) * rads;
+            cy += (tile.Y + 0.5f) * rads;
+            totalRads += rads;
+        }
+
+        if (totalRads < MinIntensity)
+            return;
+
+        cx /= totalRads;
+        cy /= totalRads;
+
+        var centroidTile = new Vector2i((int) Math.Floor(cx), (int) Math.Floor(cy));
+        var coords = _map.GridTileToLocal(gridUid, grid, centroidTile);
+
+        var uid = Spawn(null, coords);
+
+        var source = EnsureComp<RadiationSourceComponent>(uid);
+        source.Intensity = totalRads;
+        source.Enabled = true;
+
+        var despawn = EnsureComp<TimedDespawnComponent>(uid);
+        despawn.Lifetime = PulseLifetime;
+    }
+
+    /// <summary>
+    ///     BFS flood-fill from a seed tile, collecting all connected pending tiles into <see cref="_blob"/>.
+    /// </summary>
+    private void FloodFill(EntityUid gridUid, Vector2i seed)
+    {
+        _blob.Clear();
+        _queue.Clear();
+
+        var start = (gridUid, seed);
+        _queue.Enqueue(start);
+        _visited.Add(start);
+
+        while (_queue.Count > 0)
+        {
+            var (grid, tile) = _queue.Dequeue();
+            var key = (grid, tile);
+
+            if (!_pending.TryGetValue(key, out var rads))
+                continue;
+
+            if (rads < MinIntensity)
+                continue;
+
+            _blob.Add((tile, rads));
+
+            foreach (var offset in Neighbors)
+            {
+                var neighbor = (grid, tile + offset);
+                if (_visited.Add(neighbor) && _pending.ContainsKey(neighbor))
+                    _queue.Enqueue(neighbor);
+            }
+        }
+    }
+}

--- a/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
+++ b/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
@@ -26,22 +26,11 @@ public sealed class AtmosRadiationPulseSystem : EntitySystem
     private const float PulseLifetime = 1.5f;
     private const float MinIntensity = 0.5f;
 
-    /// <summary>
-    ///     Aspect ratio threshold. A blob with max(w,h)/min(w,h) above this gets split.
-    /// </summary>
-    private const float AspectThreshold = 1.5f;
-
-    /// <summary>
-    ///     Blobs at or below this tile count are never subdivided.
-    /// </summary>
-    private const int MinSplitSize = 4;
 
     // Reusable collections to avoid per-tick allocation.
     private readonly HashSet<(EntityUid, Vector2i)> _visited = new();
     private readonly Queue<(EntityUid, Vector2i)> _queue = new();
     private readonly List<(Vector2i Tile, float Rads)> _blob = new();
-    private readonly List<(Vector2i Tile, float Rads)> _splitA = new();
-    private readonly List<(Vector2i Tile, float Rads)> _splitB = new();
 
     private static readonly Vector2i[] Neighbors =
     {
@@ -91,82 +80,12 @@ public sealed class AtmosRadiationPulseSystem : EntitySystem
             if (!TryComp<MapGridComponent>(key.Grid, out var grid))
                 continue;
 
-            SpawnSubdivided(key.Grid, grid, _blob);
+            var chunks = RadiationBlobMath.Subdivide(_blob);
+            foreach (var chunk in chunks)
+                SpawnSource(key.Grid, grid, chunk);
         }
 
         _pending.Clear();
-    }
-
-    /// <summary>
-    ///     Recursively subdivides a blob along its longer bounding-box axis
-    ///     until each chunk is roughly square, then spawns a source per chunk.
-    /// </summary>
-    private void SpawnSubdivided(
-        EntityUid gridUid,
-        MapGridComponent grid,
-        List<(Vector2i Tile, float Rads)> tiles)
-    {
-        if (tiles.Count == 0)
-            return;
-
-        // Compute bounding box.
-        var minX = int.MaxValue;
-        var minY = int.MaxValue;
-        var maxX = int.MinValue;
-        var maxY = int.MinValue;
-        foreach (var (tile, _) in tiles)
-        {
-            if (tile.X < minX) minX = tile.X;
-            if (tile.Y < minY) minY = tile.Y;
-            if (tile.X > maxX) maxX = tile.X;
-            if (tile.Y > maxY) maxY = tile.Y;
-        }
-
-        var width = maxX - minX + 1;
-        var height = maxY - minY + 1;
-        var longer = Math.Max(width, height);
-        var shorter = Math.Max(1, Math.Min(width, height));
-
-        // If roughly square or too small to split, spawn a single source.
-        if (tiles.Count <= MinSplitSize || (float) longer / shorter <= AspectThreshold)
-        {
-            SpawnSource(gridUid, grid, tiles);
-            return;
-        }
-
-        // Split along the longer axis at the midpoint.
-        _splitA.Clear();
-        _splitB.Clear();
-
-        if (width >= height)
-        {
-            var midX = minX + width / 2;
-            foreach (var entry in tiles)
-            {
-                if (entry.Tile.X <= midX)
-                    _splitA.Add(entry);
-                else
-                    _splitB.Add(entry);
-            }
-        }
-        else
-        {
-            var midY = minY + height / 2;
-            foreach (var entry in tiles)
-            {
-                if (entry.Tile.Y <= midY)
-                    _splitA.Add(entry);
-                else
-                    _splitB.Add(entry);
-            }
-        }
-
-        // Copy to avoid aliasing since recursion reuses _splitA/_splitB.
-        var halfA = new List<(Vector2i, float)>(_splitA);
-        var halfB = new List<(Vector2i, float)>(_splitB);
-
-        SpawnSubdivided(gridUid, grid, halfA);
-        SpawnSubdivided(gridUid, grid, halfB);
     }
 
     private void SpawnSource(
@@ -174,49 +93,23 @@ public sealed class AtmosRadiationPulseSystem : EntitySystem
         MapGridComponent grid,
         List<(Vector2i Tile, float Rads)> tiles)
     {
-        var cx = 0f;
-        var cy = 0f;
         var totalRads = 0f;
-        var minRads = float.MaxValue;
-        var maxRads = float.MinValue;
-        var minX = int.MaxValue;
-        var minY = int.MaxValue;
-        var maxX = int.MinValue;
-        var maxY = int.MinValue;
-
-        foreach (var (tile, rads) in tiles)
-        {
-            cx += (tile.X + 0.5f) * rads;
-            cy += (tile.Y + 0.5f) * rads;
+        foreach (var (_, rads) in tiles)
             totalRads += rads;
-
-            if (rads < minRads) minRads = rads;
-            if (rads > maxRads) maxRads = rads;
-            if (tile.X < minX) minX = tile.X;
-            if (tile.Y < minY) minY = tile.Y;
-            if (tile.X > maxX) maxX = tile.X;
-            if (tile.Y > maxY) maxY = tile.Y;
-        }
 
         if (totalRads < MinIntensity)
             return;
 
-        cx /= totalRads;
-        cy /= totalRads;
-
+        var (cx, cy) = RadiationBlobMath.Centroid(tiles, totalRads);
         var centroidTile = new Vector2i((int) Math.Floor(cx), (int) Math.Floor(cy));
         var coords = _map.GridTileToLocal(gridUid, grid, centroidTile);
 
         var uid = Spawn(null, coords);
 
-        // Gradient from max (centroid) to min (edge) using slope.
-        var radius = Math.Max(maxX - minX + 1, maxY - minY + 1) / 2f;
-        var slope = radius > 0.5f && minRads > 0f
-            ? (maxRads / minRads - 1f) / radius
-            : 0.5f;
+        var (intensity, slope) = RadiationBlobMath.GradientParams(tiles);
 
         var source = EnsureComp<RadiationSourceComponent>(uid);
-        source.Intensity = maxRads;
+        source.Intensity = intensity;
         source.Slope = slope;
         source.Enabled = true;
 

--- a/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
+++ b/Content.Server/RussStation/Atmos/Systems/AtmosRadiationPulseSystem.cs
@@ -177,11 +177,25 @@ public sealed class AtmosRadiationPulseSystem : EntitySystem
         var cx = 0f;
         var cy = 0f;
         var totalRads = 0f;
+        var minRads = float.MaxValue;
+        var maxRads = float.MinValue;
+        var minX = int.MaxValue;
+        var minY = int.MaxValue;
+        var maxX = int.MinValue;
+        var maxY = int.MinValue;
+
         foreach (var (tile, rads) in tiles)
         {
             cx += (tile.X + 0.5f) * rads;
             cy += (tile.Y + 0.5f) * rads;
             totalRads += rads;
+
+            if (rads < minRads) minRads = rads;
+            if (rads > maxRads) maxRads = rads;
+            if (tile.X < minX) minX = tile.X;
+            if (tile.Y < minY) minY = tile.Y;
+            if (tile.X > maxX) maxX = tile.X;
+            if (tile.Y > maxY) maxY = tile.Y;
         }
 
         if (totalRads < MinIntensity)
@@ -195,8 +209,15 @@ public sealed class AtmosRadiationPulseSystem : EntitySystem
 
         var uid = Spawn(null, coords);
 
+        // Gradient from max (centroid) to min (edge) using slope.
+        var radius = Math.Max(maxX - minX + 1, maxY - minY + 1) / 2f;
+        var slope = radius > 0.5f && minRads > 0f
+            ? (maxRads / minRads - 1f) / radius
+            : 0.5f;
+
         var source = EnsureComp<RadiationSourceComponent>(uid);
-        source.Intensity = totalRads / tiles.Count;
+        source.Intensity = maxRads;
+        source.Slope = slope;
         source.Enabled = true;
 
         var despawn = EnsureComp<TimedDespawnComponent>(uid);

--- a/Content.Server/RussStation/Atmos/Systems/RadiationBlobMath.cs
+++ b/Content.Server/RussStation/Atmos/Systems/RadiationBlobMath.cs
@@ -1,0 +1,70 @@
+using Content.Shared.RussStation.Spatial;
+using Robust.Shared.Maths;
+
+namespace Content.Server.RussStation.Atmos.Systems;
+
+/// <summary>
+///     Radiation-specific math built on top of <see cref="TileGridMath"/>.
+///     Centroid, gradient calculation, and blob subdivision for
+///     <see cref="AtmosRadiationPulseSystem"/>.
+/// </summary>
+public static class RadiationBlobMath
+{
+    /// <summary>
+    ///     Compute the intensity-weighted centroid of a set of tiles.
+    /// </summary>
+    public static (float Cx, float Cy) Centroid(List<(Vector2i Tile, float Rads)> tiles, float totalRads)
+    {
+        Span<Vector2i> positions = stackalloc Vector2i[tiles.Count];
+        Span<float> weights = stackalloc float[tiles.Count];
+        for (var i = 0; i < tiles.Count; i++)
+        {
+            positions[i] = tiles[i].Tile;
+            weights[i] = tiles[i].Rads;
+        }
+
+        var c = TileGridMath.WeightedCentroid(positions, weights, totalRads);
+        return (c.X, c.Y);
+    }
+
+    /// <summary>
+    ///     Compute source intensity and slope for a chunk of tiles.
+    ///     Intensity is the peak tile rads; slope is derived from the
+    ///     min/max ratio so intensity falls to min at the chunk edge.
+    /// </summary>
+    public static (float Intensity, float Slope) GradientParams(List<(Vector2i Tile, float Rads)> tiles)
+    {
+        var minRads = float.MaxValue;
+        var maxRads = float.MinValue;
+        var minX = int.MaxValue;
+        var minY = int.MaxValue;
+        var maxX = int.MinValue;
+        var maxY = int.MinValue;
+
+        foreach (var (tile, rads) in tiles)
+        {
+            if (rads < minRads) minRads = rads;
+            if (rads > maxRads) maxRads = rads;
+            if (tile.X < minX) minX = tile.X;
+            if (tile.Y < minY) minY = tile.Y;
+            if (tile.X > maxX) maxX = tile.X;
+            if (tile.Y > maxY) maxY = tile.Y;
+        }
+
+        var radius = Math.Max(maxX - minX + 1, maxY - minY + 1) / 2f;
+        var slope = radius > 0.5f && minRads > 0f
+            ? (maxRads / minRads - 1f) / radius
+            : 0.5f;
+
+        return (maxRads, slope);
+    }
+
+    /// <summary>
+    ///     Recursively subdivide a blob into roughly-square chunks.
+    ///     Returns a list of tile groups, each suitable for spawning a single source.
+    /// </summary>
+    public static List<List<(Vector2i Tile, float Rads)>> Subdivide(List<(Vector2i Tile, float Rads)> tiles)
+    {
+        return TileGridMath.Subdivide(tiles, static entry => entry.Tile);
+    }
+}

--- a/Content.Shared/RussStation/Spatial/TileGridMath.cs
+++ b/Content.Shared/RussStation/Spatial/TileGridMath.cs
@@ -1,0 +1,149 @@
+using Robust.Shared.Maths;
+
+namespace Content.Shared.RussStation.Spatial;
+
+/// <summary>
+///     General-purpose spatial math for discrete tile grids.
+///     Weighted centroid, bounding-box computation, and recursive subdivision.
+/// </summary>
+public static class TileGridMath
+{
+    /// <summary>
+    ///     Default aspect ratio threshold for subdivision.
+    ///     A tile group with max(w,h)/min(w,h) above this gets split.
+    /// </summary>
+    public const float DefaultAspectThreshold = 1.5f;
+
+    /// <summary>
+    ///     Default minimum tile count below which subdivision never occurs.
+    /// </summary>
+    public const int DefaultMinSplitSize = 4;
+
+    /// <summary>
+    ///     Compute the weighted centroid of a set of tiles.
+    ///     Each tile center is at (X + 0.5, Y + 0.5) in world coordinates.
+    /// </summary>
+    /// <param name="tiles">Tile positions.</param>
+    /// <param name="weights">Per-tile weights (same length as tiles).</param>
+    /// <param name="totalWeight">Sum of all weights. Must be > 0.</param>
+    public static (float X, float Y) WeightedCentroid(
+        ReadOnlySpan<Vector2i> tiles,
+        ReadOnlySpan<float> weights,
+        float totalWeight)
+    {
+        var cx = 0f;
+        var cy = 0f;
+        for (var i = 0; i < tiles.Length; i++)
+        {
+            cx += (tiles[i].X + 0.5f) * weights[i];
+            cy += (tiles[i].Y + 0.5f) * weights[i];
+        }
+        return (cx / totalWeight, cy / totalWeight);
+    }
+
+    /// <summary>
+    ///     Compute the axis-aligned bounding box of a set of tiles.
+    /// </summary>
+    public static Box2i BoundingBox(ReadOnlySpan<Vector2i> tiles)
+    {
+        var minX = int.MaxValue;
+        var minY = int.MaxValue;
+        var maxX = int.MinValue;
+        var maxY = int.MinValue;
+
+        for (var i = 0; i < tiles.Length; i++)
+        {
+            var t = tiles[i];
+            if (t.X < minX) minX = t.X;
+            if (t.Y < minY) minY = t.Y;
+            if (t.X > maxX) maxX = t.X;
+            if (t.Y > maxY) maxY = t.Y;
+        }
+
+        return new Box2i(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
+    ///     Recursively subdivide a set of tiles into roughly-square groups
+    ///     by splitting along the longer bounding-box axis at the midpoint.
+    /// </summary>
+    /// <typeparam name="T">Arbitrary payload carried with each tile.</typeparam>
+    /// <param name="tiles">Tiles to subdivide.</param>
+    /// <param name="tileSelector">Extracts the grid position from each element.</param>
+    /// <param name="aspectThreshold">Max aspect ratio before splitting.</param>
+    /// <param name="minSplitSize">Groups at or below this size are never split.</param>
+    public static List<List<T>> Subdivide<T>(
+        List<T> tiles,
+        Func<T, Vector2i> tileSelector,
+        float aspectThreshold = DefaultAspectThreshold,
+        int minSplitSize = DefaultMinSplitSize)
+    {
+        var results = new List<List<T>>();
+        SubdivideInto(tiles, tileSelector, aspectThreshold, minSplitSize, results);
+        return results;
+    }
+
+    private static void SubdivideInto<T>(
+        List<T> tiles,
+        Func<T, Vector2i> tileSelector,
+        float aspectThreshold,
+        int minSplitSize,
+        List<List<T>> results)
+    {
+        if (tiles.Count == 0)
+            return;
+
+        var minX = int.MaxValue;
+        var minY = int.MaxValue;
+        var maxX = int.MinValue;
+        var maxY = int.MinValue;
+        foreach (var entry in tiles)
+        {
+            var pos = tileSelector(entry);
+            if (pos.X < minX) minX = pos.X;
+            if (pos.Y < minY) minY = pos.Y;
+            if (pos.X > maxX) maxX = pos.X;
+            if (pos.Y > maxY) maxY = pos.Y;
+        }
+
+        var width = maxX - minX + 1;
+        var height = maxY - minY + 1;
+        var longer = Math.Max(width, height);
+        var shorter = Math.Max(1, Math.Min(width, height));
+
+        if (tiles.Count <= minSplitSize || (float) longer / shorter <= aspectThreshold)
+        {
+            results.Add(tiles);
+            return;
+        }
+
+        var halfA = new List<T>();
+        var halfB = new List<T>();
+
+        if (width >= height)
+        {
+            var midX = minX + width / 2;
+            foreach (var entry in tiles)
+            {
+                if (tileSelector(entry).X <= midX)
+                    halfA.Add(entry);
+                else
+                    halfB.Add(entry);
+            }
+        }
+        else
+        {
+            var midY = minY + height / 2;
+            foreach (var entry in tiles)
+            {
+                if (tileSelector(entry).Y <= midY)
+                    halfA.Add(entry);
+                else
+                    halfB.Add(entry);
+            }
+        }
+
+        SubdivideInto(halfA, tileSelector, aspectThreshold, minSplitSize, results);
+        SubdivideInto(halfB, tileSelector, aspectThreshold, minSplitSize, results);
+    }
+}

--- a/Content.Tests/Server/RussStation/Atmos/RadiationBlobMathTest.cs
+++ b/Content.Tests/Server/RussStation/Atmos/RadiationBlobMathTest.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.RussStation.Atmos.Systems;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+
+namespace Content.Tests.Server.RussStation.Atmos;
+
+[TestFixture, TestOf(typeof(RadiationBlobMath))]
+[Parallelizable(ParallelScope.All)]
+public sealed class RadiationBlobMathTest
+{
+    [Test]
+    public void Centroid_SingleTile_ReturnsTileCenter()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(3, 5), 2.0f),
+        };
+
+        var (cx, cy) = RadiationBlobMath.Centroid(tiles, 2.0f);
+
+        Assert.That(cx, Is.EqualTo(3.5f).Within(0.001f));
+        Assert.That(cy, Is.EqualTo(5.5f).Within(0.001f));
+    }
+
+    [Test]
+    public void Centroid_WeightedTowardHotTile()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 1.0f),
+            (new Vector2i(4, 0), 3.0f),
+        };
+
+        var (cx, _) = RadiationBlobMath.Centroid(tiles, 4.0f);
+
+        // Weighted: (0.5*1 + 4.5*3) / 4 = 14/4 = 3.5
+        Assert.That(cx, Is.EqualTo(3.5f).Within(0.001f));
+    }
+
+    [Test]
+    public void GradientParams_SingleTile_DefaultSlope()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 3.0f),
+        };
+
+        var (intensity, slope) = RadiationBlobMath.GradientParams(tiles);
+
+        Assert.That(intensity, Is.EqualTo(3.0f));
+        Assert.That(slope, Is.EqualTo(0.5f));
+    }
+
+    [Test]
+    public void GradientParams_UniformTiles_LowSlope()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 2.0f),
+            (new Vector2i(1, 0), 2.0f),
+            (new Vector2i(2, 0), 2.0f),
+        };
+
+        var (intensity, slope) = RadiationBlobMath.GradientParams(tiles);
+
+        Assert.That(intensity, Is.EqualTo(2.0f));
+        // max/min = 1, so (1 - 1) / radius = 0
+        Assert.That(slope, Is.EqualTo(0f).Within(0.001f));
+    }
+
+    [Test]
+    public void GradientParams_HotCenter_SteeperSlope()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 1.0f),
+            (new Vector2i(1, 0), 4.0f),
+            (new Vector2i(2, 0), 1.0f),
+        };
+
+        var (intensity, slope) = RadiationBlobMath.GradientParams(tiles);
+
+        Assert.That(intensity, Is.EqualTo(4.0f));
+        // radius = 3/2 = 1.5, (4/1 - 1) / 1.5 = 2.0
+        Assert.That(slope, Is.EqualTo(2.0f).Within(0.001f));
+    }
+
+    [Test]
+    public void GradientParams_AtEdge_IntensityFallsToMin()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 1.0f),
+            (new Vector2i(1, 0), 4.0f),
+            (new Vector2i(2, 0), 1.0f),
+        };
+
+        var (intensity, slope) = RadiationBlobMath.GradientParams(tiles);
+        var radius = 1.5f;
+
+        // received = intensity / (slope * distance + 1)
+        var atEdge = intensity / (slope * radius + 1f);
+
+        Assert.That(atEdge, Is.EqualTo(1.0f).Within(0.001f));
+    }
+
+    [Test]
+    public void Subdivide_SmallBlob_NoSplit()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 1.0f),
+            (new Vector2i(1, 0), 1.0f),
+            (new Vector2i(0, 1), 1.0f),
+            (new Vector2i(1, 1), 1.0f),
+        };
+
+        var chunks = RadiationBlobMath.Subdivide(tiles);
+
+        Assert.That(chunks, Has.Count.EqualTo(1));
+        Assert.That(chunks[0], Has.Count.EqualTo(4));
+    }
+
+    [Test]
+    public void Subdivide_SquareBlob_NoSplit()
+    {
+        // 3x3 square, 9 tiles, aspect ratio 1.0
+        var tiles = new List<(Vector2i Tile, float Rads)>();
+        for (var x = 0; x < 3; x++)
+        for (var y = 0; y < 3; y++)
+            tiles.Add((new Vector2i(x, y), 1.0f));
+
+        var chunks = RadiationBlobMath.Subdivide(tiles);
+
+        Assert.That(chunks, Has.Count.EqualTo(1));
+        Assert.That(chunks[0], Has.Count.EqualTo(9));
+    }
+
+    [Test]
+    public void Subdivide_LongBlob_Splits()
+    {
+        // 6x1, aspect ratio 6.0, well above threshold
+        var tiles = new List<(Vector2i Tile, float Rads)>();
+        for (var x = 0; x < 6; x++)
+            tiles.Add((new Vector2i(x, 0), 1.0f));
+
+        var chunks = RadiationBlobMath.Subdivide(tiles);
+
+        Assert.That(chunks, Has.Count.GreaterThanOrEqualTo(2));
+
+        var totalTiles = chunks.Sum(c => c.Count);
+        Assert.That(totalTiles, Is.EqualTo(6));
+    }
+
+    [Test]
+    public void Subdivide_LShapedBlob_SplitsAlongLongerAxis()
+    {
+        // L-shape: 5 wide, 3 tall
+        var tiles = new List<(Vector2i Tile, float Rads)>
+        {
+            (new Vector2i(0, 0), 1.0f),
+            (new Vector2i(1, 0), 1.0f),
+            (new Vector2i(2, 0), 1.0f),
+            (new Vector2i(3, 0), 1.0f),
+            (new Vector2i(4, 0), 1.0f),
+            (new Vector2i(0, 1), 1.0f),
+            (new Vector2i(0, 2), 1.0f),
+        };
+
+        var chunks = RadiationBlobMath.Subdivide(tiles);
+
+        Assert.That(chunks, Has.Count.GreaterThanOrEqualTo(2));
+
+        var totalTiles = chunks.Sum(c => c.Count);
+        Assert.That(totalTiles, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Subdivide_PreservesRadsValues()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>();
+        for (var x = 0; x < 8; x++)
+            tiles.Add((new Vector2i(x, 0), x + 1.0f));
+
+        var chunks = RadiationBlobMath.Subdivide(tiles);
+        var totalRads = chunks.SelectMany(c => c).Sum(t => t.Rads);
+
+        // 1+2+3+4+5+6+7+8 = 36
+        Assert.That(totalRads, Is.EqualTo(36.0f).Within(0.001f));
+    }
+
+    [Test]
+    public void Subdivide_Empty_ReturnsEmpty()
+    {
+        var tiles = new List<(Vector2i Tile, float Rads)>();
+
+        var chunks = RadiationBlobMath.Subdivide(tiles);
+
+        Assert.That(chunks, Is.Empty);
+    }
+}

--- a/Content.Tests/Shared/RussStation/Spatial/TileGridMathTest.cs
+++ b/Content.Tests/Shared/RussStation/Spatial/TileGridMathTest.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Content.Shared.RussStation.Spatial;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+
+namespace Content.Tests.Shared.RussStation.Spatial;
+
+[TestFixture, TestOf(typeof(TileGridMath))]
+[Parallelizable(ParallelScope.All)]
+public sealed class TileGridMathTest
+{
+    [Test]
+    public void WeightedCentroid_SingleTile_ReturnsTileCenter()
+    {
+        Span<Vector2i> tiles = stackalloc Vector2i[] { new(3, 5) };
+        Span<float> weights = stackalloc float[] { 1.0f };
+
+        var (cx, cy) = TileGridMath.WeightedCentroid(tiles, weights, 1.0f);
+
+        Assert.That(cx, Is.EqualTo(3.5f).Within(0.001f));
+        Assert.That(cy, Is.EqualTo(5.5f).Within(0.001f));
+    }
+
+    [Test]
+    public void WeightedCentroid_UniformWeights_ReturnsGeometricCenter()
+    {
+        Span<Vector2i> tiles = stackalloc Vector2i[]
+        {
+            new(0, 0), new(2, 0),
+        };
+        Span<float> weights = stackalloc float[] { 1.0f, 1.0f };
+
+        var (cx, _) = TileGridMath.WeightedCentroid(tiles, weights, 2.0f);
+
+        // (0.5 + 2.5) / 2 = 1.5
+        Assert.That(cx, Is.EqualTo(1.5f).Within(0.001f));
+    }
+
+    [Test]
+    public void WeightedCentroid_HeavyWeight_PullsToward()
+    {
+        Span<Vector2i> tiles = stackalloc Vector2i[]
+        {
+            new(0, 0), new(4, 0),
+        };
+        Span<float> weights = stackalloc float[] { 1.0f, 3.0f };
+
+        var (cx, _) = TileGridMath.WeightedCentroid(tiles, weights, 4.0f);
+
+        // (0.5*1 + 4.5*3) / 4 = 14/4 = 3.5
+        Assert.That(cx, Is.EqualTo(3.5f).Within(0.001f));
+    }
+
+    [Test]
+    public void BoundingBox_SingleTile()
+    {
+        Span<Vector2i> tiles = stackalloc Vector2i[] { new(3, 5) };
+
+        var box = TileGridMath.BoundingBox(tiles);
+
+        Assert.That(box.Left, Is.EqualTo(3));
+        Assert.That(box.Bottom, Is.EqualTo(5));
+        Assert.That(box.Right, Is.EqualTo(3));
+        Assert.That(box.Top, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void BoundingBox_MultipleTiles()
+    {
+        Span<Vector2i> tiles = stackalloc Vector2i[]
+        {
+            new(1, 2), new(5, 8), new(3, 0),
+        };
+
+        var box = TileGridMath.BoundingBox(tiles);
+
+        Assert.That(box.Left, Is.EqualTo(1));
+        Assert.That(box.Bottom, Is.EqualTo(0));
+        Assert.That(box.Right, Is.EqualTo(5));
+        Assert.That(box.Top, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void Subdivide_SmallGroup_NoSplit()
+    {
+        var tiles = new List<Vector2i>
+        {
+            new(0, 0), new(1, 0), new(0, 1), new(1, 1),
+        };
+
+        var chunks = TileGridMath.Subdivide(tiles, static t => t);
+
+        Assert.That(chunks, Has.Count.EqualTo(1));
+        Assert.That(chunks[0], Has.Count.EqualTo(4));
+    }
+
+    [Test]
+    public void Subdivide_SquareGroup_NoSplit()
+    {
+        var tiles = new List<Vector2i>();
+        for (var x = 0; x < 3; x++)
+        for (var y = 0; y < 3; y++)
+            tiles.Add(new Vector2i(x, y));
+
+        var chunks = TileGridMath.Subdivide(tiles, static t => t);
+
+        Assert.That(chunks, Has.Count.EqualTo(1));
+        Assert.That(chunks[0], Has.Count.EqualTo(9));
+    }
+
+    [Test]
+    public void Subdivide_LongGroup_Splits()
+    {
+        var tiles = new List<Vector2i>();
+        for (var x = 0; x < 6; x++)
+            tiles.Add(new Vector2i(x, 0));
+
+        var chunks = TileGridMath.Subdivide(tiles, static t => t);
+
+        Assert.That(chunks, Has.Count.GreaterThanOrEqualTo(2));
+        Assert.That(chunks.Sum(c => c.Count), Is.EqualTo(6));
+    }
+
+    [Test]
+    public void Subdivide_Empty_ReturnsEmpty()
+    {
+        var tiles = new List<Vector2i>();
+
+        var chunks = TileGridMath.Subdivide(tiles, static t => t);
+
+        Assert.That(chunks, Is.Empty);
+    }
+
+    [Test]
+    public void Subdivide_WithPayload_PreservesData()
+    {
+        var tiles = new List<(Vector2i Pos, string Name)>();
+        for (var x = 0; x < 8; x++)
+            tiles.Add((new Vector2i(x, 0), $"tile_{x}"));
+
+        var chunks = TileGridMath.Subdivide(tiles, static t => t.Pos);
+        var allNames = chunks.SelectMany(c => c).Select(t => t.Name).OrderBy(n => n).ToList();
+
+        Assert.That(allNames, Has.Count.EqualTo(8));
+        for (var i = 0; i < 8; i++)
+            Assert.That(allNames[i], Is.EqualTo($"tile_{i}"));
+    }
+
+    [Test]
+    public void Subdivide_CustomThreshold_Respected()
+    {
+        // 4x1 strip: aspect 4.0, above default 1.5 but below custom 5.0
+        var tiles = new List<Vector2i>();
+        for (var x = 0; x < 4; x++)
+            tiles.Add(new Vector2i(x, 0));
+
+        var chunks = TileGridMath.Subdivide(tiles, static t => t, aspectThreshold: 5.0f);
+
+        Assert.That(chunks, Has.Count.EqualTo(1));
+    }
+}


### PR DESCRIPTION
## About the PR

Adds infrastructure for gas reactions to emit radiation pulses that respect wall occlusion and resistance via the existing gridcast system.

**New files:**
- `AtmosRadiationPulseEvent` - broadcast event reactions raise to request a radiation pulse at a grid tile
- `AtmosRadiationPulseSystem` - collects pulses per tick, flood-fills adjacent tiles into blobs, spawns short-lived `RadiationSourceComponent` entities at intensity-weighted centroids
- `RadiationPulseHelper` - static helper so reaction data definitions (which lack EntityManager access) can raise the event via IoC
- `RadiationBlobMath` - radiation-specific math (centroid, gradient, subdivision) extracted for testability, delegates generic spatial ops to `TileGridMath`
- `TileGridMath` (Content.Shared) - general-purpose spatial utilities: weighted centroid, bounding box, and recursive bounding-box subdivision for discrete tile grids

**Design highlights:**
- Cascading bounding-box subdivision keeps source count low while shaping the radiation field to match the gas cloud (a 10x10 L-shaped blob becomes 4-6 sources, not 100)
- Each source's intensity is set to the peak tile rads in its chunk, with slope derived from the min/max ratio across the chunk radius. This produces a natural gradient from hot center to cool edges, matching the gas density falloff from LINDA diffusion.
- Each source lives 1.5s (one gridcast cycle) then auto-despawns via `TimedDespawnComponent`
- Wall occlusion, resistance, and receiver logic are all handled by existing `RadiationSystem` gridcast with zero changes to upstream code
- No upstream files modified

**Depends on:** #365 (tier 1 gases, has the reactions that will call `RadiationPulseHelper.EmitRadiation`)

Wiring the Proto-Nitrate tritium and BZ reactions to emit pulses will happen when this merges into `feat/tier1-gases`.

## Why / Balance

SS13 parity: Proto-Nitrate + Tritium and Proto-Nitrate + BZ reactions should emit radiation. Upstream SS14 has a TODO comment for this in `TritiumFireReaction.cs` but never implemented it. This system is general-purpose so any future reaction can emit radiation with a one-liner.

Radiation intensity is set to the peak tile intensity within each subdivision chunk, with the slope tuned so intensity falls to the minimum tile value at the chunk edge. This means the center of a dense gas cloud radiates hardest, edges radiate weakly, and the gradient between adjacent chunks stays smooth because LINDA already smooths gas concentrations between tiles. Wall occlusion means engineering can shield areas with rad-resistant materials.

## Technical details

- `AtmosRadiationPulseEvent` is a `[ByRefEvent]` broadcast event
- Flood-fill uses BFS with 4-connectivity (cardinal neighbors only)
- Subdivision threshold: aspect ratio > 1.5 and blob size > 4 tiles
- `RadiationPulseHelper` resolves `IEntityManager` via `IoCManager.Resolve` (standard pattern for non-system code in SS14)
- Source position is the intensity-weighted centroid of each chunk, converted to `EntityCoordinates` via `SharedMapSystem.GridTileToLocal`
- Per-source slope is derived as `(maxRads / minRads - 1) / radius`, giving a gradient from peak intensity at centroid to minimum at chunk edge. Cross-chunk continuity is maintained by LINDA's gas diffusion smoothing adjacent tile concentrations.
- Generic spatial math (weighted centroid, subdivision) extracted into `Content.Shared/RussStation/Spatial/TileGridMath.cs` for reuse by other systems
- 23 unit tests covering both `TileGridMath` and `RadiationBlobMath`

## Media

No visual changes (radiation is invisible, detected via dosimeters/Geiger counters).

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None. Additive only, no upstream files modified.

**Changelog**

:cl:
- add: Gas reactions can now emit radiation pulses that respect walls and shielding. Proto-Nitrate reactions with Tritium and BZ will emit radiation once wired in the tier 1 gases PR.
: