### PR TITLE
honksquad: refactor: make carry markers source of truth (fix orphan desync)

### DIFF
--- a/Content.Client/RussStation/Carrying/CarryingSystem.cs
+++ b/Content.Client/RussStation/Carrying/CarryingSystem.cs
@@ -23,12 +23,10 @@ internal sealed class CarryingSystem : SharedCarryingSystem
     {
         base.FrameUpdate(frameTime);
 
-        var query = EntityQueryEnumerator<BeingCarriedComponent, CarriableComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out _, out var carriable, out var xform))
+        var query = EntityQueryEnumerator<BeingCarriedComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var being, out var xform))
         {
-            if (carriable.CarriedBy is not { } carrier)
-                continue;
-
+            var carrier = being.Carrier;
             if (!TryComp<CarrierComponent>(carrier, out var carrierComp))
                 continue;
 

--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
@@ -1,18 +1,17 @@
-using Content.IntegrationTests.Fixtures;
 using Content.Shared.Buckle.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Systems;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Carrying;
 
+[TestFixture]
 [TestOf(typeof(ActiveCarrierComponent))]
-public sealed class CarryStateValidationTest : GameTest
+public sealed class CarryStateValidationTest
 {
-    // Orphan-cleanup tests emit an expected WARN log ("Cleaned orphaned carry state")
-    // which GameTest teardown would otherwise treat as a test failure. Destructive
-    // pairs skip the ReportErrorLogs step entirely.
-    public override PoolSettings PoolSettings => new() { Connected = true, Destructive = true };
-
     [TestPrototypes]
     private const string Prototypes = @"
 - type: entity
@@ -73,75 +72,80 @@ public sealed class CarryStateValidationTest : GameTest
 ";
 
     /// <summary>
-    /// ActiveCarrierComponent with no actual carry target is orphaned state.
-    /// The periodic validation should remove it within a second.
+    /// Deleting the target entity mid-carry must not leave the carrier holding a stale
+    /// ActiveCarrierComponent. Previously this depended on shutdown order between
+    /// CarriableComponent and BeingCarriedComponent and could leave an orphan that a
+    /// periodic validation tick had to clean up; the marker now owns its own carrier
+    /// reference so the shutdown path no longer races.
     /// </summary>
     [Test]
-    public async Task OrphanedActiveCarrierGetsCleaned()
+    public async Task TargetDeletionCleansCarrierState()
     {
-        var server = Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
 
         EntityUid carrier = default;
 
         await server.WaitAssertion(() =>
         {
             carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
 
-            // Add the active marker without setting up a real carry to simulate corruption.
-            entityManager.EnsureComponent<ActiveCarrierComponent>(carrier);
-            var carrierComp = entityManager.GetComponent<CarrierComponent>(carrier);
-            Assert.That(carrierComp.Carrying, Is.Null);
-            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
-        });
+            // Carry() requires the target to be incapacitated.
+            mobState.ChangeMobState(target, MobState.Critical);
 
-        // Wait for the 1-second validation tick to fire.
-        await Pair.RunSeconds(2);
+            carrying.Carry(carrier, target);
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True,
+                "Carry() should have wired up the carrier marker");
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True,
+                "Carry() should have wired up the target marker");
 
-        await server.WaitAssertion(() =>
-        {
+            entityManager.DeleteEntity(target);
+
             Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
-                "Orphaned ActiveCarrierComponent should be cleaned by validation");
+                "Deleting the target must remove the carrier marker, regardless of component shutdown order");
         });
+
+        await pair.CleanReturnAsync();
     }
 
     /// <summary>
-    /// Same as <see cref="OrphanedActiveCarrierGetsCleaned"/> but with a target entity
-    /// spawned alongside, verifying cleanup still works in a populated environment.
-    /// Tests the Carrying=null + ActiveCarrierComponent corruption path, which is the
-    /// most common way carry state gets orphaned (partial cleanup by another system).
+    /// Symmetric case: deleting the carrier must clear the target's BeingCarriedComponent
+    /// without leaving an orphan, so the target can be carried again by someone else.
     /// </summary>
     [Test]
