### PR TITLE
Negotiator quirk (+1, 1.5x payroll wages)

### DIFF
--- a/Content.Server/RussStation/Economy/PayrollSystem.cs
+++ b/Content.Server/RussStation/Economy/PayrollSystem.cs
@@ -104,6 +104,13 @@ public sealed class PayrollSystem : EntitySystem
             if (wage <= 0)
                 continue;
 
+            var wageEv = new GetWageEvent(wage);
+            RaiseLocalEvent(uid, ref wageEv);
+            wage = wageEv.Wage;
+
+            if (wage <= 0)
+                continue;
+
             _balance.AddBalance(uid, wage, comp, Loc.GetString("transaction-payroll"));
             var newBalance = _balance.GetBalance(uid, comp);
             _popup.PopupEntity(Loc.GetString("payroll-received", ("wage", wage), ("balance", newBalance)), uid, uid);

--- a/Content.Server/RussStation/Traits/NegotiatorSystem.cs
+++ b/Content.Server/RussStation/Traits/NegotiatorSystem.cs
@@ -1,0 +1,18 @@
+using Content.Shared.RussStation.Economy;
+using Content.Shared.RussStation.Traits;
+
+namespace Content.Server.RussStation.Traits;
+
+public sealed class NegotiatorSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<NegotiatorComponent, GetWageEvent>(OnGetWage);
+    }
+
+    private void OnGetWage(EntityUid uid, NegotiatorComponent component, ref GetWageEvent args)
+    {
+        args.Wage = (int)(args.Wage * component.WageMultiplier);
+    }
+}

--- a/Content.Shared/RussStation/Economy/GetWageEvent.cs
+++ b/Content.Shared/RussStation/Economy/GetWageEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.RussStation.Economy;
+
+/// <summary>
+/// Raised on an entity before depositing their payroll wage.
+/// Subscribers can modify the wage amount.
+/// </summary>
+[ByRefEvent]
+public record struct GetWageEvent(int Wage);

--- a/Content.Shared/RussStation/Traits/NegotiatorComponent.cs
+++ b/Content.Shared/RussStation/Traits/NegotiatorComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NegotiatorComponent : Component
+{
+    [DataField]
+    public float WageMultiplier = 1.5f;
+}

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -1,2 +1,4 @@
 trait-ageusia-name = Ageusia
 trait-ageusia-desc = You can't taste anything.
+trait-negotiator-name = Negotiator
+trait-negotiator-desc = You negotiated a better contract. Your paycheck is 50% higher.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -6,3 +6,16 @@
   cost: 0
   components:
     - type: Ageusia
+
+- type: trait
+  id: Negotiator
+  name: trait-negotiator-name
+  description: trait-negotiator-desc
+  category: Social
+  cost: 1
+  tags:
+    - wage
+  excludedTags:
+    - wage
+  components:
+    - type: Negotiator

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -24,6 +24,7 @@
   - LightweightDrunk
   - Muted
   - Narcolepsy
+  - Negotiator # HONK
   - Pacified
   - Paracusia
   - PermanentBlindness


### PR DESCRIPTION
## About the PR

Adds the Negotiator trait: costs 1 point, multiplies payroll wages by 1.5x. Uses tag-based exclusion (`wage` tag) so it can't stack with future wage-modifying traits.

Replaces #401 which was reverted due to picking up unrelated commits during merge.

## Why / Balance

At default CVars (Lower=25, Crew=50, Command=100), Negotiator gives +12/+25/+50 per pay cycle. A meaningful perk for a 1-point trait without being game-warping.

## Technical details

- `GetWageEvent` (by-ref event) raised on the entity before payroll deposit, letting any system modify the wage
- `NegotiatorSystem` subscribes and applies the 1.5x multiplier from `NegotiatorComponent.WageMultiplier`
- PayrollSystem change: 7 lines added to raise the event between wage lookup and deposit
- `clone.yml`: Negotiator added to clone trait blacklist (upstream file, minimal 1-line change)

## Media

N/A, no visual changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

**Changelog**

:cl:
- add: New Negotiator trait (+1 point) gives 50% higher paychecks.
:cl: