### PR TITLE
refactor: migrate RussStation integration tests to GameTest

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Atmos/GasReactionTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Atmos/GasReactionTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.RussStation.Atmos;
@@ -17,22 +18,20 @@ namespace Content.IntegrationTests.Tests.RussStation.Atmos;
 /// <see cref="ReactionHelper.AdjustEnergy"/> directly because every reaction
 /// depends on it.
 /// </summary>
-[TestFixture]
-public sealed class GasReactionTest
+public sealed class GasReactionTest : GameTest
 {
     private const double Tol = 1e-3;
 
     /// <summary>
-    /// Spins up a server pool, builds a fresh mixture, runs the reaction, and
-    /// hands the result to <paramref name="assert"/>. Keeps each test body tiny.
+    /// Builds a fresh mixture, runs the reaction, and hands the result to
+    /// <paramref name="assert"/>. Keeps each test body tiny.
     /// </summary>
-    private static async Task TestReaction<T>(
+    private async Task TestReaction<T>(
         Action<GasMixture> setup,
         Action<ReactionResult, GasMixture, AtmosphereSystem> assert)
         where T : IGasReactionEffect, new()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var atmos = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
 
         await server.WaitAssertion(() =>
@@ -42,8 +41,6 @@ public sealed class GasReactionTest
             var result = new T().React(mix, null, atmos, 1f);
             assert(result, mix, atmos);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // ---- HydrogenFire ------------------------------------------------------
@@ -519,8 +516,7 @@ public sealed class GasReactionTest
     [Test]
     public async Task AdjustEnergy_PositiveEnergy_HeatsMixture()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var atmos = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
 
         await server.WaitAssertion(() =>
@@ -531,15 +527,12 @@ public sealed class GasReactionTest
             ReactionHelper.AdjustEnergy(mix, atmos, oldCap, 100_000f, 1f);
             Assert.That(mix.Temperature, Is.GreaterThan(300f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AdjustEnergy_NegativeEnergy_CoolsMixture()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var atmos = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
 
         await server.WaitAssertion(() =>
@@ -550,15 +543,12 @@ public sealed class GasReactionTest
             ReactionHelper.AdjustEnergy(mix, atmos, oldCap, -50_000f, 1f);
             Assert.That(mix.Temperature, Is.LessThan(300f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AdjustEnergy_ExtremeNegativeEnergy_ClampsToTCMB()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var atmos = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
 
         await server.WaitAssertion(() =>
@@ -569,15 +559,12 @@ public sealed class GasReactionTest
             ReactionHelper.AdjustEnergy(mix, atmos, oldCap, -1_000_000_000f, 1f);
             Assert.That(mix.Temperature, Is.EqualTo(Atmospherics.TCMB).Within(Tol));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AdjustEnergy_HeatScaleHalves_HalvesEnergyApplied()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var atmos = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
 
         await server.WaitAssertion(() =>
@@ -602,7 +589,5 @@ public sealed class GasReactionTest
                 Assert.That(delta2, Is.EqualTo(delta1 / 2f).Within(0.1));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Botany/SeedExtractorStorageTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Botany/SeedExtractorStorageTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Botany.Components;
 using Content.Shared.RussStation.Botany.Components;
 using Robust.Shared.Containers;
@@ -5,9 +6,8 @@ using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Botany;
 
-[TestFixture]
 [TestOf(typeof(SeedExtractorStorageComponent))]
-public sealed class SeedExtractorStorageTest
+public sealed class SeedExtractorStorageTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -34,10 +34,9 @@ public sealed class SeedExtractorStorageTest
     [Test]
     public async Task ComponentRegistered()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -48,8 +47,6 @@ public sealed class SeedExtractorStorageTest
             var comp = entityManager.GetComponent<SeedExtractorStorageComponent>(extractor);
             Assert.That(comp.SeedContainerId, Is.EqualTo("seed_extractor_seeds"));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -58,11 +55,10 @@ public sealed class SeedExtractorStorageTest
     [Test]
     public async Task SeedInsertionIntoContainer()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
         var containerSystem = server.ResolveDependency<IEntityManager>().System<SharedContainerSystem>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -76,8 +72,6 @@ public sealed class SeedExtractorStorageTest
             Assert.That(container.ContainedEntities, Has.Count.EqualTo(1));
             Assert.That(container.ContainedEntities[0], Is.EqualTo(seed));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -86,10 +80,9 @@ public sealed class SeedExtractorStorageTest
     [Test]
     public async Task SeedEntityHasSeedComponent()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -97,8 +90,6 @@ public sealed class SeedExtractorStorageTest
 
             Assert.That(entityManager.HasComponent<SeedComponent>(seed), Is.True);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -107,11 +98,10 @@ public sealed class SeedExtractorStorageTest
     [Test]
     public async Task MultipleSeedsCanBeStored()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
         var containerSystem = server.ResolveDependency<IEntityManager>().System<SharedContainerSystem>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -128,7 +118,5 @@ public sealed class SeedExtractorStorageTest
             Assert.That(containerSystem.Insert(seed3, container), Is.True);
             Assert.That(container.ContainedEntities, Has.Count.EqualTo(3));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
@@ -1,13 +1,18 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Buckle.Components;
 using Content.Shared.RussStation.Carrying.Components;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Carrying;
 
-[TestFixture]
 [TestOf(typeof(ActiveCarrierComponent))]
-public sealed class CarryStateValidationTest
+public sealed class CarryStateValidationTest : GameTest
 {
+    // Orphan-cleanup tests emit an expected WARN log ("Cleaned orphaned carry state")
+    // which GameTest teardown would otherwise treat as a test failure. Destructive
+    // pairs skip the ReportErrorLogs step entirely.
+    public override PoolSettings PoolSettings => new() { Connected = true, Destructive = true };
+
     [TestPrototypes]
     private const string Prototypes = @"
 - type: entity
@@ -74,10 +79,9 @@ public sealed class CarryStateValidationTest
     [Test]
     public async Task OrphanedActiveCarrierGetsCleaned()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         EntityUid carrier = default;
 
@@ -93,15 +97,13 @@ public sealed class CarryStateValidationTest
         });
 
         // Wait for the 1-second validation tick to fire.
-        await pair.RunSeconds(2);
+        await Pair.RunSeconds(2);
 
         await server.WaitAssertion(() =>
         {
             Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
                 "Orphaned ActiveCarrierComponent should be cleaned by validation");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -113,10 +115,9 @@ public sealed class CarryStateValidationTest
     [Test]
     public async Task DeletedTargetGetsCleaned()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         EntityUid carrier = default;
 
@@ -134,15 +135,13 @@ public sealed class CarryStateValidationTest
             Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
         });
 
-        await pair.RunSeconds(2);
+        await Pair.RunSeconds(2);
 
         await server.WaitAssertion(() =>
         {
             Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
                 "ActiveCarrierComponent should be removed when Carrying is null");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -152,10 +151,9 @@ public sealed class CarryStateValidationTest
     [Test]
     public async Task BuckleAttemptAllowedWhileCarried()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -177,8 +175,6 @@ public sealed class CarryStateValidationTest
             Assert.That(ev.Cancelled, Is.False,
                 "Buckling should be allowed while carried (carry gets dropped, buckle goes through)");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -188,10 +184,9 @@ public sealed class CarryStateValidationTest
     [Test]
     public async Task BuckleAttemptUnaffectedWhenNotCarried()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -213,7 +208,5 @@ public sealed class CarryStateValidationTest
             Assert.That(ev.Cancelled, Is.False,
                 "BuckleAttemptEvent should not be affected when entity is not being carried");
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryingTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryingTest.cs
@@ -1,11 +1,11 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.RussStation.Carrying.Components;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Carrying;
 
-[TestFixture]
 [TestOf(typeof(CarrierComponent))]
-public sealed class CarryingTest
+public sealed class CarryingTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -66,10 +66,9 @@ public sealed class CarryingTest
     [Test]
     public async Task CarrierComponentDefaults()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -80,8 +79,6 @@ public sealed class CarryingTest
             Assert.That(comp.WalkSpeedModifier, Is.EqualTo(0.75f));
             Assert.That(comp.SprintSpeedModifier, Is.EqualTo(0.6f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -90,10 +87,9 @@ public sealed class CarryingTest
     [Test]
     public async Task CarriableComponentDefaults()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -102,8 +98,6 @@ public sealed class CarryingTest
 
             Assert.That(comp.CarriedBy, Is.Null);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -113,10 +107,9 @@ public sealed class CarryingTest
     [Test]
     public async Task ComponentsRegistered()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -128,8 +121,6 @@ public sealed class CarryingTest
             Assert.That(entityManager.HasComponent<CarriableComponent>(target), Is.True);
             Assert.That(entityManager.HasComponent<CarrierComponent>(target), Is.False);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -139,10 +130,9 @@ public sealed class CarryingTest
     [Test]
     public async Task MarkerComponentsAbsentByDefault()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -152,7 +142,5 @@ public sealed class CarryingTest
             Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False);
             Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.RussStation.Economy;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -9,9 +10,8 @@ using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.RussStation.Economy;
 
-[TestFixture]
 [TestOf(typeof(PayrollSystem))]
-public sealed class PayrollJobUpdateTest
+public sealed class PayrollJobUpdateTest : GameTest
 {
     /// <summary>
     /// Verifies that when a role is added mid-round via RoleAddedEvent,
@@ -22,8 +22,7 @@ public sealed class PayrollJobUpdateTest
     [Test]
     public async Task RoleAddedUpdatesJobIdTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
 
@@ -49,8 +48,6 @@ public sealed class PayrollJobUpdateTest
             Assert.That(balance.JobId, Is.EqualTo("StationEngineer"),
                 "JobId should be updated to the new role after RoleAddedEvent.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -60,8 +57,7 @@ public sealed class PayrollJobUpdateTest
     [Test]
     public async Task NonJobRoleDoesNotClearJobIdTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
 
@@ -84,7 +80,5 @@ public sealed class PayrollJobUpdateTest
             Assert.That(balance.JobId, Is.EqualTo("StationEngineer"),
                 "JobId should remain unchanged when a non-job role is added.");
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Economy/VendingContrabandPricingTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/VendingContrabandPricingTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.RussStation.Economy;
 using Content.Shared.RussStation.Economy.Components;
 using Content.Shared.VendingMachines;
@@ -7,9 +8,8 @@ namespace Content.IntegrationTests.Tests.RussStation.Economy;
 /// <summary>
 /// Verifies that emag and contraband vending items are not priced.
 /// </summary>
-[TestFixture]
 [TestOf(typeof(VendingPaymentSystem))]
-public sealed class VendingContrabandPricingTest
+public sealed class VendingContrabandPricingTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -51,8 +51,7 @@ public sealed class VendingContrabandPricingTest
     [Test]
     public async Task EmagAndContrabandItemsHaveNoPriceTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entMan = server.EntMan;
 
         await server.WaitAssertion(() =>
@@ -78,7 +77,5 @@ public sealed class VendingContrabandPricingTest
 
             entMan.DeleteEntity(vendor);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/EscalatedGrab/EscalatedGrabTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/EscalatedGrab/EscalatedGrabTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.RussStation.EscalatedGrab;
@@ -7,9 +8,8 @@ using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.EscalatedGrab;
 
-[TestFixture]
 [TestOf(typeof(SharedEscalatedGrabSystem))]
-public sealed class EscalatedGrabTest
+public sealed class EscalatedGrabTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -47,10 +47,9 @@ public sealed class EscalatedGrabTest
     [Test]
     public async Task DefaultStageIsPull()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -61,8 +60,6 @@ public sealed class EscalatedGrabTest
 
             Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Pull));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -71,10 +68,9 @@ public sealed class EscalatedGrabTest
     [Test]
     public async Task TryEscalateSetsAggressive()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -87,8 +83,6 @@ public sealed class EscalatedGrabTest
             Assert.That(entityManager.HasComponent<GrabStateComponent>(puller), Is.True);
             Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Aggressive));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -97,10 +91,9 @@ public sealed class EscalatedGrabTest
     [Test]
     public async Task TryEscalateSameTargetIdempotent()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -113,8 +106,6 @@ public sealed class EscalatedGrabTest
             Assert.That(grabSystem.TryEscalate(puller, target), Is.True);
             Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Aggressive));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -123,10 +114,9 @@ public sealed class EscalatedGrabTest
     [Test]
     public async Task HasStageChecksMinimum()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -145,8 +135,6 @@ public sealed class EscalatedGrabTest
             Assert.That(grabSystem.HasStage(puller, target, GrabStage.Pull), Is.True);
             Assert.That(grabSystem.HasStage(puller, target, GrabStage.Aggressive), Is.True);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -155,10 +143,9 @@ public sealed class EscalatedGrabTest
     [Test]
     public async Task ClearEscalationResetsStage()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -174,8 +161,6 @@ public sealed class EscalatedGrabTest
             Assert.That(entityManager.HasComponent<GrabStateComponent>(puller), Is.False);
             Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Pull));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -184,10 +169,9 @@ public sealed class EscalatedGrabTest
     [Test]
     public async Task GetStagePerTarget()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -203,7 +187,5 @@ public sealed class EscalatedGrabTest
             // Different target should still be Pull (GrabStateComponent tracks one target)
             Assert.That(grabSystem.GetStage(puller, target2), Is.EqualTo(GrabStage.Pull));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Foldable/DeployFoldableDragDropTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Foldable/DeployFoldableDragDropTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.DragDrop;
 using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
@@ -5,9 +6,8 @@ using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Foldable;
 
-[TestFixture]
 [TestOf(typeof(DeployFoldableSystem))]
-public sealed class DeployFoldableDragDropTest
+public sealed class DeployFoldableDragDropTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -43,11 +43,10 @@ public sealed class DeployFoldableDragDropTest
     [Test]
     public async Task CanDropFoldableOntoSelfTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -61,8 +60,6 @@ public sealed class DeployFoldableDragDropTest
             Assert.That(canDrop.Handled, Is.True, "CanDropTargetEvent should be handled");
             Assert.That(canDrop.CanDrop, Is.True, "Should allow dropping foldable onto self");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -72,11 +69,10 @@ public sealed class DeployFoldableDragDropTest
     [Test]
     public async Task CannotDropAlreadyFoldedOntoSelfTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -96,8 +92,6 @@ public sealed class DeployFoldableDragDropTest
 
             Assert.That(canDrop.CanDrop, Is.False, "Should not allow dropping already-folded entity onto self");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -107,11 +101,10 @@ public sealed class DeployFoldableDragDropTest
     [Test]
     public async Task CannotDropNonFoldableOntoSelfTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -124,8 +117,6 @@ public sealed class DeployFoldableDragDropTest
 
             Assert.That(canDrop.CanDrop, Is.False, "Should not handle non-foldable entities");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -134,11 +125,10 @@ public sealed class DeployFoldableDragDropTest
     [Test]
     public async Task DropFoldableOntoSelfFoldsEntityTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -155,8 +145,6 @@ public sealed class DeployFoldableDragDropTest
             Assert.That(dropEvent.Handled, Is.True, "DragDropTargetEvent should be handled");
             Assert.That(foldComp.IsFolded, Is.True, "Entity should be folded after drag-drop onto self");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -166,11 +154,10 @@ public sealed class DeployFoldableDragDropTest
     [Test]
     public async Task CannotDropOntoOtherPlayerTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -184,7 +171,5 @@ public sealed class DeployFoldableDragDropTest
 
             Assert.That(canDrop.CanDrop, Is.False, "Should not allow dropping onto a different player");
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Storage/LockerAirtightWeldTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Storage/LockerAirtightWeldTest.cs
@@ -1,11 +1,11 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Storage;
 
-[TestFixture]
-public sealed class LockerAirtightWeldTest
+public sealed class LockerAirtightWeldTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -24,10 +24,9 @@ public sealed class LockerAirtightWeldTest
     [Test]
     public async Task WeldingTogglesAirtight()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -48,8 +47,6 @@ public sealed class LockerAirtightWeldTest
 
             Assert.That(storage.Airtight, Is.False, "Locker should not be airtight after unwelding");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -59,10 +56,9 @@ public sealed class LockerAirtightWeldTest
     [Test]
     public async Task DefaultLockerNotAirtight()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -71,7 +67,5 @@ public sealed class LockerAirtightWeldTest
 
             Assert.That(storage.Airtight, Is.False);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Surgery/OrganInsertionTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Surgery/OrganInsertionTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.RussStation.Surgery;
 using Content.Shared.Body;
 using Content.Shared.Body.Components;
@@ -9,9 +10,8 @@ using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.RussStation.Surgery;
 
-[TestFixture]
 [TestOf(typeof(SurgerySystem))]
-public sealed class OrganInsertionTest
+public sealed class OrganInsertionTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -52,11 +52,10 @@ public sealed class OrganInsertionTest
     [Test]
     public async Task NullCategoryDuplicateBlockedTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -82,8 +81,6 @@ public sealed class OrganInsertionTest
             Assert.That(body.Organs.ContainedEntities, Does.Not.Contain(implant2),
                 "Duplicate null-category organ of same prototype should be blocked.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -93,11 +90,10 @@ public sealed class OrganInsertionTest
     [Test]
     public async Task DifferentNullCategoryPrototypesAllowedTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -119,8 +115,6 @@ public sealed class OrganInsertionTest
             Assert.That(body.Organs.ContainedEntities, Does.Contain(implantB),
                 "Different null-category prototypes should both be allowed.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -130,11 +124,10 @@ public sealed class OrganInsertionTest
     [Test]
     public async Task SameCategoryDuplicateBlockedTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -156,8 +149,6 @@ public sealed class OrganInsertionTest
             Assert.That(body.Organs.ContainedEntities, Does.Not.Contain(heart2),
                 "Second heart (same category) should be blocked.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     private static void RaiseInteract(

--- a/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.RussStation.Surgery;
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
@@ -10,9 +11,8 @@ using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.RussStation.Surgery;
 
-[TestFixture]
 [TestOf(typeof(SharedSurgerySystem))]
-public sealed class SurgerySystemTest
+public sealed class SurgerySystemTest : GameTest
 {
     private const string TestProcedureId = "SurgeryTestProcedure";
     private const string TestProcedureMajorId = "SurgeryTestProcedureMajor";
@@ -162,8 +162,7 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task ProcedurePrototypesLoadTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -173,8 +172,6 @@ public sealed class SurgerySystemTest
             Assert.That(proto.Steps[0].Quality.Id, Is.EqualTo("Slicing"));
             Assert.That(proto.Steps[1].Quality.Id, Is.EqualTo("Retracting"));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -184,8 +181,7 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task AllProcedurePrototypesValidTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -207,8 +203,6 @@ public sealed class SurgerySystemTest
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -217,12 +211,11 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task ToolMatchesStepTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoManager = server.ResolveDependency<IPrototypeManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -240,8 +233,6 @@ public sealed class SurgerySystemTest
             Assert.That(surgerySystem.ToolMatchesStep(retractor, proto.Steps[0]), Is.False);
             Assert.That(surgerySystem.ToolMatchesStep(retractor, proto.Steps[1]), Is.True);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -251,12 +242,11 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task ToolMatchesStepIgnoresTierTagTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoManager = server.ResolveDependency<IPrototypeManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -269,8 +259,6 @@ public sealed class SurgerySystemTest
             // ToolMatchesStep only checks the quality, so this matches
             Assert.That(surgerySystem.ToolMatchesStep(nonTool, proto!.Steps[0]), Is.True);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -279,11 +267,10 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task IsCauteryToolTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -295,8 +282,6 @@ public sealed class SurgerySystemTest
             Assert.That(surgerySystem.IsCauteryTool(cautery), Is.True);
             Assert.That(surgerySystem.IsCauteryTool(scalpel), Is.False);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -306,11 +291,10 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task SurfaceSpeedModifierTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -328,8 +312,6 @@ public sealed class SurgerySystemTest
             Assert.That(buckleSystem.TryBuckle(patient, patient, table, buckleComp: buckle), Is.True);
             Assert.That(surgerySystem.GetSurfaceSpeedModifier(patient), Is.EqualTo(1f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -339,11 +321,10 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task NonSurgerySurfaceReturnsDefaultModifierTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -359,8 +340,6 @@ public sealed class SurgerySystemTest
             Assert.That(buckleSystem.TryBuckle(patient, patient, chair, buckleComp: buckle), Is.True);
             Assert.That(surgerySystem.GetSurfaceSpeedModifier(patient), Is.EqualTo(2f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -371,11 +350,10 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task DrapeSpeedModifierTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -390,8 +368,6 @@ public sealed class SurgerySystemTest
             entityManager.AddComponent<SurgeryDrapedComponent>(patient);
             Assert.That(surgerySystem.GetDrapeSpeedModifier(patient), Is.EqualTo(1.5f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -413,8 +389,7 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task BaseStepDurationFallbackTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -430,8 +405,6 @@ public sealed class SurgerySystemTest
             // Clamping step also uses centralized default (2.0)
             Assert.That(SharedSurgerySystem.GetBaseStepDuration(majorProto.Steps[1]), Is.EqualTo(2.0f));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -440,12 +413,11 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task StepDurationCombinesAllModifiersTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoManager = server.ResolveDependency<IPrototypeManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -481,8 +453,6 @@ public sealed class SurgerySystemTest
             Assert.That(surgerySystem.GetStepDuration(step, patient, SurgeryDifficulty.Minor).TotalSeconds,
                 Is.EqualTo(1.2).Within(0.001));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -491,8 +461,7 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task ProcedureDifficultyLoadsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -503,8 +472,6 @@ public sealed class SurgerySystemTest
             protoManager.TryIndex<SurgeryProcedurePrototype>(TestProcedureMajorId, out var major);
             Assert.That(major!.Difficulty, Is.EqualTo(SurgeryDifficulty.Major));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -514,11 +481,10 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task ToolTierModifierAllBranchesTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -534,8 +500,6 @@ public sealed class SurgerySystemTest
             Assert.That(surgerySystem.GetToolTierModifier(experimental), Is.EqualTo(0.7f), "Experimental tier");
             Assert.That(surgerySystem.GetToolTierModifier(improvised), Is.EqualTo(1.5f), "Improvised (no tier tag)");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -545,12 +509,11 @@ public sealed class SurgerySystemTest
     [Test]
     public async Task ToolTierAffectsStepDurationTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoManager = server.ResolveDependency<IPrototypeManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -585,7 +548,5 @@ public sealed class SurgerySystemTest
             Assert.That(baseDuration * surgerySystem.GetToolTierModifier(improvisedTool),
                 Is.EqualTo(1.5f).Within(0.001f));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Surgery/SurgicalTraySystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Surgery/SurgicalTraySystemTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Foldable;
 using Content.Shared.Friction;
 using Content.Shared.RussStation.Surgery.Components;
@@ -6,9 +7,8 @@ using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Surgery;
 
-[TestFixture]
 [TestOf(typeof(SurgicalTraySystem))]
-public sealed class SurgicalTraySystemTest
+public sealed class SurgicalTraySystemTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -38,11 +38,10 @@ public sealed class SurgicalTraySystemTest
     [Test]
     public async Task FoldTogglesFrictionTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -64,8 +63,6 @@ public sealed class SurgicalTraySystemTest
             Assert.That(foldableSystem.TrySetFolded(tray, foldable, false), Is.True);
             Assert.That(friction.Modifier, Is.EqualTo(0.4f).Within(0.001f), "Unfolded friction restored");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -74,11 +71,10 @@ public sealed class SurgicalTraySystemTest
     [Test]
     public async Task DefaultFrictionValuesTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -88,7 +84,5 @@ public sealed class SurgicalTraySystemTest
             Assert.That(comp.FoldedFriction, Is.EqualTo(0.8f));
             Assert.That(comp.UnfoldedFriction, Is.EqualTo(0.4f));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Traits/TraitPointBuyTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Traits/TraitPointBuyTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Preferences;
 using Content.Shared.Traits;
 using Robust.Shared.Prototypes;
@@ -9,9 +10,8 @@ namespace Content.IntegrationTests.Tests.RussStation.Traits;
 /// Tests for the global trait point budget system (PR #376)
 /// and tag-based quirk exclusion system (PR #381).
 /// </summary>
-[TestFixture]
 [TestOf(typeof(HumanoidCharacterProfile))]
-public sealed class TraitPointBuyTest
+public sealed class TraitPointBuyTest : GameTest
 {
     // Test trait prototypes with tags and costs for integration testing.
     // MaxTraitPoints CVar defaults to 10.
@@ -78,8 +78,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_AddingTraitRemovesConflicting()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -97,8 +96,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("TestTraitA")),
                 "Conflicting trait should be removed when excluded by new trait.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -107,8 +104,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_NonConflictingTraitsCoexist()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -122,8 +118,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Contain(new ProtoId<TraitPrototype>("TestTraitC")),
                 "Non-conflicting traits should both be present.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -132,8 +126,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_TraitsWithoutTagNeverConflict()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -147,8 +140,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Contain(new ProtoId<TraitPrototype>("TestTraitNoTag")),
                 "Trait without a tag should never be excluded.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -157,8 +148,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task GetValidTraits_FiltersConflictingTraits()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -174,8 +164,6 @@ public sealed class TraitPointBuyTest
             Assert.That(valid, Does.Not.Contain(new ProtoId<TraitPrototype>("TestTraitB")),
                 "Second conflicting trait should be filtered out.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -184,8 +172,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task GlobalBudget_RejectsOverBudgetTrait()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -201,8 +188,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("TestTraitA")),
                 "Trait should be rejected when it would exceed global budget.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -211,8 +196,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task GlobalBudget_NegativeCostTraitsAlwaysAllowed()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -232,8 +216,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Contain(new ProtoId<TraitPrototype>("TestTraitCheap")),
                 "After negative-cost trait, budget should have room for more.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -242,8 +224,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task CategoryCap_RejectsOverCategoryLimit()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -260,8 +241,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Contain(new ProtoId<TraitPrototype>("TestTraitC")),
                 "Traits at exactly the category cap should be allowed.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -270,8 +249,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task GetValidTraits_RespectsGlobalBudget()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -287,8 +265,6 @@ public sealed class TraitPointBuyTest
             Assert.That(valid, Does.Not.Contain(new ProtoId<TraitPrototype>("TestTraitA")),
                 "Second trait should be filtered when it exceeds global budget.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -299,8 +275,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_UpstreamMutedRejectsForkBoomingVoice()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -314,8 +289,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("BoomingVoice")),
                 "BoomingVoice should be rejected when Muted is already taken (shared speech tag).");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -326,8 +299,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_BlindnessAndScarredEyeMutuallyExclusive()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -343,8 +315,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("Blindness")),
                 "Blindness should be removed by newer ScarredEye (shared sight tag).");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -355,8 +325,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_PainNumbnessAndSelfAwareMutuallyExclusive()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -372,8 +341,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("PainNumbness")),
                 "PainNumbness should be removed by newer SelfAware (shared awareness tag).");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -383,8 +350,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_ImpairedMobilityRejectsSkittish()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -398,8 +364,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("Skittish")),
                 "Skittish should be rejected when ImpairedMobility is already taken (sprint excluded).");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -409,8 +373,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagExclusion_SkittishRejectsImpairedMobility()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -426,8 +389,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Not.Contain(new ProtoId<TraitPrototype>("Skittish")),
                 "Skittish should be removed when ImpairedMobility is added (sprint tag excluded).");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -437,8 +398,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagCoexistence_SoftSpokenAndAccent()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -452,8 +412,6 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Contain(new ProtoId<TraitPrototype>("FrenchAccent")),
                 "SoftSpoken and an accent share the speech tag but neither excludes it; they should coexist.");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -463,8 +421,7 @@ public sealed class TraitPointBuyTest
     [Test]
     public async Task TagCoexistence_MutedAndTough()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -478,7 +435,5 @@ public sealed class TraitPointBuyTest
             Assert.That(profile.TraitPreferences, Does.Contain(new ProtoId<TraitPrototype>("Tough")),
                 "Muted (speech domain) and Tough (wounds domain) share no tags and should coexist.");
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Weapons/ActionGunTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Weapons/ActionGunTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.RussStation.Weapons.Ranged;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
@@ -8,9 +9,8 @@ namespace Content.IntegrationTests.Tests.RussStation.Weapons;
 /// Tests for ActionGunExtComponent (fork-owned popup and sound fields for ActionGun entities).
 /// Uses the real game prototypes to avoid the complexity of setting up test action pipelines.
 /// </summary>
-[TestFixture]
 [TestOf(typeof(ActionGunExtComponent))]
-public sealed class ActionGunExtTest
+public sealed class ActionGunExtTest : GameTest
 {
     /// <summary>
     /// Verifies that the spit ActionGun entity (from species_appearance.yml) loads
@@ -19,8 +19,7 @@ public sealed class ActionGunExtTest
     [Test]
     public async Task SpitPrototypeHasExtFields()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
@@ -42,8 +41,6 @@ public sealed class ActionGunExtTest
             Assert.That(actionSpitExists, Is.True, "ActionSpit prototype should exist");
             Assert.That(projectileSpitExists, Is.True, "ProjectileSpit prototype should exist");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -53,10 +50,9 @@ public sealed class ActionGunExtTest
     [Test]
     public async Task ActionGunExtComponentDefaultValues()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
+        var server = Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await pair.CreateTestMap();
+        var mapData = await Pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
@@ -66,7 +62,5 @@ public sealed class ActionGunExtTest
             Assert.That(comp.PopupText, Is.Null, "PopupText should default to null");
             Assert.That(comp.OnShootSound, Is.Null, "OnShootSound should default to null");
         });
-
-        await pair.CleanReturnAsync();
     }
 }


### PR DESCRIPTION
## About the PR

Closes #470. Switches every fork test under `Content.IntegrationTests/Tests/RussStation/` from the legacy `PoolManager.GetServerClient` pattern to the new `GameTest` base class.

## Why / Balance

The `GameTest` fixture (upstream PR #43207) is the new shared way to write integration tests. It wires up the pair, injects dependencies, and handles teardown automatically, which drops ~200 lines of boilerplate across the fork suite and keeps us on the same rails upstream uses.

## Technical details

- 14 test files migrated, every `GetServerClient`/`CleanReturnAsync` block replaced with `var server = Server;` and `Pair.CreateTestMap()`.
- `GasReactionTest.TestReaction<T>` lost its `static` modifier so it can reach the instance `Server`.
- `CarryStateValidationTest` overrides `PoolSettings` with `Destructive = true`. Two of its tests deliberately trigger the "Cleaned orphaned carry state" WARN log to verify the cleanup tick, and GameTest teardown would otherwise treat that log as a failure. Destructive pairs skip the `ReportErrorLogs` step entirely.
- Three `InteractionTest`-based files (`ForkCartridgeInstallerTest`, `VendingPaymentTest`, `CreateAccountTest`) were intentionally left alone, they inherit from a separate fixture.

## Verification

```
dotnet test Content.IntegrationTests --filter "FullyQualifiedName~RussStation"
# Passed! - Failed: 0, Passed: 103, Skipped: 1, Total: 104
```

## Requirements

- [x] Builds cleanly
- [x] `FullyQualifiedName~RussStation` filter passes
- [x] No remaining `PoolManager` usage in `Tests/RussStation/`

## Breaking changes

None. Internal test infrastructure only.

## Changelog

No player-facing changes.