### PR TITLE
Blood Deficiency quirk

### DIFF
--- a/Content.Shared/Body/Components/BloodstreamComponent.cs
+++ b/Content.Shared/Body/Components/BloodstreamComponent.cs
@@ -17,7 +17,8 @@ namespace Content.Shared.Body.Components;
 /// </summary>
 [RegisterComponent, NetworkedComponent,]
 [AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
-[Access(typeof(SharedBloodstreamSystem))]
+[Access(typeof(SharedBloodstreamSystem),
+    typeof(RussStation.Traits.BloodDeficiencySystem))] // HONK - Blood Deficiency quirk
 public sealed partial class BloodstreamComponent : Component
 {
     public const string DefaultBloodSolutionName = "bloodstream";

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -77,7 +77,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
             // Blood level regulation. Must be alive.
             if (!_mobStateSystem.IsDead(uid))
             {
-                TryRegulateBloodLevel(uid, bloodstream.BloodRefreshAmount);
+                TryModifyBloodLevel(uid, bloodstream.BloodRefreshAmount); // HONK - support negative BloodRefreshAmount
 
                 TickBleed((uid, bloodstream));
 

--- a/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
@@ -4,16 +4,24 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
-/// Reduces blood regeneration rate for entities with this component
-/// by modifying BloodRefreshAmount on MapInit.
+/// Slowly drains blood over time, eventually killing the entity
+/// without medical intervention. Disables natural blood regeneration
+/// and applies a periodic blood loss.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class BloodDeficiencyComponent : Component
 {
     /// <summary>
-    /// Multiplier applied to BloodRefreshAmount.
-    /// At 0.0 blood won't regenerate at all; at 0.5 it regenerates at half speed.
+    /// Amount of blood removed per tick (every 3 seconds).
+    /// At 0.2 with 300 blood, takes ~10 minutes to reach bloodloss threshold
+    /// and ~75 minutes to fully drain.
     /// </summary>
     [DataField]
-    public float BloodRefreshMultiplier = 0.5f;
+    public FixedPoint2 BloodLossPerTick = 0.2f;
+
+    /// <summary>
+    /// Time accumulator for periodic drain.
+    /// </summary>
+    [ViewVariables]
+    public float Accumulator;
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
@@ -19,9 +19,4 @@ public sealed partial class BloodDeficiencyComponent : Component
     [DataField]
     public FixedPoint2 BloodLossPerTick = 0.2f;
 
-    /// <summary>
-    /// Time accumulator for periodic drain.
-    /// </summary>
-    [ViewVariables]
-    public float Accumulator;
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Reduces blood regeneration rate for entities with this component
+/// by modifying BloodRefreshAmount on MapInit.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BloodDeficiencyComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to BloodRefreshAmount.
+    /// At 0.0 blood won't regenerate at all; at 0.5 it regenerates at half speed.
+    /// </summary>
+    [DataField]
+    public float BloodRefreshMultiplier = 0f;
+}

--- a/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
@@ -15,5 +15,5 @@ public sealed partial class BloodDeficiencyComponent : Component
     /// At 0.0 blood won't regenerate at all; at 0.5 it regenerates at half speed.
     /// </summary>
     [DataField]
-    public float BloodRefreshMultiplier = 0f;
+    public float BloodRefreshMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
@@ -1,13 +1,17 @@
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
 
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
-/// Reduces blood regeneration rate for entities with BloodDeficiencyComponent
-/// by modifying BloodRefreshAmount on MapInit.
+/// Disables natural blood regeneration and slowly drains blood over time.
+/// Without treatment (transfusion, iron supplements, etc.) the entity will
+/// eventually die from bloodloss.
 /// </summary>
 public sealed class BloodDeficiencySystem : EntitySystem
 {
+    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -19,6 +23,24 @@ public sealed class BloodDeficiencySystem : EntitySystem
         if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
             return;
 
-        bloodstream.BloodRefreshAmount *= component.BloodRefreshMultiplier;
+        bloodstream.BloodRefreshAmount = 0;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<BloodDeficiencyComponent, BloodstreamComponent>();
+        while (query.MoveNext(out var uid, out var deficiency, out var bloodstream))
+        {
+            deficiency.Accumulator += frameTime;
+
+            var interval = (float) bloodstream.AdjustedUpdateInterval.TotalSeconds;
+            if (deficiency.Accumulator < interval)
+                continue;
+
+            deficiency.Accumulator -= interval;
+            _bloodstream.TryModifyBloodLevel(uid, -deficiency.BloodLossPerTick);
+        }
     }
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
@@ -1,17 +1,14 @@
 using Content.Shared.Body.Components;
-using Content.Shared.Body.Systems;
 
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
-/// Disables natural blood regeneration and slowly drains blood over time.
-/// Without treatment (transfusion, iron supplements, etc.) the entity will
-/// eventually die from bloodloss.
+/// Sets BloodRefreshAmount to a negative value on MapInit, causing
+/// the bloodstream system to slowly drain blood each tick instead of
+/// regenerating it.
 /// </summary>
 public sealed class BloodDeficiencySystem : EntitySystem
 {
-    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -23,24 +20,6 @@ public sealed class BloodDeficiencySystem : EntitySystem
         if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
             return;
 
-        bloodstream.BloodRefreshAmount = 0;
-    }
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        var query = EntityQueryEnumerator<BloodDeficiencyComponent, BloodstreamComponent>();
-        while (query.MoveNext(out var uid, out var deficiency, out var bloodstream))
-        {
-            deficiency.Accumulator += frameTime;
-
-            var interval = (float) bloodstream.AdjustedUpdateInterval.TotalSeconds;
-            if (deficiency.Accumulator < interval)
-                continue;
-
-            deficiency.Accumulator -= interval;
-            _bloodstream.TryModifyBloodLevel(uid, -deficiency.BloodLossPerTick);
-        }
+        bloodstream.BloodRefreshAmount = -component.BloodLossPerTick;
     }
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
@@ -1,14 +1,28 @@
 using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
 /// Sets BloodRefreshAmount to a negative value on MapInit, causing
 /// the bloodstream system to slowly drain blood each tick instead of
-/// regenerating it.
+/// regenerating it. Also hands the entity a starting pill canister so
+/// they can self-treat: copper pills for copper-blooded species, iron
+/// for everyone else.
 /// </summary>
 public sealed class BloodDeficiencySystem : EntitySystem
 {
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
+    private static readonly EntProtoId IronPills = "PillCanisterIron";
+    private static readonly EntProtoId CopperPills = "PillCanisterCopper";
+    private static readonly ProtoId<ReagentPrototype> CopperBlood = "CopperBlood";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -21,5 +35,18 @@ public sealed class BloodDeficiencySystem : EntitySystem
             return;
 
         bloodstream.BloodRefreshAmount = -component.BloodLossPerTick;
+
+        if (!_net.IsServer)
+            return;
+
+        if (!TryComp<HandsComponent>(uid, out var hands))
+            return;
+
+        var pills = bloodstream.BloodReferenceSolution.ContainsPrototype(CopperBlood)
+            ? CopperPills
+            : IronPills;
+
+        var pillEnt = Spawn(pills, Transform(uid).Coordinates);
+        _hands.TryPickup(uid, pillEnt, checkActionBlocker: false, handsComp: hands);
     }
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Body.Components;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Reduces blood regeneration rate for entities with BloodDeficiencyComponent
+/// by modifying BloodRefreshAmount on MapInit.
+/// </summary>
+public sealed class BloodDeficiencySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BloodDeficiencyComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, BloodDeficiencyComponent component, MapInitEvent args)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
+            return;
+
+        bloodstream.BloodRefreshAmount *= component.BloodRefreshMultiplier;
+    }
+}

