### PR TITLE
refactor: inject EntityQuery<T> in hot-path fork systems

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -35,6 +35,9 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
 
+    [Dependency] private readonly EntityQuery<SurgeryDrapedComponent> _drapedQuery = default!;
+    [Dependency] private readonly EntityQuery<ActiveSurgeryComponent> _activeSurgeryQuery = default!;
+
     private List<string> _cachedProcedureIds = new();
 
     public override void Initialize()
@@ -85,7 +88,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
         // Draping tool on non-draped patient -> open procedure selection
         if (_tool.HasQuality(used, DrapingQuality)
-            && !HasComp<SurgeryDrapedComponent>(target))
+            && !_drapedQuery.HasComp(target))
         {
             if (!_standing.IsDown(target.Owner))
             {
@@ -101,8 +104,8 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
 
         // Organ used on draped patient with active surgery -> insert directly
-        if (HasComp<OrganComponent>(used) && HasComp<SurgeryDrapedComponent>(target) &&
-            HasComp<ActiveSurgeryComponent>(target))
+        if (HasComp<OrganComponent>(used) && _drapedQuery.HasComp(target) &&
+            _activeSurgeryQuery.HasComp(target))
         {
             TryInsertOrgan(user, target, used);
             args.Handled = true;
@@ -110,11 +113,11 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
 
         // Tool used on draped patient -> surgery interaction
-        if (!HasComp<ToolComponent>(used) || !HasComp<SurgeryDrapedComponent>(target))
+        if (!HasComp<ToolComponent>(used) || !_drapedQuery.HasComp(target))
             return;
 
         // Cautery universal close on active surgery
-        if (IsCauteryTool(used) && HasComp<ActiveSurgeryComponent>(target))
+        if (IsCauteryTool(used) && _activeSurgeryQuery.HasComp(target))
         {
             StartCauteryClose(user, target, used);
             args.Handled = true;
@@ -122,7 +125,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
 
         // Active surgery: advance step
-        if (TryComp<ActiveSurgeryComponent>(target, out var active) && active.ProcedureId != null)
+        if (_activeSurgeryQuery.TryComp(target, out var active) && active.ProcedureId != null)
         {
             TryAdvanceStep(user, target, used, active);
             args.Handled = true;
@@ -183,7 +186,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             return;
 
         // Validate: patient must still be down and not already draped
-        if (HasComp<SurgeryDrapedComponent>(target.Value))
+        if (_drapedQuery.HasComp(target.Value))
         {
             _popup.PopupEntity(Loc.GetString("surgery-already-draped"), target.Value, surgeon);
             return;

--- a/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs
+++ b/Content.Shared/RussStation/Weapons/Ranged/ActionGunExtSystem.cs
@@ -19,6 +19,9 @@ public sealed class ActionGunExtSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
+    [Dependency] private readonly EntityQuery<ActionGunExtComponent> _extQuery = default!;
+    [Dependency] private readonly EntityQuery<ActionGunComponent> _actionGunQuery = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -42,7 +45,7 @@ public sealed class ActionGunExtSystem : EntitySystem
     /// </summary>
     private void OnGunShot(Entity<GunComponent> gun, ref GunShotEvent args)
     {
-        if (!TryComp<ActionGunExtComponent>(args.User, out var ext))
+        if (!_extQuery.TryComp(args.User, out var ext))
             return;
 
         if (ext.OnShootSound == null)
@@ -50,7 +53,7 @@ public sealed class ActionGunExtSystem : EntitySystem
 
         // Only fire when the shot is from the mob's action gun, not a regular
         // held weapon. Otherwise every humanoid plays the spit sound on any shot.
-        if (!TryComp<ActionGunComponent>(args.User, out var actionGun) || actionGun.Gun != gun.Owner)
+        if (!_actionGunQuery.TryComp(args.User, out var actionGun) || actionGun.Gun != gun.Owner)
             return;
 
         _audio.PlayPredicted(ext.OnShootSound, args.User, actionGun.ActionEntity);


### PR DESCRIPTION
## About the PR

Second slice of the `EntityQuery<T>` DI migration. First slice (`AtmosRadiationPulseSystem` + `SharedCarryingSystem`) landed in #478. Part of #471.

Covered here:
- `Content.Server/.../Surgery/SurgerySystem` (drape + active surgery checks in `AfterInteractUsing`)
- `ActionGunExtSystem` (`GunShotEvent` fires on every shot)

## Why / Balance

Not a balance change. Pure perf refactor. `_query.TryComp` skips the component registration dictionary lookup that `TryComp<T>` does per call, which matters on events that fire on every shot or every surgery interaction.

Cold-path fork systems kept their `TryComp` calls. Issue #471's acceptance criteria was explicit: hot-path only, no mass migration for the sake of style uniformity.

## Technical details

Pattern is the same everywhere:

\`\`\`csharp
[Dependency] private readonly EntityQuery<FooComponent> _fooQuery = default!;

// then
if (_fooQuery.TryComp(uid, out var foo)) { ... }
if (_fooQuery.HasComp(uid)) { ... }
\`\`\`

Rule used: inject for components referenced 2+ times in a hot handler. Single-use lookups stay on `TryComp`/`HasComp` since adding a field for one call site is more noise than win.

### Left alone (intentional)

- `SharedSurgerySystem` (the base class) wasn't touched. Its `TryComp` calls are all in `GetStepDuration`, called once per surgery step start, not hot enough to justify field noise.
- Every other fork system under `Content.Shared/RussStation`, `Content.Server/RussStation`, `Content.Client/RussStation`. Out of scope.

## Media

N/A, refactor.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None. Behaviorally identical.