### PR TITLE
Fix alert icon scaling for non-standard sprite sizes

### DIFF
--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -60,15 +60,13 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
 
             HorizontalAlignment = HAlignment.Left;
             _severity = severity;
-            //HONK START - Fill scales any sprite size to 64x64 (supports 16x16 wound icons)
             _icon = new SpriteView
             {
-                Scale = new Vector2(1, 1),
+                Scale = new Vector2(2, 2),
                 MaxSize = new Vector2(64, 64),
-                Stretch = SpriteView.StretchMode.Fill,
+                Stretch = SpriteView.StretchMode.None,
                 HorizontalAlignment = HAlignment.Left
             };
-            //HONK END
 
             SetupIcon();
 
@@ -102,7 +100,19 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
                 return;
             var icon = Alert.GetIcon(_severity);
             if (_sprite.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
+            {
                 _sprite.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
+
+                //HONK START - Rescale on severity change
+                var pixelSize = sprite[layer].PixelSize;
+                var maxSide = Math.Max(pixelSize.X, pixelSize.Y);
+                if (maxSide > 0)
+                {
+                    var scale = 64f / maxSide;
+                    _icon.Scale = new Vector2(scale, scale);
+                }
+                //HONK END
+            }
         }
 
         protected override void FrameUpdate(FrameEventArgs args)
@@ -131,6 +141,16 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
                 var icon = Alert.GetIcon(_severity);
                 if (_sprite.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
                     _sprite.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
+
+                //HONK START - Dynamic scale so any sprite size fills the 64x64 alert slot
+                var pixelSize = sprite[layer].PixelSize;
+                var maxSide = Math.Max(pixelSize.X, pixelSize.Y);
+                if (maxSide > 0)
+                {
+                    var scale = 64f / maxSide;
+                    _icon.Scale = new Vector2(scale, scale);
+                }
+                //HONK END
             }
 
             _icon.SetEntity(_spriteViewEntity);


### PR DESCRIPTION
## About the PR

Fixes all HUD alert icons shrinking after the wound alert commit. The previous approach changed AlertControl's SpriteView to use `Scale=(1,1)` and `Stretch=Fill` globally, which broke upstream 32x32 alert icons.

This replaces that with a dynamic scaler: after loading a sprite layer, it reads the actual pixel size and computes `scale = 64 / maxSide`. Any sprite size now renders correctly at 64x64 without touching the art assets.

## Why / Balance

The wound alert commit (#427) changed AlertControl settings that affect every alert icon in the game. Upstream icons are 32x32 and expect `Scale=(2,2)` with `Stretch=None`. The global override to `Scale=(1,1)` + `Stretch=Fill` made all of them render smaller/blurry.

## Technical details

- Reverted SpriteView constructor to upstream defaults (`Scale=2,2`, `Stretch=None`)
- Added dynamic scale computation in `SetupIcon()` and `SetSeverity()` based on `sprite[layer].PixelSize`
- 32x32 icons get Scale=2 (unchanged from upstream), 16x16 wound icons get Scale=4, future sizes handled automatically

## Media

N/A, fix restores icons to their correct size.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed all HUD alert icons appearing shrunken after the wound alert update.
:cl: