### PR TITLE
feat: escalated grab system (4-stage, Pushover quirk)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/EscalatedGrab/EscalatedGrabTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/EscalatedGrab/EscalatedGrabTest.cs
@@ -1,10 +1,21 @@
 using Content.IntegrationTests.Fixtures;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Movement.Systems;
 using Content.Shared.RussStation.EscalatedGrab;
 using Content.Shared.RussStation.EscalatedGrab.Components;
+using Content.Shared.RussStation.EscalatedGrab.Events;
 using Content.Shared.RussStation.EscalatedGrab.Systems;
+using Content.Shared.Strip.Components;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.RussStation.EscalatedGrab;
 
@@ -22,10 +33,13 @@ public sealed class EscalatedGrabTest : GameTest
   - type: Physics
     bodyType: KinematicController
   - type: Puller
+  - type: DoAfter
+  - type: Damageable
   - type: Fixtures
     fixtures:
       fix1:
-        shape: !type:PhysShapeCircle
+        shape:
+          !type:PhysShapeCircle
           radius: 0.35
 
 - type: entity
@@ -34,158 +48,543 @@ public sealed class EscalatedGrabTest : GameTest
   - type: Physics
     bodyType: KinematicController
   - type: Pullable
+  - type: DoAfter
+  - type: InputMover
+  - type: Stamina
   - type: Fixtures
     fixtures:
       fix1:
-        shape: !type:PhysShapeCircle
+        shape:
+          !type:PhysShapeCircle
           radius: 0.35
 ";
 
-    /// <summary>
-    /// Verifies that GetStage returns Pull when no escalation exists.
-    /// </summary>
     [Test]
     public async Task DefaultStageIsPull()
     {
         var server = Server;
-        var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var entMan = server.EntMan;
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var grabSystem = entityManager.System<SharedEscalatedGrabSystem>();
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var state = entMan.AddComponent<GrabStateComponent>(puller);
 
-            var puller = entityManager.SpawnEntity("GrabTestMob", mapData.GridCoords);
-            var target = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
+            Assert.That(state.Stage, Is.EqualTo(GrabStage.Pull));
 
-            Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Pull));
+            entMan.DeleteEntity(puller);
         });
     }
 
-    /// <summary>
-    /// Verifies that TryEscalate sets the grab stage to Aggressive and adds GrabStateComponent.
-    /// </summary>
     [Test]
-    public async Task TryEscalateSetsAggressive()
+    public async Task GetStageReturnsCorrectStage()
     {
         var server = Server;
-        var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var grabSystem = entityManager.System<SharedEscalatedGrabSystem>();
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
 
-            var puller = entityManager.SpawnEntity("GrabTestMob", mapData.GridCoords);
-            var target = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
 
-            Assert.That(grabSystem.TryEscalate(puller, target), Is.True);
-            Assert.That(entityManager.HasComponent<GrabStateComponent>(puller), Is.True);
             Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Aggressive));
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
         });
     }
 
-    /// <summary>
-    /// Verifies that TryEscalate on the same target is idempotent.
-    /// </summary>
     [Test]
-    public async Task TryEscalateSameTargetIdempotent()
+    public async Task GetStageReturnsPullForDifferentTarget()
     {
         var server = Server;
-        var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var grabSystem = entityManager.System<SharedEscalatedGrabSystem>();
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target1 = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+            var target2 = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
 
-            var puller = entityManager.SpawnEntity("GrabTestMob", mapData.GridCoords);
-            var target = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target1;
+            state.Stage = GrabStage.Choke;
 
-            grabSystem.TryEscalate(puller, target);
-            Assert.That(grabSystem.TryEscalate(puller, target), Is.True);
-            Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Aggressive));
+            // Querying a different target returns Pull (no escalation on that target).
+            Assert.That(grabSystem.GetStage(puller, target2), Is.EqualTo(GrabStage.Pull));
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target1);
+            entMan.DeleteEntity(target2);
         });
     }
 
-    /// <summary>
-    /// Verifies that HasStage returns true for stages at or below the current stage.
-    /// </summary>
     [Test]
     public async Task HasStageChecksMinimum()
     {
         var server = Server;
-        var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var grabSystem = entityManager.System<SharedEscalatedGrabSystem>();
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
 
-            var puller = entityManager.SpawnEntity("GrabTestMob", mapData.GridCoords);
-            var target = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
 
-            // No escalation: has Pull, not Aggressive
-            Assert.That(grabSystem.HasStage(puller, target, GrabStage.Pull), Is.True);
-            Assert.That(grabSystem.HasStage(puller, target, GrabStage.Aggressive), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(grabSystem.HasStage(puller, target, GrabStage.Pull), Is.True);
+                Assert.That(grabSystem.HasStage(puller, target, GrabStage.Grab), Is.True);
+                Assert.That(grabSystem.HasStage(puller, target, GrabStage.Aggressive), Is.True);
+                Assert.That(grabSystem.HasStage(puller, target, GrabStage.Choke), Is.False);
+            });
 
-            grabSystem.TryEscalate(puller, target);
-
-            // Aggressive: has both Pull and Aggressive
-            Assert.That(grabSystem.HasStage(puller, target, GrabStage.Pull), Is.True);
-            Assert.That(grabSystem.HasStage(puller, target, GrabStage.Aggressive), Is.True);
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
         });
     }
 
-    /// <summary>
-    /// Verifies that ClearEscalation removes the GrabStateComponent and resets stage to Pull.
-    /// </summary>
     [Test]
-    public async Task ClearEscalationResetsStage()
+    public async Task ClearEscalationRemovesComponent()
     {
         var server = Server;
-        var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var grabSystem = entityManager.System<SharedEscalatedGrabSystem>();
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
 
-            var puller = entityManager.SpawnEntity("GrabTestMob", mapData.GridCoords);
-            var target = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
-
-            grabSystem.TryEscalate(puller, target);
-            Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Aggressive));
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
 
             grabSystem.ClearEscalation(puller);
-            Assert.That(entityManager.HasComponent<GrabStateComponent>(puller), Is.False);
-            Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Pull));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<GrabStateComponent>(puller), Is.False);
+                Assert.That(grabSystem.GetStage(puller, target), Is.EqualTo(GrabStage.Pull));
+            });
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
         });
     }
 
-    /// <summary>
-    /// Verifies that GetStage differentiates between targets for the same puller.
-    /// </summary>
     [Test]
-    public async Task GetStagePerTarget()
+    public async Task TryEscalateCreatesStateWithTarget()
     {
         var server = Server;
-        var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapData = await Pair.CreateTestMap();
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var grabSystem = entityManager.System<SharedEscalatedGrabSystem>();
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
 
-            var puller = entityManager.SpawnEntity("GrabTestMob", mapData.GridCoords);
-            var target1 = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
-            var target2 = entityManager.SpawnEntity("GrabTestTarget", mapData.GridCoords);
+            // TryEscalate should create the GrabStateComponent and set the target.
+            var result = grabSystem.TryEscalate(puller, target);
+            Assert.That(result, Is.True);
 
-            grabSystem.TryEscalate(puller, target1);
+            var state = entMan.GetComponent<GrabStateComponent>(puller);
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.Target, Is.EqualTo(target));
+                // Stage stays at Pull until the do-after completes.
+                Assert.That(state.Stage, Is.EqualTo(GrabStage.Pull));
+            });
 
