### PR TITLE
fix: stabilize HumanoidCharacterAppearance.Random round-trip

### DIFF
--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -103,7 +103,11 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
             _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         };
 
-        return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());
+        //HONK START - Normalize so Random() output is round-trip stable. The constructor's
+        // 8-bit ClampColor can push the strategy's HSV output just outside its valid range,
+        // and a later EnsureVerified would then snap it to ClosestSkinColor mid-round-trip.
+        return EnsureValid(new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new()), species, sex);
+        //HONK END
     }
 
     public static Color ClampColor(Color color)


### PR DESCRIPTION
## About the PR
Makes `HumanoidCharacterAppearance.Random()` return an appearance that already round-trips through the server identically. Wraps the constructed appearance in `EnsureValid` so the strategy's `EnsureVerified` runs once locally instead of being applied implicitly during the first round-trip.

## Why / Balance
`Content.IntegrationTests.Tests.Lobby.CharacterCreationTest.CreateDeleteCreateTest` has been failing intermittently in CI on `SkinColor` mismatches (see PR #462 for a recent occurrence). The flake reproduces locally on certain RNG seeds.

Root cause: `Random()` builds an appearance via `strategy.FromUnary(...)` (or `ClosestSkinColor`), which for `HumanTonedSkinColoration` produces a color near the edge of its valid HSV range. The constructor then applies `ClampColor` (8-bit byte truncation), which can push the color just outside the strategy's `VerifySkinColor` bounds. The local profile holds this slightly-out-of-range color. When the profile is sent to the server, server-side `EnsureValid` calls `strategy.EnsureVerified(skinColor)`, which fails verification and snaps the color to `ClosestSkinColor` (the constant `ValidHumanSkinTone` for `HumanTonedSkinColoration`). The round-tripped copy now differs from the local copy by a large amount, and the test asserts inequality.

The fix runs `EnsureValid` on the freshly-constructed appearance before returning it from `Random()`, so the same normalization is applied locally that the server applies during the round-trip.

## Technical details
- `Content.Shared/Humanoid/HumanoidCharacterAppearance.cs:106` — wrap the constructed appearance in `EnsureValid(...)` before returning.
- HONK markers added since this is a fork modification of an upstream file.

Verified locally by running `CreateDeleteCreateTest` 5 times in a row, all passing. The failing test was flaking roughly 1 in 4 runs against the previous code.

## Media
Not applicable, test stability fix.

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None. `Random()` callers receive the same logical appearance, just normalized to the strategy's verified form.

**Changelog**
No player-facing change.