### PR TITLE
Move wound display to health-verb examine as flavor text

### DIFF
--- a/Content.Shared/RussStation/Wounds/Systems/WoundEffectsSystem.cs
+++ b/Content.Shared/RussStation/Wounds/Systems/WoundEffectsSystem.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Alert;
-using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.HealthExaminable;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -20,7 +20,6 @@ public sealed class WoundEffectsSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedWoundSystem _wounds = default!;
-    [Dependency] private readonly WoundDisplaySystem _display = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
@@ -42,7 +41,7 @@ public sealed class WoundEffectsSystem : EntitySystem
         SubscribeLocalEvent<WoundComponent, WoundsClearedEvent>(OnWoundsCleared);
         SubscribeLocalEvent<WoundComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<WoundComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<WoundComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<WoundComponent, HealthBeingExaminedEvent>(OnHealthExamined);
     }
 
     private void OnStartup(EntityUid uid, WoundComponent comp, ComponentStartup args)
@@ -62,21 +61,25 @@ public sealed class WoundEffectsSystem : EntitySystem
             args.ModifySpeed(MovementSlowMultiplier);
     }
 
-    private void OnExamined(EntityUid uid, WoundComponent comp, ExaminedEvent args)
+    private void OnHealthExamined(EntityUid uid, WoundComponent comp, ref HealthBeingExaminedEvent args)
     {
-        var wounds = _display.GetWoundDisplayInfo(uid, comp);
-        if (wounds.Count == 0)
-            return;
-
-        using (args.PushGroup(nameof(WoundEffectsSystem)))
+        // Bleeding is already surfaced on the health-examine path by SharedBloodstreamSystem,
+        // so we only flavor-text fractures and burns here. Self-Aware viewers get a separate
+        // clinical readout via SelfAwareSystem and don't go through this event.
+        var fractureTier = _wounds.GetWorstTier(comp, WoundCategory.Fracture);
+        if (fractureTier > 0)
         {
-            args.PushMarkup(Loc.GetString("wound-examine-header"));
+            args.Message.PushNewline();
+            args.Message.AddMarkupOrThrow(
+                Loc.GetString($"wound-examine-fracture-{fractureTier}", ("target", uid)));
+        }
 
-            foreach (var wound in wounds)
-            {
-                var name = Loc.GetString(wound.LocKey);
-                args.PushMarkup($"  - {name}");
-            }
+        var burnTier = _wounds.GetWorstTier(comp, WoundCategory.Burn);
+        if (burnTier > 0)
+        {
+            args.Message.PushNewline();
+            args.Message.AddMarkupOrThrow(
+                Loc.GetString($"wound-examine-burn-{burnTier}", ("target", uid)));
         }
     }
 

--- a/Resources/Locale/en-US/@RussStation/wounds/wounds.ftl
+++ b/Resources/Locale/en-US/@RussStation/wounds/wounds.ftl
@@ -41,6 +41,16 @@ wound-bleed-piercing-3 = Hemorrhaging
 wound-examine-entry = {$name} (Tier {$tier})
 wound-examine-header = [bold]Wounds:[/bold]
 
+# Flavor lines pushed onto the health-verb examine for external observers.
+# Self-Aware characters get a clinical readout via SelfAwareSystem instead.
+wound-examine-fracture-1 = [color=#CED2D1]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-BE($target) } favoring an injured limb.[/color]
+wound-examine-fracture-2 = [color=#FF8787]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } a clearly broken bone.[/color]
+wound-examine-fracture-3 = [color=#FF3636]{ CAPITALIZE(POSS-ADJ($target)) } bones look horribly shattered.[/color]
+
+wound-examine-burn-1 = [color=#FFA8A8]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } angry red burns.[/color]
+wound-examine-burn-2 = [color=#FF6868]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } severe burns across { POSS-ADJ($target) } skin.[/color]
+wound-examine-burn-3 = [color=#FF2121]{ CAPITALIZE(POSS-ADJ($target)) } flesh is charred and blistered.[/color]
+
 # HUD Alerts
 alerts-wound-fracture-name = { $severity ->
     [0] Hairline Fracture


### PR DESCRIPTION
Closes #435.

## About the PR

`WoundEffectsSystem.OnExamined` was subscribed to `ExaminedEvent`, dumping a clinical wound list (\"Wounds: - Compound Fracture (Tier 2)\") onto every on-hover examine. This moves it to `HealthBeingExaminedEvent` so wounds appear under the health-examine verb, alongside existing damage state, and replaces the structured list with qualitative flavor sentences in the same voice as the upstream `health-examinable` lines.

## Why / Balance

- Default examine stops being cluttered with medical detail nobody asked for.
- Wound info ends up where medics already look (the same verb that shows damage state).
- Tier numbers are no longer leaked to external observers, which matches how upstream conveys damage qualitatively.

## Technical details

- `WoundEffectsSystem.OnExamined(ExaminedEvent)` is replaced by `OnHealthExamined(HealthBeingExaminedEvent)`. The new handler reads `GetWorstTier(Fracture)` and `GetWorstTier(Burn)` and pushes one localized line per non-zero category onto `args.Message`.
- `Bleeding` is intentionally not touched here because `SharedBloodstreamSystem.OnHealthBeingExamined` already pushes bleed flavor onto the same event from upstream code; we'd just duplicate it.
- Six new `wound-examine-{fracture,burn}-{1,2,3}` flavor lines in `Resources/Locale/en-US/@RussStation/wounds/wounds.ftl`, using the same `CAPITALIZE / SUBJECT / CONJUGATE-* / POSS-ADJ` Fluent helpers as `health-examinable-carbon-*`.
- The clinical wound name keys (`wound-bluntfracture-1`, etc.) and `wound-examine-header` are left in place because `HealthAnalyzerSystem` and `SelfAwareSystem` still consume them via `WoundDisplaySystem.GetWoundDisplayInfo`.

### Self-Aware interaction

The Self-Aware trait only intercepts the health verb when the user examines *themselves* (`if (args.User != ent.Owner) return;`). On self, it builds its own markup directly via `GetWoundDisplayInfo` and never raises `HealthBeingExaminedEvent`, so its clinical wound listing is unchanged. Self-Aware viewers examining *other* characters now go through this PR's flavor path, the same as everyone else, which matches the trait's intent (self-knowledge, not better diagnosis on others).

## Media

No sprite or sound work. Examine UI text only.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None. Locale-only additions and an event-subscription move within fork-owned code.

:cl:
- tweak: Wounds no longer clutter the standard examine. Use the health-examine verb to see fracture and burn descriptions in flavor text instead of a clinical tier list.