### PR TITLE
Add taste tag exclusion to Ageusia quirk

### DIFF
--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -4,6 +4,10 @@
   description: trait-ageusia-desc
   category: Diet
   cost: 0
+  tags:
+    - taste
+  excludedTags:
+    - taste
   components:
     - type: Ageusia
 


### PR DESCRIPTION
## About the PR

Adds `taste` tag and self-exclusion to the Ageusia quirk, matching the tag-based exclusion pattern used by other quirks.

## Why / Balance

Prevents players from taking multiple taste-related quirks that would conflict with each other.

## Technical details

Added `tags: [taste]` and `excludedTags: [taste]` to the Ageusia trait prototype.

## Media

N/A - no in-game visual changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.