### PR TITLE
Quirks: global point-buy budget with domain categories

### DIFF
--- a/CVARS.md
+++ b/CVARS.md
@@ -17,8 +17,6 @@ Configuration variables added by the Honksquad fork. These can be set in the ser
 
 ## Traits
 
-<!-- TODO: game.max_trait_points (PR #376) not yet merged into release -->
-
 | CVar                    | Type | Default | Scope      | Description                                            |
 | ----------------------- | ---- | ------- | ---------- | ------------------------------------------------------ |
 | `game.max_trait_points` | int  | 10      | Replicated | Global point budget shared across all trait categories |

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Client.Lobby.UI.Roles;
 using Content.Client.Stylesheets;
+using Content.Shared.CCVar;
 using Content.Shared.Traits;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
@@ -50,19 +51,71 @@ public sealed partial class HumanoidProfileEditor
             group.Add(trait.ID);
         }
 
-        // Create UI view from model
-        foreach (var (categoryId, categoryTraits) in traitGroups)
+        // HONK START - Global trait point budget display
+        var globalMax = _cfgManager.GetCVar(CCVars.MaxTraitPoints);
+        var globalSpent = 0;
+
+        // Pre-calculate global spending
+        foreach (var (_, categoryTraits) in traitGroups)
         {
+            foreach (var traitProto in categoryTraits)
+            {
+                var trait = _prototypeManager.Index<TraitPrototype>(traitProto);
+                if (Profile?.TraitPreferences.Contains(trait.ID) == true)
+                    globalSpent += trait.Cost;
+            }
+        }
+
+        var globalAvailable = globalMax - globalSpent;
+
+        TraitsList.AddChild(new Label
+        {
+            Text = Loc.GetString("humanoid-profile-editor-trait-points-available",
+                ("points", globalAvailable)),
+            FontColorOverride = globalAvailable >= 0 ? Color.LimeGreen : Color.Red,
+            Margin = new Thickness(0, 0, 0, 8),
+            StyleClasses = { StyleClass.LabelHeading },
+            HorizontalAlignment = HAlignment.Center,
+        });
+
+        // Wrapping container for category columns
+        var columnsContainer = new GridContainer
+        {
+            Columns = 3,
+            HorizontalExpand = true,
+        };
+        TraitsList.AddChild(columnsContainer);
+        // HONK END
+
+        // Create UI view from model (sorted alphabetically by display name)
+        foreach (var (categoryId, categoryTraits) in traitGroups.OrderBy(g =>
+            g.Key == TraitCategoryPrototype.Default
+                ? string.Empty
+                : _prototypeManager.TryIndex<TraitCategoryPrototype>(g.Key, out var cat)
+                    ? Loc.GetString(cat.Name)
+                    : g.Key))
+        {
+            if (categoryTraits.Count == 0)
+                continue;
+
             TraitCategoryPrototype? category = null;
+
+            // HONK START - Each category gets its own vertical column
+            var column = new BoxContainer
+            {
+                Orientation = BoxContainer.LayoutOrientation.Vertical,
+                HorizontalExpand = true,
+            };
+            // HONK END
 
             if (categoryId != TraitCategoryPrototype.Default)
             {
                 category = _prototypeManager.Index<TraitCategoryPrototype>(categoryId);
                 // Label
-                TraitsList.AddChild(new Label
+                column.AddChild(new Label // HONK - Changed from TraitsList to column
                 {
                     Text = Loc.GetString(category.Name),
-                    Margin = new Thickness(0, 10, 0, 0),
+                    Margin = new Thickness(0, 0, 0, 0),
                     StyleClasses = { StyleClass.LabelHeading },
                 });
             }
@@ -96,29 +149,30 @@ public sealed partial class HumanoidProfileEditor
                 selectors.Add(selector);
             }
 
-            // Selection counter
+            // HONK START - Point-buy: show category cap if set
             if (category is { MaxTraitPoints: >= 0 })
             {
-                TraitsList.AddChild(new Label
+                column.AddChild(new Label
                 {
-                    Text = Loc.GetString("humanoid-profile-editor-trait-count-hint", ("current", selectionCount), ("max", category.MaxTraitPoints)),
-                    FontColorOverride = Color.Gray
+                    Text = Loc.GetString("humanoid-profile-editor-trait-category-cap",
+                        ("spent", selectionCount),
+                        ("max", category.MaxTraitPoints)),
+                    FontColorOverride = selectionCount <= category.MaxTraitPoints ? Color.LightGray : Color.Red,
+                    Margin = new Thickness(0, 0, 0, 5),
                 });
             }
+
+            // HONK END
 
             foreach (var selector in selectors)
             {
                 if (selector == null)
                     continue;
 
-                if (category is { MaxTraitPoints: >= 0 } &&
-                    selector.Cost + selectionCount > category.MaxTraitPoints)
-                {
-                    selector.Checkbox.Label.FontColorOverride = Color.Red;
-                }
-
-                TraitsList.AddChild(selector);
+                column.AddChild(selector); // HONK - Changed from TraitsList to column
             }
+
+            columnsContainer.AddChild(column); // HONK - Add to columns
         }
     }
 }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -164,13 +164,22 @@ public sealed partial class HumanoidProfileEditor
 
             // HONK END
 
