### PR TITLE
refactor: make TogglePull escalation a cancellable hook

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -509,7 +509,12 @@ public sealed class PullingSystem : EntitySystem
 
         if (pullable.Comp.Puller == pullerUid)
         {
-            //HONK START - Escalated grab: escalate instead of toggle-off
+            //HONK START - Escalated grab: re-pulling your own target escalates the
+            // grab instead of stopping it. Upstream's toggle-off semantics conflict
+            // with the escalated grab system (the same input has to either drop the
+            // pull or step the grab up a tier, not both), and toggle-off-on-re-pull
+            // also isn't standard SS13 behaviour. Stopping a pull lives on the
+            // dedicated release keybind, see OnReleasePulledObject.
             var ev = new PullGrabEscalateAttemptEvent(pullerUid, pullable.Owner);
             RaiseLocalEvent(pullable.Owner, ref ev);
             return true;

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -509,16 +509,20 @@ public sealed class PullingSystem : EntitySystem
 
         if (pullable.Comp.Puller == pullerUid)
         {
-            //HONK START - Escalated grab: re-pulling your own target escalates the
-            // grab instead of stopping it. Upstream's toggle-off semantics conflict
-            // with the escalated grab system (the same input has to either drop the
-            // pull or step the grab up a tier, not both), and toggle-off-on-re-pull
-            // also isn't standard SS13 behaviour. Stopping a pull lives on the
-            // dedicated release keybind, see OnReleasePulledObject.
+            //HONK START - Escalated grab hook. Re-pulling your own target should
+            // step the grab up a tier instead of dropping the pull, but the same
+            // input can't do both, and toggle-off-on-re-pull isn't standard SS13
+            // behaviour anyway. Raise a fork hook; if no subscriber handles it
+            // (escalated grab disabled, no GrabState for this pair, etc.) fall
+            // through to upstream's TryStopPull so vanilla behaviour is the
+            // default. The dedicated release keybind path lives in
+            // OnReleasePulledObject.
             var ev = new PullGrabEscalateAttemptEvent(pullerUid, pullable.Owner);
             RaiseLocalEvent(pullable.Owner, ref ev);
-            return true;
+            if (ev.Handled)
+                return true;
             //HONK END
+            return TryStopPull(pullable, pullable.Comp);
         }
 
         return TryStartPull(pullerUid, pullable, pullableComp: pullable);

--- a/Content.Shared/RussStation/EscalatedGrab/Events/PullGrabEscalateAttemptEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/PullGrabEscalateAttemptEvent.cs
@@ -3,6 +3,11 @@ namespace Content.Shared.RussStation.EscalatedGrab.Events;
 /// <summary>
 /// Raised on the pulled entity when the puller tries to pull a target
 /// they are already pulling. Subscribers can use this to escalate grabs.
+/// If a subscriber handles the input it should set <see cref="Handled"/>;
+/// otherwise the caller falls back to upstream toggle-off behaviour.
 /// </summary>
 [ByRefEvent]
-public record struct PullGrabEscalateAttemptEvent(EntityUid Puller, EntityUid Pulled);
+public record struct PullGrabEscalateAttemptEvent(EntityUid Puller, EntityUid Pulled)
+{
+    public bool Handled;
+}

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -28,7 +28,8 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
     private void OnEscalateAttempt(EntityUid uid, PullableComponent component, ref PullGrabEscalateAttemptEvent args)
     {
-        TryEscalate(args.Puller, args.Pulled);
+        if (TryEscalate(args.Puller, args.Pulled))
+            args.Handled = true;
     }
 
     private void OnAttemptStopPulling(EntityUid uid, PullableComponent component, ref AttemptStopPullingEvent args)


### PR DESCRIPTION
## About the PR

Reshapes the HONK in `PullingSystem.TogglePull`'s self-pull branch from "replace upstream with an unconditional escalate raise" into "raise a cancellable hook, fall through to upstream `TryStopPull` if nothing claims it." Closes #441 P1.2.

## Why / Balance

No intentional gameplay change in normal play. Re-pulling your own target still escalates the grab (because `SharedEscalatedGrabSystem.OnEscalateAttempt` always handles the event today).

The behavioural difference is at the edges: if the escalated grab system is removed, disabled, or bails out for any reason, the puller now gets vanilla SS14 toggle-off instead of a silent no-op. That's the right fallback for a fork-side feature that may not always be active.

The audit (#441 P1.2) flagged the original HONK as a "silent UX break" because the upstream toggle-off was deleted outright. The hook-with-fallback pattern keeps the escalation behaviour where it makes sense and stops trampling upstream where it doesn't.

## Technical details

Three files:

- `Content.Shared/RussStation/EscalatedGrab/Events/PullGrabEscalateAttemptEvent.cs` -- adds a `Handled` bool to the by-ref event so subscribers can claim the input.
- `Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs` -- `OnEscalateAttempt` now sets `args.Handled = true` when `TryEscalate` succeeds.
- `Content.Shared/Movement/Pulling/Systems/PullingSystem.cs` -- the HONK in `TogglePull` raises the event, returns early only if `Handled`, otherwise falls through to upstream's `TryStopPull(pullable, pullable.Comp)`. Comment explains the intent so the next rebase doesn't treat the block as an unjustified workaround.

The HONK block in the upstream file is now a pure extension point: one event raise, one Handled check, no replaced logic.

## Media

N/A, pure plumbing refactor.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

`PullGrabEscalateAttemptEvent` now has a `Handled` field. Any external subscriber that wants to claim the escalation must set it; existing in-tree subscriber updated.

**Changelog**

No player-facing change in normal play.