### PR TITLE
Quirk: Throwing Arm (+50% throw distance and speed)

### DIFF
--- a/Content.Shared/RussStation/Traits/ThrowingArmComponent.cs
+++ b/Content.Shared/RussStation/Traits/ThrowingArmComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Multiplies the entity's throw speed.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ThrowingArmComponent : Component
+{
+    [DataField]
+    public float ThrowSpeedMultiplier = 1.5f;
+}

--- a/Content.Shared/RussStation/Traits/ThrowingArmComponent.cs
+++ b/Content.Shared/RussStation/Traits/ThrowingArmComponent.cs
@@ -3,11 +3,12 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
-/// Multiplies the entity's throw speed.
+/// Scales the distance and speed of thrown items by a multiplier so
+/// the character throws further and faster.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class ThrowingArmComponent : Component
 {
     [DataField]
-    public float ThrowSpeedMultiplier = 1.5f;
+    public float ThrowMultiplier = 1.5f;
 }

--- a/Content.Shared/RussStation/Traits/ThrowingArmSystem.cs
+++ b/Content.Shared/RussStation/Traits/ThrowingArmSystem.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Throwing;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class ThrowingArmSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ThrowingArmComponent, BeforeThrowEvent>(OnBeforeThrow);
+    }
+
+    private void OnBeforeThrow(EntityUid uid, ThrowingArmComponent component, ref BeforeThrowEvent args)
+    {
+        args.ThrowSpeed *= component.ThrowSpeedMultiplier;
+    }
+}

--- a/Content.Shared/RussStation/Traits/ThrowingArmSystem.cs
+++ b/Content.Shared/RussStation/Traits/ThrowingArmSystem.cs
@@ -12,6 +12,7 @@ public sealed class ThrowingArmSystem : EntitySystem
 
     private void OnBeforeThrow(EntityUid uid, ThrowingArmComponent component, ref BeforeThrowEvent args)
     {
-        args.ThrowSpeed *= component.ThrowSpeedMultiplier;
+        args.Direction *= component.ThrowMultiplier;
+        args.ThrowSpeed *= component.ThrowMultiplier;
     }
 }

--- a/Content.Shared/Throwing/BeforeThrowEvent.cs
+++ b/Content.Shared/Throwing/BeforeThrowEvent.cs
@@ -14,7 +14,7 @@ public struct BeforeThrowEvent
     }
 
     public EntityUid ItemUid { get; set; }
-    public Vector2 Direction { get; }
+    public Vector2 Direction { get; set; } // HONK - mutable for Weak Arm quirk
     public float ThrowSpeed { get; set;}
     public EntityUid PlayerUid { get; }
 

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -2,3 +2,5 @@ trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-negotiator-name = Negotiator
 trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.
+trait-throwing-arm-name = Throwing Arm
+trait-throwing-arm-desc = You've got a hell of an arm.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -23,3 +23,16 @@
     - wage
   components:
     - type: Negotiator
+
+- type: trait
+  id: ThrowingArm
+  name: trait-throwing-arm-name
+  description: trait-throwing-arm-desc
+  category: Combat
+  cost: 2
+  tags:
+    - throwing
+  excludedTags:
+    - throwing
+  components:
+    - type: ThrowingArm

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -29,6 +29,7 @@
   - Paracusia
   - PermanentBlindness
   - Snoring
+  - ThrowingArm # HONK
   - Unrevivable
   # accents
   - Accentless


### PR DESCRIPTION
## About the PR

Adds the **Throwing Arm** positive quirk. Characters with this trait throw items 50% further and 50% faster.

- Costs 2 points in the quirk budget
- Subscribes to `BeforeThrowEvent` and scales both `Direction` and `ThrowSpeed` by 1.5
- Configurable via `ThrowingArmComponent.ThrowMultiplier`
- Added to the clone whitelist

Part of #375.

## Why / Balance

The mirror of Weak Arm. Because `ThrowingSystem.TryThrow` compensates for friction, scaling `ThrowSpeed` alone only changes how fast items travel, not how far, so the quirk also scales `Direction` to actually extend the throw distance. At 2 points it buys a noticeable but situational combat and utility edge (grenades, improvised weapons, bolas).

## Technical details

- `ThrowingArmComponent` (shared, networked) holds `ThrowMultiplier` (default 1.5)
- `ThrowingArmSystem` handles `BeforeThrowEvent` and multiplies both `args.Direction` and `args.ThrowSpeed`
- Requires `BeforeThrowEvent.Direction` to be mutable. One-line HONK-marked upstream edit changes `{ get; }` to `{ get; set; }` on that property
- Prototype: `@RussStation/Traits/quirks.yml`
- Locale: `@RussStation/traits/quirks.ftl`
- Clone whitelist entry added to `clone.yml`

## Media

N/A (no visual changes).

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

`BeforeThrowEvent.Direction` is now settable. Any external code that relied on it being read-only would need to adjust, but nothing in the codebase does.

**Changelog**

:cl:
- add: Throwing Arm quirk: throw items 50% further and 50% faster (2 points).