--- a/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
@@ -2,6 +2,9 @@ using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 
@@ -10,14 +13,16 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Sets BloodRefreshAmount to a negative value on MapInit, causing
 /// the bloodstream system to slowly drain blood each tick instead of
-/// regenerating it. Also hands the entity a starting pill canister so
+/// regenerating it. Also gives the entity a starter pill canister so
 /// they can self-treat: copper pills for copper-blooded species, iron
-/// for everyone else.
+/// for everyone else. Prefers the backpack, falls back to hand.
 /// </summary>
 public sealed class BloodDeficiencySystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
 
     private static readonly EntProtoId IronPills = "PillCanisterIron";
     private static readonly EntProtoId CopperPills = "PillCanisterCopper";
@@ -39,14 +44,20 @@ public sealed class BloodDeficiencySystem : EntitySystem
         if (!_net.IsServer)
             return;
 
-        if (!TryComp<HandsComponent>(uid, out var hands))
-            return;
-
         var pills = bloodstream.BloodReferenceSolution.ContainsPrototype(CopperBlood)
             ? CopperPills
             : IronPills;
 
         var pillEnt = Spawn(pills, Transform(uid).Coordinates);
-        _hands.TryPickup(uid, pillEnt, checkActionBlocker: false, handsComp: hands);
+
+        if (_inventory.TryGetSlotEntity(uid, "back", out var backpack)
+            && HasComp<StorageComponent>(backpack)
+            && _storage.Insert(backpack.Value, pillEnt, out _, playSound: false))
+        {
+            return;
+        }
+
+        if (TryComp<HandsComponent>(uid, out var hands))
+            _hands.TryPickup(uid, pillEnt, checkActionBlocker: false, handsComp: hands);
     }
 }

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,5 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+
+trait-blood-deficiency-name = Blood Deficiency
+trait-blood-deficiency-desc = Your blood runs thin.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,19 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: BloodDeficiency
+  name: trait-blood-deficiency-name
+  description: trait-blood-deficiency-desc
+  category: Combat
+  cost: -6
+  tags:
+    - blood
+  excludedTags:
+    - blood
+  whitelist:
+    components:
+      - Bloodstream
+  components:
+    - type: BloodDeficiency

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -29,6 +29,7 @@
   - PermanentBlindness
   - Snoring
   - Unrevivable
