### PR TITLE
Extract fold sound to fork-owned FoldSoundSystem

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -8,9 +8,6 @@ using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
-//HONK START - Fold sound
-using Robust.Shared.Audio.Systems;
-//HONK END
 
 namespace Content.Shared.Foldable;
 
@@ -22,9 +19,6 @@ public sealed class FoldableSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly AnchorableSystem _anchorable = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    //HONK START - Fold sound
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
-    //HONK END
 
     public override void Initialize()
     {
@@ -90,11 +84,6 @@ public sealed class FoldableSystem : EntitySystem
         Dirty(uid, component);
         _appearance.SetData(uid, FoldedVisuals.State, folded);
         _buckle.StrapSetEnabled(uid, !component.IsFolded);
-
-        //HONK START - Play buckle sound on fold/unfold (only when a user triggers it)
-        if (user != null)
-            _audio.PlayPredicted(new Robust.Shared.Audio.SoundPathSpecifier("/Audio/Effects/buckle.ogg"), uid, user);
-        //HONK END
 
         var ev = new FoldedEvent(folded, user);
         RaiseLocalEvent(uid, ref ev);

--- a/Content.Shared/RussStation/Foldable/FoldSoundSystem.cs
+++ b/Content.Shared/RussStation/Foldable/FoldSoundSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Foldable;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Shared.RussStation.Foldable;
+
+/// <summary>
+/// Plays a buckle sound when an entity is folded or unfolded by a user.
+/// </summary>
+public sealed class FoldSoundSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    private static readonly SoundPathSpecifier FoldSound = new("/Audio/Effects/buckle.ogg");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FoldableComponent, FoldedEvent>(OnFolded);
+    }
+
+    private void OnFolded(EntityUid uid, FoldableComponent component, ref FoldedEvent args)
+    {
+        if (args.User != null)
+            _audio.PlayPredicted(FoldSound, uid, args.User);
+    }
+}


### PR DESCRIPTION
## About the PR

Moves the fold/unfold sound effect from upstream `FoldableSystem` to a new fork-owned `FoldSoundSystem` that subscribes to `FoldedEvent`.

## Why / Balance

Eliminates all three HONK blocks from `FoldableSystem.cs` (using, dependency, play call), restoring it to upstream state. The ECS event subscription pattern is the correct way to extend upstream behavior without modifying upstream files. Part of the upstream tampering audit (#403).

## Technical details

- Created `Content.Shared/RussStation/Foldable/FoldSoundSystem.cs`
- Subscribes to `FoldedEvent` on `FoldableComponent` entities
- Plays buckle sound via `PlayPredicted` only when `User` is non-null (same guard as before)
- Removed all HONK modifications from `Content.Shared/Foldable/FoldableSystem.cs`

## Media

N/A

## Requirements

- [x] Builds with 0 errors
- [x] Upstream file fully restored

## Breaking changes

None.

## Changelog

:cl:
- tweak: No player-facing changes (internal refactor)