### PR TITLE
Revert AttemptStopPullingEvent.Force parameter (441 P0.4)

### DIFF
--- a/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
+++ b/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
@@ -5,11 +5,8 @@ namespace Content.Shared.Pulling.Events;
 /// </summary>
 
 [ByRefEvent]
-//HONK START - Escalated grab: added Force parameter
-public record struct AttemptStopPullingEvent(EntityUid? User = null, bool Force = false)
+public record struct AttemptStopPullingEvent(EntityUid? User = null)
 {
     public readonly EntityUid? User = User;
-    public readonly bool Force = Force;
-    //HONK END
     public bool Cancelled;
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -277,7 +277,7 @@ public sealed class PullingSystem : EntitySystem
             return;
 
         if (TryComp(component.BlockingEntity, out PullableComponent? pullable))
-            TryStopPull(component.BlockingEntity, pullable, user: args.User, force: true);
+            TryStopPull(component.BlockingEntity, pullable, user: args.User);
     }
     //HONK END
 
@@ -451,9 +451,12 @@ public sealed class PullingSystem : EntitySystem
             return;
         }
 
-        //HONK START - Force release on keybind
-        TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player, force: true);
+        //HONK START - Escalated grab: request release so fork can clear escalation
+        var releaseReq = new PullReleaseRequestedEvent(player, pullerComp.Pulling.Value);
+        RaiseLocalEvent(player, ref releaseReq);
         //HONK END
+
+        TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player);
     }
 
     public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null)
@@ -636,16 +639,14 @@ public sealed class PullingSystem : EntitySystem
         return true;
     }
 
-    //HONK START - Escalated grab: added force parameter
-    public bool TryStopPull(EntityUid pullableUid, PullableComponent pullable, EntityUid? user = null, bool force = false)
+    public bool TryStopPull(EntityUid pullableUid, PullableComponent pullable, EntityUid? user = null)
     {
         var pullerUidNull = pullable.Puller;
 
         if (pullerUidNull == null)
             return true;
 
-        var msg = new AttemptStopPullingEvent(user, force);
-        //HONK END
+        var msg = new AttemptStopPullingEvent(user);
         RaiseLocalEvent(pullableUid, ref msg, true);
 
         if (msg.Cancelled)

--- a/Content.Shared/RussStation/EscalatedGrab/Events/PullReleaseRequestedEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/PullReleaseRequestedEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.RussStation.EscalatedGrab.Events;
+
+/// <summary>
+/// Raised on the puller when the release-pull keybind is pressed, so fork
+/// systems can clear escalation state before the underlying pull stops.
+/// </summary>
+[ByRefEvent]
+public record struct PullReleaseRequestedEvent(EntityUid Puller, EntityUid Pulled);

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.RussStation.EscalatedGrab.Events;
 using Content.Shared.Popups;
-using Content.Shared.Pulling.Events;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.EscalatedGrab.Systems;
@@ -22,7 +21,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PullableComponent, PullGrabEscalateAttemptEvent>(OnEscalateAttempt);
-        SubscribeLocalEvent<PullableComponent, AttemptStopPullingEvent>(OnAttemptStopPulling);
+        SubscribeLocalEvent<PullerComponent, PullReleaseRequestedEvent>(OnPullReleaseRequested);
         SubscribeLocalEvent<GrabStateComponent, PullStoppedMessage>(OnPullStopped);
     }
 
@@ -32,17 +31,9 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
             args.Handled = true;
     }
 
-    private void OnAttemptStopPulling(EntityUid uid, PullableComponent component, ref AttemptStopPullingEvent args)
+    private void OnPullReleaseRequested(EntityUid uid, PullerComponent component, ref PullReleaseRequestedEvent args)
     {
-        if (args.Cancelled || args.User == null)
-            return;
-
-        // Release keybind clears escalation and lets the pull stop.
-        if (args.Force)
-        {
-            ClearEscalation(args.User.Value);
-            return;
-        }
+        ClearEscalation(args.Puller);
     }
 
     private void OnPullStopped(EntityUid uid, GrabStateComponent component, PullStoppedMessage args)


### PR DESCRIPTION
## About the PR

Reverts the fork-added `Force` parameter on `AttemptStopPullingEvent` and `PullingSystem.TryStopPull`, restoring both to upstream state. The release-keybind path now raises a fork-owned `PullReleaseRequestedEvent` so escalation state gets cleared without touching the upstream stop-pull event.

## Why / Balance

Part of the inverse upstream tampering audit (#441, P0.4). The `Force` flag was a self-referential tamper pair: a fork-added parameter that only existed so a fork system could read it, and the handler that read it was a no-op on the upstream data (it never cancelled the event). Removing the flag deletes dead code from `SharedEscalatedGrabSystem` and cuts two HONK markers out of the most rebase-volatile file in the fork.

No gameplay change. The keybind still clears escalation before the pull stops; the virtual-item-drop path still releases pulls, it just no longer pretends to "force" anything it never forced.

## Technical details

- `AttemptStopPullingEvent`: `Force` field removed, restored to upstream signature
- `PullingSystem.TryStopPull`: `force` parameter removed, HONK marker dropped
- `PullingSystem.OnReleasePulledObject`: raises new `PullReleaseRequestedEvent(player, pulled)` before calling `TryStopPull`
- `PullingSystem.OnVirtualItemDropped`: drops the `force: true` argument
- New `PullReleaseRequestedEvent` record struct in `Content.Shared/RussStation/EscalatedGrab/Events/`
- `SharedEscalatedGrabSystem`: drops the dead `OnAttemptStopPulling` handler entirely, subscribes to `PullReleaseRequestedEvent` on `PullerComponent` and calls `ClearEscalation` from there

The `OnPullStopped` fallback (which removes `GrabStateComponent` on a `PullStoppedMessage`) is untouched, so escalation state still ends up cleaned up no matter which path stops the pull.

## Media

N/A, refactor with no visible gameplay change.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

`AttemptStopPullingEvent` no longer has a `Force` field, and `PullingSystem.TryStopPull` no longer accepts a `force` parameter. Any fork code that was passing `force: true` or reading `args.Force` needs to switch to `PullReleaseRequestedEvent` instead.

**Changelog**

No player-facing change.