### PR TITLE
Eagle Eye quirk (+2, increased examine range)

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -140,6 +140,13 @@ namespace Content.Shared.Examine
         /// </summary>
         public float GetExaminerRange(EntityUid examiner, MobStateComponent? mobState = null)
         {
+            //HONK START - Allow components to modify examine range
+            var range = ExamineRange;
+            var ev = new GetExamineRangeEvent(range);
+            RaiseLocalEvent(examiner, ref ev);
+            range = ev.Range;
+            //HONK END
+
             if (Resolve(examiner, ref mobState, logMissing: false))
             {
                 if (MobStateSystem.IsDead(examiner, mobState))
@@ -149,9 +156,9 @@ namespace Content.Shared.Examine
                     return CritExamineRange;
 
                 if (TryComp<BlurryVisionComponent>(examiner, out var blurry))
-                    return Math.Clamp(ExamineRange - blurry.Magnitude * ExamineBlurrinessMult, 2, ExamineRange);
+                    return Math.Clamp(range - blurry.Magnitude * ExamineBlurrinessMult, 2, range);
             }
-            return ExamineRange;
+            return range;
         }
 
         /// <summary>

--- a/Content.Shared/Examine/GetExamineRangeEvent.cs
+++ b/Content.Shared/Examine/GetExamineRangeEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Examine;
+
+/// <summary>
+/// Raised on an examining entity before calculating examine range.
+/// Subscribers can modify the range.
+/// </summary>
+[ByRefEvent]
+public record struct GetExamineRangeEvent(float Range);

--- a/Content.Shared/RussStation/Traits/EagleEyeComponent.cs
+++ b/Content.Shared/RussStation/Traits/EagleEyeComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Increases the entity's examine range beyond the default.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EagleEyeComponent : Component
+{
+    [DataField]
+    public float ExamineRange = 24f;
+}

--- a/Content.Shared/RussStation/Traits/EagleEyeSystem.cs
+++ b/Content.Shared/RussStation/Traits/EagleEyeSystem.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Examine;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class EagleEyeSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EagleEyeComponent, GetExamineRangeEvent>(OnGetExamineRange);
+    }
+
+    private void OnGetExamineRange(EntityUid uid, EagleEyeComponent component, ref GetExamineRangeEvent args)
+    {
+        args.Range = component.ExamineRange;
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -2,3 +2,5 @@ trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-negotiator-name = Negotiator
 trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.
+trait-eagle-eye-name = Eagle Eye
+trait-eagle-eye-desc = You have sharp eyes.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -23,3 +23,16 @@
     - wage
   components:
     - type: Negotiator
+
+- type: trait
+  id: EagleEye
+  name: trait-eagle-eye-name
+  description: trait-eagle-eye-desc
+  category: Senses
+  cost: 2
+  tags:
+    - examine-range
+  excludedTags:
+    - examine-range
+  components:
+    - type: EagleEye

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -18,6 +18,7 @@
   # traits
   - Ageusia # HONK
   - BlackAndWhiteOverlay
+  - EagleEye # HONK
   - Clumsy
   - ImpairedMobility
   # - LegsParalyzed (you get healed)


### PR DESCRIPTION
## About the PR

Adds the Eagle Eye quirk, which increases examine range to 24 tiles (up from default 16). Opposite of Touchy.

## Why / Balance

Eagle Eye is a minor positive quirk (+2 points) that lets you examine things from further away. Useful for scouting and situational awareness. Balanced against Touchy which restricts examine to touch range.

Relates to #375.

## Technical details

- `GetExamineRangeEvent` (new shared `ByRefEvent`): raised on the examiner in `ExamineSystemShared.GetExaminerRange()` with the default range. Subscribers can modify the range.
- `EagleEyeComponent` (new): holds `ExamineRange` (default 24f), `[NetworkedComponent]` for replication
- `EagleEyeSystem` (new shared): subscribes to `GetExamineRangeEvent`, sets the range
- `ExamineSystemShared.cs`: HONK block raises the event, uses modified range for blurry vision math
- Added to clone.yml Body settings for cloning persistence
- Conflicts with Touchy

The event is shared with the Touchy quirk branch (identical file, merges cleanly).

## Media

N/A, no visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes

None.

## Changelog

:cl:
- add: Eagle Eye quirk (+2 points) increases your examine range