### PR TITLE
refactor: extract ActionGun popup/sound into fork-owned ActionGunExt

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Weapons/ActionGunTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Weapons/ActionGunTest.cs
@@ -1,23 +1,23 @@
-using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.RussStation.Weapons.Ranged;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.RussStation.Weapons;
 
 /// <summary>
-/// Tests for HONK modifications to ActionGunComponent (PopupText and OnShootSound fields).
+/// Tests for ActionGunExtComponent (fork-owned popup and sound fields for ActionGun entities).
 /// Uses the real game prototypes to avoid the complexity of setting up test action pipelines.
 /// </summary>
 [TestFixture]
-[TestOf(typeof(ActionGunComponent))]
-public sealed class ActionGunTest
+[TestOf(typeof(ActionGunExtComponent))]
+public sealed class ActionGunExtTest
 {
     /// <summary>
     /// Verifies that the spit ActionGun entity (from species_appearance.yml) loads
-    /// correctly with the HONK PopupText and OnShootSound fields set.
+    /// correctly with the ActionGunExt PopupText and OnShootSound fields set.
     /// </summary>
     [Test]
-    public async Task SpitPrototypeHasHonkFields()
+    public async Task SpitPrototypeHasExtFields()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -25,7 +25,7 @@ public sealed class ActionGunTest
 
         await server.WaitAssertion(() =>
         {
-            // The spit ActionGun is defined as a component on HumanoidAppearance in species_appearance.yml.
+            // The spit ActionGun + ActionGunExt are defined on HumanoidAppearance in species_appearance.yml.
             // We verify the prototype loads without errors (implicitly tested by pool startup)
             // and that the real spit gun and action prototypes exist.
             var allProtos = protoManager.EnumeratePrototypes<EntityPrototype>();
@@ -47,12 +47,11 @@ public sealed class ActionGunTest
     }
 
     /// <summary>
-    /// Verifies that ActionGunComponent's PopupText and OnShootSound DataFields are
-    /// correctly defined (nullable defaults) by spawning a minimal entity without the
-    /// ActionGun component, then adding it manually.
+    /// Verifies that ActionGunExtComponent's PopupText and OnShootSound DataFields
+    /// default to null when added without YAML data.
     /// </summary>
     [Test]
-    public async Task ActionGunComponentDefaultValues()
+    public async Task ActionGunExtComponentDefaultValues()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -61,10 +60,8 @@ public sealed class ActionGunTest
 
         await server.WaitAssertion(() =>
         {
-            // Create a bare entity and add the component manually to test defaults
-            // without triggering MapInit (which requires action setup).
             var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
-            var comp = entityManager.AddComponent<ActionGunComponent>(entity);
+            var comp = entityManager.AddComponent<ActionGunExtComponent>(entity);
 
             Assert.That(comp.PopupText, Is.Null, "PopupText should default to null");
             Assert.That(comp.OnShootSound, Is.Null, "OnShootSound should default to null");

--- a/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtComponent.cs
+++ b/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtComponent.cs
@@ -1,0 +1,29 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.RussStation.Weapons.Ranged;
+
+/// <summary>
+/// Fork extension for <see cref="Content.Shared.Weapons.Ranged.Components.ActionGunComponent"/>.
+/// Adds popup text on shoot and a manual sound workaround.
+/// The upstream action gun spawns the gun entity in nullspace, so
+/// Audio.PlayPredicted from that entity produces no audible sound.
+/// This component lets us play the sound from the mob instead.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ActionGunExtComponent : Component
+{
+    /// <summary>
+    /// Optional popup text shown when firing (e.g. "spits").
+    /// Displayed as "[EntityName] [PopupText]!".
+    /// </summary>
+    [DataField]
+    public string? PopupText;
+
+    /// <summary>
+    /// Sound played from the mob on successful shot.
+    /// Works around the upstream issue where the gun entity has no world position.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? OnShootSound;
+}

--- a/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs
+++ b/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Popups;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Shared.RussStation.Weapons.Ranged;
+
+/// <summary>
+/// Handles fork-specific action gun extensions: popup text and sound workaround.
+/// Subscribes alongside upstream's ActionGunSystem without modifying it.
+/// </summary>
+/// <remarks>
+/// The upstream action gun spawns the gun entity in nullspace (no world position),
+/// so Audio.PlayPredicted from that entity produces no audible sound.
+/// This system plays the sound from the mob entity instead.
+/// </remarks>
+public sealed class ActionGunExtSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ActionGunExtComponent, ActionGunShootEvent>(OnShoot);
+        SubscribeLocalEvent<GunComponent, GunShotEvent>(OnGunShot);
+    }
+
+    private void OnShoot(Entity<ActionGunExtComponent> ent, ref ActionGunShootEvent args)
+    {
+        if (ent.Comp.PopupText == null)
+            return;
+
+        var name = Comp<MetaDataComponent>(ent).EntityName;
+        _popup.PopupPredicted(name + " " + ent.Comp.PopupText + "!", ent, ent, type: PopupType.Small);
+    }
+
+    /// <summary>
+    /// After a successful gun shot, play the action gun's sound from the mob
+    /// instead of the gun entity (which has no world position).
+    /// </summary>
+    private void OnGunShot(Entity<GunComponent> gun, ref GunShotEvent args)
+    {
+        if (!TryComp<ActionGunExtComponent>(args.User, out var ext))
+            return;
+
+        if (ext.OnShootSound == null)
+            return;
+
+        // Find the action entity for prediction.
+        TryComp<ActionGunComponent>(args.User, out var actionGun);
+
+        _audio.PlayPredicted(ext.OnShootSound, args.User, actionGun?.ActionEntity);
+    }
+}

--- a/Content.Shared/Weapons/Ranged/Components/ActionGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/ActionGunComponent.cs
@@ -2,9 +2,7 @@ using Content.Shared.Actions;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-//HONK START
-using Robust.Shared.Audio;
-//HONK END
+
 namespace Content.Shared.Weapons.Ranged.Components;
 
 /// <summary>
@@ -31,14 +29,6 @@ public sealed partial class ActionGunComponent : Component
 
     [DataField]
     public EntityUid? Gun;
-
-    //HONK START
-    [DataField]
-    public string? PopupText = null;
-
-    [DataField]
-    public SoundSpecifier? OnShootSound;
-    //HONK END
 }
 
 /// <summary>

--- a/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
@@ -1,23 +1,12 @@
 using Content.Shared.Actions;
 using Content.Shared.Weapons.Ranged.Components;
 
-//HONK START
-using Content.Shared.Popups;
-using Robust.Shared.Audio.Systems;
-using Content.Shared.Actions.Components;
-//HONK END
-
 namespace Content.Shared.Weapons.Ranged.Systems;
 
 public sealed class ActionGunSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;
-
-    //HONK START
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
-    //HONK END
 
     public override void Initialize()
     {
@@ -45,16 +34,7 @@ public sealed class ActionGunSystem : EntitySystem
 
     private void OnShoot(Entity<ActionGunComponent> ent, ref ActionGunShootEvent args)
     {
-        //HONK START
-        if (ent.Comp.PopupText != null)
-            _popup.PopupPredicted(Comp<MetaDataComponent>(ent).EntityName + " " + ent.Comp.PopupText + "!", ent, ent, type: PopupType.Small);
-
         if (TryComp<GunComponent>(ent.Comp.Gun, out var gun))
-        {
-            if (_gun.AttemptShoot(ent, (ent.Comp.Gun.Value, gun), args.Target) == true)
-                _audio.PlayPredicted(ent.Comp.OnShootSound, ent, ent.Comp.ActionEntity); //Fixes shooting sounds for action guns
-        }
-        //HONK END
+            _gun.AttemptShoot(ent, (ent.Comp.Gun.Value, gun), args.Target);
     }
 }
-

--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -96,6 +96,7 @@
   - type: ActionGun
     action: ActionSpit
     gunProto: SpitGun
+  - type: ActionGunExt
     popupText: spits
     onShootSound: /Audio/@RussStation/Spit/russstation_sound_voice_spit_release.ogg
   # HONK END


### PR DESCRIPTION
## About the PR

Extracts fork-specific `PopupText` and `OnShootSound` fields from upstream's `ActionGunComponent` / `ActionGunSystem` into a new fork-owned `ActionGunExtComponent` + `ActionGunExtSystem`. Restores both upstream files to their exact upstream state, eliminating fork diff surface.

Also fixes the root cause of inaudible action gun sounds. The upstream system spawns the gun entity in nullspace (no coordinates), so `Audio.PlayPredicted` from the gun's position produces no sound.

Closes #411

## Why / Balance

Part of the upstream tampering audit (#403). Every HONK block in an upstream file creates rebase friction. Moving the popup and sound logic into fork-owned files under `Content.Shared/RussStation/` avoids future merge conflicts when upstream updates `ActionGunSystem.cs`.

## Technical details

- New `ActionGunExtComponent` holds `PopupText` and `OnShootSound` (fork-only DataFields)
- New `ActionGunExtSystem` subscribes to `ActionGunShootEvent` for popup and `GunShotEvent` for sound
- Sound uses `GunShotEvent` (raised on gun entity post-shot) to play from `args.User` (the mob), not the nullspace gun
- `species_appearance.yml` now has both `ActionGun` (upstream) and `ActionGunExt` (fork) components
- Test updated to reference `ActionGunExtComponent`

## Media

N/A (no visual changes)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- fix: action gun sounds (like spitting) now play audibly instead of silently firing from nullspace