### PR TITLE
honksquad: refactor: cartridge loader inline contributor seam

### DIFF
--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -382,14 +382,14 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
         //inline set instead of running after MapInit and deduping against installed state.
         var toInstall = new HashSet<string>(component.PreinstalledPrograms);
         var ev = new CartridgeLoaderInitialProgramsEvent(uid, toInstall);
-        RaiseLocalEvent(uid, ref ev);
-        //HONK END
+        RaiseLocalEvent(uid, ref ev, broadcast: true);
 
         // TODO remove this and use container fill.
         foreach (var prototype in toInstall)
         {
             InstallProgram(uid, prototype, deinstallable: false);
         }
+        //HONK END
     }
 
     private void OnUsed(EntityUid uid, CartridgeLoaderComponent component, AfterInteractEvent args)

--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -378,8 +378,15 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
     /// </summary>
     private void OnMapInit(EntityUid uid, CartridgeLoaderComponent component, MapInitEvent args)
     {
+        //HONK START - extension seam: contributors raise their cartridges into a single
+        //inline set instead of running after MapInit and deduping against installed state.
+        var toInstall = new HashSet<string>(component.PreinstalledPrograms);
+        var ev = new CartridgeLoaderInitialProgramsEvent(uid, toInstall);
+        RaiseLocalEvent(uid, ref ev);
+        //HONK END
+
         // TODO remove this and use container fill.
-        foreach (var prototype in component.PreinstalledPrograms)
+        foreach (var prototype in toInstall)
         {
             InstallProgram(uid, prototype, deinstallable: false);
         }
@@ -519,3 +526,14 @@ public sealed class CartridgeAfterInteractEvent : EntityEventArgs
 /// </summary>
 [ByRefEvent]
 public record struct ProgramInstallationAttempt(EntityUid LoaderUid, string Prototype, bool Cancelled = false);
+
+//HONK START - extension seam for fork-side initial-cartridge contributors.
+/// <summary>
+/// Raised on a cartridge loader during MapInit so contributors can add prototype IDs
+/// to the initial install set. The set is a HashSet, so duplicates are silently merged.
+/// Subscribers must mutate <see cref="Programs"/> in place; the loader installs the
+/// merged set inline, with no second pass.
+/// </summary>
+[ByRefEvent]
+public record struct CartridgeLoaderInitialProgramsEvent(EntityUid Loader, HashSet<string> Programs);
+//HONK END

--- a/Content.Server/RussStation/CartridgeLoader/PdaCartridgeInstallerSystem.cs
+++ b/Content.Server/RussStation/CartridgeLoader/PdaCartridgeInstallerSystem.cs
@@ -1,20 +1,20 @@
 using System.Linq;
 using Content.Server.CartridgeLoader;
-using Content.Shared.CartridgeLoader;
 using Content.Shared.PDA;
 using Content.Shared.RussStation.CartridgeLoader;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.RussStation.CartridgeLoader;
 
 /// <summary>
-/// Installs fork-specific cartridges on all PDAs at map init,
+/// Contributes fork-specific cartridges to the initial install set on PDAs,
 /// driven by ForkCartridgeSetPrototype definitions rather than per-entity YAML.
+/// Hooks the upstream CartridgeLoaderInitialProgramsEvent seam, so cartridges
+/// land in the same install pass as PreinstalledPrograms — no after-ordering,
+/// no idempotency tracking against already-installed state.
 /// </summary>
 public sealed class PdaCartridgeInstallerSystem : EntitySystem
 {
-    [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly IComponentFactory _compFactory = default!;
 
@@ -22,39 +22,24 @@ public sealed class PdaCartridgeInstallerSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PdaComponent, MapInitEvent>(OnMapInit,
-            after: [typeof(CartridgeLoaderSystem)]);
+        SubscribeLocalEvent<CartridgeLoaderInitialProgramsEvent>(OnInitialPrograms);
     }
 
-    private void OnMapInit(EntityUid uid, PdaComponent pda, MapInitEvent args)
+    private void OnInitialPrograms(ref CartridgeLoaderInitialProgramsEvent args)
     {
-        if (!TryComp<CartridgeLoaderComponent>(uid, out var loader))
+        if (!HasComp<PdaComponent>(args.Loader))
             return;
-
-        var installed = _cartridgeLoader.GetInstalled(uid);
-        var existing = new HashSet<string>();
-        foreach (var prog in installed)
-        {
-            if (MetaData(prog).EntityPrototype?.ID is { } id)
-                existing.Add(id);
-        }
 
         var sets = _protoManager.EnumeratePrototypes<ForkCartridgeSetPrototype>()
             .OrderBy(s => s.Order);
 
         foreach (var set in sets)
         {
-            if (!MatchesFilter(uid, set))
+            if (!MatchesFilter(args.Loader, set))
                 continue;
 
             foreach (var cartridge in set.Cartridges)
-            {
-                if (existing.Contains(cartridge))
-                    continue;
-
-                _cartridgeLoader.InstallProgram(uid, cartridge, deinstallable: false, loader: loader);
-                existing.Add(cartridge);
-            }
+                args.Programs.Add(cartridge);
         }
     }
 


### PR DESCRIPTION
## About the PR
Adds a `CartridgeLoaderInitialProgramsEvent` extension seam on the upstream `CartridgeLoaderSystem` so fork systems can contribute initial cartridges into the same `MapInit` install pass as `PreinstalledPrograms`. Rewrites `PdaCartridgeInstallerSystem` to use the new seam and drop its `after: [typeof(CartridgeLoaderSystem)]` ordering plus the HashSet idempotency dance.

Closes P2.4 of #441.

## Why / Balance
No gameplay change. The fork's PDA cartridge installer previously had to run *after* the upstream loader's `MapInit` handler and rebuild a duplicate-detection HashSet from already-installed state, because it had no in-line way to extend the initial install set. The seam lets it contribute alongside `PreinstalledPrograms` in a single pass, removing the ordering coupling and the runtime dedupe.

## Technical details
- `Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs` (HONK):
  - `OnMapInit` now builds a `HashSet<string>` from `PreinstalledPrograms`, raises a new `CartridgeLoaderInitialProgramsEvent` on the loader entity, then iterates the merged set and installs each program.
  - Adds the new `[ByRefEvent]` `CartridgeLoaderInitialProgramsEvent(EntityUid Loader, HashSet<string> Programs)` at the bottom of the file.
  - Both additions wrapped in `HONK START` / `HONK END` markers.
- `Content.Server/RussStation/CartridgeLoader/PdaCartridgeInstallerSystem.cs`:
  - Drops the `MapInit` subscription with `after: [typeof(CartridgeLoaderSystem)]`.
  - Drops the `CartridgeLoaderSystem` dependency, the `GetInstalled` call, and the existing-program HashSet that was deduping against runtime state.
  - Subscribes to `CartridgeLoaderInitialProgramsEvent` instead, gates on `HasComp<PdaComponent>(args.Loader)`, then walks `ForkCartridgeSetPrototype` (sorted by `Order`) and adds matching cartridges to `args.Programs`.
  - The base loop's `HashSet` handles dedup, so the fork contributor no longer cares whether something is already in `PreinstalledPrograms` or contributed by another set.

## Media
Refactor only, no in-game visual changes.

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None. The new event type is additive. Other forks or downstreams subscribing to the same `MapInit` with `after:` would still work as before.

**Changelog**

No player-facing change.