### PR TITLE
Quirk: Scarred Eye (partial blindness + eyepatch)

### DIFF
--- a/Content.Shared/RussStation/Eye/BlindnessSourceHelper.cs
+++ b/Content.Shared/RussStation/Eye/BlindnessSourceHelper.cs
@@ -1,0 +1,29 @@
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
+
+namespace Content.Shared.RussStation.Eye;
+
+// Shared apply/remove dance for components that act as a "blindness source"
+// (ScarredEye, PermanentBlindness, etc). Set MinDamage on init, clear it and
+// heal residual EyeDamage on shutdown so cures leave the eye fully healed.
+public static class BlindnessSourceHelper
+{
+    public static void Apply(IEntityManager entMan, BlindableSystem blinding, EntityUid uid, int damage)
+    {
+        if (!entMan.TryGetComponent<BlindableComponent>(uid, out var blindable))
+            return;
+
+        blinding.SetMinDamage((uid, blindable), damage);
+    }
+
+    public static void Remove(IEntityManager entMan, BlindableSystem blinding, EntityUid uid)
+    {
+        if (!entMan.TryGetComponent<BlindableComponent>(uid, out var blindable))
+            return;
+
+        if (blindable.MinDamage != 0)
+            blinding.SetMinDamage((uid, blindable), 0);
+
+        blinding.AdjustEyeDamage((uid, blindable), -blindable.EyeDamage);
+    }
+}

--- a/Content.Shared/RussStation/Traits/ScarredEyeComponent.cs
+++ b/Content.Shared/RussStation/Traits/ScarredEyeComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ScarredEyeComponent : Component
+{
+    [DataField]
+    public int Blindness = 4;
+}

--- a/Content.Shared/RussStation/Traits/ScarredEyeComponent.cs
+++ b/Content.Shared/RussStation/Traits/ScarredEyeComponent.cs
@@ -6,5 +6,5 @@ namespace Content.Shared.RussStation.Traits;
 public sealed partial class ScarredEyeComponent : Component
 {
     [DataField]
-    public int Blindness = 4;
+    public int Blindness = 2;
 }

--- a/Content.Shared/RussStation/Traits/ScarredEyeSystem.cs
+++ b/Content.Shared/RussStation/Traits/ScarredEyeSystem.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class ScarredEyeSystem : EntitySystem
+{
+    [Dependency] private readonly BlindableSystem _blinding = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ScarredEyeComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ScarredEyeComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private void OnMapInit(Entity<ScarredEyeComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<BlindableComponent>(ent, out var blindable))
+            return;
+
+        _blinding.SetMinDamage((ent, blindable), ent.Comp.Blindness);
+    }
+
+    // Mirrors PermanentBlindnessSystem.OnShutdown so changelings and surgical cures
+    // leave the eye in a fully-healed state instead of stuck blind minus the marker.
+    private void OnShutdown(Entity<ScarredEyeComponent> ent, ref ComponentShutdown args)
+    {
+        if (!TryComp<BlindableComponent>(ent, out var blindable))
+            return;
+
+        if (blindable.MinDamage != 0)
+            _blinding.SetMinDamage((ent, blindable), 0);
+
+        _blinding.AdjustEyeDamage((ent, blindable), -blindable.EyeDamage);
+    }
+}

--- a/Content.Shared/RussStation/Traits/ScarredEyeSystem.cs
+++ b/Content.Shared/RussStation/Traits/ScarredEyeSystem.cs
@@ -1,5 +1,5 @@
-using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.RussStation.Eye;
 
 namespace Content.Shared.RussStation.Traits;
 
@@ -15,23 +15,8 @@ public sealed class ScarredEyeSystem : EntitySystem
     }
 
     private void OnMapInit(Entity<ScarredEyeComponent> ent, ref MapInitEvent args)
