### PR TITLE
feat: add Glass Jaw quirk (-4 points)

### DIFF
--- a/Content.Shared/RussStation/Traits/GlassJawComponent.cs
+++ b/Content.Shared/RussStation/Traits/GlassJawComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Lowers the stamina crit threshold, making the entity easier to knock down
+/// from stamina damage (batons, disablers, etc.).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GlassJawComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to the stamina crit threshold via RefreshStaminaCritThresholdEvent.
+    /// Lower = knocked down by less stamina damage. Default 0.7 means 70% of normal threshold.
+    /// </summary>
+    [DataField]
+    public float CritThresholdModifier = 0.7f;
+}

--- a/Content.Shared/RussStation/Traits/GlassJawSystem.cs
+++ b/Content.Shared/RussStation/Traits/GlassJawSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Damage.Events;
+using Content.Shared.Damage.Systems;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class GlassJawSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GlassJawComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<GlassJawComponent, RefreshStaminaCritThresholdEvent>(OnRefreshCritThreshold);
+    }
+
+    private void OnMapInit(EntityUid uid, GlassJawComponent component, MapInitEvent args)
+    {
+        _stamina.RefreshStaminaCritThreshold((uid, null));
+    }
+
+    private void OnRefreshCritThreshold(EntityUid uid, GlassJawComponent component, ref RefreshStaminaCritThresholdEvent args)
+    {
+        args.Modifier *= component.CritThresholdModifier;
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,5 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+
+trait-glassjaw-name = Glass Jaw
+trait-glassjaw-desc = One good hit and you're seeing stars.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,16 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: GlassJaw
+  name: trait-glassjaw-name
+  description: trait-glassjaw-desc
+  category: Combat
+  cost: -4
+  tags:
+    - stamina
+  excludedTags:
+    - stamina
+  components:
+    - type: GlassJaw

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -19,6 +19,7 @@
   - Ageusia # HONK
   - BlackAndWhiteOverlay
   - Clumsy
+  - GlassJaw # HONK
   - ImpairedMobility
   # - LegsParalyzed (you get healed)
   - LightweightDrunk


### PR DESCRIPTION
## About the PR

Adds the **Glass Jaw** quirk (-4 points): stamina crit threshold reduced to 70%, making you easier to knock out from batons, disablers, and other stamina damage.

Part of #375.

## Why / Balance

Negative quirk refunding 4 points. Lowering the stamina crit threshold from 100 to 70 means fewer baton hits to enter stam crit. This is a significant combat disadvantage without being unplayable, matching the -4 cost tier.

## Technical details

- `GlassJawComponent` (`CritThresholdModifier = 0.7f`) and `GlassJawSystem` in `Content.Shared/RussStation/Traits/`
- Subscribes to `RefreshStaminaCritThresholdEvent` to multiply the threshold modifier down
- Triggers refresh on `MapInitEvent` so the threshold is applied at spawn
- Uses the existing stamina modifier event system (no upstream file changes needed)
- Registered in clone.yml Body settings

## Media

N/A (trait appears in character editor)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Added Glass Jaw quirk (-4 points). Stamina damage from batons and disablers takes you down faster.
:cl: