### PR TITLE
Add CVARS.md fork configuration reference

### DIFF
--- a/CVARS.md
+++ b/CVARS.md
@@ -1,0 +1,31 @@
+# Fork CVars
+
+Configuration variables added by the Honksquad fork. These can be set in the server config or changed at runtime via the `cvar` command.
+
+## Economy
+
+| CVar                               | Type  | Default | Scope  | Description                                                |
+| ---------------------------------- | ----- | ------- | ------ | ---------------------------------------------------------- |
+| `economy.default_starting_balance` | int   | 250     | Server | Starting balance granted to players on spawn (spesos)      |
+| `economy.payroll_interval`         | float | 300     | Server | Seconds between payroll deposits                           |
+| `economy.wage_lower`               | int   | 25      | Server | Wage per interval for lower-tier jobs (assistant, visitor) |
+| `economy.wage_crew`                | int   | 50      | Server | Wage per interval for standard crew jobs                   |
+| `economy.wage_command`             | int   | 100     | Server | Wage per interval for command-tier jobs                    |
+| `economy.vend_cargo_markup`        | float | 1.5     | Server | Multiplier on cargo value for vending price                |
+| `economy.vend_material_markup`     | float | 0.5     | Server | Multiplier on recipe material cost for vending price       |
+| `economy.vend_min_price`           | int   | 5       | Server | Absolute minimum vending price (last-resort fallback)      |
+
+## Traits
+
+<!-- TODO: game.max_trait_points (PR #376) not yet merged into release -->
+
+| CVar                    | Type | Default | Scope      | Description                                            |
+| ----------------------- | ---- | ------- | ---------- | ------------------------------------------------------ |
+| `game.max_trait_points` | int  | 10      | Replicated | Global point budget shared across all trait categories |
+
+## UI
+
+| CVar             | Type   | Default  | Scope  | Description                 |
+| ---------------- | ------ | -------- | ------ | --------------------------- |
+| `ui.font_family` | string | NotoSans | Client | UI font family name         |
+| `ui.font_size`   | int    | 12       | Client | UI base font size in points |


### PR DESCRIPTION
## About the PR

Adds `CVARS.md` to document all fork-specific configuration variables in one place. Covers Economy (8 CVars), Traits (1, pending PR #376), and UI (2).

## Why / Balance

No gameplay changes. Makes it easier for admins and contributors to discover and tune fork settings without digging through source.

## Technical details

- Single markdown file in repo root with tables per domain
- TODO comment on `game.max_trait_points` since PR #376 hasn't merged yet

## Media

N/A

## Requirements

None

## Breaking changes

None

## Changelog

N/A (internal documentation only)