### PR TITLE
fix: clear wounds when Rejuvenate or Godmode is used

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRejuvenateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRejuvenateTest.cs
@@ -1,0 +1,59 @@
+using Content.Shared.Rejuvenate;
+using Content.Shared.RussStation.Wounds;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Wounds;
+
+[TestFixture]
+[TestOf(typeof(Content.Shared.RussStation.Wounds.Systems.SharedWoundSystem))]
+public sealed class WoundRejuvenateTest
+{
+    [Test]
+    public async Task RejuvenateClearsActiveWoundsAndBleedSource()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
+            var comp = entityManager.AddComponent<WoundComponent>(entity);
+
+            comp.ActiveWounds.Add(new WoundEntry("BluntFracture", 2));
+            comp.BleedSourceDamageType = "Slash";
+
+            entityManager.EventBus.RaiseLocalEvent(entity, new RejuvenateEvent());
+
+            Assert.That(comp.ActiveWounds, Is.Empty,
+                "RejuvenateEvent should clear ActiveWounds.");
+            Assert.That(comp.BleedSourceDamageType, Is.Null,
+                "RejuvenateEvent should reset BleedSourceDamageType.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RejuvenateOnCleanWoundComponentIsNoOp()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
+            var comp = entityManager.AddComponent<WoundComponent>(entity);
+
+            entityManager.EventBus.RaiseLocalEvent(entity, new RejuvenateEvent());
+
+            Assert.That(comp.ActiveWounds, Is.Empty);
+            Assert.That(comp.BleedSourceDamageType, Is.Null);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs
+++ b/Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Rejuvenate;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
@@ -19,6 +20,7 @@ public abstract class SharedWoundSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<WoundComponent, DamageChangedEvent>(OnDamageChanged);
+        SubscribeLocalEvent<WoundComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
         CacheWoundTypes();
     }
@@ -36,6 +38,17 @@ public abstract class SharedWoundSystem : EntitySystem
         {
             _woundTypes.Add(proto);
         }
+    }
+
+    private void OnRejuvenate(EntityUid uid, WoundComponent comp, RejuvenateEvent args)
+    {
+        if (comp.ActiveWounds.Count == 0 && comp.BleedSourceDamageType is null)
+            return;
+
+        comp.ActiveWounds.Clear();
+        comp.BleedSourceDamageType = null;
+        Dirty(uid, comp);
+        RaiseLocalEvent(uid, new WoundsClearedEvent());
     }
 
     private void OnDamageChanged(EntityUid uid, WoundComponent comp, DamageChangedEvent args)


### PR DESCRIPTION
## About the PR
Subscribes `SharedWoundSystem` to `RejuvenateEvent` so the admin Rejuvenate verb (and Godmode toggle, which raises the same event) actually clear `ActiveWounds` and `BleedSourceDamageType`. Closes #438.

## Why / Balance
Without this subscription, Rejuvenate and Godmode reset damage and stamina but leave fracture and burn wounds in place. Admins then have to fall back to surgery or console commands to fully restore a mob, which defeats the "make this mob normal again" purpose of those verbs. Same symptom on both verbs because Godmode's enable path raises `RejuvenateEvent` itself.

## Technical details
- `Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs` — subscribe to `RejuvenateEvent` and clear `ActiveWounds` + `BleedSourceDamageType`, then `Dirty` the component and raise `WoundsClearedEvent` so the health analyzer UI and wound alerts catch up. Early-out when there is nothing to clear so we do not spam dirty/state churn on already-clean wound components.
- Godmode does not need a separate guard: it cancels damage in `BeforeDamageChangedEvent`, so `DamageChangedEvent` never fires while godmode is active and `OnDamageChanged` cannot apply new wounds. The single `RejuvenateEvent` subscription covers both the admin verb and the godmode-on case.
- `Content.IntegrationTests/Tests/RussStation/Wounds/WoundRejuvenateTest.cs` — two integration tests:
  - `RejuvenateClearsActiveWoundsAndBleedSource` — seeds an ActiveWound + BleedSourceDamageType, raises `RejuvenateEvent`, asserts both are cleared.
  - `RejuvenateOnCleanWoundComponentIsNoOp` — verifies the early-out path on a fresh component.

## Media
Not applicable, admin tooling fix with no visual change.

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Rejuvenate and Godmode now clear active fracture and burn wounds, so admins do not have to follow up with surgery to fully heal a mob.