### PR TITLE
refactor: extract AccountNumber to BankLinkedCardComponent

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/CreateAccountTest.cs
@@ -1,6 +1,5 @@
 using Content.IntegrationTests.Tests.Interaction;
 using Content.Server.RussStation.Economy;
-using Content.Shared.Access.Components;
 using Content.Shared.RussStation.Economy.Components;
 
 namespace Content.IntegrationTests.Tests.RussStation.Economy;
@@ -25,9 +24,8 @@ public sealed class CreateAccountTest : InteractionTest
             // Player should not have an account yet.
             Assert.That(SEntMan.HasComponent<PlayerBalanceComponent>(SPlayer), Is.False);
 
-            // ID should be blank.
-            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
-            Assert.That(string.IsNullOrEmpty(idComp.AccountNumber), Is.True);
+            // ID should be blank (no BankLinkedCardComponent).
+            Assert.That(SEntMan.HasComponent<BankLinkedCardComponent>(idEnt), Is.False);
 
             // Create account.
             var accountNumber = balanceSys.CreateAccount(SPlayer);
@@ -114,17 +112,17 @@ public sealed class CreateAccountTest : InteractionTest
 
             // Create account and stamp it on the ID.
             var oldAccount = balanceSys.CreateAccount(SPlayer);
-            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
-            idComp.AccountNumber = oldAccount;
+            var bankComp = SEntMan.EnsureComponent<BankLinkedCardComponent>(idEnt);
+            bankComp.AccountNumber = oldAccount;
 
             // Verify it resolves.
-            Assert.That(balanceSys.TryGetByAccount(idComp.AccountNumber, out _), Is.True);
+            Assert.That(balanceSys.TryGetByAccount(bankComp.AccountNumber!, out _), Is.True);
 
             // Create a new account (invalidates old).
             balanceSys.CreateAccount(SPlayer);
 
             // The ID still has the old account number, which should no longer resolve.
-            Assert.That(balanceSys.TryGetByAccount(idComp.AccountNumber, out _), Is.False,
+            Assert.That(balanceSys.TryGetByAccount(bankComp.AccountNumber!, out _), Is.False,
                 "ID with old account number should fail lookup after invalidation.");
         });
     }
