### PR TITLE
Move font CVars to fork-owned partial class

### DIFF
--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -34,21 +34,6 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> SeparatedScreenChatSize =
         CVarDef.Create("ui.separated_chat_size", "0.6,0", CVar.CLIENTONLY | CVar.ARCHIVE);
 
-    // HONK START - Font customization
-    /// <summary>
-    /// The font family used for UI text. "NotoSans" is the default.
-    /// User-provided fonts can be placed in the UserData/fonts/ directory.
-    /// </summary>
-    public static readonly CVarDef<string> UIFontFamily =
-        CVarDef.Create("ui.font_family", "NotoSans", CVar.CLIENTONLY | CVar.ARCHIVE);
-
-    /// <summary>
-    /// Base font size for UI text.
-    /// </summary>
-    public static readonly CVarDef<int> UIFontSize =
-        CVarDef.Create("ui.font_size", 12, CVar.CLIENTONLY | CVar.ARCHIVE);
-    // HONK END
-
     public static readonly CVarDef<bool> OutlineEnabled =
         CVarDef.Create("outline.enabled", true, CVar.CLIENTONLY);
 

--- a/Content.Shared/RussStation/CCVar/CCVars.Font.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Font.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// The font family used for UI text. "NotoSans" is the default.
+    /// User-provided fonts can be placed in the UserData/fonts/ directory.
+    /// </summary>
+    public static readonly CVarDef<string> UIFontFamily =
+        CVarDef.Create("ui.font_family", "NotoSans", CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Base font size for UI text.
+    /// </summary>
+    public static readonly CVarDef<int> UIFontSize =
+        CVarDef.Create("ui.font_size", 12, CVar.CLIENTONLY | CVar.ARCHIVE);
+}


### PR DESCRIPTION
## About the PR

Extracts `UIFontFamily` and `UIFontSize` CVars from upstream `CCVars.Interface.cs` into a fork-owned partial class at `Content.Shared/RussStation/CCVar/CCVars.Font.cs`.

## Why / Balance

Reduces upstream diff surface for cleaner rebases. The partial class pattern lets us add fork CVars without touching upstream files. Part of the upstream tampering audit (#403).

## Technical details

- Created `Content.Shared/RussStation/CCVar/CCVars.Font.cs` as a `partial class CCVars` in the same namespace
- Removed the HONK-marked block from `CCVars.Interface.cs`, restoring it to upstream state
- No behavioral change, CVars retain the same names and defaults

## Media

N/A

## Requirements

- [x] Builds with 0 errors
- [x] No upstream files modified beyond removing fork additions

## Breaking changes

None.

## Changelog

:cl:
- tweak: No player-facing changes (internal refactor)