-    public async Task DeletedTargetGetsCleaned()
+    public async Task CarrierDeletionCleansTargetState()
     {
-        var server = Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
 
-        EntityUid carrier = default;
-
-        await server.WaitAssertion(() =>
-        {
-            carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
-            entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
-
-            var carrierComp = entityManager.GetComponent<CarrierComponent>(carrier);
-            entityManager.EnsureComponent<ActiveCarrierComponent>(carrier);
-
-            // [Access] prevents writing to Carrying from tests, so we test the
-            // Carrying=null orphan case directly, which is the most common corruption.
-            Assert.That(carrierComp.Carrying, Is.Null);
-            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
-        });
-
-        await Pair.RunSeconds(2);
+        EntityUid target = default;
 
         await server.WaitAssertion(() =>
         {
-            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
-                "ActiveCarrierComponent should be removed when Carrying is null");
+            var carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+
+            carrying.Carry(carrier, target);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True);
+
+            entityManager.DeleteEntity(carrier);
+
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False,
+                "Deleting the carrier must remove the target marker, regardless of component shutdown order");
         });
+
+        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -151,9 +155,10 @@ public sealed class CarryStateValidationTest : GameTest
     [Test]
     public async Task BuckleAttemptAllowedWhileCarried()
     {
-        var server = Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var mapData = await pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -175,6 +180,8 @@ public sealed class CarryStateValidationTest : GameTest
             Assert.That(ev.Cancelled, Is.False,
                 "Buckling should be allowed while carried (carry gets dropped, buckle goes through)");
         });
+
+        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -184,9 +191,10 @@ public sealed class CarryStateValidationTest : GameTest
     [Test]
     public async Task BuckleAttemptUnaffectedWhenNotCarried()
     {
-        var server = Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var mapData = await pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -208,5 +216,7 @@ public sealed class CarryStateValidationTest : GameTest
             Assert.That(ev.Cancelled, Is.False,
                 "BuckleAttemptEvent should not be affected when entity is not being carried");
         });
+
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryingTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryingTest.cs
@@ -61,7 +61,7 @@ public sealed class CarryingTest : GameTest
 ";
 
     /// <summary>
-    /// Verifies CarrierComponent defaults: carrying is null, speed modifiers are set.
+    /// Verifies CarrierComponent defaults: speed modifiers are set, no active marker present.
     /// </summary>
     [Test]
     public async Task CarrierComponentDefaults()
@@ -75,14 +75,14 @@ public sealed class CarryingTest : GameTest
             var carrier = entityManager.SpawnEntity("CarryTestCarrier", mapData.GridCoords);
             var comp = entityManager.GetComponent<CarrierComponent>(carrier);
 
-            Assert.That(comp.Carrying, Is.Null);
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False);
             Assert.That(comp.WalkSpeedModifier, Is.EqualTo(0.75f));
             Assert.That(comp.SprintSpeedModifier, Is.EqualTo(0.6f));
         });
     }
 
     /// <summary>
-    /// Verifies CarriableComponent defaults: not being carried.
+    /// Verifies CarriableComponent is a permission tag with no active marker by default.
     /// </summary>
     [Test]
     public async Task CarriableComponentDefaults()
@@ -94,9 +94,9 @@ public sealed class CarryingTest : GameTest
         await server.WaitAssertion(() =>
         {
             var target = entityManager.SpawnEntity("CarryTestTarget", mapData.GridCoords);
-            var comp = entityManager.GetComponent<CarriableComponent>(target);
 
-            Assert.That(comp.CarriedBy, Is.Null);
+            Assert.That(entityManager.HasComponent<CarriableComponent>(target), Is.True);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False);
         });
     }
 

--- a/Content.Shared/RussStation/Carrying/Components/ActiveCarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/ActiveCarrierComponent.cs
@@ -1,9 +1,22 @@
+using Content.Shared.RussStation.Carrying.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
-/// Active marker component on an entity currently carrying another entity.
+/// Active marker on an entity currently carrying another entity.
+/// Owns the carrier-to-target reference: the marker IS the relationship,
+/// so it cannot drift out of sync with anything else. <see cref="BeingCarriedComponent"/>
+/// is the symmetric marker on the target side.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class ActiveCarrierComponent : Component;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedCarryingSystem))]
+public sealed partial class ActiveCarrierComponent : Component
+{
+    /// <summary>
+    /// The entity being carried. Set atomically with the marker's add and
+    /// guaranteed valid for the marker's entire lifetime.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid Target;
+}

--- a/Content.Shared/RussStation/Carrying/Components/BeingCarriedComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/BeingCarriedComponent.cs
@@ -1,14 +1,28 @@
+using Content.Shared.RussStation.Carrying.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
 /// Active marker on an entity currently being carried.
