### PR TITLE
Fix action gun sound leak and clown spit backfire

### DIFF
--- a/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs
+++ b/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs
@@ -48,9 +48,11 @@ public sealed class ActionGunExtSystem : EntitySystem
         if (ext.OnShootSound == null)
             return;
 
-        // Find the action entity for prediction.
-        TryComp<ActionGunComponent>(args.User, out var actionGun);
+        // Only fire when the shot is from the mob's action gun, not a regular
+        // held weapon. Otherwise every humanoid plays the spit sound on any shot.
+        if (!TryComp<ActionGunComponent>(args.User, out var actionGun) || actionGun.Gun != gun.Owner)
+            return;
 
-        _audio.PlayPredicted(ext.OnShootSound, args.User, actionGun?.ActionEntity);
+        _audio.PlayPredicted(ext.OnShootSound, args.User, actionGun.ActionEntity);
     }
 }

--- a/Resources/Prototypes/@RussStation/spit.yml
+++ b/Resources/Prototypes/@RussStation/spit.yml
@@ -32,6 +32,7 @@
     soundGunshot: /Audio/@RussStation/Spit/russstation_sound_voice_spit_release.ogg
     soundEmpty: null
     projectileSpeed: 10
+    clumsyProof: true
 
 - type: entity
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
## About the PR
Two small fork-side bugs around the humanoid spit ability:

1. Every gun in the game played the spit sound from the shooter. `ActionGunExtSystem.OnGunShot` subscribed globally to `GunShotEvent` and only gated on whether the shooter had `ActionGunExtComponent`. Every humanoid carries that component (for the spit ability added in `species_appearance.yml`), so firing any regular weapon piped `OnShootSound` through the mob.
2. Clowns rolling the clumsy gun backfire check when spitting. The spit ability routes through the normal `SharedGunSystem` shoot path, which raises `SelfBeforeGunShotEvent`, so `ClumsySystem` would randomly cancel the spit, stun the clown, and pop up a "your gun failed to fire" message for a gun they don't visibly hold.

## Why / Balance
Spit is cosmetic flavor, not a weapon. The sound leak made every real firefight sound like a wet cartoon, and the clumsy backfire punished clowns for using a zero-damage roleplay action.

## Technical details
- `Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs`: in `OnGunShot`, also look up `ActionGunComponent` on the shooter and require `actionGun.Gun == gun.Owner` before playing the sound. `ActionGunComponent.Gun` is the nullspace gun entity the action spawns, so this restricts the hook to shots that actually came from the action gun.
- `Resources/Prototypes/@RussStation/spit.yml`: add `clumsyProof: true` to `SpitGun`'s `Gun` component so `ClumsySystem.BeforeGunShotEvent` early-returns on the `args.Gun.Comp.ClumsyProof` check.

## Media
Not applicable, audio/behavior fix.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Firing normal weapons no longer plays the spit sound from the shooter.
- fix: Clowns can no longer fumble the spit ability through clumsy gun backfire.