### PR TITLE
Move fork clone-trait list off upstream clone.yml

### DIFF
--- a/Content.Server/RussStation/Cloning/RussStationCloningSystem.cs
+++ b/Content.Server/RussStation/Cloning/RussStationCloningSystem.cs
@@ -1,0 +1,48 @@
+using Content.Shared.Cloning;
+using Content.Shared.Cloning.Events;
+using Content.Shared.Humanoid;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Cloning;
+
+/// <summary>
+/// Copies fork-side trait components onto clones via a side-channel
+/// CloningSettings prototype, so adding a new fork trait does not require
+/// editing upstream clone.yml.
+/// </summary>
+public sealed class RussStationCloningSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    /// <summary>
+    /// ID of the fork-side cloningSettings prototype whose Components hashset
+    /// lists every trait component the fork wants copied during cloning.
+    /// </summary>
+    public static readonly ProtoId<CloningSettingsPrototype> ForkExtensionsId = "RussStationBodyExtensions";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<HumanoidProfileComponent, CloningEvent>(OnCloned);
+    }
+
+    private void OnCloned(Entity<HumanoidProfileComponent> ent, ref CloningEvent args)
+    {
+        if (!_proto.TryIndex(ForkExtensionsId, out var extensions))
+            return;
+
+        foreach (var componentName in extensions.Components)
+        {
+            if (!Factory.TryGetRegistration(componentName, out var registration))
+            {
+                Log.Error($"RussStationCloningSystem: invalid component name in {ForkExtensionsId}: {componentName}");
+                continue;
+            }
+
+            // Mirror upstream CloneComponents: clone gets the component iff the original has it.
+            RemComp(args.CloneUid, registration.Type);
+            if (EntityManager.TryGetComponent(ent.Owner, registration.Type, out var sourceComp))
+                CopyComp(ent.Owner, args.CloneUid, sourceComp);
+        }
+    }
+}

--- a/Resources/Prototypes/@RussStation/Cloning/clone_extensions.yml
+++ b/Resources/Prototypes/@RussStation/Cloning/clone_extensions.yml
@@ -1,0 +1,38 @@
+# Fork-side trait registration for cloning.
+#
+# Components listed here are copied from the original to the clone whenever a
+# humanoid is cloned, regardless of which CloningSettings the cloner used.
+# RussStationCloningSystem reads this prototype on every CloningEvent and
+# applies the same copy-iff-original-has-it rule that the upstream CloneComponents
+# loop uses.
+#
+# Add new fork traits here instead of editing
+# Resources/Prototypes/Entities/Mobs/Player/clone.yml.
+- type: cloningSettings
+  id: RussStationBodyExtensions
+  components:
+    # traits
+    - Ageusia
+    - AlcoholTolerance
+    - BloodDeficiency
+    - BoomingVoice
+    - Frail
+    - Freerunning
+    - GlassJaw
+    - Indebted
+    - IronJaw
+    - LightStep
+    - Negotiator
+    - Papyrophobia
+    - PoorAim
+    - Prosopagnosia
+    - ScarredEye
+    - SelfAware
+    - Skittish
+    - SoftSpoken
+    - SteadyHand
+    - ThrowingArm
+    - Touchy
+    - Tough
+    - Vegetarian
+    - WeakArm

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -30,32 +30,8 @@
   - PermanentBlindness
   - Snoring
   - Unrevivable
-  # HONK START - fork-added trait components copied to clones
-  - Ageusia
-  - AlcoholTolerance
-  - BlockWriting
-  - BloodDeficiency
-  - BoomingVoice
-  - Frail
-  - Freerunning
-  - GlassJaw
-  - Indebted
-  - IronJaw
-  - LightStep
-  - Negotiator
-  - Papyrophobia
-  - PoorAim
-  - Prosopagnosia
-  - ScarredEye
-  - SelfAware
-  - Skittish
-  - SoftSpoken
-  - SteadyHand
-  - ThrowingArm
-  - Touchy
-  - Tough
-  - Vegetarian
-  - WeakArm
+  # HONK START - fork traits live in Resources/Prototypes/@RussStation/Cloning/clone_extensions.yml
+  # and are copied by RussStationCloningSystem on CloningEvent.
   # HONK END
   # accents
   - Accentless


### PR DESCRIPTION
## About the PR

Fork traits no longer need a line in upstream `Resources/Prototypes/Entities/Mobs/Player/clone.yml` to be preserved through cloning. Instead, they live in a fork-side `cloningSettings` prototype called `RussStationBodyExtensions`, and a new server system copies them onto the clone via the existing `CloningEvent` hook.

## Why

Every new fork trait used to mean another HONK-marked line in upstream `clone.yml`, which is one of the more rebase-fragile spots in the tree. The upstream comment in that file even hints at the right escape hatch ("Subscribe to CloningEvent instead if that is not enough"), so this PR just takes them up on it. After this, adding a new fork trait to the clone path is one line in a fork-only YAML file and zero touches to upstream.

## Technical details

- `Content.Server/RussStation/Cloning/RussStationCloningSystem.cs` subscribes to `CloningEvent` on `HumanoidProfileComponent` (the same gate `CloningSystem.TryCloning` uses) and walks the `Components` set on the `RussStationBodyExtensions` cloningSettings prototype. For each component it does the same thing the upstream `CloneComponents` loop does: `RemComp` on the clone, then `CopyComp` from the original if the original has it. This matches the "clone matches original" invariant for any clone path that previously inherited from `Body`, including paradox clones and changeling identity copies.
- `Resources/Prototypes/@RussStation/Cloning/clone_extensions.yml` declares `RussStationBodyExtensions` with the 24 fork traits that used to be HONK-marked in upstream `clone.yml` (Ageusia, AlcoholTolerance, BloodDeficiency, BoomingVoice, Frail, Freerunning, GlassJaw, Indebted, IronJaw, LightStep, Negotiator, Papyrophobia, PoorAim, Prosopagnosia, ScarredEye, SelfAware, Skittish, SoftSpoken, SteadyHand, ThrowingArm, Touchy, Tough, Vegetarian, WeakArm).
- Upstream `clone.yml` loses all 24 HONK lines and gets a 3-line HONK pointer comment instead, so future rebasers can find the new home.

The `RussStationBodyExtensions` prototype is never inherited from or referenced by `parent:` in any other cloningSettings, so it does not perturb upstream inheritance.

## Media

No visuals.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None for players. For fork developers: new traits should be registered in `clone_extensions.yml`, not `clone.yml`.

:cl:
- tweak: Cloning still preserves all the same fork traits it did before; the registration just lives in a fork-side file now.