+/// Owns the target-to-carrier reference: the marker IS the relationship,
+/// so it cannot drift out of sync with anything else. <see cref="ActiveCarrierComponent"/>
+/// is the symmetric marker on the carrier side.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedCarryingSystem))]
 public sealed partial class BeingCarriedComponent : Component
 {
-    // Saved by the client CarryingSystem on startup so draw depth can be restored when carrying ends.
+    /// <summary>
+    /// The entity carrying this one. Set atomically with the marker's add and
+    /// guaranteed valid for the marker's entire lifetime.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid Carrier;
+
+    /// <summary>
+    /// Saved by the client CarryingSystem on startup so draw depth can be restored when carrying ends.
+    /// </summary>
     [ViewVariables]
     public int? OriginalDrawDepth;
 }

--- a/Content.Shared/RussStation/Carrying/Components/CarriableComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarriableComponent.cs
@@ -4,12 +4,10 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
-/// Indicates this entity can be fireman carried.
+/// Indicates this entity can be fireman carried (permission tag).
+/// The active relationship lives on <see cref="BeingCarriedComponent"/>;
+/// this component carries no per-carry state.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedCarryingSystem))]
-public sealed partial class CarriableComponent : Component
-{
-    [AutoNetworkedField, DataField]
-    public EntityUid? CarriedBy;
-}
+public sealed partial class CarriableComponent : Component;

--- a/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
@@ -4,15 +4,15 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.RussStation.Carrying.Components;
 
 /// <summary>
-/// Indicates this entity can fireman carry another entity.
+/// Indicates this entity can fireman carry another entity, and configures
+/// the speed penalties and visual offset while doing so.
+/// The active relationship lives on <see cref="ActiveCarrierComponent"/>;
+/// this component is config-only.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedCarryingSystem))]
 public sealed partial class CarrierComponent : Component
 {
-    [AutoNetworkedField, DataField]
-    public EntityUid? Carrying;
-
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float WalkSpeedModifier = 0.75f;
 

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -25,7 +25,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.RussStation.Carrying.Systems;
@@ -45,23 +44,10 @@ public abstract class SharedCarryingSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-
-    [Dependency] private readonly EntityQuery<CarrierComponent> _carrierQuery = default!;
-    [Dependency] private readonly EntityQuery<CarriableComponent> _carriableQuery = default!;
-    [Dependency] private readonly EntityQuery<ActiveCarrierComponent> _activeCarrierQuery = default!;
-    [Dependency] private readonly EntityQuery<PullerComponent> _pullerQuery = default!;
-    [Dependency] private readonly EntityQuery<PullableComponent> _pullableQuery = default!;
-    [Dependency] private readonly EntityQuery<BuckleComponent> _buckleQuery = default!;
-    [Dependency] private readonly EntityQuery<PhysicsComponent> _physicsQuery = default!;
-    [Dependency] private readonly EntityQuery<KnockedDownComponent> _knockedDownQuery = default!;
 
     // Carriers currently setting up or tearing down a carry. While in this set,
     // OnVirtualItemDeleted won't call Drop(), preventing double-drop cascades.
     private readonly HashSet<EntityUid> _transitioning = new();
-
-    private TimeSpan _nextValidation;
-    private static readonly TimeSpan ValidationInterval = TimeSpan.FromSeconds(1);
 
     public override void Initialize()
     {
@@ -90,6 +76,10 @@ public abstract class SharedCarryingSystem : EntitySystem
         // Drop carry when the carried entity gets buckled
         SubscribeLocalEvent<BeingCarriedComponent, BuckleAttemptEvent>(OnCarriedBuckleAttempt);
 
+        // Reactive escape detection: if something reparents the target away from the carrier
+        // without going through Drop(), we need to tear the carry down immediately.
+        SubscribeLocalEvent<BeingCarriedComponent, EntParentChangedMessage>(OnCarriedParentChanged);
+
         // Cleanup
         SubscribeLocalEvent<BeingCarriedComponent, ComponentShutdown>(OnBeingCarriedShutdown);
         SubscribeLocalEvent<ActiveCarrierComponent, ComponentShutdown>(OnActiveCarrierShutdown);
@@ -116,7 +106,7 @@ public abstract class SharedCarryingSystem : EntitySystem
             Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png")),
             Act = () =>
             {
-                if (_carrierQuery.TryGetComponent(args.User, out var carrier) && CanCarry(args.User, args.Target))
+                if (TryComp<CarrierComponent>(args.User, out var carrier) && CanCarry(args.User, args.Target))
                     StartCarryDoAfter(args.User, args.Target, carrier);
             },
         });
