### PR TITLE
Unify radial menu and alert icon scaling behind one helper

### DIFF
--- a/Content.Client/RussStation/UserInterface/IconScaling.cs
+++ b/Content.Client/RussStation/UserInterface/IconScaling.cs
@@ -1,0 +1,28 @@
+using System.Numerics;
+using Robust.Shared.Maths;
+
+namespace Content.Client.RussStation.UserInterface;
+
+/// <summary>
+/// Shared icon scaling helpers for UI controls that need to fit an arbitrary
+/// pixel-sized sprite into a fixed display box. Replaces ad-hoc tiered
+/// scaling in places like the radial menu and alert panel.
+/// </summary>
+public static class IconScaling
+{
+    /// <summary>
+    /// Returns a uniform scale that fits a sprite of <paramref name="pixelSize"/>
+    /// into a square of <paramref name="targetPx"/> pixels per side, preserving
+    /// aspect ratio. Returns <see cref="Vector2.One"/> for empty input so callers
+    /// don't have to null-guard.
+    /// </summary>
+    public static Vector2 FitScale(Vector2i pixelSize, float targetPx)
+    {
+        var maxSide = Math.Max(pixelSize.X, pixelSize.Y);
+        if (maxSide <= 0)
+            return Vector2.One;
+
+        var scale = targetPx / maxSide;
+        return new Vector2(scale, scale);
+    }
+}

--- a/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml.cs
+++ b/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml.cs
@@ -9,6 +9,9 @@ using Robust.Client.UserInterface.XAML;
 using Robust.Client.Input;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
+//HONK START - shared icon scaling helper
+using Content.Client.RussStation.UserInterface;
+//HONK END
 
 namespace Content.Client.UserInterface.Controls;
 
@@ -178,24 +181,16 @@ public sealed partial class SimpleRadialMenu : RadialMenu
         return entView;
     }
 
-    // HONK START - Auto-scale 16x16 textures to fill 64x64 button area
+    // HONK START - Pixel-aware fit so any sprite size fills the button box, not just 16/32 px
     private static Control CreateTexture(SpriteSpecifier spriteSpecifier, SpriteSystem sprites)
     {
         var texture = sprites.Frame0(spriteSpecifier);
 
-        var scale = Vector2.One;
-        if (texture.Width <= 16)
-            scale *= 4;
-        else if (texture.Width <= 32)
-            scale *= 2;
-
-        var imageControl = new TextureRect
+        return new TextureRect
         {
             Texture = texture,
-            TextureScale = scale,
+            TextureScale = IconScaling.FitScale(texture.Size, ButtonSize),
         };
-
-        return imageControl;
     }
     // HONK END
 

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -7,6 +7,9 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+//HONK START - shared icon scaling helper
+using Content.Client.RussStation.UserInterface;
+//HONK END
 
 namespace Content.Client.UserInterface.Systems.Alerts.Controls
 {
@@ -104,13 +107,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
                 _sprite.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
 
                 //HONK START - Rescale on severity change
-                var pixelSize = sprite[layer].PixelSize;
-                var maxSide = Math.Max(pixelSize.X, pixelSize.Y);
-                if (maxSide > 0)
-                {
-                    var scale = 64f / maxSide;
-                    _icon.Scale = new Vector2(scale, scale);
-                }
+                _icon.Scale = IconScaling.FitScale(sprite[layer].PixelSize, 64f);
                 //HONK END
             }
         }
@@ -143,13 +140,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
                     _sprite.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
 
                 //HONK START - Dynamic scale so any sprite size fills the 64x64 alert slot
-                var pixelSize = sprite[layer].PixelSize;
-                var maxSide = Math.Max(pixelSize.X, pixelSize.Y);
-                if (maxSide > 0)
-                {
-                    var scale = 64f / maxSide;
-                    _icon.Scale = new Vector2(scale, scale);
-                }
+                _icon.Scale = IconScaling.FitScale(sprite[layer].PixelSize, 64f);
                 //HONK END
             }
 


### PR DESCRIPTION
Closes #436.

## About the PR

Both `SimpleRadialMenu.CreateTexture` and `AlertControl` had their own pixel-to-box scaler. The radial menu's HONK block used a coarse `<= 16 ? *4 : <= 32 ? *2 : 1` tier that only looked at width, ignored height, and silently fell back to 1x for anything between 33 and 63 pixels. `AlertControl` already had the right approach (`64 / max(width, height)`). This pulls that logic into a single helper and has both call sites use it.

Surgery procedure icons that aren't exactly 16 or 32 pixels were the visible symptom on the radial side.

## Why / Balance

Pure refactor, no balance impact. The radial menu now correctly fills the 64 px button box for any sprite size; the alert panel's behavior is unchanged.

## Technical details

- New `Content.Client/RussStation/UserInterface/IconScaling.cs` with a single `FitScale(Vector2i pixelSize, float targetPx)` helper. Returns `Vector2.One` for empty input so callers don't have to null-guard.
- `SimpleRadialMenu.CreateTexture` (HONK-gated) now calls `IconScaling.FitScale(texture.Size, ButtonSize)`. Drops the tiered branch and the dead `Vector2.One` fallback.
- `AlertControl.SetupIcon` and `SetSeverity` (both HONK-gated) call the same helper instead of inlining the math twice.

Both modified files were already fork-owned via HONK markers; the diff is contained inside the existing markers. The new helper lives under `RussStation/` so it doesn't collide with upstream paths.

## Media

No visual changes for the alert panel. For the radial menu, surgery icons in the 33-63 px or non-square range now render at the intended size instead of 1x.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

:cl:
- fix: Surgery procedure icons in the radial menu now scale correctly regardless of source sprite size, instead of only working for 16 and 32 pixel sprites.