+            // HONK - 2-column grid for trait selectors within each category
+            var traitGrid = new GridContainer
+            {
+                Columns = 2,
+                HorizontalExpand = true,
+            };
+
             foreach (var selector in selectors)
             {
                 if (selector == null)
                     continue;
 
-                column.AddChild(selector); // HONK - Changed from TraitsList to column
+                traitGrid.AddChild(selector);
             }
+
+            column.AddChild(traitGrid);
 
             columnsContainer.AddChild(column); // HONK - Add to columns
         }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -409,6 +409,22 @@ namespace Content.Shared.Preferences
 
             var list = new HashSet<ProtoId<TraitPrototype>>(_traitPreferences) { traitId };
 
+            // HONK START - Global trait point budget
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+            var globalMax = configManager.GetCVar(CCVars.MaxTraitPoints);
+
+            // Check global budget across all categories
+            var globalCount = 0;
+            foreach (var trait in list)
+            {
+                if (protoManager.TryIndex<TraitPrototype>(trait, out var otherProto))
+                    globalCount += otherProto.Cost;
+            }
+
+            if (globalCount > globalMax && traitProto.Cost > 0)
+                return new(this);
+            // HONK END
+
             if (traitCategory == null || traitCategory.MaxTraitPoints < 0)
             {
                 return new(this)
@@ -421,13 +437,13 @@ namespace Content.Shared.Preferences
             foreach (var trait in list)
             {
                 // If trait not found or another category don't count its points.
-                if (!protoManager.TryIndex<TraitPrototype>(trait, out var otherProto) ||
-                    otherProto.Category != traitCategory)
+                if (!protoManager.TryIndex<TraitPrototype>(trait, out var otherProto2) ||
+                    otherProto2.Category != traitCategory)
                 {
                     continue;
                 }
 
-                count += otherProto.Cost;
+                count += otherProto2.Cost;
             }
 
             if (count > traitCategory.MaxTraitPoints && traitProto.Cost != 0)
@@ -656,14 +672,27 @@ namespace Content.Shared.Preferences
             var groups = new Dictionary<string, int>();
             var result = new List<ProtoId<TraitPrototype>>();
 
+            // HONK START - Global trait point budget
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+            var globalMax = configManager.GetCVar(CCVars.MaxTraitPoints);
+            var globalCount = 0;
+            // HONK END
+
             foreach (var trait in traits)
             {
                 if (!protoManager.TryIndex(trait, out var traitProto))
                     continue;
 
+                // HONK START - Check global budget
+                var newGlobal = globalCount + traitProto.Cost;
+                if (newGlobal > globalMax && traitProto.Cost > 0)
+                    continue;
+                // HONK END
+
                 // Always valid.
                 if (traitProto.Category == null)
                 {
+                    globalCount = newGlobal; // HONK - Track global spending
                     result.Add(trait);
                     continue;
                 }
@@ -680,6 +709,7 @@ namespace Content.Shared.Preferences
                     continue;
 
                 groups[category.ID] = existing;
+                globalCount = newGlobal; // HONK - Track global spending
                 result.Add(trait);
             }
 

--- a/Content.Shared/RussStation/CCVar/CCVars.Traits.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Traits.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// Global point budget shared across all trait categories.
+    /// Negative-cost traits refund points, positive-cost traits spend them.
+    /// </summary>
+    public static readonly CVarDef<int> MaxTraitPoints =
+        CVarDef.Create("game.max_trait_points", 10, CVar.REPLICATED | CVar.SERVER);
+}

