### PR TITLE
Move QuickDialogCloseEvent to fork namespace

### DIFF
--- a/Content.Client/Administration/QuickDialogSystem.cs
+++ b/Content.Client/Administration/QuickDialogSystem.cs
@@ -1,5 +1,8 @@
 using Content.Client.UserInterface.Controls;
 using Content.Shared.Administration;
+//HONK START
+using Content.Shared.RussStation.Economy.Events;
+//HONK END
 
 namespace Content.Client.Administration;
 

--- a/Content.Server/Administration/QuickDialogSystem.cs
+++ b/Content.Server/Administration/QuickDialogSystem.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration;
+//HONK START
+using Content.Shared.RussStation.Economy.Events;
+//HONK END
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Network;

--- a/Content.Shared/Administration/QuickDialogOpenEvent.cs
+++ b/Content.Shared/Administration/QuickDialogOpenEvent.cs
@@ -101,22 +101,6 @@ public sealed class QuickDialogEntry
     }
 }
 
-// HONK START - Server-initiated dialog close (#163)
-/// <summary>
-/// A networked event raised when the server wants to close an open quick dialog.
-/// </summary>
-[Serializable, NetSerializable]
-public sealed class QuickDialogCloseEvent : EntityEventArgs
-{
-    public int DialogId;
-
-    public QuickDialogCloseEvent(int dialogId)
-    {
-        DialogId = dialogId;
-    }
-}
-// HONK END
-
 /// <summary>
 /// The buttons available in a quick dialog.
 /// </summary>

--- a/Content.Shared/RussStation/Economy/Events/QuickDialogCloseEvent.cs
+++ b/Content.Shared/RussStation/Economy/Events/QuickDialogCloseEvent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.Economy.Events;
+
+/// <summary>
+/// A networked event raised when the server wants to close an open quick dialog.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class QuickDialogCloseEvent : EntityEventArgs
+{
+    public int DialogId;
+
+    public QuickDialogCloseEvent(int dialogId)
+    {
+        DialogId = dialogId;
+    }
+}


### PR DESCRIPTION
## About the PR

Extracts `QuickDialogCloseEvent` from upstream `QuickDialogOpenEvent.cs` into `Content.Shared/RussStation/Economy/Events/QuickDialogCloseEvent.cs`.

## Why / Balance

The event was appended to an upstream file, creating unnecessary rebase friction. Moving it to the fork namespace restores the upstream file to its original state. Part of the upstream tampering audit (#403).

## Technical details

- Created `Content.Shared/RussStation/Economy/Events/QuickDialogCloseEvent.cs` with proper fork namespace
- Removed the HONK block from `QuickDialogOpenEvent.cs`
- Added HONK-marked `using` statements in `Content.Client/Administration/QuickDialogSystem.cs` and `Content.Server/Administration/QuickDialogSystem.cs`
- No behavioral change

## Media

N/A

## Requirements

- [x] Builds with 0 errors
- [x] Upstream file restored to original state

## Breaking changes

None.

## Changelog

:cl:
- tweak: No player-facing changes (internal refactor)