### PR TITLE
Widen Body/Organ Access to drop fork namespace import (441 P3.1)

### DIFF
--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -9,7 +9,9 @@ namespace Content.Shared.Body;
 /// <seealso cref="BodySystem" />
 /// <seealso cref="SharedVisualBodySystem" />
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)] //HONK: surgery system writes body state
+// HONK START - surgery system writes body state
+[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)]
+// HONK END
 public sealed partial class BodyComponent : Component
 {
     public const string ContainerID = "body_organs";

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.RussStation.Surgery.Systems; //HONK
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 
@@ -10,9 +9,7 @@ namespace Content.Shared.Body;
 /// <seealso cref="BodySystem" />
 /// <seealso cref="SharedVisualBodySystem" />
 [RegisterComponent, NetworkedComponent]
-//HONK START - Surgery system needs access to Organs container
-[Access(typeof(BodySystem), typeof(SharedSurgerySystem))]
-//HONK END
+[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)] //HONK: surgery system writes body state
 public sealed partial class BodyComponent : Component
 {
     public const string ContainerID = "body_organs";

--- a/Content.Shared/Body/OrganComponent.cs
+++ b/Content.Shared/Body/OrganComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.RussStation.Surgery.Systems; //HONK
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -9,9 +8,7 @@ namespace Content.Shared.Body;
 /// </summary>
 /// <seealso cref="BodySystem" />
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-//HONK START - Surgery system needs to read organ Category
-[Access(typeof(BodySystem), typeof(SharedSurgerySystem))]
-//HONK END
+[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)] //HONK: surgery system writes organ state
 public sealed partial class OrganComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Body/OrganComponent.cs
+++ b/Content.Shared/Body/OrganComponent.cs
@@ -8,7 +8,9 @@ namespace Content.Shared.Body;
 /// </summary>
 /// <seealso cref="BodySystem" />
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)] //HONK: surgery system writes organ state
+// HONK START - surgery system writes organ state
+[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)]
+// HONK END
 public sealed partial class OrganComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## About the PR

Removes the cross-namespace inversion on `BodyComponent` and `OrganComponent`. Both upstream files used to `using Content.Shared.RussStation.Surgery.Systems;` so they could list `SharedSurgerySystem` on their `[Access]` friends attribute. This PR widens `Other` to `AccessPermissions.ReadWrite` instead, so upstream's friends list no longer has to name fork systems.

## Why / Balance

Part of the inverse upstream tampering audit (#441, P3.1). Upstream shared files importing a fork namespace is a dependency arrow pointing the wrong way, and every such import creates rebase friction whenever upstream touches these files. Widening `Other` keeps the compile-time contract honest (BodySystem is still documented as the canonical writer) while dropping the fork reference.

Compile-time only refactor. No runtime behavior change, no gameplay change.

## Technical details

- `Content.Shared/Body/BodyComponent.cs`: removed `using Content.Shared.RussStation.Surgery.Systems; //HONK`, changed `[Access(typeof(BodySystem), typeof(SharedSurgerySystem))]` to `[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)]`
- `Content.Shared/Body/OrganComponent.cs`: same treatment
- HONK START/END marker blocks collapsed into a single inline `//HONK` comment on the attribute line, documenting why `Other` is widened

The widened `Other` means any assembly can read/write these components, which matches how the fork surgery code was already using them. The friends list now documents intent (BodySystem is the canonical owner) without requiring cross-namespace compile-time enforcement.

## Media

N/A, compile-time refactor.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None. `BodyComponent` and `OrganComponent` are now writable from any system, which is strictly more permissive than before. Nothing that compiled against the previous attribute needs to change.

**Changelog**

No player-facing change.