### PR TITLE
fix: drop duplicate RussStation.Traits import in GunSystem

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee;
-using Content.Shared.RussStation.Traits; //HONK
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;


### PR DESCRIPTION
## About the PR

Release currently fails to build with:

```
Content.Server/Weapons/Ranged/Systems/GunSystem.cs(23,7): error CS0105: The using directive for 'Content.Shared.RussStation.Traits' appeared previously in this namespace
```

The Steady Hand quirk (8157786bd3) added an inline `using Content.Shared.RussStation.Traits; //HONK` without noticing that the Poor Aim quirk (32bd9ce778) had already imported the same namespace inside a `//HONK START/END` block further down the file.

## Why / Balance

CI on every open fork PR is currently failing on the YAML Linter job (which runs `dotnet build` as part of its check) because of this duplicate. Needs to land before anything else.

## Technical details

Removed the inline `using Content.Shared.RussStation.Traits; //HONK` at line 9 and kept the `//HONK START/END` block at lines 22 through 24, which matches the canonical HONK marker convention in CLAUDE.md.

## Verification

- [x] `dotnet build Content.Server` passes locally, 0 errors
- [x] File still imports the namespace once (via the HONK block form)

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

## Changelog

No player-facing changes.