### PR TITLE
Relocate drop-to-release pull handler out of PullingSystem

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -11,9 +11,6 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
-//HONK START - Escalated grab: drop-to-release pull
-using Content.Shared.Interaction.Events;
-//HONK END
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
 using Content.Shared.Mobs;
@@ -81,9 +78,6 @@ public sealed class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullerComponent, EntGotInsertedIntoContainerMessage>(OnPullerContainerInsert);
         SubscribeLocalEvent<PullerComponent, EntityUnpausedEvent>(OnPullerUnpaused);
         SubscribeLocalEvent<PullerComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
-        //HONK START - Drop virtual item releases pull
-        SubscribeLocalEvent<VirtualItemComponent, DroppedEvent>(OnVirtualItemDropped);
-        //HONK END
         SubscribeLocalEvent<PullerComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
         SubscribeLocalEvent<PullerComponent, DropHandItemsEvent>(OnDropHandItems);
         SubscribeLocalEvent<PullerComponent, StopPullingAlertEvent>(OnStopPullingAlert);
@@ -266,20 +260,6 @@ public sealed class PullingSystem : EntitySystem
             TryStopPull(args.BlockingEntity, comp);
         }
     }
-
-    //HONK START - Drop virtual item releases pull
-    private void OnVirtualItemDropped(EntityUid uid, VirtualItemComponent component, DroppedEvent args)
-    {
-        if (!TryComp<PullerComponent>(args.User, out var puller))
-            return;
-
-        if (puller.Pulling != component.BlockingEntity)
-            return;
-
-        if (TryComp(component.BlockingEntity, out PullableComponent? pullable))
-            TryStopPull(component.BlockingEntity, pullable, user: args.User);
-    }
-    //HONK END
 
     private void AddPullVerbs(EntityUid uid, PullableComponent component, GetVerbsEvent<Verb> args)
     {

--- a/Content.Shared/RussStation/Pulling/VirtualItemPullReleaseSystem.cs
+++ b/Content.Shared/RussStation/Pulling/VirtualItemPullReleaseSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Interaction.Events;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+
+namespace Content.Shared.RussStation.Pulling;
+
+// Stops the pull when a player drops the virtual item representing a pulled entity.
+// Relocated out of upstream PullingSystem.cs to keep rebase surface minimal (issue #441 P0.1).
+public sealed class VirtualItemPullReleaseSystem : EntitySystem
+{
+    [Dependency] private readonly PullingSystem _pulling = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<VirtualItemComponent, DroppedEvent>(OnVirtualItemDropped);
+    }
+
+    private void OnVirtualItemDropped(EntityUid uid, VirtualItemComponent component, DroppedEvent args)
+    {
+        if (!TryComp<PullerComponent>(args.User, out var puller))
+            return;
+
+        if (puller.Pulling != component.BlockingEntity)
+            return;
+
+        if (TryComp(component.BlockingEntity, out PullableComponent? pullable))
+            _pulling.TryStopPull(component.BlockingEntity, pullable, user: args.User);
+    }
+}


### PR DESCRIPTION
## About the PR
Moves the fork's drop-to-release-pull subscription out of upstream `PullingSystem.cs` and into a new fork-owned `VirtualItemPullReleaseSystem` under `Content.Shared/RussStation/Pulling/`. Pure relocation, no behavior change.

Addresses P0.1 from #441.

## Why / Balance
`PullingSystem.cs` is the single most rebase-volatile file in the fork. Every HONK block inside it is a potential merge conflict against upstream. The drop-to-release handler had no reason to live there, it was added during escalated-grab development because that's the file the author was already editing. `TryStopPull` is already public and the handler has no private state, so the relocation is free.

No gameplay impact. The behavior (drop the virtual pull item to release the pull) is preserved exactly.

## Technical details
- New file: `Content.Shared/RussStation/Pulling/VirtualItemPullReleaseSystem.cs`. Subscribes to `VirtualItemComponent, DroppedEvent`, takes `PullingSystem` as a dependency, calls `TryStopPull` on the blocking entity.
- Deleted three HONK blocks from `Content.Shared/Movement/Pulling/Systems/PullingSystem.cs`: the `using Content.Shared.Interaction.Events;` import, the subscription line in `Initialize()`, and the `OnVirtualItemDropped` handler method.
- The `force: true` call into `TryStopPull` is unchanged. That parameter is itself a HONK addition and will be replaced when P0.4 lands (it will update the new file at that point).

### Subscription-ordering sanity check
There are 11 `DroppedEvent` subscribers in the codebase, each filtering on a different component. Only this handler targets `VirtualItemComponent`. On a virtual pull item entity the upstream `ItemComponent` subscriber in `ExamineSystem` also fires, but it only closes a local examine tooltip and doesn't interact with pull state. No handlers gate on `args.Handled` or set it, and this one doesn't either. Safe.

## Media
N/A. No player-visible change.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None. Behavior is preserved.

**Changelog**

<!-- No changelog entry. Internal refactor, no player-facing change. -->