### PR TITLE
Booming Voice quirk (+2, increased chat range)

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -667,7 +667,12 @@ public sealed partial class ChatSystem : SharedChatSystem
     /// </summary>
     private void SendInVoiceRange(ChatChannel channel, string message, string wrappedMessage, EntityUid source, ChatTransmitRange range, NetUserId? author = null)
     {
-        foreach (var (session, data) in GetRecipients(source, VoiceRange))
+        //HONK START - Allow components to modify voice range
+        var voiceRangeEv = new GetVoiceRangeEvent(VoiceRange);
+        RaiseLocalEvent(source, ref voiceRangeEv);
+        //HONK END
+
+        foreach (var (session, data) in GetRecipients(source, voiceRangeEv.Range))
         {
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)

--- a/Content.Shared/Chat/GetVoiceRangeEvent.cs
+++ b/Content.Shared/Chat/GetVoiceRangeEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Chat;
+
+/// <summary>
+/// Raised on a speaking entity before gathering chat recipients.
+/// Subscribers can modify the voice range.
+/// </summary>
+[ByRefEvent]
+public record struct GetVoiceRangeEvent(float Range);

--- a/Content.Shared/RussStation/Traits/BoomingVoiceComponent.cs
+++ b/Content.Shared/RussStation/Traits/BoomingVoiceComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Increases the entity's voice chat range by a multiplier.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BoomingVoiceComponent : Component
+{
+    [DataField]
+    public float RangeMultiplier = 1.5f;
+}

--- a/Content.Shared/RussStation/Traits/BoomingVoiceSystem.cs
+++ b/Content.Shared/RussStation/Traits/BoomingVoiceSystem.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Chat;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class BoomingVoiceSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BoomingVoiceComponent, GetVoiceRangeEvent>(OnGetVoiceRange);
+    }
+
+    private void OnGetVoiceRange(EntityUid uid, BoomingVoiceComponent component, ref GetVoiceRangeEvent args)
+    {
+        args.Range *= component.RangeMultiplier;
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -2,3 +2,5 @@ trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-negotiator-name = Negotiator
 trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.
+trait-booming-voice-name = Booming Voice
+trait-booming-voice-desc = Your voice carries further than most.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -23,3 +23,16 @@
     - wage
   components:
     - type: Negotiator
+
+- type: trait
+  id: BoomingVoice
+  name: trait-booming-voice-name
+  description: trait-booming-voice-desc
+  category: Social
+  cost: 2
+  tags:
+    - voice-volume
+  excludedTags:
+    - voice-volume
+  components:
+    - type: BoomingVoice

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -18,6 +18,7 @@
   # traits
   - Ageusia # HONK
   - BlackAndWhiteOverlay
+  - BoomingVoice # HONK
   - Clumsy
   - ImpairedMobility
   # - LegsParalyzed (you get healed)


### PR DESCRIPTION
## About the PR

Adds the Booming Voice quirk, which increases chat voice range by 50%. Opposite of Soft-Spoken.

## Why / Balance

Booming Voice is a minor positive quirk (+2 points) that extends your voice range by 1.5x. This means more people can hear you in local chat, useful for command staff or anyone who needs to be heard across a room. Balanced against Soft-Spoken which reduces range.

Relates to #375.

## Technical details

- `GetVoiceRangeEvent` (new shared `ByRefEvent`): raised on the speaking entity in `ChatSystem.SendInVoiceRange()` with the default voice range. Subscribers can modify the range.
- `BoomingVoiceComponent` (new): holds `RangeMultiplier` (default 1.5), `[NetworkedComponent]` for replication
- `BoomingVoiceSystem` (new shared): subscribes to `GetVoiceRangeEvent`, applies the multiplier
- `ChatSystem.cs`: HONK block raises the event before gathering recipients
- Added to clone.yml Body settings for cloning persistence
- Conflicts with SoftSpoken

The event is shared with the Soft-Spoken quirk branch (identical file, merges cleanly).

## Media

N/A, no visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes

None.

## Changelog

:cl:
- add: Booming Voice quirk (+2 points) increases your chat range by 50%