### PR TITLE
refactor: idempotent InstallProgram, simpler fork cartridge installer

### DIFF
--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -198,6 +198,14 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
         if (!_containerSystem.TryGetContainer(loaderUid, InstalledContainerId, out var container))
             return false;
 
+        //HONK START - Idempotency: skip if this cartridge prototype is already installed (#441 P2.4)
+        foreach (var existing in container.ContainedEntities)
+        {
+            if (MetaData(existing).EntityPrototype?.ID == prototype)
+                return true;
+        }
+        //HONK END
+
         if (container.Count >= loader.DiskSpace)
             return false;
 

--- a/Content.Server/RussStation/CartridgeLoader/PdaCartridgeInstallerSystem.cs
+++ b/Content.Server/RussStation/CartridgeLoader/PdaCartridgeInstallerSystem.cs
@@ -1,20 +1,23 @@
 using System.Linq;
 using Content.Server.CartridgeLoader;
+using Content.Shared.CartridgeLoader;
 using Content.Shared.PDA;
 using Content.Shared.RussStation.CartridgeLoader;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.RussStation.CartridgeLoader;
 
 /// <summary>
-/// Contributes fork-specific cartridges to the initial install set on PDAs,
+/// Installs fork-specific cartridges on all PDAs at map init,
 /// driven by ForkCartridgeSetPrototype definitions rather than per-entity YAML.
-/// Hooks the upstream CartridgeLoaderInitialProgramsEvent seam, so cartridges
-/// land in the same install pass as PreinstalledPrograms — no after-ordering,
-/// no idempotency tracking against already-installed state.
+/// Relies on <see cref="CartridgeLoaderSystem.InstallProgram"/> being idempotent
+/// (HONK in upstream): duplicate calls for the same prototype no-op, so this
+/// system doesn't need ordering or its own bookkeeping set.
 /// </summary>
 public sealed class PdaCartridgeInstallerSystem : EntitySystem
 {
+    [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly IComponentFactory _compFactory = default!;
 
@@ -22,12 +25,12 @@ public sealed class PdaCartridgeInstallerSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CartridgeLoaderInitialProgramsEvent>(OnInitialPrograms);
+        SubscribeLocalEvent<PdaComponent, MapInitEvent>(OnMapInit);
     }
 
-    private void OnInitialPrograms(ref CartridgeLoaderInitialProgramsEvent args)
+    private void OnMapInit(EntityUid uid, PdaComponent pda, MapInitEvent args)
     {
-        if (!HasComp<PdaComponent>(args.Loader))
+        if (!TryComp<CartridgeLoaderComponent>(uid, out var loader))
             return;
 
         var sets = _protoManager.EnumeratePrototypes<ForkCartridgeSetPrototype>()
@@ -35,11 +38,11 @@ public sealed class PdaCartridgeInstallerSystem : EntitySystem
 
         foreach (var set in sets)
         {
-            if (!MatchesFilter(args.Loader, set))
+            if (!MatchesFilter(uid, set))
                 continue;
 
             foreach (var cartridge in set.Cartridges)
-                args.Programs.Add(cartridge);
+                _cartridgeLoader.InstallProgram(uid, cartridge, deinstallable: false, loader: loader);
         }
     }
 


### PR DESCRIPTION
## About the PR

Continues #441 P2.4. Two changes that travel together:

1. `CartridgeLoaderSystem.InstallProgram` now no-ops when a cartridge of the requested prototype is already installed in the loader (5-line HONK in upstream).
2. `PdaCartridgeInstallerSystem` drops its `after: [typeof(CartridgeLoaderSystem)]` ordering and the HashSet that tracked already-installed cartridge prototype IDs, because both existed solely to avoid colliding with upstream's `PreinstalledPrograms` loop.

The audit's recommended fix was a `protected virtual GetInitialCartridges` hook on `CartridgeLoaderSystem`, which would need an upstream PR. Idempotency is a smaller HONK that achieves the same end (no double-install) and incidentally hardens upstream's own API against the same bug.

## Why / Balance

No gameplay change. Same cartridges land on the same PDAs at map init.

The previous setup was correct but fragile: the fork system depended on running strictly after the upstream MapInit handler and on its own snapshot of which prototypes were already installed. Either invariant slipping (upstream changing handler ordering, fork system being moved, a third installer joining the party) would silently produce duplicate cartridges.

After this PR, calling `InstallProgram(...)` twice with the same prototype is a no-op everywhere, and the fork system is just a `MapInitEvent` subscriber that walks `ForkCartridgeSetPrototype`s and calls install. No ordering, no bookkeeping.

## Technical details

- `Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs` -- HONK block in `InstallProgram` after the container resolve and before the disk-space check: walks `container.ContainedEntities`, returns `true` early if any entity's prototype ID matches the one being installed. Uses `MetaData(...).EntityPrototype?.ID` for the comparison.
- `Content.Server/RussStation/CartridgeLoader/PdaCartridgeInstallerSystem.cs` -- removed the HashSet construction and the per-cartridge `existing.Contains` guard, dropped `after: [typeof(CartridgeLoaderSystem)]` from the subscription, updated the doc comment to point at the upstream HONK as the reason ordering isn't needed.

The `OnMapInit` body is now ~12 lines instead of ~25.

## Media

N/A, server-only refactor.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

`CartridgeLoaderSystem.InstallProgram(...)` is now idempotent per-prototype. Callers that intentionally relied on being able to install two copies of the same cartridge into one loader will get one copy and a `true` return instead of two copies. No such caller exists in-tree.

**Changelog**

No player-facing change.