--- a/Content.Shared/Traits/TraitCategoryPrototype.cs
+++ b/Content.Shared/Traits/TraitCategoryPrototype.cs
@@ -25,4 +25,5 @@ public sealed partial class TraitCategoryPrototype : IPrototype
     /// </summary>
     [DataField]
     public int? MaxTraitPoints;
+
 }

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -69,4 +69,5 @@ public sealed partial class TraitPrototype : IPrototype
     /// </summary>
     [DataField]
     public ProtoId<TraitCategoryPrototype>? Category;
+
 }

--- a/Resources/Locale/en-US/@RussStation/traits.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits.ftl
@@ -1,0 +1,8 @@
+humanoid-profile-editor-trait-points-available = {$points} points available
+humanoid-profile-editor-trait-category-cap = {$spent}/{$max}
+
+trait-category-combat = Combat
+trait-category-senses = Senses
+trait-category-movement = Movement
+trait-category-social = Social
+trait-category-diet = Diet

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -56,7 +56,8 @@ humanoid-profile-editor-flavortext-tab = Description
 # Traits
 humanoid-profile-editor-traits-tab = Traits
 humanoid-profile-editor-no-traits = No traits available
-
 humanoid-profile-editor-trait-count-hint = Points available: [{$current}/{$max}]
+
+# Trait categories
 trait-category-disabilities = Disabilities
 trait-category-speech = Speech

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -58,7 +58,5 @@ humanoid-profile-editor-traits-tab = Traits
 humanoid-profile-editor-no-traits = No traits available
 
 humanoid-profile-editor-trait-count-hint = Points available: [{$current}/{$max}]
-
 trait-category-disabilities = Disabilities
-trait-category-speech = Speech traits
-trait-category-quirks = Quirks
+trait-category-speech = Speech

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -12,8 +12,8 @@ trait-pacifist-desc = You cannot attack or hurt any living beings.
 
 permanent-blindness-trait-examined = [color=lightblue]{CAPITALIZE(POSS-ADJ($target))} eyes are glassy and unfocused. It doesn't seem like {SUBJECT($target)} can see you well, if at all.[/color]
 
-trait-lightweight-name = Lightweight drunk
-trait-lightweight-desc = Alcohol has a stronger effect on you.
+trait-lightweight-name = Lightweight
+trait-lightweight-desc = Alcohol hits you much harder than most.
 
 trait-monochromacy-name = Monochromacy
 trait-monochromacy-desc = You are fully colorblind, everything you perceive ranges from blacks to whites.
@@ -30,31 +30,31 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 trait-accentless-name = Accentless
 trait-accentless-desc = You don't have the accent that your species would usually have.
 
-trait-frontal-lisp-name = Frontal lisp
+trait-frontal-lisp-name = Frontal Lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.
 
 trait-socialanxiety-name = Stutter
 trait-socialanxiety-desc = You speak with a stutter.
 
-trait-southern-name = Southern drawl
+trait-southern-name = Southern Drawl
 trait-southern-desc = You have a different way of speakin'.
 
 trait-snoring-name = Snoring
 trait-snoring-desc = You will snore while sleeping.
 
-trait-liar-name = Pathological liar
+trait-liar-name = Pathological Liar
 trait-liar-desc = You can hardly bring yourself to tell the truth. Sometimes you lie anyway.
 
-trait-german-name = German accent
+trait-german-name = German Accent
 trait-german-desc = You seem to come from space Germany.
 
-trait-french-name = French accent
+trait-french-name = French Accent
 trait-french-desc = Your accent seems to have a certain «je ne sais quoi».
 
-trait-spanish-name = Spanish accent
+trait-spanish-name = Spanish Accent
 trait-spanish-desc = Hola señor, donde esta la biblioteca.
 
-trait-scottish-name = Scottish accent
+trait-scottish-name = Scottish Accent
 trait-scottish-desc = Ye're speaking like ae proper Scot!
 
 trait-painnumbness-name = Numb

