### PR TITLE
honksquad: Implemented Skittish trait

### DIFF
--- a/Content.Server/RussStation/Traits/SkittishSystem.cs
+++ b/Content.Server/RussStation/Traits/SkittishSystem.cs
@@ -67,6 +67,6 @@ public sealed class SkittishSystem : EntitySystem
         if (lockComp != null)
             _lock.Lock(other, null, lockComp);
 
-        _popup.PopupEntity(Loc.GetString("skittish-hide", ("container", other)), uid, uid);
+        _popup.PopupEntity(Loc.GetString("trait-skittish-hide", ("container", other)), uid, uid);
     }
 }

--- a/Content.Server/RussStation/Traits/SkittishSystem.cs
+++ b/Content.Server/RussStation/Traits/SkittishSystem.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Lock;
+using Content.Shared.Movement.Components;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Traits;
+using Content.Shared.Storage.Components;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Timing;
+
+namespace Content.Server.RussStation.Traits;
+
+public sealed class SkittishSystem : EntitySystem
+{
+    [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly LockSystem _lock = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SkittishComponent, StartCollideEvent>(OnCollide);
+    }
+
+    private void OnCollide(Entity<SkittishComponent> ent, ref StartCollideEvent args)
+    {
+        var uid = ent.Owner;
+        var other = args.OtherEntity;
+
+        // Don't trigger if already inside a container.
+        if (_container.IsEntityInContainer(uid))
+            return;
+
+        // Only trigger when the player is sprinting, not walking.
+        if (TryComp<InputMoverComponent>(uid, out var mover) && !mover.Sprinting)
+            return;
+
+        // The collided entity must be a closed storage.
+        if (!TryComp<EntityStorageComponent>(other, out var storageComp) || storageComp.Open)
+            return;
+
+        // The entity must be able to fit inside.
+        if (!_entityStorage.CanInsert(uid, other, storageComp))
+            return;
+
+        // If the container is locked, the player must have access.
+        if (TryComp<LockComponent>(other, out var lockComp) && lockComp.Locked && !_lock.TryUnlock(other, uid, lockComp))
+            return;
+
+        // Play the open and close sounds back-to-back for effect.
+        _audio.PlayPvs(storageComp.OpenSound, other);
+        _audio.PlayPvs(storageComp.CloseSound, other);
+
+        // Insert directly into the closed container.
+        _entityStorage.Insert(uid, other, storageComp);
+
+        // Block the internal-movement handler from immediately re-opening the storage due to the
+        // lingering movement input that triggered this collision.
+        storageComp.NextInternalOpenAttempt = _timing.CurTime + TimeSpan.FromSeconds(1.0);
+        Dirty(other, storageComp);
+
+        // Lock the container after entering.
+        if (lockComp != null)
+            _lock.Lock(other, null, lockComp);
+
+        _popup.PopupEntity(Loc.GetString("skittish-hide", ("container", other)), uid, uid);
+    }
+}

--- a/Content.Shared/RussStation/Traits/SkittishComponent.cs
+++ b/Content.Shared/RussStation/Traits/SkittishComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Traits;
+
+/// <summary>
+/// When this entity bumps into a closed container it can fit inside,
+/// it automatically opens the container, enters it, closes it, and
+/// locks it if the container supports locking.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SkittishComponent : Component
+{
+}

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -92,9 +92,11 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (target.Open)
             args.Cancelled = true;
 
+        // HONK START - We don't want to disable (un)locking from the inside for gameplay reasons.
         // Cannot (un)lock from the inside. Maybe a bad idea? Security jocks could trap nerds in lockers?
-        if (target.Contents.Contains(args.User))
-            args.Cancelled = true;
+        // if (target.Contents.Contains(args.User))
+        //     args.Cancelled = true;
+        // HONK END
     }
 
     private void OnDestruction(EntityUid uid, EntityStorageComponent component, DestructionEventArgs args)

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -51,3 +51,6 @@ trait-throwing-arm-name = Throwing Arm
 trait-throwing-arm-desc = You've got a hell of an arm.
 trait-frail-name = Frail
 trait-frail-desc = Your body is fragile.
+trait-skittish-name = Skittish
+trait-skittish-desc = You startle easily. Bumping into a closed container you could fit inside causes you to panic and hide inside it, slamming the door shut behind you if possible.
+skittish-hide = You panic and dive into the {THE($container)}!

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -53,4 +53,4 @@ trait-frail-name = Frail
 trait-frail-desc = Your body is fragile.
 trait-skittish-name = Skittish
 trait-skittish-desc = You startle easily. Bumping into a closed container you could fit inside causes you to panic and hide inside it, slamming the door shut behind you if possible.
-skittish-hide = You panic and dive into the {THE($container)}!
+trait-skittish-hide = You panic and dive into the {THE($container)}!

--- a/Resources/Locale/en-US/@RussStation/traits/skittish.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/skittish.ftl
@@ -1,4 +1,0 @@
-trait-skittish-name = Skittish
-trait-skittish-desc = You startle easily. Bumping into a closed container you could fit inside causes you to panic and hide inside it, slamming the door shut behind you if possible.
-
-skittish-hide = You panic and dive into the {THE($container)}!

--- a/Resources/Locale/en-US/@RussStation/traits/skittish.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/skittish.ftl
@@ -1,0 +1,4 @@
+trait-skittish-name = Skittish
+trait-skittish-desc = You startle easily. Bumping into a closed container you could fit inside causes you to panic and hide inside it, slamming the door shut behind you if possible.
+
+skittish-hide = You panic and dive into the {THE($container)}!

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -303,3 +303,15 @@
     - wounds
   components:
     - type: Frail
+
+- type: trait
+  id: Skittish
+  name: trait-skittish-name
+  description: trait-skittish-desc
+  category: Movement
+  cost: 8
+  blacklist:
+    components:
+      - BorgChassis
+  components:
+    - type: Skittish

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -51,6 +51,7 @@
   - WeakArm # HONK
   - ThrowingArm # HONK
   - Tough # HONK
+  - Skittish # HONK
   # accents
   - Accentless
   - BackwardsAccent


### PR DESCRIPTION
## About the PR
Implemented the Skittish trait from SS13.

## Why / Balance
Because it adds an additional gameplay element to have fun with.

## Technical details
Players with the skittish trait:
- Will automatically enter closed containers if:
    - The container is unlocked or does not have a lock.
    - The container is locked but the player can unlock it.
    - The player is not walking.
- Will, once entered, close the container, locking it if it has a lock.

This trait has a cost of 8.

As much of the implementation is implemented independently of the upstream code, but one critical change was made. In the SS14 upstream codebase, players cannot unlock a container from the inside even if they have the requisite access. This has been commented out to match the original situation from SS13 for gameplay reasons. It is a two-line change from upstream that is clearly documented. Additionally, the comment in the upstream codebase seems to suggest that the original author wasn't entirely sure whether this deviation from SS13 was actually a good idea.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
`Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs`: No longer prevents a player from unlocking a container from within.

**Changelog**
:cl:
- add: Skittish trait
