### PR TITLE
docs: janitorial guidebook, toolkit and trolley tricks

### DIFF
--- a/Resources/ServerInfo/Guidebook/Service/Janitorial.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Janitorial.xml
@@ -36,6 +36,48 @@ You keep things clean, it's a rough job sometimes, but someone's gotta do it. Th
 <GuideEntityEmbed Entity="FloorDrain"/>
 </Box>
 
+## Your Toolkit
+Your standard kit. Nothing in here is for show, so learn it before you need it.
+
+### Mop
+Every janitor's starter weapon. If there's a puddle on the floor, this is how you deal with it.
+
+- Wet the mop at a [color=#88ccff]bucket[/color]. Sinks and water tanks can top a bucket up, but you can't wet the mop on them directly. A dry mop is useless.
+- Mopping a puddle swaps some of the mop's water into the puddle (turning it into plain water) and pulls the puddle's reagents back into the mop. The water left behind evaporates on its own, and that's the part that slips people, so keep signs up until it dries.
+- Re-wetting the mop at the bucket works the same way in reverse: it dumps whatever the mop picked up into the bucket and pulls clean water out. The bucket slowly gets dirty as you work, so drain it at a [color=#88ccff]floor drain[/color] when it fills. Drains are usually in medical, the kitchen, and your own closet.
+- The [color=#88ccff]advanced mop[/color] (ask R&D) refills its reservoir on its own, saving you the bucket trips.
+
+### Trash bag
+Everything loose and useless ends up in here eventually. Empty it before it bursts.
+
+- Click near loose trash with the bag out to scoop everything in range at once; individual clicks work too.
+- Click the bag on a [color=#88ccff]disposal chute[/color] to empty it in one go.
+
+### Light replacer
+Broken bulbs in, working ones out, all in one motion. Saves you carrying a crate of spares every time engineering misses a fuse.
+
+- Broken bulbs and plain [color=#88ccff]glass shards[/color] recycle into points. Click them onto the replacer.
+- Used on a broken fixture, it consumes the old bulb for a point, then looks for a replacement: an exact-match stored bulb, any stored bulb of the same type, or a fresh one printed from points if storage can't cover it.
+- [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color] (use in hand) opens a window with Take buttons for stored bulbs and print options for anything else. Storage caps at 12, the same as a full light box.
+
+### Space cleaner
+For the messes a mop can't chew through, and whatever someone scribbled on the wall between shifts.
+
+- Sprayed on a puddle, it converts the whole thing into plain water and deletes the reagents outright. The mop only trades reagents around; space cleaner actually destroys them, which matters when someone's spilled something nasty.
+- Scrubs player-sprayed graffiti off floors and walls. Some station-standard markings placed by mappers are currently immune.
+- Refill at the [color=#88ccff]cleaner dispenser[/color] on the custodial closet wall. Chemistry can brew more if the dispenser runs dry, and a [color=#88ccff]cleaner grenade[/color] wipes a large mess in one toss.
+
+### Wet floor signs and holosign projector
+Your legal defense when someone eats the floor.
+
+- Place them [italic]before[/italic] you mop, not after.
+- The holosign projector is a good backup when you've run out of physical signs.
+
+### Soap
+Small, slippery, useful twice over. Cleans tiles and floors anyone running across them.
+
+- Drop it on the floor and anyone running over it slips. Also actually cleans things.
+
 ## Your Cart
 Your [color=#88ccff]janitorial trolley[/color] is the closest thing to a mobile office you'll ever get. It has dedicated slots for your mop, trash bag, bucket, plunger, light replacer, spray bottle, and up to four wet floor signs, plus enough room in the trash bag for whatever disasters you find on the way. A few tricks the tutorial doesn't mention:
 
@@ -46,20 +88,8 @@ Your [color=#88ccff]janitorial trolley[/color] is the closest thing to a mobile 
 - Dragging a [color=#88ccff]sink[/color] or [color=#88ccff]floor drain[/color] onto the trolley tops up the bucket in place. Beats parking next to the sink every five minutes.
 - And if you really must, [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color] lets you [italic]drink[/italic] from the bucket. The chaplain says it builds character.
 
-## Tidying up.
-Now, onto the (figurative) meat and potatoes. We're here to clean, right? Lets keep it simple. The main tools you'll be putting to use are the trusty mop, a trash bag, space cleaner, and one of the three different buckets.
-
-Mopping: Fill your cart up with water, then, find some puddles! Wet your mop, and wipe them up, the resulting water puddle will dry after a short time. Don't forget the wet floor signs!
-- To drain your cart, drag it (with your cursor) onto a floor drain. This will dump all the fluids inside! Floor drains can usually be found somewhere in medical, the kitchen freezer, and of course, the janitor closet.
-
-Trash: Place it in the bag directly, or hold it in your hand. Click -near- trash to scoop -all- nearby junk up, or click on each piece individually. Using the bag on a disposal will empty it.
-- Cargo might want some of your trash, it might be worthwhile to check in from time to time!
-
-Space Cleaner: This miracle spray can do two things, clean graffiti, and in a pinch, clean up puddles!
-- You might be able to get more of this from chemistry.
-
 ## Extra Duties
-A good janitor is always on the lookout for a bit more to do, and there are plenty of tools at your disposal. Keep an eye out for broken lights, help the chef take care of mice in the kitchen, and if you're feeling -really- generous, try to restock the vending machines and emergency closets around the station!
+A good janitor is always on the lookout for a bit more to do. Keep an eye out for broken lights, help the chef take care of mice in the kitchen, and if you're feeling -really- generous, try to restock the vending machines and emergency closets around the station. Cargo will also take scrap off your hands; a full trash bag now and then adds up over a shift.
 
 ##Additional Information:
 <GuideReagentEmbed Reagent="SpaceCleaner"/>

--- a/Resources/ServerInfo/Guidebook/Service/Janitorial.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Janitorial.xml
@@ -36,6 +36,16 @@ You keep things clean, it's a rough job sometimes, but someone's gotta do it. Th
 <GuideEntityEmbed Entity="FloorDrain"/>
 </Box>
 
+## Your Cart
+Your [color=#88ccff]janitorial trolley[/color] is the closest thing to a mobile office you'll ever get. It has dedicated slots for your mop, trash bag, bucket, plunger, light replacer, spray bottle, and up to four wet floor signs, plus enough room in the trash bag for whatever disasters you find on the way. A few tricks the tutorial doesn't mention:
+
+- With a janitorial tool in hand, press [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] on the trolley to drop it into the matching slot. No fumbling, no misclicks.
+- With anything else (or an empty hand), [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] opens a [italic]radial menu[/italic]. Perfect for when you need your plunger and your mop is in the way.
+- An empty-hand [color=yellow][bold][keybind="Use"][/bold][/color] yanks out the highest-priority item, which is usually your mop. Quick-draw.
+- [bold]Found trash on the floor?[/bold] Scoop it up, click the trolley, and it drops straight into the bag. No need to dig the bag out first.
+- Dragging a [color=#88ccff]sink[/color] or [color=#88ccff]floor drain[/color] onto the trolley tops up the bucket in place. Beats parking next to the sink every five minutes.
+- And if you really must, [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color] lets you [italic]drink[/italic] from the bucket. The chaplain says it builds character.
+
 ## Tidying up.
 Now, onto the (figurative) meat and potatoes. We're here to clean, right? Lets keep it simple. The main tools you'll be putting to use are the trusty mop, a trash bag, space cleaner, and one of the three different buckets.
 


### PR DESCRIPTION
## About the PR

Fleshes out the Janitorial guidebook page with two sections:

- **Your Toolkit** — a short flavor intro per tool plus bullets covering the real mechanics. Covers mop (reagent trade with puddles, bucket draining, advanced mop auto-refill), trash bag, light replacer (the recycler / fixture-replace flow / inventory window from #285), space cleaner (reagent destruction, graffiti limits, dispenser refill, cleaner grenade), wet floor signs + holosign projector, and soap.
- **Your Cart** — the trolley-specific interactions from #286 (alt-click slot insertion, radial eject, empty-hand priority eject, trash-bag pass-through, drag-to-refill from sinks/drains, drink-from-bucket). This started as its own section; pulled it beneath Your Toolkit so the flow reads in-hand gear, then the container that carries them.

Also drops the old "Tidying up" section: its mop/trash/cleaner prose duplicated everything Your Toolkit covers. The two bits that were genuinely unique (floor drain locations, cargo-buys-scrap) survive folded into the mop bullet and Extra Duties.

## Why / Balance

Guidebook-only. No gameplay change.

The janitor page had been a thin intro with no per-tool behavior detail. Players coming in green bounced between the tutorial and the wiki to figure out why a dry mop did nothing or what the light replacer's new window did. This puts the answers in the guide.

## Technical details

One file changed, `Resources/ServerInfo/Guidebook/Service/Janitorial.xml`. Uses the existing markup (GuideEntityEmbed, keybind tags, color tags). Section structure reorganized, no schema changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches. (See \`BRANCHING.md\`.)
- [X] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix. (See \`CONTRIBUTING.md\`.)

## Breaking changes

None.

**Changelog**

:cl:
- add: The Janitorial guidebook page now covers each tool's actual behavior and the trolley's alt-click / radial / drag interactions.