### PR TITLE
Quirk: Frail (-4, 20% lower wound thresholds)

### DIFF
--- a/Content.Shared/RussStation/Traits/FrailComponent.cs
+++ b/Content.Shared/RussStation/Traits/FrailComponent.cs
@@ -1,14 +1,16 @@
-using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
-/// Increases all incoming damage by a configurable multiplier.
+/// Lowers wound spike thresholds, making the entity easier to wound.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class FrailComponent : Component
 {
+    /// <summary>
+    /// Multiplier applied to wound thresholds. Lower = wounds trigger more easily.
+    /// </summary>
     [DataField]
-    public FixedPoint2 DamageMultiplier = 1.25f;
+    public float ThresholdMultiplier = 0.8f;
 }

--- a/Content.Shared/RussStation/Traits/FrailComponent.cs
+++ b/Content.Shared/RussStation/Traits/FrailComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Increases all incoming damage by a configurable multiplier.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class FrailComponent : Component
+{
+    [DataField]
+    public FixedPoint2 DamageMultiplier = 1.25f;
+}

--- a/Content.Shared/RussStation/Traits/FrailSystem.cs
+++ b/Content.Shared/RussStation/Traits/FrailSystem.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class FrailSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FrailComponent, DamageModifyEvent>(OnDamageModify);
+    }
+
+    private void OnDamageModify(EntityUid uid, FrailComponent component, DamageModifyEvent args)
+    {
+        args.Damage = args.Damage * component.DamageMultiplier;
+    }
+}

--- a/Content.Shared/RussStation/Traits/FrailSystem.cs
+++ b/Content.Shared/RussStation/Traits/FrailSystem.cs
@@ -1,5 +1,4 @@
-using Content.Shared.Damage;
-using Content.Shared.Damage.Systems;
+using Content.Shared.RussStation.Wounds;
 
 namespace Content.Shared.RussStation.Traits;
 
@@ -8,11 +7,24 @@ public sealed class FrailSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FrailComponent, DamageModifyEvent>(OnDamageModify);
+        SubscribeLocalEvent<FrailComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<FrailComponent, ComponentRemove>(OnRemove);
     }
 
-    private void OnDamageModify(EntityUid uid, FrailComponent component, DamageModifyEvent args)
+    private void OnInit(EntityUid uid, FrailComponent component, ComponentInit args)
     {
-        args.Damage = args.Damage * component.DamageMultiplier;
+        if (!TryComp<WoundComponent>(uid, out var wound))
+            return;
+
+        wound.ThresholdMultiplier *= component.ThresholdMultiplier;
+    }
+
+    private void OnRemove(EntityUid uid, FrailComponent component, ComponentRemove args)
+    {
+        if (!TryComp<WoundComponent>(uid, out var wound))
+            return;
+
+        if (component.ThresholdMultiplier != 0f)
+            wound.ThresholdMultiplier /= component.ThresholdMultiplier;
     }
 }

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -2,3 +2,5 @@ trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-negotiator-name = Negotiator
 trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.
+trait-frail-name = Frail
+trait-frail-desc = Your body is fragile.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -23,3 +23,16 @@
     - wage
   components:
     - type: Negotiator
+
+- type: trait
+  id: Frail
+  name: trait-frail-name
+  description: trait-frail-desc
+  category: Combat
+  cost: -4
+  tags:
+    - wounds
+  excludedTags:
+    - wounds
+  components:
+    - type: Frail

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -19,6 +19,7 @@
   - Ageusia # HONK
   - BlackAndWhiteOverlay
   - Clumsy
+  - Frail # HONK
   - ImpairedMobility
   # - LegsParalyzed (you get healed)
   - LightweightDrunk


### PR DESCRIPTION
## About the PR

Adds the **Frail** negative quirk. Characters with this trait suffer fracture and burn wounds 20% more easily. Spikes of damage that a normal person would shrug off now leave them limping.

- Refunds 4 points in the quirk budget
- Mutually exclusive with Tough via the `wounds` tag
- Configurable via `FrailComponent.ThresholdMultiplier` (default 0.8)
- Added to the clone whitelist

Part of #375.

## Why / Balance

The negative mirror of Tough (#382). Rather than flat damage amplification, which stacks oddly with armor and damage resistance, Frail widens the band of hits that trigger a wound. Everyday damage still lands the same, but the bursts that would have been tanked now leave a scar. Four-point refund reflects the situational downside, heavier on frontline roles where wound spikes are common.

## Technical details

- `FrailComponent` (shared, networked) holds `ThresholdMultiplier` (default 0.8)
- `FrailSystem` multiplies `WoundComponent.ThresholdMultiplier` by the value on init and divides it back out on remove, symmetric with `ToughSystem`
- Relies on `SharedWoundSystem.OnDamageChanged` dividing the incoming spike amount by `ThresholdMultiplier` before checking tier thresholds, which already exists from the Tough work
- Prototype: `@RussStation/Traits/quirks.yml`
- Locale: `@RussStation/traits/quirks.ftl`
- Clone whitelist entry added to `clone.yml`

## Media

N/A (no visual changes).

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Frail quirk: fracture and burn wounds trigger 20% more easily (-4 points).
