### PR TITLE
Steady Hand quirk (+4, reduced shot spread)

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee;
+using Content.Shared.RussStation.Traits; //HONK
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
@@ -71,6 +72,14 @@ public sealed partial class GunSystem : SharedGunSystem
         var mapDirection = toMap - fromMap.Position;
         var mapAngle = mapDirection.ToAngle();
         var angle = GetRecoilAngle(Timing.CurTime, gun, mapDirection.ToAngle());
+
+        //HONK START - Steady Hand: reduce shot spread for entities with SteadyHandComponent
+        if (user != null && TryComp<SteadyHandComponent>(user.Value, out var steadyHand))
+        {
+            var deviation = angle.Theta - mapAngle.Theta;
+            angle = new Angle(mapAngle.Theta + deviation * steadyHand.SpreadMultiplier);
+        }
+        //HONK END
 
         // If applicable, this ensures the projectile is parented to grid on spawn, instead of the map.
         var fromEnt = MapManager.TryFindGridAt(fromMap, out var gridUid, out _)

--- a/Content.Shared/RussStation/Traits/SteadyHandComponent.cs
+++ b/Content.Shared/RussStation/Traits/SteadyHandComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SteadyHandComponent : Component
+{
+    [DataField]
+    public float SpreadMultiplier = 0.5f;
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -2,3 +2,5 @@ trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
 trait-negotiator-name = Negotiator
 trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.
+trait-steady-hand-name = Steady Hand
+trait-steady-hand-desc = Your hands are rock steady.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -23,3 +23,16 @@
     - wage
   components:
     - type: Negotiator
+
+- type: trait
+  id: SteadyHand
+  name: trait-steady-hand-name
+  description: trait-steady-hand-desc
+  category: Combat
+  cost: 4
+  tags:
+    - accuracy
+  excludedTags:
+    - accuracy
+  components:
+    - type: SteadyHand

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -29,6 +29,7 @@
   - Paracusia
   - PermanentBlindness
   - Snoring
+  - SteadyHand # HONK
   - Unrevivable
   # accents
   - Accentless


### PR DESCRIPTION
## About the PR

Adds the Steady Hand quirk, which reduces ranged weapon shot spread by 50%. Opposite of Poor Aim.

## Why / Balance

Steady Hand is a positive quirk (+4 points) that halves the angular deviation on your shots, making ranged combat more accurate. Balanced against Poor Aim which doubles the spread.

Relates to #375.

## Technical details

- `SteadyHandComponent` (new): holds `SpreadMultiplier` (default 0.5f), `[NetworkedComponent]` for replication
- `GunSystem.cs`: HONK block in `Shoot()` checks for `SteadyHandComponent` via `TryComp` and applies the spread multiplier to the deviation angle (same pattern as Poor Aim but with 0.5x instead of 2.0x)
- Added to clone.yml Body settings for cloning persistence
- Conflicts with PoorAim

When both branches merge, the two HONK blocks will be adjacent and can be combined into a single block.

## Media

N/A, no visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes

None.

## Changelog

:cl:
- add: Steady Hand quirk (+4 points) improves your ranged accuracy