### PR TITLE
feat: add Vegetarian quirk (0 points)

### DIFF
--- a/Content.Shared/RussStation/Traits/VegetarianComponent.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianComponent.cs
@@ -1,11 +1,17 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
 /// Causes the entity to vomit after eating meat.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class VegetarianComponent : Component
 {
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(5);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan NextTrigger;
 }

--- a/Content.Shared/RussStation/Traits/VegetarianComponent.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Causes the entity to vomit after eating meat.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class VegetarianComponent : Component
+{
+}

--- a/Content.Shared/RussStation/Traits/VegetarianComponent.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianComponent.cs
@@ -1,17 +1,11 @@
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.RussStation.Traits;
 
 /// <summary>
 /// Causes the entity to vomit after eating meat.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class VegetarianComponent : Component
 {
-    [DataField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(5);
-
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
-    public TimeSpan NextTrigger;
 }

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Medical;
 using Content.Shared.Nutrition;
 using Content.Shared.Popups;
@@ -9,6 +10,7 @@ namespace Content.Shared.RussStation.Traits;
 public sealed class VegetarianSystem : EntitySystem
 {
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly VomitSystem _vomit = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
@@ -26,7 +28,8 @@ public sealed class VegetarianSystem : EntitySystem
         if (!_tag.HasTag(args.Food, MeatTag))
             return;
 
-        _popup.PopupPredicted(Loc.GetString("trait-vegetarian-nausea"), uid, uid, PopupType.MediumCaution);
+        var coords = _transform.GetMoverCoordinates(uid).Offset(new Vector2(0, 0.5f));
+        _popup.PopupPredictedCoordinates(Loc.GetString("trait-vegetarian-nausea"), coords, uid, PopupType.MediumCaution);
         _vomit.Vomit(uid, -20f, -20f);
     }
 }

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -26,7 +26,7 @@ public sealed class VegetarianSystem : EntitySystem
         if (!_tag.HasTag(args.Food, MeatTag))
             return;
 
-        _popup.PopupClient(Loc.GetString("trait-vegetarian-nausea"), uid, uid, PopupType.MediumCaution);
+        _popup.PopupPredicted(Loc.GetString("trait-vegetarian-nausea"), uid, uid, PopupType.MediumCaution);
         _vomit.Vomit(uid, -20f, -20f);
     }
 }

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Medical;
+using Content.Shared.Nutrition;
+using Content.Shared.Popups;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class VegetarianSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly VomitSystem _vomit = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    private static readonly ProtoId<TagPrototype> MeatTag = "Meat";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<VegetarianComponent, IngestingEvent>(OnIngesting);
+    }
+
+    private void OnIngesting(EntityUid uid, VegetarianComponent component, ref IngestingEvent args)
+    {
+        if (!_tag.HasTag(args.Food, MeatTag))
+            return;
+
+        _popup.PopupEntity(Loc.GetString("trait-vegetarian-nausea"), uid, uid);
+        _vomit.Vomit(uid, -20f, -20f);
+    }
+}

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -28,7 +28,7 @@ public sealed class VegetarianSystem : EntitySystem
         if (!_tag.HasTag(args.Food, MeatTag))
             return;
 
-        var coords = _transform.GetMoverCoordinates(uid).Offset(new Vector2(0, 0.5f));
+        var coords = _transform.GetMoverCoordinates(uid).Offset(new Vector2(0, 0.25f));
         _popup.PopupPredictedCoordinates(Loc.GetString("trait-vegetarian-nausea"), coords, uid, PopupType.MediumCaution);
         _vomit.Vomit(uid, -20f, -20f);
     }

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -3,13 +3,11 @@ using Content.Shared.Nutrition;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.Traits;
 
 public sealed class VegetarianSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly VomitSystem _vomit = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -25,16 +23,10 @@ public sealed class VegetarianSystem : EntitySystem
 
     private void OnIngesting(EntityUid uid, VegetarianComponent component, ref IngestingEvent args)
     {
-        if (_timing.CurTime < component.NextTrigger)
-            return;
-
         if (!_tag.HasTag(args.Food, MeatTag))
             return;
 
-        component.NextTrigger = _timing.CurTime + component.Cooldown;
-        Dirty(uid, component);
-
-        _popup.PopupEntity(Loc.GetString("trait-vegetarian-nausea"), uid, uid);
+        _popup.PopupClient(Loc.GetString("trait-vegetarian-nausea"), uid, uid);
         _vomit.Vomit(uid, -20f, -20f);
     }
 }

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -3,11 +3,13 @@ using Content.Shared.Nutrition;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.Traits;
 
 public sealed class VegetarianSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly VomitSystem _vomit = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -23,8 +25,14 @@ public sealed class VegetarianSystem : EntitySystem
 
     private void OnIngesting(EntityUid uid, VegetarianComponent component, ref IngestingEvent args)
     {
+        if (_timing.CurTime < component.NextTrigger)
+            return;
+
         if (!_tag.HasTag(args.Food, MeatTag))
             return;
+
+        component.NextTrigger = _timing.CurTime + component.Cooldown;
+        Dirty(uid, component);
 
         _popup.PopupEntity(Loc.GetString("trait-vegetarian-nausea"), uid, uid);
         _vomit.Vomit(uid, -20f, -20f);

--- a/Content.Shared/RussStation/Traits/VegetarianSystem.cs
+++ b/Content.Shared/RussStation/Traits/VegetarianSystem.cs
@@ -26,7 +26,7 @@ public sealed class VegetarianSystem : EntitySystem
         if (!_tag.HasTag(args.Food, MeatTag))
             return;
 
-        _popup.PopupClient(Loc.GetString("trait-vegetarian-nausea"), uid, uid);
+        _popup.PopupClient(Loc.GetString("trait-vegetarian-nausea"), uid, uid, PopupType.MediumCaution);
         _vomit.Vomit(uid, -20f, -20f);
     }
 }

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,6 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+
+trait-vegetarian-name = Vegetarian
+trait-vegetarian-desc = Meat just doesn't sit right with you.
+trait-vegetarian-nausea = You feel nauseous... that was meat!

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,16 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: Vegetarian
+  name: trait-vegetarian-name
+  description: trait-vegetarian-desc
+  category: Diet
+  cost: 0
+  tags:
+    - diet
+  excludedTags:
+    - diet
+  components:
+    - type: Vegetarian

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -19,6 +19,7 @@
   - Ageusia # HONK
   - BlackAndWhiteOverlay
   - Clumsy
+  - Vegetarian # HONK
   - ImpairedMobility
   # - LegsParalyzed (you get healed)
   - LightweightDrunk


### PR DESCRIPTION
## About the PR

Adds the **Vegetarian** quirk (0 points): eating meat makes you vomit.

Part of #375.

## Why / Balance

Neutral quirk (0 cost) for roleplay flavor. Meat-eating triggers vomiting at half severity (-20 hunger/thirst vs the default -40), providing a meaningful penalty without being crippling since most food options are non-meat.

## Technical details

- `VegetarianComponent` (marker) and `VegetarianSystem` in `Content.Shared/RussStation/Traits/`
- Subscribes to `IngestingEvent` on the eater entity, checks food for `Meat` tag
- Triggers `VomitSystem.Vomit()` at half severity and shows a nausea popup
- Uses `ProtoId<TagPrototype>` constant for the Meat tag to satisfy `[ForbidLiteral]`
- Registered in clone.yml Body settings

## Media

N/A (trait appears in character editor)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Added Vegetarian quirk (0 points). You can't stomach meat, eating it makes you sick.
:cl: