### PR TITLE
Dedupe stylesheet font customization HONK blocks (441 P2.1)

### DIFF
--- a/Content.Client/RussStation/Stylesheets/ForkFontCustomization.cs
+++ b/Content.Client/RussStation/Stylesheets/ForkFontCustomization.cs
@@ -1,0 +1,39 @@
+using Content.Client.Stylesheets;
+using Content.Client.Stylesheets.Fonts;
+using Robust.Client.UserInterface;
+
+namespace Content.Client.RussStation.Stylesheets;
+
+/// <summary>
+/// Fork-owned helper for applying runtime font customization to a stylesheet's
+/// base font and size list. Replaces the byte-identical HONK block that used to
+/// live in both <c>NanotrasenStylesheet</c> and <c>SystemStylesheet</c>.
+/// </summary>
+public static class ForkFontCustomization
+{
+    /// <summary>
+    /// Configures <paramref name="baseFont"/> from the current font manager settings
+    /// and returns a scaled copy of <paramref name="defaultSizes"/> if the user's
+    /// primary font size differs from <paramref name="primaryFontSize"/>.
+    /// </summary>
+    public static List<(string?, int)> Apply(
+        NotoFontFamilyStack baseFont,
+        StylesheetManager man,
+        int primaryFontSize,
+        int fontSizeStep,
+        List<(string?, int)> defaultSizes)
+    {
+        baseFont.SetPrimaryFont(man.FontManager.GetFontPathTemplate(), man.FontManager.GetAvailableKinds());
+
+        var customSize = man.FontManager.CurrentSize;
+        if (customSize == primaryFontSize)
+            return defaultSizes;
+
+        return new List<(string?, int)>
+        {
+            (null, customSize),
+            (StyleClass.FontSmall, customSize - fontSizeStep),
+            (StyleClass.FontLarge, customSize + fontSizeStep),
+        };
+    }
+}

--- a/Content.Client/Stylesheets/StylesheetManager.cs
+++ b/Content.Client/Stylesheets/StylesheetManager.cs
@@ -52,9 +52,9 @@ namespace Content.Client.Stylesheets
             IoCManager.InjectDependencies(FontManager);
             FontManager.Initialize();
             FontManager.FontsChanged += RebuildStylesheets;
-            // HONK END
 
             BuildStylesheets();
+            // HONK END
 
             // warn about unused sheetlets
             if (UnusedSheetlets.Count > 0)

--- a/Content.Client/Stylesheets/StylesheetManager.cs
+++ b/Content.Client/Stylesheets/StylesheetManager.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+//HONK START
 using Content.Client.Stylesheets.Fonts;
+//HONK END
 using Content.Client.Stylesheets.Stylesheets;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;

--- a/Content.Client/Stylesheets/StylesheetManager.cs
+++ b/Content.Client/Stylesheets/StylesheetManager.cs
@@ -54,17 +54,7 @@ namespace Content.Client.Stylesheets
             FontManager.FontsChanged += RebuildStylesheets;
             // HONK END
 
-            // add all sheetlets to the hashset
-            var tys = _reflection.FindTypesWithAttribute<CommonSheetletAttribute>();
-            UnusedSheetlets = [..tys];
-
-            Stylesheets = new Dictionary<string, Stylesheet>();
-            SheetNanotrasen = Init(new NanotrasenStylesheet(new BaseStylesheet.NoConfig(), this));
-            SheetSystem = Init(new SystemStylesheet(new BaseStylesheet.NoConfig(), this));
-            SheetNano = new StyleNano(_resCache).Stylesheet; // TODO: REMOVE (obsolete)
-            SheetSpace = new StyleSpace(_resCache).Stylesheet; // TODO: REMOVE (obsolete)
-
-            _userInterfaceManager.Stylesheet = SheetNanotrasen;
+            BuildStylesheets();
 
             // warn about unused sheetlets
             if (UnusedSheetlets.Count > 0)
@@ -89,20 +79,25 @@ namespace Content.Client.Stylesheets
             sawmill.Debug("Rebuilding stylesheets for font change...");
             var sw = Stopwatch.StartNew();
 
+            BuildStylesheets();
+
+            sawmill.Debug($"Rebuilt {_styleRuleCount} style rules in {sw.Elapsed}");
+        }
+
+        private void BuildStylesheets()
+        {
             var tys = _reflection.FindTypesWithAttribute<CommonSheetletAttribute>();
             UnusedSheetlets = [..tys];
 
-            Stylesheets.Clear();
+            Stylesheets = new Dictionary<string, Stylesheet>();
             _styleRuleCount = 0;
 
             SheetNanotrasen = Init(new NanotrasenStylesheet(new BaseStylesheet.NoConfig(), this));
             SheetSystem = Init(new SystemStylesheet(new BaseStylesheet.NoConfig(), this));
-            SheetNano = new StyleNano(_resCache).Stylesheet;
-            SheetSpace = new StyleSpace(_resCache).Stylesheet;
+            SheetNano = new StyleNano(_resCache).Stylesheet; // TODO: REMOVE (obsolete)
+            SheetSpace = new StyleSpace(_resCache).Stylesheet; // TODO: REMOVE (obsolete)
 
             _userInterfaceManager.Stylesheet = SheetNanotrasen;
-
-            sawmill.Debug($"Rebuilt {_styleRuleCount} style rules in {sw.Elapsed}");
         }
         // HONK END
 

--- a/Content.Client/Stylesheets/Stylesheets/NanotrasenStylesheet.cs
+++ b/Content.Client/Stylesheets/Stylesheets/NanotrasenStylesheet.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
-using Content.Client.RussStation.Stylesheets; //HONK
+//HONK START
+using Content.Client.RussStation.Stylesheets;
+//HONK END
 using Content.Client.Stylesheets.Fonts;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;