-            Assert.That(grabSystem.GetStage(puller, target1), Is.EqualTo(GrabStage.Aggressive));
-            // Different target should still be Pull (GrabStateComponent tracks one target)
-            Assert.That(grabSystem.GetStage(puller, target2), Is.EqualTo(GrabStage.Pull));
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task GrabStageBlocksTargetMovement()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var actionBlocker = entMan.System<ActionBlockerSystem>();
+        var pullSystem = entMan.System<PullingSystem>();
+        var handSystem = entMan.System<SharedHandsSystem>();
+
+        var map = await Pair.CreateTestMap();
+        var coords = map.MapCoords;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", coords);
+            var target = entMan.SpawnEntity("GrabTestTarget", coords);
+
+            handSystem.AddHand(puller, "hand", HandLocation.Left);
+
+            Assert.That(pullSystem.TryStartPull(puller, target), Is.True);
+
+            // At Pull stage, target can still move.
+            actionBlocker.UpdateCanMove(target);
+            Assert.That(actionBlocker.CanMove(target), Is.True, "Target should move at Pull stage");
+
+            // Escalate to Grab - target movement should be blocked.
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Grab;
+            actionBlocker.UpdateCanMove(target);
+            Assert.That(actionBlocker.CanMove(target), Is.False, "Target should not move at Grab stage");
+
+            // Escalate to Aggressive - still blocked.
+            state.Stage = GrabStage.Aggressive;
+            actionBlocker.UpdateCanMove(target);
+            Assert.That(actionBlocker.CanMove(target), Is.False, "Target should not move at Aggressive stage");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task ClearEscalationRestoresTargetMovement()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var actionBlocker = entMan.System<ActionBlockerSystem>();
+        var pullSystem = entMan.System<PullingSystem>();
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
+        var handSystem = entMan.System<SharedHandsSystem>();
+
+        var map = await Pair.CreateTestMap();
+        var coords = map.MapCoords;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", coords);
+            var target = entMan.SpawnEntity("GrabTestTarget", coords);
+
+            handSystem.AddHand(puller, "hand", HandLocation.Left);
+            pullSystem.TryStartPull(puller, target);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Grab;
+            actionBlocker.UpdateCanMove(target);
+            Assert.That(actionBlocker.CanMove(target), Is.False, "Movement should be blocked at Grab");
+
+            // Clear escalation - target should be able to move again.
+            grabSystem.ClearEscalation(puller);
+            Assert.That(actionBlocker.CanMove(target), Is.True, "Movement should be restored after clearing escalation");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task PullerSpeedModifiedByGrabStage()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Stage = GrabStage.Grab;
+
+            // Raise the event directly to check the modifier is applied.
+            var ev = new RefreshMovementSpeedModifiersEvent();
+            entMan.EventBus.RaiseLocalEvent(puller, ev);
+
+            var expected = GrabStateComponent.PullerSpeedModifiers[(int) GrabStage.Grab];
+            Assert.Multiple(() =>
+            {
+                Assert.That(ev.WalkSpeedModifier, Is.EqualTo(expected).Within(0.001f), "Walk speed modifier should match Grab stage");
+                Assert.That(ev.SprintSpeedModifier, Is.EqualTo(expected).Within(0.001f), "Sprint speed modifier should match Grab stage");
+            });
+
+            entMan.DeleteEntity(puller);
+        });
+    }
+
+    [Test]
+    public async Task DropStageReducesFromAggressiveToGrab()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
+
+            grabSystem.DropStage(puller, state);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<GrabStateComponent>(puller), Is.True);
+                Assert.That(state.Stage, Is.EqualTo(GrabStage.Grab));
+            });
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task DropStageAtGrabClearsEscalation()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Grab;
+
+            grabSystem.DropStage(puller, state);
+
+            Assert.That(entMan.HasComponent<GrabStateComponent>(puller), Is.False,
+                "GrabStateComponent should be removed when dropping from Grab stage");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task TryResistStartsDoAfter()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
+
+        var map = await Pair.CreateTestMap();
+        var coords = map.MapCoords;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", coords);
+            var target = entMan.SpawnEntity("GrabTestTarget", coords);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
+
+            grabSystem.TryResist(target, puller, state);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.ResistDoAfter, Is.Not.Null, "Resist do-after should be started");
+                // Stage should not change yet (do-after still in progress).
+                Assert.That(state.Stage, Is.EqualTo(GrabStage.Aggressive));
+            });
+
+            // Clean up do-afters before deleting entities.
+            grabSystem.ClearEscalation(puller);
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task ChokeStageAppliesStaminaDamage()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var grabSystem = entMan.System<SharedEscalatedGrabSystem>();
+
+        var map = await Pair.CreateTestMap();
+        var coords = map.MapCoords;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", coords);
+            var target = entMan.SpawnEntity("GrabTestTarget", coords);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Choke;
+
+            var stamina = entMan.GetComponent<StaminaComponent>(target);
+            var initialStamina = stamina.StaminaDamage;
+
+            // Simulate enough time for at least one tick (0.5s interval).
+            grabSystem.Update(1.0f);
+
+            Assert.That(stamina.StaminaDamage, Is.GreaterThan(initialStamina),
+                "Target should take stamina damage during choke");
+
+            grabSystem.ClearEscalation(puller);
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task DamageAboveThresholdDropsGrabStage()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
+
+            // Raise DamageChangedEvent with damage above threshold (15).
+            var damageable = entMan.GetComponent<DamageableComponent>(puller);
+            var damageSpec = new DamageSpecifier();
+            damageSpec.DamageDict["Blunt"] = FixedPoint2.New(20);
+            var ev = new DamageChangedEvent(damageable, damageSpec, true, null);
+            entMan.EventBus.RaiseLocalEvent(puller, ev);
+
+            Assert.That(state.Stage, Is.EqualTo(GrabStage.Grab),
+                "Stage should drop from Aggressive to Grab after taking heavy damage");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task DamageBelowThresholdKeepsGrabStage()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
+
+            // Raise DamageChangedEvent with damage below threshold (15).
+            var damageable = entMan.GetComponent<DamageableComponent>(puller);
+            var damageSpec = new DamageSpecifier();
+            damageSpec.DamageDict["Blunt"] = FixedPoint2.New(10);
+            var ev = new DamageChangedEvent(damageable, damageSpec, true, null);
+            entMan.EventBus.RaiseLocalEvent(puller, ev);
+
+            Assert.That(state.Stage, Is.EqualTo(GrabStage.Aggressive),
+                "Stage should remain Aggressive when damage is below threshold");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task StripTimeReducedAtHigherGrabStages()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var pullSystem = entMan.System<PullingSystem>();
+        var handSystem = entMan.System<SharedHandsSystem>();
+
+        var map = await Pair.CreateTestMap();
+        var coords = map.MapCoords;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", coords);
+            var target = entMan.SpawnEntity("GrabTestTarget", coords);
+
+            handSystem.AddHand(puller, "hand", HandLocation.Left);
+            pullSystem.TryStartPull(puller, target);
+
+            var state = entMan.EnsureComponent<GrabStateComponent>(puller);
+            state.Target = target;
+            state.Stage = GrabStage.Aggressive;
+
+            // Raise BeforeGettingStrippedEvent on target and check multiplier.
+            var baseTime = TimeSpan.FromSeconds(5);
+            var stripEv = new BeforeGettingStrippedEvent(baseTime);
+            entMan.EventBus.RaiseLocalEvent(target, ref stripEv);
+
+            var expected = GrabStateComponent.StripTimeModifiers[(int) GrabStage.Aggressive];
+            Assert.That(stripEv.Multiplier, Is.EqualTo(expected).Within(0.001f),
+                "Strip time multiplier should match Aggressive stage modifier");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task PushoverQuirkIncreasesResistTime()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+
+            var pushover = entMan.AddComponent<PushoverComponent>(target);
+
+            var baseResistTime = TimeSpan.FromSeconds(5);
+            var ev = new GrabResistAttemptEvent(puller, target, GrabStage.Aggressive, baseResistTime);
+            entMan.EventBus.RaiseLocalEvent(target, ref ev);
+
+            var expected = baseResistTime * pushover.ResistTimeMultiplier;
+            Assert.That(ev.ResistTime, Is.EqualTo(expected),
+                "Pushover quirk should multiply resist time by ResistTimeMultiplier");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
+        });
+    }
+
+    [Test]
+    public async Task ResistTimeUnchangedWithoutPushover()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+
+        await server.WaitPost(() =>
+        {
+            var puller = entMan.SpawnEntity("GrabTestMob", MapCoordinates.Nullspace);
+            var target = entMan.SpawnEntity("GrabTestTarget", MapCoordinates.Nullspace);
+
+            var baseResistTime = TimeSpan.FromSeconds(5);
+            var ev = new GrabResistAttemptEvent(puller, target, GrabStage.Aggressive, baseResistTime);
+            entMan.EventBus.RaiseLocalEvent(target, ref ev);
+
+            Assert.That(ev.ResistTime, Is.EqualTo(baseResistTime),
+                "Resist time should be unchanged without Pushover component");
+
+            entMan.DeleteEntity(puller);
+            entMan.DeleteEntity(target);
         });
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Physics/CrossMapPullGuardTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Physics/CrossMapPullGuardTest.cs
@@ -1,5 +1,7 @@
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.RussStation.EscalatedGrab;
+using Content.Shared.RussStation.EscalatedGrab.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -103,6 +105,53 @@ public sealed class CrossMapPullGuardTest
 
             Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.Null);
             Assert.That(entMan.GetComponent<PullableComponent>(pullable).Puller, Is.Null);
