### PR TITLE
Quirk: Hard Drinker (+2, half-duration drunkenness)

### DIFF
--- a/Content.Shared/RussStation/Traits/AlcoholToleranceComponent.cs
+++ b/Content.Shared/RussStation/Traits/AlcoholToleranceComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Reduces the duration of drunkenness by a configurable multiplier.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AlcoholToleranceComponent : Component
+{
+    [DataField]
+    public float BoozeStrengthMultiplier = 0.5f;
+}

--- a/Content.Shared/RussStation/Traits/AlcoholToleranceSystem.cs
+++ b/Content.Shared/RussStation/Traits/AlcoholToleranceSystem.cs
@@ -1,0 +1,17 @@
+using static Content.Shared.Drunk.SharedDrunkSystem;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class AlcoholToleranceSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AlcoholToleranceComponent, DrunkEvent>(OnDrunk);
+    }
+
+    private void OnDrunk(EntityUid uid, AlcoholToleranceComponent component, ref DrunkEvent args)
+    {
+        args.Duration *= component.BoozeStrengthMultiplier;
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,4 +1,4 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
-trait-alcohol-tolerance-name = Alcohol Tolerance
+trait-alcohol-tolerance-name = Hard Drinker
 trait-alcohol-tolerance-desc = You can hold your liquor. Drunkenness effects last half as long.

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,4 +1,4 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-alcohol-tolerance-name = Hard Drinker
-trait-alcohol-tolerance-desc = You can hold your liquor. Drunkenness effects last half as long.
+trait-alcohol-tolerance-desc = You can hold your liquor.

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,4 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+trait-alcohol-tolerance-name = Alcohol Tolerance
+trait-alcohol-tolerance-desc = You can hold your liquor. Drunkenness effects last half as long.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,16 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: AlcoholTolerance
+  name: trait-alcohol-tolerance-name
+  description: trait-alcohol-tolerance-desc
+  category: Diet
+  cost: 2
+  tags:
+    - alcohol
+  excludedTags:
+    - alcohol
+  components:
+    - type: AlcoholTolerance

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -17,6 +17,7 @@
   - NpcFactionMember
   # traits
   - Ageusia # HONK
+  - AlcoholTolerance # HONK
   - BlackAndWhiteOverlay
   - Clumsy
   - ImpairedMobility

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -15,6 +15,12 @@
   description: trait-lightweight-desc
   category: Diet # HONK - Reassigned from Quirks
   cost: -2 # HONK - Negative quirk, refunds points
+  # HONK START - Tag for mutual exclusion with AlcoholTolerance
+  tags:
+    - alcohol
+  excludedTags:
+    - alcohol
+  # HONK END
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 2


### PR DESCRIPTION
## About the PR

Adds the **Hard Drinker** positive quirk. Characters with this trait shrug off booze, taking drunkenness effects that last half as long as a normal person.

- Costs 2 points in the quirk budget
- Mutually exclusive with Lightweight Drunk via the `alcohol` tag
- Configurable via `AlcoholToleranceComponent.BoozeStrengthMultiplier` (default 0.5)
- Added to the clone whitelist

Part of #375.

## Why / Balance

The positive mirror of Lightweight Drunk. Useful for social and bar RP where long drunk states would otherwise get in the way of play, without touching combat balance. At 2 points it's a mild upside that leans into roleplay rather than mechanical advantage.

## Technical details

- `AlcoholToleranceComponent` (shared, networked) holds `BoozeStrengthMultiplier` (default 0.5)
- `AlcoholToleranceSystem` subscribes to `SharedDrunkSystem.DrunkEvent` and scales the incoming duration by the multiplier before upstream applies it
- Needs its own component instead of reusing `LightweightDrunkComponent`, since ECS only allows one instance per component type per entity, and LightweightDrunk applies a multiplier in the opposite direction
- `LightweightDrunk` in `Resources/Prototypes/Traits/quirks.yml` gets an `alcohol` tag (HONK-marked) so the two traits exclude each other through the tag system
- Prototype ID in YAML is `AlcoholTolerance`; player-facing name is "Hard Drinker" (locale only)
- Prototype: `@RussStation/Traits/quirks.yml`
- Locale: `@RussStation/traits/quirks.ftl`
- Clone whitelist entry added to `clone.yml`

## Media

N/A (no visual changes).

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Hard Drinker quirk: drunkenness effects last half as long (2 points).