@@ -142,11 +140,11 @@ public sealed class CreateAccountTest : InteractionTest
         await Server.WaitPost(() =>
         {
             var balanceSys = SEntMan.System<PlayerBalanceSystem>();
-            var idComp = SEntMan.GetComponent<IdCardComponent>(idEnt);
+            var bankComp = SEntMan.EnsureComponent<BankLinkedCardComponent>(idEnt);
 
             // Create an account and stamp it on the ID (simulates normal spawn).
             var firstAccount = balanceSys.CreateAccount(SPlayer);
-            idComp.AccountNumber = firstAccount;
+            bankComp.AccountNumber = firstAccount;
 
             // Create a second account (simulates "Create Account" verb).
             // The mob gets a new account, but the ID should still have the old number.
@@ -154,7 +152,7 @@ public sealed class CreateAccountTest : InteractionTest
             Assert.That(secondAccount, Is.Not.EqualTo(firstAccount));
 
             // ID still has the first account number (locked).
-            Assert.That(idComp.AccountNumber, Is.EqualTo(firstAccount),
+            Assert.That(bankComp.AccountNumber, Is.EqualTo(firstAccount),
                 "ID with account set should not be overwritten by creating a new account.");
 
             // The old account on the ID is now invalid (invalidated by second create).

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -63,7 +63,9 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (!_hands.IsHolding(args.User, uid))
             return;
 
-        if (string.IsNullOrEmpty(comp.AccountNumber))
+        var accountNumber = CompOrNull<BankLinkedCardComponent>(uid)?.AccountNumber;
+
+        if (string.IsNullOrEmpty(accountNumber))
         {
             args.Verbs.Add(new AlternativeVerb
             {
@@ -75,7 +77,7 @@ public sealed class IdCardAccountSystem : EntitySystem
                 Impact = LogImpact.Low,
             });
         }
-        else if (_balance.TryGetByAccount(comp.AccountNumber, out _))
+        else if (_balance.TryGetByAccount(accountNumber, out _))
         {
             args.Verbs.Add(new AlternativeVerb
             {
@@ -100,7 +102,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (!_hands.IsHolding(args.User, uid))
             return;
 
-        if (!string.IsNullOrEmpty(comp.AccountNumber))
+        if (!string.IsNullOrEmpty(CompOrNull<BankLinkedCardComponent>(uid)?.AccountNumber))
             return;
 
         args.Verbs.Add(new ActivationVerb
@@ -120,12 +122,13 @@ public sealed class IdCardAccountSystem : EntitySystem
 
     private void OnExamine(EntityUid uid, IdCardComponent comp, ExaminedEvent args)
     {
-        if (string.IsNullOrEmpty(comp.AccountNumber))
+        var accountNumber = CompOrNull<BankLinkedCardComponent>(uid)?.AccountNumber;
+        if (string.IsNullOrEmpty(accountNumber))
             return;
 
         using (args.PushGroup(nameof(IdCardAccountSystem)))
         {
-            if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner)
+            if (!_balance.TryGetByAccount(accountNumber, out var owner)
                 || !TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
             {
                 args.PushMarkup(Loc.GetString("id-card-account-invalid-examine"));
@@ -167,13 +170,14 @@ public sealed class IdCardAccountSystem : EntitySystem
 
     private bool TryDeposit(EntityUid idCard, IdCardComponent comp, EntityUid cash, EntityUid user)
     {
-        if (string.IsNullOrEmpty(comp.AccountNumber))
+        var accountNumber = CompOrNull<BankLinkedCardComponent>(idCard)?.AccountNumber;
+        if (string.IsNullOrEmpty(accountNumber))
             return false;
 
         if (!TryComp<StackComponent>(cash, out var stack) || stack.StackTypeId != CreditStack)
             return false;
 
-        if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
+        if (!_balance.TryGetByAccount(accountNumber, out var owner))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, user, PopupType.MediumCaution);
             return true;
@@ -196,10 +200,11 @@ public sealed class IdCardAccountSystem : EntitySystem
 
     private void OnCreateAccount(EntityUid idCard, EntityUid user, ICommonSession session)
     {
-        if (!TryComp<IdCardComponent>(idCard, out var comp))
+        if (!HasComp<IdCardComponent>(idCard))
             return;
 
-        if (!string.IsNullOrEmpty(comp.AccountNumber))
+        var bankComp = CompOrNull<BankLinkedCardComponent>(idCard);
+        if (!string.IsNullOrEmpty(bankComp?.AccountNumber))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-locked"), idCard, session, PopupType.MediumCaution);
             return;
@@ -207,18 +212,19 @@ public sealed class IdCardAccountSystem : EntitySystem
 
         var accountNumber = _balance.CreateAccount(user);
 
-        comp.AccountNumber = accountNumber;
-        Dirty(idCard, comp);
+        bankComp = EnsureComp<BankLinkedCardComponent>(idCard);
+        bankComp.AccountNumber = accountNumber;
 
         _popup.PopupEntity(Loc.GetString("id-card-create-account-success"), idCard, session, PopupType.Medium);
     }
 
     private void OnAccountEntered(EntityUid idCard, EntityUid user, ICommonSession session, string accountNumber)
     {
-        if (!TryComp<IdCardComponent>(idCard, out var comp))
+        if (!HasComp<IdCardComponent>(idCard))
             return;
 
-        if (!string.IsNullOrEmpty(comp.AccountNumber))
+        var bankComp = CompOrNull<BankLinkedCardComponent>(idCard);
+        if (!string.IsNullOrEmpty(bankComp?.AccountNumber))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-locked"), idCard, session, PopupType.MediumCaution);
             return;
@@ -235,24 +241,25 @@ public sealed class IdCardAccountSystem : EntitySystem
             return;
         }
 
-        comp.AccountNumber = accountNumber;
-        Dirty(idCard, comp);
+        bankComp = EnsureComp<BankLinkedCardComponent>(idCard);
+        bankComp.AccountNumber = accountNumber;
 
         _popup.PopupEntity(Loc.GetString("id-card-set-account-success"), idCard, session, PopupType.Medium);
     }
 
     private void OnWithdraw(EntityUid idCard, EntityUid user, ICommonSession session, int amount)
     {
-        if (!TryComp<IdCardComponent>(idCard, out var comp))
+        if (!HasComp<IdCardComponent>(idCard))
             return;
 
-        if (string.IsNullOrEmpty(comp.AccountNumber))
+        var accountNumber = CompOrNull<BankLinkedCardComponent>(idCard)?.AccountNumber;
+        if (string.IsNullOrEmpty(accountNumber))
             return;
 
         if (amount <= 0)
             return;
 
-        if (!_balance.TryGetByAccount(comp.AccountNumber, out var owner))
+        if (!_balance.TryGetByAccount(accountNumber, out var owner))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, session, PopupType.MediumCaution);
             return;

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.RussStation.Memories;
-using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.RussStation.Economy;
@@ -73,9 +72,8 @@ public sealed class PlayerBalanceSystem : EntitySystem
         // Stamp account number onto the player's ID card.
         if (_idCard.TryFindIdCard(args.Mob, out var idCard))
         {
-            var idComp = Comp<IdCardComponent>(idCard);
-            idComp.AccountNumber = comp.AccountNumber;
-            Dirty(idCard, idComp);
+            var bankComp = EnsureComp<BankLinkedCardComponent>(idCard);
+            bankComp.AccountNumber = comp.AccountNumber;
         }
 
         // Register account number in the player's memories.
@@ -94,13 +92,13 @@ public sealed class PlayerBalanceSystem : EntitySystem
         if (!_idCard.TryFindIdCard(args.Entity, out var idCard))
             return;
 
-        var idComp = Comp<IdCardComponent>(idCard);
-        if (!string.IsNullOrEmpty(idComp.AccountNumber))
+        var bankComp = CompOrNull<BankLinkedCardComponent>(idCard);
+        if (!string.IsNullOrEmpty(bankComp?.AccountNumber))
             return;
 
         var accountNumber = CreateAccount(args.Entity, _defaultStartingBalance);
-        idComp.AccountNumber = accountNumber;
-        Dirty(idCard, idComp);
+        bankComp = EnsureComp<BankLinkedCardComponent>(idCard);
+        bankComp.AccountNumber = accountNumber;
     }
 
     private void OnRemove(EntityUid uid, PlayerBalanceComponent comp, ComponentRemove args)

--- a/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
+++ b/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Cargo.Systems;
-using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Materials;
@@ -169,9 +168,9 @@ public sealed class VendingPaymentSystem : EntitySystem
 
         // Account balance.
         if (_idCard.TryFindIdCard(buyer, out var idCard)
-            && TryComp<IdCardComponent>(idCard, out var id)
-            && !string.IsNullOrEmpty(id.AccountNumber)
-            && _balance.TryGetByAccount(id.AccountNumber, out var owner))
+            && TryComp<BankLinkedCardComponent>(idCard, out var bankCard)
+            && !string.IsNullOrEmpty(bankCard.AccountNumber)
+            && _balance.TryGetByAccount(bankCard.AccountNumber, out var owner))
         {
             funds += _balance.GetBalance(owner);
         }
@@ -193,9 +192,9 @@ public sealed class VendingPaymentSystem : EntitySystem
     private bool TryPayByAccount(EntityUid buyer, int price)
     {
         if (_idCard.TryFindIdCard(buyer, out var idCard)
-            && TryComp<IdCardComponent>(idCard, out var id)
-            && !string.IsNullOrEmpty(id.AccountNumber)
-            && _balance.TryGetByAccount(id.AccountNumber, out var owner)
+            && TryComp<BankLinkedCardComponent>(idCard, out var bankCard)
+            && !string.IsNullOrEmpty(bankCard.AccountNumber)
+            && _balance.TryGetByAccount(bankCard.AccountNumber, out var owner)
             && TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
         {
             return _balance.TryDeduct(owner, price, balanceComp, Loc.GetString("transaction-vending"));

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -64,12 +64,4 @@ public sealed partial class IdCardComponent : Component
 
     [DataField]
     public bool CanMicrowave = true;
-
-    //HONK START - Bank account number for economy system (#163)
-    /// <summary>
-    /// Bank account number linked to the player's balance. Set at spawn, can be manually set on new IDs.
-    /// </summary>
-    [DataField]
-    public string? AccountNumber;
-    //HONK END
 }

--- a/Content.Shared/RussStation/Economy/Components/BankLinkedCardComponent.cs
+++ b/Content.Shared/RussStation/Economy/Components/BankLinkedCardComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.RussStation.Economy.Components;
+
+/// <summary>
+/// Added at runtime to ID cards that have been linked to a bank account.
+/// Holds the account number separately from the upstream IdCardComponent to avoid modifying it.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BankLinkedCardComponent : Component
+{
+    [DataField]
+    public string? AccountNumber;
+}


### PR DESCRIPTION
## About the PR
Extracts the fork-added `AccountNumber` field from the upstream `IdCardComponent` into a new fork-owned `BankLinkedCardComponent`. This removes the HONK block from `Content.Shared/Access/Components/IdCardComponent.cs`, reducing upstream diff surface.

## Why / Balance
Part of the upstream tampering audit (#403, specifically #406). Every field we add to upstream components creates rebase friction. By moving `AccountNumber` to a separate fork-owned component, the upstream `IdCardComponent` stays untouched.

No gameplay changes. The bank account system works identically, just reads/writes from `BankLinkedCardComponent` instead of `IdCardComponent`.

## Technical details
- New `BankLinkedCardComponent` in `Content.Shared/RussStation/Economy/Components/`
- `IdCardAccountSystem` uses `CompOrNull<BankLinkedCardComponent>` for reads, `EnsureComp<BankLinkedCardComponent>` for writes
- `PlayerBalanceSystem` stamps account number on `BankLinkedCardComponent` instead of `IdCardComponent`
- `VendingPaymentSystem` reads account from `BankLinkedCardComponent`
- Integration tests updated to use the new component
- Removed unused `IdCardComponent` imports where no longer needed

## Media
Refactor only, no in-game changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
`IdCardComponent.AccountNumber` has been removed. Use `BankLinkedCardComponent.AccountNumber` instead. Any code accessing account numbers on ID cards must `TryComp<BankLinkedCardComponent>` instead of reading from `IdCardComponent`.