+  - BloodDeficiency # HONK
   # accents
   - Accentless
   - BackwardsAccent


### PR DESCRIPTION
## About the PR

Adds the Blood Deficiency quirk (-6). Your blood slowly drains over time instead of regenerating, so without medical intervention you bleed out on your own. You spawn with a canister of iron pills in your backpack (or copper pills if you're copper-blooded) to self-treat.

## Why / Balance

Negative Combat quirk that creates sustained medical demand. At the default `BloodLossPerTick` of 0.2 (per 3s tick), a fresh human with 300 blood hits the bloodloss damage threshold around 10 minutes in and fully drains around 75. Tagged `blood` so it can't stack with future bloodstream quirks. Whitelisted on `Bloodstream` so species without blood don't see it.

## Technical details

New `BloodDeficiencyComponent` + `BloodDeficiencySystem` in `Content.Shared/RussStation/Traits/`. On `MapInit` the system flips the entity's `BloodstreamComponent.BloodRefreshAmount` to the negative of `BloodLossPerTick`, reusing the existing bloodstream tick instead of running a second timer. Upstream `BloodstreamComponent` has a HONK-marked `Access` attribute expansion to let the fork system write the field.

The same handler also gives the entity a `PillCanisterIron`, or `PillCanisterCopper` if `BloodReferenceSolution` contains `CopperBlood`, so detection stays species-agnostic and any future copper-blooded species gets the right pills for free. The canister goes into the `back` slot via `InventorySystem.TryGetSlotEntity` + `SharedStorageSystem.Insert`, falling back to the hand if there's no backpack or it won't fit. Spawn is gated on `_net.IsServer` to keep the client from predicting the canister.

## Media

N/A.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:

- add: New quirk, Blood Deficiency. Your blood slowly drains instead of regenerating. You start with a canister of iron pills in your bag to manage it.
