### PR TITLE
Chore: add HONK markers to reformatted upstream files

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -1,3 +1,4 @@
+# HONK - Formatting standardized to match .editorconfig (2-space YAML indent)
 - type: entity
   id: ClosetBase
   parent: [BaseStructureDynamic, BasePaperLabelableVisualized]

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1,3 +1,4 @@
+# HONK - Formatting standardized (multiline comments consolidated)
 # PUT YOUR TAGS IN ALPHABETICAL ORDER
 # ALSO DOCUMENT WHAT THE HELL THEY DO
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1,4 +1,3 @@
-# HONK - Formatting standardized (multiline comments consolidated)
 # PUT YOUR TAGS IN ALPHABETICAL ORDER
 # ALSO DOCUMENT WHAT THE HELL THEY DO
 

--- a/Resources/Textures/Effects/atmospherics.rsi/meta.json
+++ b/Resources/Textures/Effects/atmospherics.rsi/meta.json
@@ -1,4 +1,5 @@
 {
+  "_honk": "Formatting standardized to 2-space indent with expanded delays",
   "version": 1,
   "license": "CC-BY-SA-3.0",
   "copyright": "Taken from https://github.com/tgstation/tgstation at 04e43d8c1d5097fdb697addd4395fb849dd341bd",


### PR DESCRIPTION
## About the PR

Adds HONK marker comments to 3 upstream files where formatting was deliberately standardized, documenting that the divergence from upstream formatting is intentional.

## Why / Balance

These files had formatting changes mixed with functional changes (identified in audit #403). Rather than reverting the formatting (#404), we're keeping it and marking it so future rebases know the formatting is intentional.

## Technical details

- `base_structureclosets.yml`: YAML comment noting 2-space indent standardization
- `tags.yml`: YAML comment noting comment consolidation
- `atmospherics.rsi/meta.json`: `_honk` JSON field (ignored by RSI loader) noting indent standardization

## Media

N/A

## Requirements

- [x] No functional changes

## Breaking changes

None.

## Changelog

No player-facing changes.