### PR TITLE
Fix ci-local.sh YAML linter step using exit code

### DIFF
--- a/ci-local.sh
+++ b/ci-local.sh
@@ -134,7 +134,7 @@ fi
 if [ "$SKIP_LINT" = false ]; then
     echo "--- YAML Linter ---"
     step_start
-    if dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj --no-build 2>&1 | tee /dev/stderr | grep -q "0 errors"; then
+    if dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj --no-build 2>&1 | tee /dev/stderr; [ "${PIPESTATUS[0]}" -eq 0 ]; then
         step_end "YAML Linter"
         pass "YAML Linter" "${STEP_TIMES["YAML Linter"]}"
     else


### PR DESCRIPTION
## About the PR
The local CI script's YAML linter step always reported FAIL, even on a clean repo. Switched the success check to use the linter's exit code via `PIPESTATUS`.

## Why / Balance
Pure tooling fix. No gameplay impact. The script became unreliable for the "run local CI before pushing" workflow because it always reported the linter as broken.

## Technical details
The success check at `ci-local.sh:137` was grepping the linter output for the literal string `"0 errors"`, but `Content.YAMLLinter` prints `"No errors found in N ms."` on success. The grep never matched, so the YAML Linter step always took the `else` branch and called `fail`.

Replaced the grep with a `PIPESTATUS[0]` check on the `dotnet run` exit code. The linter exits 0 on success, so the step now tracks the actual result instead of a string that drifts whenever the linter's output format changes.

Verified locally with `./ci-local.sh --skip-tests`: build passes, YAML linter step now reports PASS, and the overall script exits CI PASSED.

## Media
Tooling fix, no media.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
No player-facing changes.