### PR TITLE
Fix pre-welded map lockers leaking atmos (441 P1.3)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Storage/LockerAirtightWeldTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Storage/LockerAirtightWeldTest.cs
@@ -14,6 +14,7 @@ public sealed class LockerAirtightWeldTest : GameTest
   components:
   - type: EntityStorage
     airtight: false
+    airtightWhenWelded: true
   - type: Weldable
 ";
 

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 //HONK START - Airtight lockers when welded
+using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 //HONK END
 using Robust.Server.GameObjects;
@@ -37,6 +38,14 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
 
     private void OnMapInit(EntityUid uid, EntityStorageComponent component, MapInitEvent args)
     {
+        //HONK START - 441 P1.3: sync Airtight from the initial weld state so map-placed pre-welded storages seal correctly
+        if (component.AirtightWhenWelded
+            && TryComp<WeldableComponent>(uid, out var weldable))
+        {
+            component.Airtight = weldable.IsWelded;
+        }
+        //HONK END
+
         if (!component.Open && component.Air.TotalMoles == 0)
         {
             // If we're closed on spawn and have no air already saved, we need to pull some air into our environment from where we spawned,
@@ -93,10 +102,14 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
     }
 
     //HONK START - Airtight lockers when welded
-    // NOTE: This only fires on state change, so lockers placed pre-welded in maps
-    // won't become airtight until unwelded and re-welded.
+    // Only opted-in storages sync their Airtight to the weld state. Storages
+    // that are prototype-airtight (e.g. SuitStorageBase) leave AirtightWhenWelded
+    // unset and keep their configured value regardless of welding.
     private void OnWeldChanged(EntityUid uid, EntityStorageComponent component, ref WeldableChangedEvent args)
     {
+        if (!component.AirtightWhenWelded)
+            return;
+
         if (args.IsWelded)
         {
             component.Airtight = true;

--- a/Content.Shared/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/EntityStorageComponent.cs
@@ -108,6 +108,18 @@ public sealed partial class EntityStorageComponent : Component, IGasMixtureHolde
     [DataField]
     public bool Airtight = true;
 
+    //HONK START - 441 P1.3: opt-in sync of Airtight to the Weldable state
+    /// <summary>
+    /// When true, <see cref="Airtight"/> is kept in sync with the entity's
+    /// <see cref="Content.Shared.Tools.Components.WeldableComponent.IsWelded"/>
+    /// state. Welding seals the container, unwelding vents it. Applied at
+    /// <see cref="MapInitEvent"/> so map-placed pre-welded storages are sealed
+    /// correctly on spawn.
+    /// </summary>
+    [DataField]
+    public bool AirtightWhenWelded;
+    //HONK END
+
     /// <summary>
     /// Whether or not the entitystorage is open or closed.
     /// </summary>

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -45,8 +45,9 @@
         layer:
         - MachineLayer
   - type: EntityStorage
-    # HONK START - Lockers not airtight unless welded
+    # HONK START - Lockers not airtight unless welded (441 P1.3)
     airtight: false
+    airtightWhenWelded: true
     # HONK END
   - type: ContainerContainer
     containers:
@@ -144,8 +145,9 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
   - type: EntityStorage
-    # HONK START - Wall closets not airtight unless welded
+    # HONK START - Wall closets not airtight unless welded (441 P1.3)
     airtight: false
+    airtightWhenWelded: true
     # HONK END
     isCollidableWhenOpen: true
     enteringOffset: 0, -0.6


### PR DESCRIPTION
## About the PR

Lockers placed pre-welded on station maps were not sealing their atmos until someone cycled the weld. The fork's own inline comment documented the leak. This PR wires the weld state into the `EntityStorageComponent.Airtight` field at `MapInitEvent` so pre-welded lockers trap gas the moment they spawn.

## Why / Balance

Players get what the visual welded state implies. A welded locker on a map holds its air instead of silently venting into the room it was placed in, which matters for any map-preset locker carrying a non-breathable or flammable fill. Same gameplay surface as before for lockers welded mid-round; only the silent regression is closed.

Also fixes a quieter adjacent bug: the prior handler was mutating `Airtight` on every `WeldableChangedEvent` unconditionally, which would have flipped `SuitStorageBase` (prototype airtight) off the first time someone welded and unwelded it. Suit storage is now immune because it does not opt in.

Addresses 441 P1.3.

## Technical details

- New `AirtightWhenWelded` `DataField` on `EntityStorageComponent`. Default false, opt-in.
- `EntityStorageSystem.OnMapInit` reads `WeldableComponent.IsWelded` and syncs `Airtight` for opted-in storages, so prototype-welded maps are handled on spawn instead of requiring a state change.
- `EntityStorageSystem.OnWeldChanged` is now filtered by `AirtightWhenWelded`. Storages that aren't opted in (like suit storage) are no longer mutated.
- `ClosetBase` and `BaseWallCloset` set `airtightWhenWelded: true`. Every in-game weldable locker inherits from one of these two, so this single opt-in covers the intended set without touching child prototypes.
- `SuitStorageBase` intentionally does not opt in. It stays airtight via its upstream prototype default and is now protected from the unweld-flip bug.

HONK touches:
- `Content.Shared/Storage/Components/EntityStorageComponent.cs`: one new field, HONK-wrapped.
- `Content.Server/Storage/EntitySystems/EntityStorageSystem.cs`: existing HONK blocks kept, `OnMapInit` gains a small HONK block, `OnWeldChanged` gets the opt-in filter.
- `Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml`: two existing HONK blocks gain one extra field.

## Media

Not attached. The user-visible effect is that a closed welded locker holding exotic gas no longer bleeds into the room on roundstart. Verifiable with any pre-welded plasma closet preset.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None. New field defaults to `false`, existing behavior preserved for any prototype that doesn't set it. The only observable change is that suit storage no longer flips non-airtight on unweld, which nothing was relying on.

**Changelog**

:cl:
- fix: Lockers welded shut on a station map now hold their air correctly on roundstart instead of leaking until someone cycles the weld.