+
+            entMan.DeleteEntity(mapSys.GetMap(mapA));
+            entMan.DeleteEntity(mapSys.GetMap(mapB));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Escalated-grab counterpart to <see cref="PullStateClearsWhenPullableCrossesMaps"/>:
+    /// the joint guard already breaks the underlying pull on cross-map reparent, but the
+    /// fork-side <see cref="GrabStateComponent"/> has to fall along with it via the
+    /// <c>PullStoppedMessage</c> cascade. The full shuttle-FTL case (grid reparents while
+    /// mobs keep grid as their parent) isn't reachable through plain SetParent in tests
+    /// — the engine's grid-map propagation has its own pathway — but the direct reparent
+    /// still exercises the grab cleanup path that FTL ultimately depends on.
+    /// </summary>
+    [Test]
+    public async Task EscalatedGrabClearsWhenPairCrossesMaps()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var pulling = entMan.System<PullingSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapA);
+            mapSys.CreateMap(out var mapB);
+
+            var puller = entMan.SpawnEntity("CrossMapPullBody", new MapCoordinates(0, 0, mapA));
+            var pullable = entMan.SpawnEntity("CrossMapPullBody", new MapCoordinates(0.5f, 0, mapA));
+
+            Assert.That(pulling.TryStartPull(puller, pullable), Is.True);
+
+            var grab = entMan.EnsureComponent<GrabStateComponent>(puller);
+            grab.Target = pullable;
+            grab.Stage = GrabStage.Aggressive;
+
+            xformSys.SetParent(pullable, mapSys.GetMap(mapB));
+
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.Null,
+                "Pull should be torn down after the pullable crosses maps");
+            Assert.That(entMan.HasComponent<GrabStateComponent>(puller), Is.False,
+                "Escalated grab state should clear when its underlying pull breaks");
 
             entMan.DeleteEntity(mapSys.GetMap(mapA));
             entMan.DeleteEntity(mapSys.GetMap(mapB));

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -18,7 +18,8 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
-//HONK START - Escalated grab event
+//HONK START - Escalated grab
+using Content.Shared.RussStation.EscalatedGrab.Components;
 using Content.Shared.RussStation.EscalatedGrab.Events;
 //HONK END
 using Content.Shared.Movement.Systems;
@@ -302,6 +303,11 @@ public sealed class PullingSystem : EntitySystem
             args.ModifySpeed(walkMod, sprintMod);
             return;
         }
+
+        // HONK START - Escalated grab applies its own speed modifiers per stage
+        if (HasComp<GrabStateComponent>(uid))
+            return;
+        // HONK END
 
         args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
     }

--- a/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
@@ -29,13 +29,13 @@ public sealed partial class GrabStateComponent : Component
     /// <summary>
     /// Active escalation do-after, if any.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public DoAfterId? EscalateDoAfter;
 
     /// <summary>
     /// Active resist do-after on the target, if any.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public DoAfterId? ResistDoAfter;
 
     /// <summary>
@@ -48,13 +48,13 @@ public sealed partial class GrabStateComponent : Component
     /// Seconds between choke damage ticks.
     /// </summary>
     [DataField]
-    public float ChokeTickInterval = 0.5f;
+    public float ChokeTickInterval = EscalatedGrabConstants.ChokeTickInterval;
 
     /// <summary>
     /// Stamina damage dealt per choke tick.
     /// </summary>
     [DataField]
-    public float ChokeStaminaPerTick = 5f;
+    public float ChokeStaminaPerTick = EscalatedGrabConstants.ChokeStaminaPerTick;
 
     /// <summary>
     /// Minimum single-hit damage to drop one grab stage.

--- a/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
@@ -27,15 +27,18 @@ public sealed partial class GrabStateComponent : Component
     public GrabStage Stage = GrabStage.Pull;
 
     /// <summary>
-    /// Active escalation do-after, if any.
+    /// Active escalation do-after, if any. Server-only handle, not networked
+    /// (DoAfterId is not netserializable). Writers must Dirty the component to
+    /// satisfy HONK0010 even though this field itself does not replicate.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public DoAfterId? EscalateDoAfter;
 
     /// <summary>
-    /// Active resist do-after on the target, if any.
+    /// Active resist do-after on the target, if any. Server-only handle; see note on
+    /// <see cref="EscalateDoAfter"/>.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public DoAfterId? ResistDoAfter;
 
     /// <summary>

--- a/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
@@ -60,7 +60,13 @@ public sealed partial class GrabStateComponent : Component
     /// Minimum single-hit damage to drop one grab stage.
     /// </summary>
     [DataField]
-    public FixedPoint2 DamageDropThreshold = FixedPoint2.New(15);
+    public FixedPoint2 DamageDropThreshold = FixedPoint2.New(DefaultDamageDropThreshold);
+
+    /// <summary>
+    /// Default value for <see cref="DamageDropThreshold"/>. Also used by the vanilla-pull
+    /// damage break in <c>SharedEscalatedGrabSystem</c> for entities with no GrabState.
+    /// </summary>
+    public const int DefaultDamageDropThreshold = 15;
 
     /// <summary>
     /// Do-after durations for each escalation step (index = target stage).

--- a/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/GrabStateComponent.cs
@@ -1,13 +1,14 @@
+using Content.Shared.DoAfter;
+using Content.Shared.FixedPoint;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.RussStation.Carrying.Components;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.RussStation.EscalatedGrab.Components;
 
 /// <summary>
-/// Added to a puller when their grab escalates beyond a standard pull.
-/// Tracks the current <see cref="GrabStage"/> and target entity.
+/// Added to a puller entity to track escalated grab state against a target.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GrabStateComponent : Component
@@ -23,6 +24,86 @@ public sealed partial class GrabStateComponent : Component
     public EntityUid Target;
 
     [DataField, AutoNetworkedField]
-    public GrabStage Stage = GrabStage.Aggressive;
+    public GrabStage Stage = GrabStage.Pull;
 
+    /// <summary>
+    /// Active escalation do-after, if any.
+    /// </summary>
+    [DataField]
+    public DoAfterId? EscalateDoAfter;
+
+    /// <summary>
+    /// Active resist do-after on the target, if any.
+    /// </summary>
+    [DataField]
+    public DoAfterId? ResistDoAfter;
+
+    /// <summary>
+    /// Accumulator for choke stamina damage ticks.
+    /// </summary>
+    [DataField]
+    public float ChokeDamageAccumulator;
+
+    /// <summary>
+    /// Seconds between choke damage ticks.
+    /// </summary>
+    [DataField]
+    public float ChokeTickInterval = 0.5f;
+
+    /// <summary>
+    /// Stamina damage dealt per choke tick.
+    /// </summary>
+    [DataField]
+    public float ChokeStaminaPerTick = 5f;
+
+    /// <summary>
+    /// Minimum single-hit damage to drop one grab stage.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 DamageDropThreshold = FixedPoint2.New(15);
+
+    /// <summary>
+    /// Do-after durations for each escalation step (index = target stage).
+    /// </summary>
+    public static readonly TimeSpan[] EscalationTimes =
+    [
+        TimeSpan.Zero,             // Pull (never used, pull is instant)
+        TimeSpan.FromSeconds(2),   // Grab
+        TimeSpan.FromSeconds(3),   // Aggressive
+        TimeSpan.FromSeconds(4),   // Choke
+    ];
+
+    /// <summary>
+    /// Resist do-after durations by current stage.
+    /// </summary>
+    public static readonly TimeSpan[] ResistTimes =
+    [
+        TimeSpan.Zero,             // Pull (instant release)
+        TimeSpan.FromSeconds(3),   // Grab
+        TimeSpan.FromSeconds(5),   // Aggressive
+        TimeSpan.FromSeconds(6),   // Choke
+    ];
+
+    /// <summary>
+    /// Walk/sprint speed multipliers for the puller at each stage.
+    /// </summary>
+    public static readonly float[] PullerSpeedModifiers =
+    [
+        0.95f, // Pull (existing upstream value)
+        0.85f, // Grab
+        0.75f, // Aggressive
+        0.65f, // Choke
+    ];
+
+    /// <summary>
+    /// Strip time multipliers applied to the target at each stage.
+    /// Lower values mean faster stripping.
+    /// </summary>
+    public static readonly float[] StripTimeModifiers =
+    [
+        1.0f, // Pull (no change)
+        0.8f, // Grab
+        0.5f, // Aggressive
+        0.3f, // Choke
+    ];
 }

--- a/Content.Shared/RussStation/EscalatedGrab/Components/PushoverComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/PushoverComponent.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.RussStation.EscalatedGrab.Components;
 /// <summary>
 /// Added by the Pushover quirk. Multiplies grab resist time, making it harder to break free.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PushoverComponent : Component
 {
-    [DataField]
-    public float ResistTimeMultiplier = 1.5f;
+    [DataField, AutoNetworkedField]
+    public float ResistTimeMultiplier = EscalatedGrabConstants.PushoverResistTimeMultiplier;
 }

