### PR TITLE
docs: cross-reference the three holding-state components (#441 P2.2)

### DIFF
--- a/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.RussStation.Carrying.Systems;
+using Content.Shared.RussStation.EscalatedGrab.Components;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Carrying.Components;

--- a/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.RussStation.Carrying.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 
@@ -10,6 +12,13 @@ namespace Content.Shared.RussStation.EscalatedGrab.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GrabStateComponent : Component
 {
+    /// <summary>
+    /// Entity being held in an escalated grab (physically restrained at a tier).
+    /// One of three independent "holding" relationships on a mob, alongside
+    /// <see cref="PullerComponent.Pulling"/> (standard drag-pull) and
+    /// <see cref="CarrierComponent.Carrying"/> (fireman carry / lift).
+    /// A single entity may legitimately participate in more than one at the same time.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid Target;
 


### PR DESCRIPTION
## About the PR
Adds a short XML doc comment to `CarrierComponent.Carrying` and `GrabStateComponent.Target` pointing at each other and at upstream's `PullerComponent.Pulling`, so a reader landing on any one of them sees that fireman carry, escalated grab, and standard pull are three separate state machines that all happen to track a held entity.

## Why / Balance
Inverse upstream audit (#441) item P2.2 flagged the overlap between these three components as confusing. The names already make the distinction reasonably clear once you see them side by side, but until you've grepped for all three it is easy to assume one of them duplicates the others. A pair of cross-reference comments is the lowest-risk way to leave a sign-post without touching upstream `PullerComponent` or restructuring any of the systems.

No gameplay or balance impact, no behaviour change.

## Technical details
- `CarrierComponent.Carrying` -- new summary describing it as the fireman-carry slot, with `<see cref>` to the other two fields.
- `GrabStateComponent.Target` -- new summary describing it as the escalated-grab slot, with `<see cref>` to the other two fields.
- Two `using` directives added per file so the crefs resolve without fully-qualified names.
- Upstream `PullerComponent.Pulling` is intentionally left alone: any change there is a HONK-marker merge surface for every future upstream rebase, and the fork-side comments already point at it.

## Media
Docs-only, no in-game change.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
No player-facing changes.