### PR TITLE
honksquad: fix: raise ServiceJanitorial cargo cost above sell value

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -4,7 +4,8 @@
     sprite: Objects/Specific/Janitorial/spray_bottle.rsi
     state: cleaner
   product: CrateServiceJanitorialSupplies
-  cost: 560
+  # HONK - raised from 560 to clear NoCargoOrderArbitrage (crate sells for ~714)
+  cost: 750
   category: cargoproduct-category-name-service
   group: market
 


### PR DESCRIPTION
## About the PR

Raises the \`ServiceJanitorial\` \`cargoProduct\` cost from 560 to 750 so \`NoCargoOrderArbitrage\` stops failing. HONK comment left on the cost line to flag it during rebase.

Closes #426.

## Why / Balance

The janitorial supply crate's contents currently price out at ~714 when sold, which is more than the 560 it costs to order — free money. The test \`NoCargoOrderArbitrage\` catches this and has been failing CI on every branch rebased onto \`release\`. 750 puts a small positive cargo margin back in place (~5% over the sell value) without overshooting.

## Technical details

One-line YAML value change in \`Resources/Prototypes/Catalog/Cargo/cargo_service.yml\`:

\`\`\`yaml
- type: cargoProduct
  id: ServiceJanitorial
  ...
  # HONK - raised from 560 to clear NoCargoOrderArbitrage (crate sells for ~714)
  cost: 750
\`\`\`

Ran \`dotnet test Content.IntegrationTests --filter "FullyQualifiedName~NoCargoOrderArbitrage"\` — passes.

When upstream fixes this themselves (either by re-pricing the contents or bumping the cost), the HONK comment makes the intent visible so rebase can drop the fork-side bump cleanly.

## Media

No visible change.

## Requirements

- [x] I have read and am following [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested all added content.
- [x] I have added the relevant changelog.

## Breaking changes

Janitorial supply crates are 190 spesos more expensive to order. Small economic nudge; not a gameplay break.

## Changelog

:cl:
- tweak: The janitorial supply crate from Cargo now costs 750 instead of 560.