--- a/Content.Shared/RussStation/EscalatedGrab/Components/PushoverComponent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Components/PushoverComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.EscalatedGrab.Components;
+
+/// <summary>
+/// Added by the Pushover quirk. Multiplies grab resist time, making it harder to break free.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PushoverComponent : Component
+{
+    [DataField]
+    public float ResistTimeMultiplier = 1.5f;
+}

--- a/Content.Shared/RussStation/EscalatedGrab/EscalatedGrabConstants.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/EscalatedGrabConstants.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.RussStation.EscalatedGrab;
+
+public static class EscalatedGrabConstants
+{
+    public const float ChokeTickInterval = 0.5f;
+
+    public const float ChokeStaminaPerTick = 5f;
+
+    public const float PushoverResistTimeMultiplier = 1.5f;
+}

--- a/Content.Shared/RussStation/EscalatedGrab/Events/GrabEscalateDoAfterEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/GrabEscalateDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.EscalatedGrab.Events;
+
+/// <summary>
+/// DoAfter event for grab escalation completion.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class GrabEscalateDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/RussStation/EscalatedGrab/Events/GrabEscalatedEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/GrabEscalatedEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.RussStation.EscalatedGrab.Events;
+
+/// <summary>
+/// Raised on the puller after a grab stage change, for other systems to react.
+/// </summary>
+[ByRefEvent]
+public record struct GrabEscalatedEvent(EntityUid Puller, EntityUid Target, GrabStage OldStage, GrabStage NewStage);

--- a/Content.Shared/RussStation/EscalatedGrab/Events/GrabResistAttemptEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/GrabResistAttemptEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.RussStation.EscalatedGrab.Events;
+
+/// <summary>
+/// Raised on the target when they start resisting a grab.
+/// Subscribers (e.g. Pushover quirk) can modify <see cref="ResistTime"/> to make resisting harder/easier.
+/// </summary>
+[ByRefEvent]
+public record struct GrabResistAttemptEvent(EntityUid Puller, EntityUid Pulled, GrabStage Stage, TimeSpan ResistTime);

--- a/Content.Shared/RussStation/EscalatedGrab/Events/GrabResistDoAfterEvent.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Events/GrabResistDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.EscalatedGrab.Events;
+
+/// <summary>
+/// DoAfter event for grab resist completion.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class GrabResistDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/RussStation/EscalatedGrab/GrabStage.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/GrabStage.cs
@@ -15,7 +15,17 @@ public enum GrabStage : byte
     Pull = 0,
 
     /// <summary>
-    /// Aggressive grab. First escalation from a standard pull.
+    /// Target locked to puller, cannot move independently. Can still act.
     /// </summary>
-    Aggressive = 1,
+    Grab = 1,
+
+    /// <summary>
+    /// Target locked and cannot act (use/interact blocked). Enables easier stripping.
+    /// </summary>
+    Aggressive = 2,
+
+    /// <summary>
+    /// Target takes periodic stamina damage. Near-helpless.
+    /// </summary>
+    Choke = 3,
 }

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -1,15 +1,19 @@
 using Content.Shared.ActionBlocker;
+using Content.Shared.Buckle.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
 using Content.Shared.RussStation.EscalatedGrab.Components;
 using Content.Shared.RussStation.EscalatedGrab.Events;
 using Content.Shared.Strip.Components;
+using Content.Shared.Teleportation.Components;
+using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.EscalatedGrab.Systems;
@@ -26,6 +30,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+    [Dependency] private readonly PullingSystem _pulling = default!;
 
     public override void Initialize()
     {
@@ -41,6 +46,50 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         SubscribeLocalEvent<PullableComponent, GrabResistDoAfterEvent>(OnResistDoAfterFinished);
         SubscribeLocalEvent<GrabStateComponent, DamageChangedEvent>(OnPullerDamaged);
         SubscribeLocalEvent<PullableComponent, BeforeGettingStrippedEvent>(OnTargetBeingStripped);
+
+        // Portal interactions: force-break the pull before the portal teleports either side.
+        // Upstream's SharedPortalSystem already calls TryStopPull on portal collision, but the
+        // joint can survive a re-prediction race when escalated grab keeps the pair tethered
+        // longer than vanilla pulls. We pre-empt the teleport here so the joint is fully torn
+        // down before SetCoordinates runs and the next physics tick tries to re-init it cross-map.
+        SubscribeLocalEvent<GrabStateComponent, StartCollideEvent>(OnPullerStartCollide);
+        SubscribeLocalEvent<PullableComponent, StartCollideEvent>(OnPullableStartCollide);
+
+        // Puller getting buckled: drop escalation and stop the pull so the puller's joint
+        // doesn't get reparented onto the strap. (The pulled-getting-buckled side is already
+        // handled by upstream's PullingSystem.OnGotBuckled, which calls StopPulling and
+        // therefore fires PullStoppedMessage into our OnPullStopped clean-up path.)
+        SubscribeLocalEvent<GrabStateComponent, BuckledEvent>(OnPullerBuckled);
+    }
+
+    private void OnPullerStartCollide(EntityUid uid, GrabStateComponent component, ref StartCollideEvent args)
+    {
+        if (!HasComp<PortalComponent>(args.OtherEntity))
+            return;
+
+        var target = component.Target;
+        ClearEscalation(uid);
+
+        if (target.IsValid() && TryComp<PullableComponent>(target, out var pullable) && pullable.Puller == uid)
+            _pulling.TryStopPull(target, pullable);
+    }
+
+    private void OnPullableStartCollide(EntityUid uid, PullableComponent component, ref StartCollideEvent args)
+    {
+        if (!HasComp<PortalComponent>(args.OtherEntity))
+            return;
+
+        if (component.Puller is { } puller && HasComp<GrabStateComponent>(puller))
+            ClearEscalation(puller);
+    }
+
+    private void OnPullerBuckled(EntityUid uid, GrabStateComponent component, ref BuckledEvent args)
+    {
+        var target = component.Target;
+        ClearEscalation(uid);
+
+        if (target.IsValid() && TryComp<PullableComponent>(target, out var pullable) && pullable.Puller == uid)
+            _pulling.TryStopPull(target, pullable);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -1,20 +1,31 @@
-using Content.Shared.RussStation.EscalatedGrab.Components;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Damage.Systems;
+using Content.Shared.DoAfter;
+using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
-using Content.Shared.RussStation.EscalatedGrab.Events;
+using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Pulling.Events;
+using Content.Shared.RussStation.EscalatedGrab.Components;
+using Content.Shared.RussStation.EscalatedGrab.Events;
+using Content.Shared.Strip.Components;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.EscalatedGrab.Systems;
 
 /// <summary>
 /// Manages grab escalation. Re-clicking pull on a target escalates the grab
-/// through <see cref="GrabStage"/> tiers instead of releasing.
+/// through <see cref="GrabStage"/> tiers via do-afters instead of releasing.
 /// </summary>
 public abstract class SharedEscalatedGrabSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
 
     public override void Initialize()
     {
@@ -22,7 +33,39 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
         SubscribeLocalEvent<PullableComponent, PullGrabEscalateAttemptEvent>(OnEscalateAttempt);
         SubscribeLocalEvent<PullerComponent, PullReleaseRequestedEvent>(OnPullReleaseRequested);
+        SubscribeLocalEvent<PullableComponent, AttemptStopPullingEvent>(OnAttemptStopPulling);
+        SubscribeLocalEvent<PullableComponent, UpdateCanMoveEvent>(OnPullableCanMove);
         SubscribeLocalEvent<GrabStateComponent, PullStoppedMessage>(OnPullStopped);
+        SubscribeLocalEvent<GrabStateComponent, GrabEscalateDoAfterEvent>(OnEscalateDoAfterFinished);
+        SubscribeLocalEvent<GrabStateComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshPullerSpeed);
+        SubscribeLocalEvent<PullableComponent, GrabResistDoAfterEvent>(OnResistDoAfterFinished);
+        SubscribeLocalEvent<GrabStateComponent, DamageChangedEvent>(OnPullerDamaged);
+        SubscribeLocalEvent<PullableComponent, BeforeGettingStrippedEvent>(OnTargetBeingStripped);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        var query = EntityQueryEnumerator<GrabStateComponent>();
+        while (query.MoveNext(out var uid, out var state))
+        {
+            if (state.Stage != GrabStage.Choke)
+                continue;
+
+            if (!state.Target.IsValid())
+                continue;
+
+            state.ChokeDamageAccumulator += frameTime;
+            while (state.ChokeDamageAccumulator >= state.ChokeTickInterval)
+            {
+                state.ChokeDamageAccumulator -= state.ChokeTickInterval;
+                _stamina.TakeStaminaDamage(state.Target, state.ChokeStaminaPerTick, source: uid);
+            }
+        }
     }
 
     private void OnEscalateAttempt(EntityUid uid, PullableComponent component, ref PullGrabEscalateAttemptEvent args)
@@ -36,30 +79,187 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         ClearEscalation(args.Puller);
     }
 
+    private void OnPullableCanMove(EntityUid uid, PullableComponent component, UpdateCanMoveEvent args)
+    {
+        if (!component.BeingPulled || component.Puller is not { } puller)
+            return;
+
+        if (TryComp<GrabStateComponent>(puller, out var state)
+            && state.Target == uid
+            && state.Stage >= GrabStage.Grab)
+        {
+            args.Cancel();
+        }
+    }
+
+    private void OnRefreshPullerSpeed(EntityUid uid, GrabStateComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        var modifier = GrabStateComponent.PullerSpeedModifiers[(int) component.Stage];
+        args.ModifySpeed(modifier, modifier);
+    }
+
+    private void OnPullerDamaged(EntityUid uid, GrabStateComponent component, DamageChangedEvent args)
+    {
+        if (!args.DamageIncreased)
+            return;
+
+        if (args.DamageDelta == null)
+            return;
+
+        var total = args.DamageDelta.GetTotal();
+        if (total < component.DamageDropThreshold)
+            return;
+
+        _popup.PopupPredicted(
+            Loc.GetString("escalated-grab-broken-by-damage"),
+            Loc.GetString("escalated-grab-broken-by-damage"),
+            uid, uid);
+
+        DropStage(uid, component);
+    }
+
+    private void OnTargetBeingStripped(EntityUid uid, PullableComponent component, BeforeGettingStrippedEvent args)
+    {
+        if (!component.BeingPulled || component.Puller is not { } puller)
+            return;
+
+        if (!TryComp<GrabStateComponent>(puller, out var state) || state.Target != uid)
+            return;
+
+        args.Multiplier *= GrabStateComponent.StripTimeModifiers[(int) state.Stage];
+    }
+
+    private void OnAttemptStopPulling(EntityUid uid, PullableComponent component, ref AttemptStopPullingEvent args)
+    {
+        if (args.Cancelled || args.User == null)
+            return;
+
+        if (component.Puller is not { } puller)
+            return;
+
+        if (!TryComp<GrabStateComponent>(puller, out var state) || state.Target != uid)
+            return;
+
+        // At Pull stage, no resist needed - let the normal stop-pull proceed.
+        if (state.Stage <= GrabStage.Pull)
+            return;
+
+        // Cancel the stop-pull and start a resist do-after instead.
+        args.Cancelled = true;
+        TryResist(uid, puller, state);
+    }
+
     private void OnPullStopped(EntityUid uid, GrabStateComponent component, PullStoppedMessage args)
     {
-        RemComp<GrabStateComponent>(uid);
+        ClearEscalation(uid);
+    }
+
+    private void OnEscalateDoAfterFinished(EntityUid uid, GrabStateComponent component, GrabEscalateDoAfterEvent args)
+    {
+        component.EscalateDoAfter = null;
+
+        if (args.Cancelled)
+            return;
+
+        if (!TryComp<PullerComponent>(uid, out var puller) || puller.Pulling == null)
+            return;
+
+        // Only escalate if still pulling the same target.
+        if (puller.Pulling.Value != component.Target)
+            return;
+
+        var nextStage = component.Stage + 1;
+        if (nextStage > GrabStage.Choke)
+            return;
+
+        SetStage(uid, component, nextStage);
     }
 
     /// <summary>
-    /// Escalates the grab to the next stage. Currently always succeeds
-    /// (returns true unconditionally), but the return value is kept for
-    /// future multi-stage gating.
+    /// Starts a do-after to escalate the grab to the next stage.
+    /// If the puller has no escalation yet, the first escalation to Grab is started.
     /// </summary>
     public bool TryEscalate(EntityUid puller, EntityUid target)
     {
-        if (TryComp<GrabStateComponent>(puller, out var existing) && existing.Target == target)
-            return true;
-
         if (!_timing.IsFirstTimePredicted)
             return true;
 
         var state = EnsureComp<GrabStateComponent>(puller);
+
+        // If already escalating, don't start another.
+        if (state.EscalateDoAfter != null)
+            return true;
+
+        // Already grabbed a different target, can't escalate.
+        if (state.Target != default && state.Target != target)
+            return false;
+
         state.Target = target;
-        state.Stage = GrabStage.Aggressive;
         Dirty(puller, state);
-        _popup.PopupPredicted(Loc.GetString("escalated-grab-aggressive"), target, puller);
+
+        var nextStage = state.Stage + 1;
+        if (nextStage > GrabStage.Choke)
+            return true; // Already at max stage.
+
+        var delay = GrabStateComponent.EscalationTimes[(int) nextStage];
+        if (delay == TimeSpan.Zero)
+        {
+            // Instant escalation (shouldn't happen with current config but handle gracefully).
+            SetStage(puller, state, nextStage);
+            return true;
+        }
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, puller, delay, new GrabEscalateDoAfterEvent(), puller, target)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            DamageThreshold = 15,
+            NeedHand = true,
+            DistanceThreshold = 2f,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfterArgs, out var doAfterId))
+        {
+            state.EscalateDoAfter = doAfterId;
+        }
+
         return true;
+    }
+
+    /// <summary>
+    /// Sets the grab stage and raises events/popups.
+    /// </summary>
+    private void SetStage(EntityUid puller, GrabStateComponent state, GrabStage newStage)
+    {
+        var oldStage = state.Stage;
+        state.Stage = newStage;
+        state.ChokeDamageAccumulator = 0f;
+        Dirty(puller, state);
+
+        // Popup messages: puller sees recipientMessage, everyone else (including target) sees othersMessage.
+        var target = state.Target;
+        var localeKey = newStage switch
+        {
+            GrabStage.Grab => "escalated-grab-grab",
+            GrabStage.Aggressive => "escalated-grab-aggressive",
+            GrabStage.Choke => "escalated-grab-choke",
+            _ => null,
+        };
+
+        if (localeKey != null)
+        {
+            _popup.PopupPredicted(
+                Loc.GetString($"{localeKey}-puller", ("target", target)),
+                Loc.GetString($"{localeKey}-others", ("puller", puller), ("target", target)),
+                target, puller);
+        }
+
+        // Refresh movement modifiers for both puller and target.
+        _movementSpeed.RefreshMovementSpeedModifiers(puller);
+        _actionBlocker.UpdateCanMove(target);
+
+        var ev = new GrabEscalatedEvent(puller, target, oldStage, newStage);
+        RaiseLocalEvent(puller, ref ev);
     }
 
     /// <summary>
@@ -83,10 +283,126 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
     }
 
     /// <summary>
-    /// Removes grab escalation from a puller.
+    /// Removes grab escalation from a puller, cancelling any active do-afters.
     /// </summary>
     public void ClearEscalation(EntityUid puller)
     {
+        if (!TryComp<GrabStateComponent>(puller, out var state))
+            return;
+
+        var target = state.Target;
+
+        _doAfter.Cancel(state.EscalateDoAfter);
+        _doAfter.Cancel(state.ResistDoAfter);
+        state.EscalateDoAfter = null;
+        state.ResistDoAfter = null;
+
         RemComp<GrabStateComponent>(puller);
+
+        // Re-enable target movement and reset puller speed.
+        if (target.IsValid())
+            _actionBlocker.UpdateCanMove(target);
+
+        _movementSpeed.RefreshMovementSpeedModifiers(puller);
+    }
+
+    /// <summary>
+    /// Starts a resist do-after for the grabbed target. Drops one stage on completion.
+    /// </summary>
+    public void TryResist(EntityUid target, EntityUid puller, GrabStateComponent state)
+    {
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        // Already resisting.
+        if (state.ResistDoAfter != null)
+            return;
+
+        var resistTime = GrabStateComponent.ResistTimes[(int) state.Stage];
+
+        // Raise attempt event so quirks can modify resist time.
+        var attemptEv = new GrabResistAttemptEvent(puller, target, state.Stage, resistTime);
+        RaiseLocalEvent(target, ref attemptEv);
+        resistTime = attemptEv.ResistTime;
+
+        if (resistTime <= TimeSpan.Zero)
+        {
+            // Instant resist (e.g. Pull stage, shouldn't reach here but handle gracefully).
+            DropStage(puller, state);
+            return;
+        }
+
+        _popup.PopupPredicted(
+            Loc.GetString("escalated-grab-resist-start-target"),
+            Loc.GetString("escalated-grab-resist-start-others", ("target", target)),
+            target, target);
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, target, resistTime, new GrabResistDoAfterEvent(), target, puller)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = false,
+            NeedHand = false,
+            DistanceThreshold = 2f,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfterArgs, out var doAfterId))
+        {
+            state.ResistDoAfter = doAfterId;
+        }
+    }
+
+    private void OnResistDoAfterFinished(EntityUid uid, PullableComponent component, GrabResistDoAfterEvent args)
+    {
+        if (component.Puller is not { } puller)
+            return;
+
+        if (!TryComp<GrabStateComponent>(puller, out var state))
+            return;
+
+        state.ResistDoAfter = null;
+
+        if (args.Cancelled)
+            return;
+
+        // Only process if still grabbing the same target.
+        if (state.Target != uid)
+            return;
+
+        DropStage(puller, state);
+    }
+
+    /// <summary>
+    /// Drops the grab by one stage. If already at Grab, clears escalation entirely.
+    /// </summary>
+    public void DropStage(EntityUid puller, GrabStateComponent state)
+    {
+        var target = state.Target;
+
+        if (state.Stage <= GrabStage.Grab)
+        {
+            // At Grab or below, fully release.
+            ClearEscalation(puller);
+
+            if (target.IsValid())
+            {
+                _popup.PopupPredicted(
+                    Loc.GetString("escalated-grab-resist-success-target"),
+                    Loc.GetString("escalated-grab-resist-success-others", ("target", target)),
+                    target, target);
+            }
+
+            return;
+        }
+
+        var newStage = state.Stage - 1;
+        SetStage(puller, state, newStage);
+
+        if (target.IsValid())
+        {
+            _popup.PopupPredicted(
+                Loc.GetString("escalated-grab-resist-success-target"),
+                Loc.GetString("escalated-grab-resist-success-others", ("target", target)),
+                target, target);
+        }
     }
 }

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -261,6 +261,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
     private void OnEscalateDoAfterFinished(EntityUid uid, GrabStateComponent component, GrabEscalateDoAfterEvent args)
     {
         component.EscalateDoAfter = null;
+        Dirty(uid, component);
 
         if (args.Cancelled)
             return;
@@ -461,6 +462,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         if (_doAfter.TryStartDoAfter(doAfterArgs, out var doAfterId))
         {
             state.ResistDoAfter = doAfterId;
+            Dirty(puller, state);
         }
     }
 
@@ -473,6 +475,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
             return;
 
         state.ResistDoAfter = null;
+        Dirty(puller, state);
 
         if (args.Cancelled)
             return;

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -451,8 +451,11 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
         if (state.Stage <= GrabStage.Grab)
         {
-            // At Grab or below, fully release.
+            // At Grab or below, fully release - drop both the escalation and the underlying pull.
             ClearEscalation(puller);
+
+            if (target.IsValid() && TryComp<PullableComponent>(target, out var pullable) && pullable.Puller == puller)
+                _pulling.TryStopPull(target, pullable);
 
             if (target.IsValid())
             {

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -208,6 +208,12 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
     private void OnPullStopped(EntityUid uid, GrabStateComponent component, PullStoppedMessage args)
     {
+        // Mutual grab: if A and B are grabbing each other, ending A's pull on B raises
+        // PullStoppedMessage on both A and B. B has its own GrabStateComponent for its
+        // grab on A, which is unrelated; only clear when this message is for our pull.
+        if (args.PullerUid != uid || args.PulledUid != component.Target)
+            return;
+
         ClearEscalation(uid);
     }
 

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -309,7 +309,8 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
             _ => null,
         };
 
-        if (localeKey != null)
+        // Only announce the stage popup on escalation; dropping a stage has its own messaging.
+        if (localeKey != null && newStage > oldStage)
         {
             _popup.PopupPredicted(
                 Loc.GetString($"{localeKey}-puller", ("target", target)),
@@ -467,13 +468,5 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
         var newStage = state.Stage - 1;
         SetStage(puller, state, newStage);
-
-        if (target.IsValid())
-        {
-            _popup.PopupPredicted(
-                Loc.GetString("escalated-grab-resist-success-target"),
-                Loc.GetString("escalated-grab-resist-success-others", ("target", target)),
-                target, target);
-        }
     }
 }

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -140,6 +140,14 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         if (!TryComp<GrabStateComponent>(puller, out var state) || state.Target != uid)
             return;
 
+        // The puller releasing their own grab always succeeds; resist is target-side only.
+        if (args.User == puller)
+            return;
+
+        // Anyone other than the grabbed target (e.g. third-party rescuers) goes through normal stop-pull.
+        if (args.User != uid)
+            return;
+
         // At Pull stage, no resist needed - let the normal stop-pull proceed.
         if (state.Stage <= GrabStage.Pull)
             return;
@@ -292,10 +300,18 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
         var target = state.Target;
 
-        _doAfter.Cancel(state.EscalateDoAfter);
-        _doAfter.Cancel(state.ResistDoAfter);
+        // Capture and null the ids before cancelling so the do-after handlers don't see a stale id,
+        // and so we don't re-cancel an id the engine already retired (which logs an error).
+        var escalateId = state.EscalateDoAfter;
+        var resistId = state.ResistDoAfter;
         state.EscalateDoAfter = null;
         state.ResistDoAfter = null;
+        Dirty(puller, state);
+
+        if (escalateId != null && _doAfter.GetStatus(escalateId) == DoAfterStatus.Running)
+            _doAfter.Cancel(escalateId);
+        if (resistId != null && _doAfter.GetStatus(resistId) == DoAfterStatus.Running)
+            _doAfter.Cancel(resistId);
 
         RemComp<GrabStateComponent>(puller);
 

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Events;
+using Content.Shared.Mobs;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
@@ -47,6 +48,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         SubscribeLocalEvent<GrabStateComponent, DamageChangedEvent>(OnPullerDamaged);
         SubscribeLocalEvent<PullerComponent, DamageChangedEvent>(OnVanillaPullerDamaged);
         SubscribeLocalEvent<PullableComponent, BeforeGettingStrippedEvent>(OnTargetBeingStripped);
+        SubscribeLocalEvent<PullableComponent, MobStateChangedEvent>(OnTargetMobStateChanged);
 
         // Portal interactions: force-break the pull before the portal teleports either side.
         // Upstream's SharedPortalSystem already calls TryStopPull on portal collision, but the
@@ -196,6 +198,25 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
             return;
 
         args.Multiplier *= GrabStateComponent.StripTimeModifiers[(int) state.Stage];
+    }
+
+    private void OnTargetMobStateChanged(EntityUid uid, PullableComponent component, MobStateChangedEvent args)
+    {
+        // Choke ticks shouldn't keep going on a corpse; release the grab when the target dies.
+        // Crit alone doesn't release - you can choke an unconscious target until they die.
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        if (component.Puller is not { } puller)
+            return;
+
+        if (!TryComp<GrabStateComponent>(puller, out var state) || state.Target != uid)
+            return;
+
+        ClearEscalation(puller);
+
+        if (TryComp<PullableComponent>(uid, out var pullable) && pullable.Puller == puller)
+            _pulling.TryStopPull(uid, pullable);
     }
 
     private void OnAttemptStopPulling(EntityUid uid, PullableComponent component, ref AttemptStopPullingEvent args)

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -45,6 +45,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         SubscribeLocalEvent<GrabStateComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshPullerSpeed);
         SubscribeLocalEvent<PullableComponent, GrabResistDoAfterEvent>(OnResistDoAfterFinished);
         SubscribeLocalEvent<GrabStateComponent, DamageChangedEvent>(OnPullerDamaged);
+        SubscribeLocalEvent<PullerComponent, DamageChangedEvent>(OnVanillaPullerDamaged);
         SubscribeLocalEvent<PullableComponent, BeforeGettingStrippedEvent>(OnTargetBeingStripped);
 
         // Portal interactions: force-break the pull before the portal teleports either side.
@@ -164,6 +165,26 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
             uid, uid, PopupType.MediumCaution);
 
         DropStage(uid, component);
+    }
+
+    private void OnVanillaPullerDamaged(EntityUid uid, PullerComponent component, DamageChangedEvent args)
+    {
+        // Escalated grabs are handled by OnPullerDamaged; this only covers vanilla pulls so a
+        // pull on its own can also be broken by a solid hit.
+        if (HasComp<GrabStateComponent>(uid))
+            return;
+
+        if (!args.DamageIncreased || args.DamageDelta == null)
+            return;
+
+        if (component.Pulling is not { } pulled)
+            return;
+
+        if (args.DamageDelta.GetTotal() < GrabStateComponent.DefaultDamageDropThreshold)
+            return;
+
+        if (TryComp<PullableComponent>(pulled, out var pullable))
+            _pulling.TryStopPull(pulled, pullable);
     }
 
     private void OnTargetBeingStripped(EntityUid uid, PullableComponent component, BeforeGettingStrippedEvent args)

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -159,10 +159,9 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         if (total < component.DamageDropThreshold)
             return;
 
-        _popup.PopupPredicted(
+        _popup.PopupClient(
             Loc.GetString("escalated-grab-broken-by-damage"),
-            Loc.GetString("escalated-grab-broken-by-damage"),
-            uid, uid);
+            uid, uid, PopupType.MediumCaution);
 
         DropStage(uid, component);
     }

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -159,7 +159,7 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         if (total < component.DamageDropThreshold)
             return;
 
-        _popup.PopupClient(
+        _popup.PopupEntity(
             Loc.GetString("escalated-grab-broken-by-damage"),
             uid, uid, PopupType.MediumCaution);
 
@@ -467,5 +467,13 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
 
         var newStage = state.Stage - 1;
         SetStage(puller, state, newStage);
+
+        if (target.IsValid())
+        {
+            _popup.PopupPredicted(
+                Loc.GetString("escalated-grab-loosened-puller", ("target", target)),
+                Loc.GetString("escalated-grab-loosened-others", ("puller", puller), ("target", target)),
+                target, puller);
+        }
     }
 }

--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedPushoverSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedPushoverSystem.cs
@@ -1,0 +1,22 @@
+using Content.Shared.RussStation.EscalatedGrab.Components;
+using Content.Shared.RussStation.EscalatedGrab.Events;
+
+namespace Content.Shared.RussStation.EscalatedGrab.Systems;
+
+/// <summary>
+/// Handles the Pushover quirk: multiplies grab resist time so it takes longer to break free.
+/// </summary>
+public sealed class SharedPushoverSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PushoverComponent, GrabResistAttemptEvent>(OnGrabResistAttempt);
+    }
+
+    private void OnGrabResistAttempt(EntityUid uid, PushoverComponent component, ref GrabResistAttemptEvent args)
+    {
+        args.ResistTime *= component.ResistTimeMultiplier;
+    }
+}

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -49,7 +49,10 @@ public sealed class PullMapGuardSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        // Pass 1 - active pulls: tear down any pull whose endpoints now sit on different maps.
+        // Active pulls: tear down any pull whose endpoints now sit on different maps.
+        // We deliberately do NOT scan all JointComponents here - that approach feedback-loops
+        // with state replication when the server has a stuck cross-map joint and floods the
+        // log with ClearJoints calls every tick.
         var pullerQuery = EntityQueryEnumerator<PullerComponent>();
         while (pullerQuery.MoveNext(out var uid, out var puller))
         {
@@ -64,36 +67,6 @@ public sealed class PullMapGuardSystem : EntitySystem
 
             _joints.ClearJoints(pulled);
             _joints.ClearJoints(uid);
-        }
-
-        // Pass 2 - orphaned joints: a joint can outlive its pull state when it was deferred
-        // into SharedJointSystem.AddedJoints during state replication (transform was Nullspace
-        // when the joint state arrived) and the matching pull was broken before the deferred
-        // joint got drained. The next physics tick processes AddedJoints via InitJoint, which
-        // asserts cross-map. We can't enumerate AddedJoints from outside the engine, but
-        // ClearJoints does sweep it for the targeted entity, so walk every JointComponent and
-        // clear ones whose own committed joints already point cross-map. The same call will
-        // drop any same-pair entries waiting in AddedJoints.
-        var jointQuery = EntityQueryEnumerator<JointComponent>();
-        while (jointQuery.MoveNext(out var uid, out var jointComp))
-        {
-            if (jointComp.GetJoints.Count == 0)
-                continue;
-
-            var myMap = _transform.GetMapId(uid);
-            var diverged = false;
-            foreach (var joint in jointComp.GetJoints.Values)
-            {
-                var other = joint.BodyAUid == uid ? joint.BodyBUid : joint.BodyAUid;
-                if (_transform.GetMapId(other) != myMap)
-                {
-                    diverged = true;
-                    break;
-                }
-            }
-
-            if (diverged)
-                _joints.ClearJoints(uid);
         }
     }
 

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -9,6 +9,13 @@
 // state rollback) before it lands in JointComponent.Joints, in which
 // case the JointComponent-only path misses the transition (e.g. a
 // pullable walking into a portal while the joint is mid-init).
+//
+// Per-tick sweep: the EntParentChanged handlers can miss the case where
+// one body's transform arrives from server state on a later tick than
+// the joint state (the engine defers such joints into AddedJoints, and
+// our parent-changed handler ran before the second transform landed).
+// The sweep runs UpdatesBefore SharedJointSystem.Update so divergent
+// pulls are torn down before InitJoint trips its cross-map assert.
 using System.Collections.Generic;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
@@ -31,9 +38,35 @@ public sealed class PullMapGuardSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        UpdatesBefore.Add(typeof(SharedJointSystem));
         SubscribeLocalEvent<JointComponent, EntParentChangedMessage>(OnJointParentChanged);
         SubscribeLocalEvent<PullerComponent, EntParentChangedMessage>(OnPullerParentChanged);
         SubscribeLocalEvent<PullableComponent, EntParentChangedMessage>(OnPullableParentChanged);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<PullerComponent>();
+        while (query.MoveNext(out var uid, out var puller))
+        {
+            if (puller.Pulling is not { } pulled)
+                continue;
+
+            if (!MapsDiverged(uid, pulled))
+                continue;
+
+            // Tear down both the high-level pull state and the joints themselves.
+            // ClearJoints sweeps SharedJointSystem.AddedJoints too, which is the
+            // path that the EntParentChanged handlers can't reach for joints that
+            // arrived via server state replication mid-teleport.
+            if (TryComp<PullableComponent>(pulled, out var pullable))
+                _pulling.TryStopPull(pulled, pullable);
+
+            _joints.ClearJoints(pulled);
+            _joints.ClearJoints(uid);
+        }
     }
 
     private void OnJointParentChanged(Entity<JointComponent> ent, ref EntParentChangedMessage args)

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -49,8 +49,9 @@ public sealed class PullMapGuardSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<PullerComponent>();
-        while (query.MoveNext(out var uid, out var puller))
+        // Pass 1 - active pulls: tear down any pull whose endpoints now sit on different maps.
+        var pullerQuery = EntityQueryEnumerator<PullerComponent>();
+        while (pullerQuery.MoveNext(out var uid, out var puller))
         {
             if (puller.Pulling is not { } pulled)
                 continue;
@@ -58,15 +59,41 @@ public sealed class PullMapGuardSystem : EntitySystem
             if (!MapsDiverged(uid, pulled))
                 continue;
 
-            // Tear down both the high-level pull state and the joints themselves.
-            // ClearJoints sweeps SharedJointSystem.AddedJoints too, which is the
-            // path that the EntParentChanged handlers can't reach for joints that
-            // arrived via server state replication mid-teleport.
             if (TryComp<PullableComponent>(pulled, out var pullable))
                 _pulling.TryStopPull(pulled, pullable);
 
             _joints.ClearJoints(pulled);
             _joints.ClearJoints(uid);
+        }
+
+        // Pass 2 - orphaned joints: a joint can outlive its pull state when it was deferred
+        // into SharedJointSystem.AddedJoints during state replication (transform was Nullspace
+        // when the joint state arrived) and the matching pull was broken before the deferred
+        // joint got drained. The next physics tick processes AddedJoints via InitJoint, which
+        // asserts cross-map. We can't enumerate AddedJoints from outside the engine, but
+        // ClearJoints does sweep it for the targeted entity, so walk every JointComponent and
+        // clear ones whose own committed joints already point cross-map. The same call will
+        // drop any same-pair entries waiting in AddedJoints.
+        var jointQuery = EntityQueryEnumerator<JointComponent>();
+        while (jointQuery.MoveNext(out var uid, out var jointComp))
+        {
+            if (jointComp.GetJoints.Count == 0)
+                continue;
+
+            var myMap = _transform.GetMapId(uid);
+            var diverged = false;
+            foreach (var joint in jointComp.GetJoints.Values)
+            {
+                var other = joint.BodyAUid == uid ? joint.BodyBUid : joint.BodyAUid;
+                if (_transform.GetMapId(other) != myMap)
+                {
+                    diverged = true;
+                    break;
+                }
+            }
+
+            if (diverged)
+                _joints.ClearJoints(uid);
         }
     }
 
@@ -103,6 +130,8 @@ public sealed class PullMapGuardSystem : EntitySystem
 
         if (TryComp<PullableComponent>(pullable, out var pullableComp))
             _pulling.TryStopPull(pullable, pullableComp);
+
+        DrainPendingJoints(ent.Owner, pullable);
     }
 
     private void OnPullableParentChanged(Entity<PullableComponent> ent, ref EntParentChangedMessage args)
@@ -114,6 +143,21 @@ public sealed class PullMapGuardSystem : EntitySystem
             return;
 
         _pulling.TryStopPull(ent.Owner, ent.Comp);
+        DrainPendingJoints(ent.Owner, puller);
+    }
+
+    /// <summary>
+    /// Removes both endpoints' joints, including any deferred ones in <c>SharedJointSystem.AddedJoints</c>.
+    /// Plain <c>RemoveJoint(uid, id)</c> only touches <c>JointComponent.Joints</c>, so a joint that arrived
+    /// via state replication while one transform was Nullspace can outlive the pull state that birthed it
+    /// and still reach <c>InitJoint</c> the next tick. <c>ClearJoints</c> drains both sets.
+    /// </summary>
+    private void DrainPendingJoints(EntityUid a, EntityUid b)
+    {
+        if (HasComp<JointComponent>(a))
+            _joints.ClearJoints(a);
+        if (HasComp<JointComponent>(b))
+            _joints.ClearJoints(b);
     }
 
     private bool MapsDiverged(EntityUid a, EntityUid b)

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -42,6 +42,7 @@ public sealed class PullMapGuardSystem : EntitySystem
         SubscribeLocalEvent<JointComponent, EntParentChangedMessage>(OnJointParentChanged);
         SubscribeLocalEvent<PullerComponent, EntParentChangedMessage>(OnPullerParentChanged);
         SubscribeLocalEvent<PullableComponent, EntParentChangedMessage>(OnPullableParentChanged);
+
     }
 
     public override void Update(float frameTime)
@@ -117,8 +118,13 @@ public sealed class PullMapGuardSystem : EntitySystem
 
     private bool MapsDiverged(EntityUid a, EntityUid b)
     {
+        // Treat Nullspace-vs-real as divergent too. The engine's deferred-joint path
+        // (JointComponent state arriving while one body's transform is still Nullspace)
+        // queues the joint into AddedJoints, where the next physics tick's InitJoint
+        // asserts on the cross-map comparison once the transform lands. We need to
+        // tear down before that happens, even if one side is currently Nullspace.
         var mapA = _transform.GetMapId(a);
         var mapB = _transform.GetMapId(b);
-        return mapA != mapB && mapA != MapId.Nullspace && mapB != MapId.Nullspace;
+        return mapA != mapB;
     }
 }

--- a/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
+++ b/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
@@ -14,3 +14,7 @@ escalated-grab-resist-success-others = {CAPITALIZE(THE($target))} breaks free!
 
 # Grab broken by damage
 escalated-grab-broken-by-damage = Your grip loosens from the impact!
+
+# Partial drop (down one stage, still grabbed)
+escalated-grab-loosened-puller = Your grip on {THE($target)} loosens.
+escalated-grab-loosened-others = {CAPITALIZE(THE($puller))}'s grip on {THE($target)} loosens.

--- a/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
+++ b/Resources/Locale/en-US/@RussStation/escalated-grab/escalated-grab.ftl
@@ -1,1 +1,16 @@
-escalated-grab-aggressive = You tighten your grip.
+# Escalation popups
+escalated-grab-grab-puller = You grab {THE($target)}.
+escalated-grab-grab-others = {CAPITALIZE(THE($puller))} grabs {THE($target)}!
+escalated-grab-aggressive-puller = You aggressively grab {THE($target)}.
+escalated-grab-aggressive-others = {CAPITALIZE(THE($puller))} aggressively grabs {THE($target)}!
+escalated-grab-choke-puller = You put {THE($target)} in a chokehold.
+escalated-grab-choke-others = {CAPITALIZE(THE($puller))} puts {THE($target)} in a chokehold!
+
+# Resist popups
+escalated-grab-resist-start-target = You start resisting the grab...
+escalated-grab-resist-start-others = {CAPITALIZE(THE($target))} is trying to break free!
+escalated-grab-resist-success-target = You break free from the grab!
+escalated-grab-resist-success-others = {CAPITALIZE(THE($target))} breaks free!
+
+# Grab broken by damage
+escalated-grab-broken-by-damage = Your grip loosens from the impact!

--- a/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
+++ b/Resources/Locale/en-US/@RussStation/traits/quirks.ftl
@@ -63,3 +63,5 @@ trait-tough-desc = You can take a beating.
 trait-skittish-name = Skittish
 trait-skittish-desc = You startle easily. Bumping into a closed container you could fit inside causes you to panic and hide inside it, slamming the door shut behind you if possible.
 trait-skittish-hide = You panic and dive into the {THE($container)}!
+trait-pushover-name = Pushover
+trait-pushover-desc = You're easier to push around. It takes you longer to resist being grabbed.

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -1,0 +1,9 @@
+- type: trait
+  id: Pushover
+  name: trait-pushover-name
+  description: trait-pushover-desc
+  category: Quirks
+  cost: -8
+  components:
+    - type: Pushover
+      resistTimeMultiplier: 1.5

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -27,6 +27,9 @@
   - Narcolepsy
   - Pacified
   - Paracusia
+  # HONK START - Pushover quirk
+  - Pushover
+  # HONK END
   - PermanentBlindness
   - Snoring
   - Unrevivable


### PR DESCRIPTION
## About the PR

Closes #402. Replaces the existing two-state pull (Pull, Aggressive) with a four-stage escalation: Pull, Grab, Aggressive, Choke. Each tier is a deliberate do-after the target can interrupt with a resist alert, and stage-based consequences (movement blocking at Grab+, puller speed penalties, choke stamina ticks, damage-breaks-grab, strip time scaling) make the higher tiers actually feel heavier. Adds the Pushover quirk for resist-time tradeoffs.

## Why / Balance

The release grab is a toggle with no counterplay. This makes escalation a commitment for the puller and gives the target a way to fight back.

| Stage | Escalation | Resist | Puller Speed |
|-------|------------|--------|-------------|
| Pull | instant | n/a | -5% |
| Grab | 2s | 3s | -15% |
| Aggressive | 3s | 5s | -25% |
| Choke | 4s | 6s | -35% |

Choke ticks 5 stamina damage every 0.5s. The puller taking >15 damage in one hit drops one stage. Strip time scales 1.0x / 0.8x / 0.5x / 0.3x. Pushover quirk costs -8 points and multiplies resist time by 1.5x.

A solid hit (>=15 damage) also breaks vanilla pulls now, not just escalated grabs - keeps the rules consistent regardless of whether the puller has bothered to escalate.

## Technical details

- `SharedEscalatedGrabSystem` is the bulk of the change: do-after based escalation and resist, choke tick loop, hand-occupation gating via `NeedHand` on the do-after, damage-breaks-grab path, mutual-grab cleanup, MobStateChangedEvent handler that releases on death.
- `GrabStateComponent` tracks the current stage and per-stage tunables; `GrabStage` enum gains `Grab` and `Choke`.
- `SharedPushoverSystem` hooks `GrabResistAttemptEvent` to apply the resist time multiplier from `PushoverComponent`.
- `PullingSystem.OnRefreshMovespeed` short-circuits when `GrabStateComponent` is present so the escalated grab applies its own per-stage modifiers. Wrapped in HONK markers, one import added, four lines in the method body.
- `PullMapGuardSystem` extended: per-tick `PullerComponent` sweep that catches cross-map divergence (FTL or portal teleport) before `SharedJointSystem.Update` reaches `InitJoint`, with `UpdatesBefore` ordering. Treats `Nullspace`-vs-real as divergent. The escalated grab system also tears down state on portal collide and on the puller getting buckled.
- 19 integration tests in `EscalatedGrabTest` cover stages, resist, damage, mutual grab, strip, Pushover; `CrossMapPullGuardTest` adds an escalated-grab cleanup case for cross-map reparent.
- `quirks.yml` adds the Pushover quirk; `clone.yml` whitelists it.

## Media

<!-- screenshots/video to add -->

## Breaking changes

`GrabStage` enum gains `Grab` and `Choke` values. Code that exhaustively switches on `GrabStage` needs new arms. `GrabStateComponent.Stage` defaults to `Pull`; previously defaulted to `Grab`.

## Changelog

:cl:
- add: Grabs now escalate through four stages (Pull, Grab, Aggressive, Choke) with a resist alert that breaks out one stage at a time.
- add: Higher grab stages slow the grabber and Choke deals stamina damage over time.
- add: Pushover quirk: resist grabs 50% slower, -8 points.
- tweak: Solid hits (15+ damage in one hit) break the puller's pull, not just escalated grabs.
- fix: Pulls no longer survive a portal teleport with a stale joint that desyncs the puller and pulled across maps.