### PR TITLE
Iron Jaw quirk (+4, harder to stam crit)

### DIFF
--- a/Content.Shared/RussStation/Traits/IronJawComponent.cs
+++ b/Content.Shared/RussStation/Traits/IronJawComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// Increases the stamina crit threshold, making the entity harder to knock down.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class IronJawComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to the stamina crit threshold.
+    /// Higher = harder to knock down. Default 1.3 means 130% of normal threshold.
+    /// </summary>
+    [DataField]
+    public float CritThresholdModifier = 1.3f;
+}

--- a/Content.Shared/RussStation/Traits/IronJawSystem.cs
+++ b/Content.Shared/RussStation/Traits/IronJawSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Damage.Events;
+using Content.Shared.Damage.Systems;
+
+namespace Content.Shared.RussStation.Traits;
+
+public sealed class IronJawSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IronJawComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<IronJawComponent, RefreshStaminaCritThresholdEvent>(OnRefreshCritThreshold);
+    }
+
+    private void OnMapInit(EntityUid uid, IronJawComponent component, MapInitEvent args)
+    {
+        _stamina.RefreshStaminaCritThreshold((uid, null));
+    }
+
+    private void OnRefreshCritThreshold(EntityUid uid, IronJawComponent component, ref RefreshStaminaCritThresholdEvent args)
+    {
+        args.Modifier *= component.CritThresholdModifier;
+    }
+}

--- a/Content.Shared/RussStation/Traits/IronJawSystem.cs
+++ b/Content.Shared/RussStation/Traits/IronJawSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
 
@@ -17,7 +18,10 @@ public sealed class IronJawSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, IronJawComponent component, MapInitEvent args)
     {
-        _stamina.RefreshStaminaCritThreshold((uid, null));
+        if (!TryComp<StaminaComponent>(uid, out var stamina))
+            return;
+
+        _stamina.RefreshStaminaCritThreshold((uid, stamina));
     }
 
     private void OnRefreshCritThreshold(EntityUid uid, IronJawComponent component, ref RefreshStaminaCritThresholdEvent args)

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -2,3 +2,5 @@ trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-negotiator-name = Negotiator
 trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.
+trait-iron-jaw-name = Iron Jaw
+trait-iron-jaw-desc = You can take a hit.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -23,3 +23,16 @@
     - wage
   components:
     - type: Negotiator
+
+- type: trait
+  id: IronJaw
+  name: trait-iron-jaw-name
+  description: trait-iron-jaw-desc
+  category: Combat
+  cost: 4
+  tags:
+    - stamina
+  excludedTags:
+    - stamina
+  components:
+    - type: IronJaw

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -28,6 +28,7 @@
   - Pacified
   - Paracusia
   - PermanentBlindness
+  - IronJaw # HONK
   - Snoring
   - Unrevivable
   # accents


### PR DESCRIPTION
## About the PR

Adds the Iron Jaw quirk, which increases the stamina crit threshold by 30%. Opposite of Glass Jaw.

## Why / Balance

Iron Jaw is a positive quirk (+4 points) that makes you harder to knock down from stamina damage. Your stamina crit threshold is 30% higher, meaning you can absorb more baton hits before going down. Balanced against Glass Jaw which lowers the threshold.

Relates to #375.

## Technical details

- `IronJawComponent` (new): holds `CritThresholdModifier` (default 1.3f), `[NetworkedComponent]` for replication
- `IronJawSystem` (new shared): subscribes to `MapInitEvent` to trigger threshold refresh, and `RefreshStaminaCritThresholdEvent` to apply the modifier
- No upstream file changes needed (the `RefreshStaminaCritThresholdEvent` hook already exists from the Glass Jaw branch, merges cleanly)
- Added to clone.yml Body settings for cloning persistence
- Conflicts with GlassJaw

## Media

N/A, no visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes

None.

## Changelog

:cl:
- add: Iron Jaw quirk (+4 points) makes you harder to knock down from stamina damage