--- a/Resources/Prototypes/@RussStation/Traits/categories.yml
+++ b/Resources/Prototypes/@RussStation/Traits/categories.yml
@@ -1,0 +1,19 @@
+- type: traitCategory
+  id: Combat
+  name: trait-category-combat
+
+- type: traitCategory
+  id: Diet
+  name: trait-category-diet
+
+- type: traitCategory
+  id: Movement
+  name: trait-category-movement
+
+- type: traitCategory
+  id: Senses
+  name: trait-category-senses
+
+- type: traitCategory
+  id: Social
+  name: trait-category-social

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -5,11 +5,3 @@
 - type: traitCategory
   id: SpeechTraits
   name: trait-category-speech
-  maxTraitPoints: 2
-
-# HONK START - Point-buy budget for quirks
-- type: traitCategory
-  id: Quirks
-  name: trait-category-quirks
-  maxTraitPoints: 10
-# HONK END

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -7,6 +7,9 @@
   name: trait-category-speech
   maxTraitPoints: 2
 
+# HONK START - Point-buy budget for quirks
 - type: traitCategory
   id: Quirks
   name: trait-category-quirks
+  maxTraitPoints: 10
+# HONK END

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -5,6 +5,7 @@
   name: trait-pacifist-name
   description: trait-pacifist-desc
   category: Quirks
+  cost: -8 # HONK - Negative quirk, refunds points
   components:
   - type: Pacified
 
@@ -13,6 +14,7 @@
   name: trait-lightweight-name
   description: trait-lightweight-desc
   category: Quirks
+  cost: -2 # HONK - Negative quirk, refunds points
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 2

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -4,7 +4,7 @@
   id: Pacifist
   name: trait-pacifist-name
   description: trait-pacifist-desc
-  category: Quirks
+  category: Combat # HONK - Reassigned from Quirks
   cost: -8 # HONK - Negative quirk, refunds points
   components:
   - type: Pacified
@@ -13,7 +13,7 @@
   id: LightweightDrunk
   name: trait-lightweight-name
   description: trait-lightweight-desc
-  category: Quirks
+  category: Diet # HONK - Reassigned from Quirks
   cost: -2 # HONK - Negative quirk, refunds points
   components:
   - type: LightweightDrunk
@@ -23,6 +23,6 @@
   id: Snoring
   name: trait-snoring-name
   description: trait-snoring-desc
-  category: Quirks
+  category: Social # HONK - Reassigned from Quirks
   components:
   - type: Snoring


### PR DESCRIPTION
## About the PR

Adds a global point-buy budget for quirks/traits and reorganizes them into domain-specific categories.

- Global point pool (`game.max_trait_points` CVar, default 10) shared across all categories
- 5 new domain categories: Combat, Diet, Movement, Senses, Social
- Optional per-category caps via `maxTraitPoints` on TraitCategoryPrototype
- UI rework: global points display, 3-column category grid, 2-column trait selectors, alphabetical sorting
- Trait name cleanup to title case
- Updates CVARS.md with the new trait budget CVar

## Why / Balance

Replaces the old unlimited trait selection with a point budget. Players pick a mix of positive-cost (+) and negative-cost (-) traits that must net within the budget. Domain categories make the trait list scannable and allow per-category caps if needed later.

## Technical details

- `CCVars.MaxTraitPoints` (replicated) controls the global budget
- `WithTraitPreference` checks global budget first, then per-category cap
- `GetValidTraits` enforces budget on profile load/validation
- Fork categories in `@RussStation/Traits/categories.yml`, locale in `@RussStation/traits.ftl`
- Upstream trait files touched minimally (cost + category fields on existing traits)
- Dead polarity code removed from TraitPrototype, TraitCategoryPrototype, TraitPreferenceSelector

## Media

N/A (needs in-game screenshot)

## Requirements

None

## Breaking changes

Existing trait selections may be trimmed on profile load if they exceed the new 10-point budget.

## Changelog

:cl:
- add: Trait point-buy system with 10-point global budget
- add: Domain categories (Combat, Diet, Movement, Senses, Social) for trait organization
- tweak: Trait names standardized to title case