### PR TITLE
fix: Don't trigger skittish if the player is dead or in critical condition

### DIFF
--- a/Content.Server/RussStation/Traits/SkittishSystem.cs
+++ b/Content.Server/RussStation/Traits/SkittishSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Lock;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Traits;
@@ -7,6 +8,7 @@ using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Traits;
@@ -15,6 +17,7 @@ public sealed class SkittishSystem : EntitySystem
 {
     [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
     [Dependency] private readonly LockSystem _lock = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -33,6 +36,10 @@ public sealed class SkittishSystem : EntitySystem
 
         // Don't trigger if already inside a container.
         if (_container.IsEntityInContainer(uid))
+            return;
+
+        // Don't trigger if the player is dead, critical, or otherwise incapacitated.
+        if (!_mobState.IsAlive(uid))
             return;
 
         // Only trigger when the player is sprinting, not walking.

--- a/Content.Server/RussStation/Traits/SkittishSystem.cs
+++ b/Content.Server/RussStation/Traits/SkittishSystem.cs
@@ -1,14 +1,13 @@
 using Content.Shared.Lock;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Traits;
+using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Events;
-using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Traits;
@@ -17,10 +16,10 @@ public sealed class SkittishSystem : EntitySystem
 {
     [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
     [Dependency] private readonly LockSystem _lock = default!;
-    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -38,8 +37,8 @@ public sealed class SkittishSystem : EntitySystem
         if (_container.IsEntityInContainer(uid))
             return;
 
-        // Don't trigger if the player is dead, critical, or otherwise incapacitated.
-        if (!_mobState.IsAlive(uid))
+        // Don't trigger if the player isn't standing upright.
+        if (_standing.IsDown(uid))
             return;
 
         // Only trigger when the player is sprinting, not walking.


### PR DESCRIPTION
## About the PR
Fixes a bug where the Skittish trait would activate on dead, critical, or otherwise incapacitated players when their corpse was dragged into a container.

## Why / Balance
Corpses shouldn't be jumping into lockers on their own. This was a purely unintended side effect of the collision-based trigger not checking player state.

## Technical details
Added a MobStateSystem dependency to SkittishSystem and an early-return guard in OnCollide that skips the trait logic if _mobState.IsAlive(uid) returns `false`.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- fix: Skittish trait no longer activates on dead, critical, or downed players when their body is moved near a container.
