### PR TITLE
Quirk: Ageusia (can't taste)

### DIFF
--- a/Content.Shared/RussStation/Traits/AgeusiaComponent.cs
+++ b/Content.Shared/RussStation/Traits/AgeusiaComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Prevents the entity from tasting anything.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AgeusiaComponent : Component;

--- a/Content.Shared/RussStation/Traits/AgeusiaSystem.cs
+++ b/Content.Shared/RussStation/Traits/AgeusiaSystem.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Nutrition.EntitySystems;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class AgeusiaSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AgeusiaComponent, FlavorProfileModificationEvent>(OnFlavor);
+    }
+
+    private static void OnFlavor(EntityUid uid, AgeusiaComponent comp, FlavorProfileModificationEvent args)
+    {
+        if (args.User == uid)
+            args.Flavors.Clear();
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,0 +1,2 @@
+trait-ageusia-name = Ageusia
+trait-ageusia-desc = You can't taste anything.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -1,0 +1,8 @@
+- type: trait
+  id: Ageusia
+  name: trait-ageusia-name
+  description: trait-ageusia-desc
+  category: Diet
+  cost: 0
+  components:
+    - type: Ageusia

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -16,6 +16,7 @@
   - HumanoidProfile # Age, Sex, Gender
   - NpcFactionMember
   # traits
+  - Ageusia # HONK
   - BlackAndWhiteOverlay
   - Clumsy
   - ImpairedMobility


### PR DESCRIPTION
## About the PR

Adds the Ageusia quirk, a neutral (0-cost) quirk that prevents the player from tasting anything. All flavor text is suppressed when eating or drinking.

## Why / Balance

Neutral quirk (0 points). Pure flavor/RP, no mechanical advantage. Players who find food taste messages annoying can opt out.

## Technical details

- `AgeusiaComponent` (marker component, networked for clone support)
- `AgeusiaSystem` hooks `FlavorProfileModificationEvent` and clears the flavor set when the user has the component
- Added to clone whitelist

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None

**Changelog**

:cl:
- add: Added Ageusia quirk. You can't taste anything.