--- a/Content.Client/Stylesheets/Stylesheets/NanotrasenStylesheet.cs
+++ b/Content.Client/Stylesheets/Stylesheets/NanotrasenStylesheet.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.Client.RussStation.Stylesheets; //HONK
 using Content.Client.Stylesheets.Fonts;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
@@ -39,22 +40,10 @@ public partial class NanotrasenStylesheet : CommonStylesheet
     {
         BaseFont = new NotoFontFamilyStack(ResCache);
 
-        // HONK START - Font customization
-        var fontTemplate = man.FontManager.GetFontPathTemplate();
-        var fontKinds = man.FontManager.GetAvailableKinds();
-        BaseFont.SetPrimaryFont(fontTemplate, fontKinds);
-
+        //HONK START - Font customization (fork-owned helper)
+        _commonFontSizes = ForkFontCustomization.Apply(BaseFont, man, PrimaryFontSize, FontSizeStep, _commonFontSizes);
         var customSize = man.FontManager.CurrentSize;
-        if (customSize != PrimaryFontSize)
-        {
-            _commonFontSizes = new List<(string?, int)>
-            {
-                (null, customSize),
-                (StyleClass.FontSmall, customSize - FontSizeStep),
-                (StyleClass.FontLarge, customSize + FontSizeStep),
-            };
-        }
-        // HONK END
+        //HONK END
 
         var rules = new[]
         {

--- a/Content.Client/Stylesheets/Stylesheets/SystemStylesheet.cs
+++ b/Content.Client/Stylesheets/Stylesheets/SystemStylesheet.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Client.RussStation.Stylesheets; //HONK
 using Content.Client.Stylesheets.Fonts;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
@@ -38,22 +39,10 @@ public partial class SystemStylesheet : CommonStylesheet
     {
         BaseFont = new NotoFontFamilyStack(ResCache);
 
-        // HONK START - Font customization
-        var fontTemplate = man.FontManager.GetFontPathTemplate();
-        var fontKinds = man.FontManager.GetAvailableKinds();
-        BaseFont.SetPrimaryFont(fontTemplate, fontKinds);
-
+        //HONK START - Font customization (fork-owned helper)
+        _commonFontSizes = ForkFontCustomization.Apply(BaseFont, man, PrimaryFontSize, FontSizeStep, _commonFontSizes);
         var customSize = man.FontManager.CurrentSize;
-        if (customSize != PrimaryFontSize)
-        {
-            _commonFontSizes = new List<(string?, int)>
-            {
-                (null, customSize),
-                (StyleClass.FontSmall, customSize - FontSizeStep),
-                (StyleClass.FontLarge, customSize + FontSizeStep),
-            };
-        }
-        // HONK END
+        //HONK END
 
         var rules = new[]
         {

--- a/Content.Client/Stylesheets/Stylesheets/SystemStylesheet.cs
+++ b/Content.Client/Stylesheets/Stylesheets/SystemStylesheet.cs
@@ -1,5 +1,7 @@
 using System.Linq;
-using Content.Client.RussStation.Stylesheets; //HONK
+//HONK START
+using Content.Client.RussStation.Stylesheets;
+//HONK END
 using Content.Client.Stylesheets.Fonts;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;


### PR DESCRIPTION
## About the PR

Deduplicates the fork's stylesheet customization footprint in upstream files. Fork-owned `ForkFontCustomization.Apply` replaces the byte-identical HONK block that had been copy-pasted into both `NanotrasenStylesheet` and `SystemStylesheet`. `StylesheetManager.Initialize` and `RebuildStylesheets` now share a private `BuildStylesheets()` helper instead of keeping two near-verbatim copies of the same sheetlet construction code.

## Why / Balance

Part of the inverse upstream tampering audit (#441, P2.1). Two problems this addresses:

1. Every upstream update to `NanotrasenStylesheet` or `SystemStylesheet` produced two conflict sites because the HONK font customization block was duplicated across both. One fork-owned helper means one call site per stylesheet.
2. `RebuildStylesheets` was a near-verbatim copy of the sheetlet block inside `Initialize`, added by the fork to support runtime font reloads. Any future upstream change to sheetlet construction would need to be applied twice.

The audit's long-term recommendation is upstream seams (`BuildSheetlets()` and `ApplyFontCustomization(ISheetlet)`). This PR does the fork-side half of that work, so when those seams land upstream the fork migration is a one-file delete.

## Technical details

- New `Content.Client/RussStation/Stylesheets/ForkFontCustomization.cs` with `Apply(baseFont, man, primaryFontSize, fontSizeStep, defaultSizes)`. Returns the configured font size list, mutates `baseFont` in place.
- `NanotrasenStylesheet` and `SystemStylesheet`: HONK block shrinks from 15 lines to a one-line helper call plus the `var customSize = ...` line (still needed below the block). Adds a `using Content.Client.RussStation.Stylesheets; //HONK` directive.
- `StylesheetManager.Initialize` and `RebuildStylesheets` both delegate to a new private `BuildStylesheets()` method that resets `Stylesheets`, `_styleRuleCount`, and `UnusedSheetlets` before re-running the sheetlet constructors. Unused-sheetlet warning and stopwatch logging remain in their original methods.

## Media

N/A, refactor with no visible changes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None. All public signatures and runtime behavior are unchanged. Font-size customization still triggers a rebuild and still produces the same sheetlets.

**Changelog**

No player-facing change.