@@ -124,7 +114,7 @@ public abstract class SharedCarryingSystem : EntitySystem
 
     private void AddDropVerb(EntityUid uid, BeingCarriedComponent component, GetVerbsEvent<InteractionVerb> args)
     {
-        if (!_carriableQuery.TryGetComponent(uid, out var carriable) || carriable.CarriedBy != args.User)
+        if (component.Carrier != args.User)
             return;
 
         args.Verbs.Add(new InteractionVerb
@@ -165,7 +155,7 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (!CanCarry(args.User, uid))
             return;
 
-        if (!_carrierQuery.TryGetComponent(args.User, out var carrierComp))
+        if (!TryComp<CarrierComponent>(args.User, out var carrierComp))
             return;
 
         StartCarryDoAfter(args.User, uid, carrierComp);
@@ -181,10 +171,10 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (carrier == target)
             return false;
 
-        if (!_carrierQuery.TryGetComponent(carrier, out var carrierComp) || carrierComp.Carrying != null)
+        if (!HasComp<CarrierComponent>(carrier) || HasComp<ActiveCarrierComponent>(carrier))
             return false;
 
-        if (!_carriableQuery.TryGetComponent(target, out var carriableComp) || carriableComp.CarriedBy != null)
+        if (!HasComp<CarriableComponent>(target) || HasComp<BeingCarriedComponent>(target))
             return false;
 
         if (_standing.IsDown(carrier) || _mobState.IsIncapacitated(carrier))
@@ -193,7 +183,7 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (!_mobState.IsIncapacitated(target))
             return false;
 
-        if (_buckleQuery.TryGetComponent(target, out var buckle) && buckle.Buckled)
+        if (TryComp<BuckleComponent>(target, out var buckle) && buckle.Buckled)
             return false;
 
         if (!_actionBlocker.CanInteract(carrier, target))
@@ -206,7 +196,7 @@ public abstract class SharedCarryingSystem : EntitySystem
         // The pull's virtual item will be freed when the pull stops during Carry(),
         // so count it as available.
         var freeHands = _hands.CountFreeHands(carrier);
-        var pullingTarget = _pullerQuery.TryGetComponent(carrier, out var pullerCheck) && pullerCheck.Pulling == target;
+        var pullingTarget = TryComp<PullerComponent>(carrier, out var pullerCheck) && pullerCheck.Pulling == target;
         var effectiveFreeHands = freeHands + (pullingTarget ? 1 : 0);
         if (effectiveFreeHands < 2)
             return false;
@@ -232,15 +222,18 @@ public abstract class SharedCarryingSystem : EntitySystem
             return;
 
         args.Handled = true;
-        Carry(uid, args.Target.Value, component);
+        Carry(uid, args.Target.Value);
     }
 
-    private void Carry(EntityUid carrier, EntityUid target, CarrierComponent? carrierComp = null, CarriableComponent? carriableComp = null)
+    /// <summary>
+    /// Wires up the carry relationship: adds both marker components with their cross-references,
+    /// reparents the target onto the carrier, spawns the virtual hand items, and locks the target's
+    /// movement. Public so integration tests can set up a carry without satisfying the verb path's
+    /// preconditions (aggressive grab, hand count, etc.).
+    /// </summary>
+    public void Carry(EntityUid carrier, EntityUid target)
     {
-        if (!Resolve(carrier, ref carrierComp) || !Resolve(target, ref carriableComp))
-            return;
-
-        if (carrierComp.Carrying != null || carriableComp.CarriedBy != null)
+        if (HasComp<ActiveCarrierComponent>(carrier) || HasComp<BeingCarriedComponent>(target))
             return;
 
         if (!_standing.IsDown(target) && !_mobState.IsIncapacitated(target))
@@ -259,20 +252,20 @@ public abstract class SharedCarryingSystem : EntitySystem
         // guard, those deletions would call Drop() while we're still setting up.
         _transitioning.Add(carrier);
 
-        if (_pullableQuery.TryGetComponent(target, out var pullable) && pullable.Puller != null)
+        if (TryComp<PullableComponent>(target, out var pullable) && pullable.Puller != null)
             _pulling.TryStopPull(target, pullable);
 
-        if (_pullerQuery.TryGetComponent(carrier, out var puller) && puller.Pulling != null
-            && _pullableQuery.TryGetComponent(puller.Pulling.Value, out var pullerPullable))
+        if (TryComp<PullerComponent>(carrier, out var puller) && puller.Pulling != null
+            && TryComp<PullableComponent>(puller.Pulling.Value, out var pullerPullable))
             _pulling.TryStopPull(puller.Pulling.Value, pullerPullable);
 
-        carrierComp.Carrying = target;
-        carriableComp.CarriedBy = carrier;
-        Dirty(carrier, carrierComp);
-        Dirty(target, carriableComp);
+        var active = EnsureComp<ActiveCarrierComponent>(carrier);
+        active.Target = target;
+        Dirty(carrier, active);
 
-        EnsureComp<ActiveCarrierComponent>(carrier);
-        EnsureComp<BeingCarriedComponent>(target);
+        var being = EnsureComp<BeingCarriedComponent>(target);
+        being.Carrier = carrier;
+        Dirty(target, being);
 
         if (!_virtualItem.TrySpawnVirtualItemInHand(target, carrier))
             Log.Warning($"Failed to spawn first carry virtual item on {ToPrettyString(carrier)}");
@@ -287,20 +280,16 @@ public abstract class SharedCarryingSystem : EntitySystem
         _transitioning.Remove(carrier);
 
         // The reparent above can cause other systems to move the target back (e.g.
-        // buckle detecting a parent change and unbuckling). If that happened, clean
-        // up instead of continuing with a half-built carry.
-        if (carrierComp.Carrying != target || Transform(target).ParentUid != carrier)
-        {
-            Log.Warning($"Carry disrupted during setup: {ToPrettyString(carrier)} -> {ToPrettyString(target)}");
-            CleanOrphanedCarryState(carrier, carrierComp);
+        // buckle detecting a parent change and unbuckling). Reactive parent-change
+        // handler will have called Drop() in that case; verify and bail if so.
+        if (!HasComp<ActiveCarrierComponent>(carrier) || Transform(target).ParentUid != carrier)
             return;
-        }
 
         _joints.SetRelay(target, carrier);
 
         _standing.Down(target, playSound: false, dropHeldItems: false, force: true);
 
-        if (_physicsQuery.TryGetComponent(target, out var physics))
+        if (TryComp<PhysicsComponent>(target, out var physics))
             _physics.ResetDynamics(target, physics);
 
         _movementSpeed.RefreshMovementSpeedModifiers(carrier);
@@ -314,49 +303,23 @@ public abstract class SharedCarryingSystem : EntitySystem
         RaiseLocalEvent(target, ref ev);
     }
 
-    public void Drop(EntityUid carrier, CarrierComponent? carrierComp = null)
+    /// <summary>
+    /// Public API to drop whoever <paramref name="carrier"/> is currently carrying, if any.
+    /// </summary>
+    public void Drop(EntityUid carrier)
     {
-        if (!Resolve(carrier, ref carrierComp) || carrierComp.Carrying is not { } target)
+        if (!TryComp<ActiveCarrierComponent>(carrier, out var active))
             return;
 
-        if (!_carriableQuery.TryGetComponent(target, out var carriableComp))
-            return;
+        var target = active.Target;
 
-        carrierComp.Carrying = null;
-        carriableComp.CarriedBy = null;
-        Dirty(carrier, carrierComp);
-        Dirty(target, carriableComp);
-
-        // Remove immediately so carried-entity event handlers (like OnCarriedCanMove
-        // and OnCarriedStood) don't fire after the drop.
-        RemComp<BeingCarriedComponent>(target);
+        // Tearing down the relationship: removing the marker fires its shutdown handler,
+        // which is responsible for removing the symmetric BeingCarriedComponent and
+        // performing the visible cleanup (virtual items, reparent, joints, popups, events).
+        // Marker removal is the single point of truth for ending a carry.
         RemComp<ActiveCarrierComponent>(carrier);
-
-        _virtualItem.DeleteInHandsMatching(carrier, target);
-
-        if (!Terminating(carrier) && !Terminating(target))
-        {
-            var targetXform = Transform(target);
-            if (targetXform.ParentUid == carrier)
-            {
-                _transform.PlaceNextTo((target, targetXform), (carrier, Transform(carrier)));
-                targetXform.ActivelyLerping = false;
-            }
-        }
-
-        _joints.RefreshRelay(target);
-        _movementSpeed.RefreshMovementSpeedModifiers(carrier);
-        _actionBlocker.UpdateCanMove(target);
-
-        if (!_mobState.IsIncapacitated(target) && !_knockedDownQuery.HasComponent(target))
-            _standing.Stand(target);
-
-        _popup.PopupClient(Loc.GetString("carrying-drop-carrier", ("target", target)), carrier, carrier);
-        _popup.PopupClient(Loc.GetString("carrying-drop-carried", ("carrier", carrier)), target, target);
-
-        var ev = new CarryStoppedEvent(carrier, target);
-        RaiseLocalEvent(carrier, ref ev);
-        RaiseLocalEvent(target, ref ev);
+        DebugTools.Assert(Terminating(target) || !HasComp<BeingCarriedComponent>(target),
+            "OnActiveCarrierShutdown should have removed the BeingCarriedComponent");
     }
 
     #endregion
@@ -365,7 +328,7 @@ public abstract class SharedCarryingSystem : EntitySystem
 
     private void OnRefreshMoveSpeed(EntityUid uid, ActiveCarrierComponent component, RefreshMovementSpeedModifiersEvent args)
     {
-        if (!_carrierQuery.TryGetComponent(uid, out var carrier) || carrier.Carrying == null)
+        if (!TryComp<CarrierComponent>(uid, out var carrier))
             return;
 
         args.ModifySpeed(carrier.WalkSpeedModifier, carrier.SprintSpeedModifier);
@@ -383,22 +346,17 @@ public abstract class SharedCarryingSystem : EntitySystem
     private void OnCarriedMobStateChanged(EntityUid uid, BeingCarriedComponent component, MobStateChangedEvent args)
     {
         if (args.NewMobState == MobState.Alive)
-        {
-            if (_carriableQuery.TryGetComponent(uid, out var carriable) && carriable.CarriedBy is { } carrier)
-                Drop(carrier);
-        }
+            Drop(component.Carrier);
     }
 
     private void OnCarriedStood(EntityUid uid, BeingCarriedComponent component, StoodEvent args)
     {
-        if (_carriableQuery.TryGetComponent(uid, out var carriable) && carriable.CarriedBy is { } carrier)
-            Drop(carrier);
+        Drop(component.Carrier);
     }
 
     private void OnCarriedBuckled(EntityUid uid, BeingCarriedComponent component, ref BuckledEvent args)
     {
-        if (_carriableQuery.TryGetComponent(uid, out var carriable) && carriable.CarriedBy is { } carrier)
-            Drop(carrier);
+        Drop(component.Carrier);
     }
 
     private void OnCarrierMobStateChanged(EntityUid uid, ActiveCarrierComponent component, MobStateChangedEvent args)
@@ -419,8 +377,7 @@ public abstract class SharedCarryingSystem : EntitySystem
 
     private void OnCarriedInserted(EntityUid uid, BeingCarriedComponent component, EntGotInsertedIntoContainerMessage args)
     {
-        if (_carriableQuery.TryGetComponent(uid, out var carriable) && carriable.CarriedBy is { } carrier)
-            Drop(carrier);
+        Drop(component.Carrier);
     }
 
     private void OnCarrierInserted(EntityUid uid, ActiveCarrierComponent component, EntGotInsertedIntoContainerMessage args)
@@ -428,35 +385,96 @@ public abstract class SharedCarryingSystem : EntitySystem
         Drop(uid);
     }
 
+    private void OnCarriedBuckleAttempt(EntityUid uid, BeingCarriedComponent component, ref BuckleAttemptEvent args)
+    {
+        Drop(component.Carrier);
+    }
+
+    private void OnCarriedParentChanged(EntityUid uid, BeingCarriedComponent component, ref EntParentChangedMessage args)
+    {
+        // Ignore the reparent we trigger ourselves during Carry() setup.
+        if (_transitioning.Contains(component.Carrier))
+            return;
+
+        // Entity deletion detaches before component shutdown. Skip — the marker's
+        // own ComponentShutdown handler will run the teardown for the deletion case.
+        if (Terminating(uid))
+            return;
+
+        if (Transform(uid).ParentUid != component.Carrier)
+            Drop(component.Carrier);
+    }
+
     #endregion
 
     #region Cleanup
 
+    /// <summary>
+    /// The single teardown path for a carry. Fires when the target's marker is removed —
+    /// whether that removal came from <see cref="Drop"/>, the carrier-side shutdown handler,
+    /// or because the target entity itself is being deleted. Reads the carrier reference
+    /// off the marker so it never depends on any other component still being intact.
+    /// </summary>
     private void OnBeingCarriedShutdown(EntityUid uid, BeingCarriedComponent component, ComponentShutdown args)
     {
-        if (_carriableQuery.TryGetComponent(uid, out var carriable) && carriable.CarriedBy is { } carrier && _carrierQuery.TryGetComponent(carrier, out var carrierComp))
-        {
-            carrierComp.Carrying = null;
-            Dirty(carrier, carrierComp);
-            RemCompDeferred<ActiveCarrierComponent>(carrier);
+        var carrier = component.Carrier;
 
+        // Remove the symmetric carrier-side marker first. Skip if the carrier is itself
+        // terminating — its own component shutdown is already running the symmetric path.
+        if (!Terminating(carrier) && HasComp<ActiveCarrierComponent>(carrier))
+            RemComp<ActiveCarrierComponent>(carrier);
+
+        if (Exists(carrier) && !Terminating(carrier))
+        {
             _transitioning.Add(carrier);
             _virtualItem.DeleteInHandsMatching(carrier, uid);
             _transitioning.Remove(carrier);
-
             _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+
+            _popup.PopupClient(Loc.GetString("carrying-drop-carrier", ("target", uid)), carrier, carrier);
         }
+
+        if (!Terminating(uid))
+        {
+            if (Exists(carrier) && !Terminating(carrier))
+            {
+                var targetXform = Transform(uid);
+                if (targetXform.ParentUid == carrier)
+                {
+                    _transform.PlaceNextTo((uid, targetXform), (carrier, Transform(carrier)));
+                    targetXform.ActivelyLerping = false;
+                }
+            }
+
+            _joints.RefreshRelay(uid);
+            _actionBlocker.UpdateCanMove(uid);
+
+            if (!_mobState.IsIncapacitated(uid) && !HasComp<KnockedDownComponent>(uid))
+                _standing.Stand(uid);
+
+            _popup.PopupClient(Loc.GetString("carrying-drop-carried", ("carrier", carrier)), uid, uid);
+        }
+
+        var ev = new CarryStoppedEvent(carrier, uid);
+        if (Exists(carrier))
+            RaiseLocalEvent(carrier, ref ev);
+        RaiseLocalEvent(uid, ref ev);
     }
 
+    /// <summary>
+    /// Symmetric handler for when the carrier-side marker is removed first — typically
+    /// from <see cref="Drop"/> or the carrier entity itself being deleted. Mirrors removal
+    /// to the target marker; the rest of the teardown then runs from
+    /// <see cref="OnBeingCarriedShutdown"/>.
+    /// </summary>
     private void OnActiveCarrierShutdown(EntityUid uid, ActiveCarrierComponent component, ComponentShutdown args)
     {
-        if (_carrierQuery.TryGetComponent(uid, out var carrier) && carrier.Carrying is { } target && _carriableQuery.TryGetComponent(target, out var carriable))
-        {
-            carriable.CarriedBy = null;
-            Dirty(target, carriable);
-            RemCompDeferred<BeingCarriedComponent>(target);
-            _actionBlocker.UpdateCanMove(target);
-        }
+        var target = component.Target;
+        // Skip if the target is itself terminating — its BeingCarriedComponent is either
+        // already in shutdown (we're being called from it) or will be when the deletion
+        // walk reaches it.
+        if (!Terminating(target) && HasComp<BeingCarriedComponent>(target))
+            RemComp<BeingCarriedComponent>(target);
     }
 
     private void OnDropHandItems(EntityUid uid, ActiveCarrierComponent component, DropHandItemsEvent args)
@@ -466,98 +484,11 @@ public abstract class SharedCarryingSystem : EntitySystem
 
     private void OnVirtualItemDeleted(EntityUid uid, CarrierComponent component, VirtualItemDeletedEvent args)
     {
-        if (!_transitioning.Contains(uid) && component.Carrying == args.BlockingEntity)
-            Drop(uid, component);
-    }
-
-    private void OnCarriedBuckleAttempt(EntityUid uid, BeingCarriedComponent component, ref BuckleAttemptEvent args)
-    {
-        if (_carriableQuery.TryGetComponent(uid, out var carriable) && carriable.CarriedBy is { } carrier)
-            Drop(carrier);
-    }
-
-    #endregion
-
-    #region State Validation
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        if (_timing.CurTime < _nextValidation)
+        if (_transitioning.Contains(uid))
             return;
-        _nextValidation = _timing.CurTime + ValidationInterval;
 
-        var query = EntityQueryEnumerator<ActiveCarrierComponent, CarrierComponent>();
-        while (query.MoveNext(out var uid, out _, out var carrier))
-        {
-            if (_transitioning.Contains(uid))
-                continue;
-
-            if (carrier.Carrying is not { } target || !Exists(target) || Terminating(target))
-            {
-                CleanOrphanedCarryState(uid, carrier);
-                continue;
-            }
-
-            if (Transform(target).ParentUid != uid)
-            {
-                // Target escaped the carrier. Try a normal Drop first, then
-                // fall back to orphan cleanup if Drop couldn't fully resolve it.
-                Drop(uid, carrier);
-                if (_activeCarrierQuery.HasComponent(uid))
-                    CleanOrphanedCarryState(uid, carrier);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Fallback cleanup for when <see cref="Drop"/> can't fully resolve a broken carry,
-    /// such as when the target no longer exists or Carrying was already nulled but
-    /// marker components and virtual items are still hanging around.
-    /// </summary>
-    private void CleanOrphanedCarryState(EntityUid uid, CarrierComponent carrier)
-    {
-        var target = carrier.Carrying;
-
-        carrier.Carrying = null;
-        Dirty(uid, carrier);
-
-        if (target != null && Exists(target.Value) && !Terminating(target.Value))
-        {
-            if (_carriableQuery.TryGetComponent(target.Value, out var carriable))
-            {
-                carriable.CarriedBy = null;
-                Dirty(target.Value, carriable);
-            }
-
-            RemCompDeferred<BeingCarriedComponent>(target.Value);
-
-            _transitioning.Add(uid);
-            _virtualItem.DeleteInHandsMatching(uid, target.Value);
-            _transitioning.Remove(uid);
-
-            if (!Terminating(uid))
-            {
-                var xform = Transform(target.Value);
-                if (xform.ParentUid == uid)
-                {
-                    _transform.PlaceNextTo((target.Value, xform), (uid, Transform(uid)));
-                    xform.ActivelyLerping = false;
-                }
-            }
-
-            _joints.RefreshRelay(target.Value);
-            _actionBlocker.UpdateCanMove(target.Value);
-
-            if (!_mobState.IsIncapacitated(target.Value) && !_knockedDownQuery.HasComponent(target.Value))
-                _standing.Stand(target.Value);
-        }
-
-        RemComp<ActiveCarrierComponent>(uid);
-        _movementSpeed.RefreshMovementSpeedModifiers(uid);
-
-        Log.Warning($"Cleaned orphaned carry state on {ToPrettyString(uid)}");
+        if (TryComp<ActiveCarrierComponent>(uid, out var active) && active.Target == args.BlockingEntity)
+            Drop(uid);
     }
 
     #endregion


### PR DESCRIPTION
## About the PR
Refactors the carry system so the marker components own the relationship rather than mirroring it onto `CarrierComponent` / `CarriableComponent`. Eliminates the polling validation tick (`CleanOrphanedBearState`) that existed only to clean up state left behind by a component shutdown ordering race.

Part of #441 P2.2.

## Why / Balance
No gameplay change. Pure refactor that fixes a class of subtle desync where a carrier could be left holding an `ActiveCarrierComponent` referencing a deleted target until the next periodic validation tick caught up.

## Technical details
- `ActiveCarrierComponent` now owns `Target: EntityUid` (`[AutoNetworkedField]`).
- `BeingCarriedComponent` now owns `Carrier: EntityUid` (`[AutoNetworkedField]`); `OriginalDrawDepth` stays for client draw-depth restore.
- `CarrierComponent` becomes config-only (speed modifiers, carry offset).
- `CarriableComponent` becomes an empty permission tag.
- `Carry()` is the single setup path; `Drop()` is now `RemComp<ActiveCarrierComponent>`. Component shutdown handlers do the symmetric removal and the rest of the teardown — there is no longer any code path where one side of the relationship survives the other.
- Replaced the periodic validation tick with reactive `EntParentChangedMessage` handling for the target-escape case.
- Shutdown handlers guard against the counterpart entity already terminating, so entity deletion doesn't recurse into the symmetric removal of a component that is already in shutdown.

## Media
Refactor only, no in-game visual changes.

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
`CarrierComponent.Carrying` and `CarriableComponent.CarriedBy` are gone. Anything that needs the relationship should query the marker components instead (`ActiveCarrierComponent.Target`, `BeingCarriedComponent.Carrier`). Only the carry system itself read these fields, so no downstream callers are affected within this fork.

**Changelog**

No player-facing change.