-    {
-        if (!TryComp<BlindableComponent>(ent, out var blindable))
-            return;
+        => BlindnessSourceHelper.Apply(EntityManager, _blinding, ent, ent.Comp.Blindness);
 
-        _blinding.SetMinDamage((ent, blindable), ent.Comp.Blindness);
-    }
-
-    // Mirrors PermanentBlindnessSystem.OnShutdown so changelings and surgical cures
-    // leave the eye in a fully-healed state instead of stuck blind minus the marker.
     private void OnShutdown(Entity<ScarredEyeComponent> ent, ref ComponentShutdown args)
-    {
-        if (!TryComp<BlindableComponent>(ent, out var blindable))
-            return;
-
-        if (blindable.MinDamage != 0)
-            _blinding.SetMinDamage((ent, blindable), 0);
-
-        _blinding.AdjustEyeDamage((ent, blindable), -blindable.EyeDamage);
-    }
+        => BlindnessSourceHelper.Remove(EntityManager, _blinding, ent);
 }

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,5 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+
+trait-scarred-eye-name = Scarred Eye
+trait-scarred-eye-desc = An old wound left one of your eyes barely functional.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -26,8 +26,7 @@
     components:
       - Blindable
   components:
-    - type: PermanentBlindness
-      blindness: 4
+    - type: ScarredEye
 
 - type: trait
   id: Papyrophobia

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -12,11 +12,12 @@
   name: trait-scarred-eye-name
   description: trait-scarred-eye-desc
   traitGear: ClothingEyesEyepatch
-  category: Quirks
+  category: Senses
   cost: -2
-  conflicts:
-    - Blindness
-    - PoorVision
+  tags:
+    - sight
+  excludedTags:
+    - sight
   whitelist:
     components:
       - Blindable

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,20 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: ScarredEye
+  name: trait-scarred-eye-name
+  description: trait-scarred-eye-desc
+  traitGear: ClothingEyesEyepatch
+  category: Quirks
+  cost: -2
+  conflicts:
+    - Blindness
+    - PoorVision
+  whitelist:
+    components:
+      - Blindable
+  components:
+    - type: PermanentBlindness
+      blindness: 4

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -37,6 +37,7 @@
   - IronJaw # HONK
   - PoorAim # HONK
   - Prosopagnosia # HONK
+  - ScarredEye # HONK
   - SelfAware # HONK
   - Snoring
   - SoftSpoken # HONK


### PR DESCRIPTION
## About the PR

Adds the Scarred Eye quirk, a -2 cost negative quirk. One of your eyes was badly damaged, leaving you with partial blindness and an eyepatch in hand at roundstart.

## Why / Balance

Cheap RP-flavored negative quirk in the Senses category. Lighter eye damage than PoorVision (`blindness: 2` vs 4), but ships with an eyepatch instead of glasses. -2 points matches the other light negative senses quirks (Papyrophobia, Touchy, Prosopagnosia). Uses the shared `sight` exclusion tag so it can't stack with PoorVision or full Blindness.

## Technical details

- New `ScarredEyeComponent` + `ScarredEyeSystem` in `Content.Shared/RussStation/Traits/`, mirrors the shutdown dance from `PermanentBlindnessSystem` so changelings and surgical cures leave the eye fully healed instead of stuck partially blind.
- Extracted `BlindnessSourceHelper` in `Content.Shared/RussStation/Eye/` with `Apply` and `Remove` methods for the `MinDamage` + `EyeDamage` reset pattern. Future fork quirks that act as blindness sources drop in with one line per handler. Upstream `PermanentBlindnessSystem` is left alone to avoid rebase churn.
- `traitGear: ClothingEyesEyepatch` spawns the eyepatch in hand.
- `ScarredEye` added to the `Body` cloning settings so clones keep the trait.
- Whitelists on `Blindable` so it hides for species that can't be blinded.

## Media

N/A.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:

- add: New quirk, Scarred Eye. One of your eyes is damaged, you start with an eyepatch and reduced vision.
