### PR TITLE
Poor Aim quirk (-4 points)

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -18,6 +18,9 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Robust.Shared.Random;
+//HONK START
+using Content.Shared.RussStation.Traits;
+//HONK END
 
 namespace Content.Server.Weapons.Ranged.Systems;
 
@@ -71,6 +74,14 @@ public sealed partial class GunSystem : SharedGunSystem
         var mapDirection = toMap - fromMap.Position;
         var mapAngle = mapDirection.ToAngle();
         var angle = GetRecoilAngle(Timing.CurTime, gun, mapDirection.ToAngle());
+
+        //HONK START - Poor Aim: increase shot spread for entities with PoorAimComponent
+        if (user != null && TryComp<PoorAimComponent>(user.Value, out var poorAim))
+        {
+            var deviation = angle.Theta - mapAngle.Theta;
+            angle = new Angle(mapAngle.Theta + deviation * poorAim.SpreadMultiplier);
+        }
+        //HONK END
 
         // If applicable, this ensures the projectile is parented to grid on spawn, instead of the map.
         var fromEnt = MapManager.TryFindGridAt(fromMap, out var gridUid, out _)

--- a/Content.Shared/RussStation/Traits/PoorAimComponent.cs
+++ b/Content.Shared/RussStation/Traits/PoorAimComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Increases weapon spread when firing ranged weapons, making the entity less accurate.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PoorAimComponent : Component
+{
+    /// <summary>
+    /// Multiplier for angular deviation from the target direction.
+    /// Higher = worse accuracy. Default 2.0 means twice the normal spread.
+    /// </summary>
+    [DataField]
+    public float SpreadMultiplier = 2.0f;
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,5 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+
+trait-pooraim-name = Poor Aim
+trait-pooraim-desc = Your hands just won't stay steady.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,16 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: PoorAim
+  name: trait-pooraim-name
+  description: trait-pooraim-desc
+  category: Combat
+  cost: -4
+  tags:
+    - accuracy
+  excludedTags:
+    - accuracy
+  components:
+    - type: PoorAim

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -25,6 +25,7 @@
   - Muted
   - Narcolepsy
   - Pacified
+  - PoorAim # HONK
   - Paracusia
   - PermanentBlindness
   - Snoring


### PR DESCRIPTION
## About the PR

Adds the **Poor Aim** quirk (-4 points): ranged weapon accuracy is halved, doubling the angular spread when firing guns.

Part of #375.

## Why / Balance

Negative quirk refunding 4 points. Doubles the recoil-based spread on every shot, making it noticeably harder to hit targets at range. Doesn't affect melee or thrown weapons. A meaningful combat disadvantage at -4 cost.

## Technical details

- `PoorAimComponent` (`SpreadMultiplier = 2.0f`) in `Content.Shared/RussStation/Traits/`
- No separate system needed, the spread modification is a HONK block in server `GunSystem.Shoot()` that scales the angular deviation from the target direction after recoil is computed
- Registered in clone.yml Body settings

## Media

N/A (trait appears in character editor, effect is spread-based)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: Added Poor Aim quirk (-4 points). Your ranged weapons have noticeably worse accuracy.
:cl: