### PR TITLE
honksquad: fix: soften paycheck notification sound

### DIFF
--- a/Content.Server/RussStation/Economy/PayrollSystem.cs
+++ b/Content.Server/RussStation/Economy/PayrollSystem.cs
@@ -121,7 +121,7 @@ public sealed class PayrollSystem : EntitySystem
     }
 
     private static readonly SoundSpecifier PaycheckSound =
-        new SoundPathSpecifier("/Audio/Machines/chime.ogg", AudioParams.Default.WithVolume(-4f));
+        new SoundPathSpecifier("/Audio/Machines/twobeep.ogg", AudioParams.Default.WithVolume(-6f));
 
     private void PlayPdaChime(EntityUid mob)
     {


### PR DESCRIPTION
## About the PR

Swaps the wallet paycheck notification sound from `/Audio/Machines/chime.ogg` to `/Audio/Machines/twobeep.ogg` and drops the volume from -4dB to -6dB.

Closes #282.

## Why / Balance

The chime was a placeholder and it cut through everything else every payroll tick. Twobeep is short, soft, and reads as a passive UI ping rather than an alert, which is what a recurring background notification should sound like.

## Technical details

One-line change in `Content.Server/RussStation/Economy/PayrollSystem.cs`:

```csharp
private static readonly SoundSpecifier PaycheckSound =
    new SoundPathSpecifier("/Audio/Machines/twobeep.ogg", AudioParams.Default.WithVolume(-6f));
```

Both files already exist in the upstream Audio/Machines bank, so no new assets were added.

## Media

No visual change. Audible only in-game when a paycheck fires.

## Requirements

- [x] I have read and am following [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested all added content.
- [x] I have added the relevant changelog.

## Breaking changes

None.

## Changelog

:cl:
- tweak: The wallet paycheck notification is now a quieter two-beep instead of the louder chime.