### PR TITLE
Fix ignored CashPaymentTest in VendingPaymentTest (441 P1.5)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Economy/VendingPaymentTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/VendingPaymentTest.cs
@@ -143,7 +143,6 @@ public sealed class VendingPaymentTest : InteractionTest
     /// Mobs holding physical spesos should be able to pay with them.
     /// </summary>
     [Test]
-    [Ignore("Cash payment fails in integration test environment (pre-existing issue).")]
     public async Task CashPaymentTest()
     {
         await SpawnTarget(VendingMachineProtoId);
@@ -154,8 +153,11 @@ public sealed class VendingPaymentTest : InteractionTest
 
         Assert.That(items.First().Amount, Is.EqualTo(5));
 
-        // Put spesos in the player's hand
-        var spesos = await SpawnEntity("SpaceCash100", SEntMan.GetCoordinates(PlayerCoords));
+        // Put spesos in the player's hand. SpawnEntity rewrites any entity
+        // with a StackComponent into a stack spawn using EntitySpecifier.Quantity,
+        // so the "SpaceCash100" suffix is cosmetic -- the quantity must be
+        // passed explicitly or the player ends up holding a single credit.
+        var spesos = await SpawnEntity(("SpaceCash", 500), SEntMan.GetCoordinates(PlayerCoords));
         await Server.WaitPost(() =>
         {
             var hands = SEntMan.System<SharedHandsSystem>();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Unignores \`VendingPaymentTest.CashPaymentTest\` and fixes the one-line spawn mistake that was making it fail. Addresses item P1.5 in issue #441.

## Why / Balance
The test was marked \`[Ignore]\` as a \"pre-existing issue\" even though the cash-payment code path itself works. Leaving the test ignored meant we had zero integration coverage of \`VendingPaymentSystem.TryPayByCash\`, which is the fallback for players paying without an ID or account balance. Re-enabling it closes that gap without changing any production behavior.

## Technical details
The failing line was:

\`\`\`csharp
var spesos = await SpawnEntity(\"SpaceCash100\", SEntMan.GetCoordinates(PlayerCoords));
\`\`\`

\`InteractionTest.SpawnEntity\` (in \`Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifier.cs\`) rewrites any entity prototype that carries a \`StackComponent\` into a stack-prototype spawn, using \`EntitySpecifier.Quantity\` for the count. When the specifier is built from an implicit \`string → EntitySpecifier\` conversion, \`Quantity\` defaults to \`1\`. So \"SpaceCash100\" silently became \"Credit with count 1\", and the player ended up holding a single speso. \`VendingPaymentSystem.TryPayByCash\` correctly rejected the purchase because 1 credit does not cover the item price, and the test failed at the final assertion.

The fix is a tuple specifier that sets the quantity explicitly, plus a short comment so the next reader does not trip on the same gotcha:

\`\`\`csharp
var spesos = await SpawnEntity((\"SpaceCash\", 500), SEntMan.GetCoordinates(PlayerCoords));
\`\`\`

500 credits comfortably covers the test vending price with room to spare if future pricing tweaks raise it.

Verified locally that all four tests in \`VendingPaymentTest\` pass, including the previously-ignored one.

## Media
N/A, test-only change.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
No player-facing changes.