### PR TITLE
docs: upstream-source rule, cross-repo PR guidance, and PR template checkboxes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,39 @@
 <!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
 
 ## About the PR
+
 <!-- What did you change? -->
 
 ## Why / Balance
+
 <!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
 
 ## Technical details
+
 <!-- Summary of code changes for easier review. -->
 
 ## Media
+
 <!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
 Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
 
 ## Requirements
+
 <!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
+
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 - [ ] I have added media to this PR or it does not require an in-game showcase.
-<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
+- [ ] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
+- [ ] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)
+  <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
 
 ## Breaking changes
+
 <!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
 This will be posted in #codebase-changes. -->
 
 **Changelog**
+
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
 Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
 Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -6,7 +6,7 @@ This document describes the branching strategy for the HonkSquad SS14 fork, desi
 
 **`wizden/stable` is the only upstream source for this fork.** Never merge `wizden/master`, `upstream/master`, or any non-stable upstream branch into `staging`, `release`, or any branch destined for `release`. The `release-base-integrity` CI job (`.github/workflows/check-release-base.yml`) enforces this, blocking any push or PR whose merge-base with `origin/upstream/stable` is not itself reachable from `wizden/stable`.
 
-Every fork-authored commit must use the `honksquad:` subject prefix. The `commit-prefix` CI job enforces this for authors listed in `Tools/honk/fork_authors.txt`.
+Every fork-authored commit must use the `honksquad:` subject prefix. The `commit-prefix` CI job enforces this automatically: commits reachable from `origin/upstream/stable` are exempt (upstream), everything else must carry the prefix.
 
 If release drifts onto a non-stable base, the recovery procedure is a full resync: reclassify every commit as fork-preserve or upstream-drop, replay the fork commits onto a clean `wizden/stable` base, force-push release, and rebase all open PRs with `git rebase --onto origin/release <pre-resync-tag>`.
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -2,6 +2,20 @@
 
 This document describes the branching strategy for the HonkSquad SS14 fork, designed to cleanly manage upstream (Wizden) syncs and fork-specific development.
 
+## The upstream rule
+
+**`wizden/stable` is the only upstream source for this fork.** Never merge `wizden/master`, `upstream/master`, or any non-stable upstream branch into `staging`, `release`, or any branch destined for `release`. The `release-base-integrity` CI job (`.github/workflows/check-release-base.yml`) enforces this, blocking any push or PR whose merge-base with `origin/upstream/stable` is not itself reachable from `wizden/stable`.
+
+Every fork-authored commit must use the `honksquad:` subject prefix. The `commit-prefix` CI job enforces this for authors listed in `Tools/honk/fork_authors.txt`.
+
+If you need to reverse a master-based drift, see `docs/plans/2026-04-16-upstream-stable-resync.md`.
+
+## Cross-repository PRs
+
+External contributors submit PRs from their own forks. When rebasing these PRs (e.g., during an upstream sync), push to the **contributor's fork**, not `origin`. Pushing to `origin` creates a dangling mirror branch that does not update the PR.
+
+Use `gh pr checkout <N>` to fetch the contributor's branch, rebase, then force-push back to their remote. You will need to add their fork as a named remote and fetch before `--force-with-lease` works (the `gh`-configured URL is not a tracked remote).
+
 ## Branch Overview
 
 ```
@@ -128,7 +142,7 @@ After the fix PR merges, the parent feature branch picks up the changes. Repeat 
 ### Handling Upstream Conflicts
 
 - **Namespace fork code.** Keep fork-specific files in subdirectories (e.g., `RussStation/`, `HonkSquad/`) and prefix component names to minimize collisions.
-- **Mark fork changes.** Use `// honksquad:` comments near inline changes to upstream files so they're easy to find during conflict resolution.
+- **Mark fork changes.** Use `//HONK START` / `//HONK END` block markers around inline changes to upstream files. Inline `// honksquad:` tails are not accepted by the HONK audit; see `CONTRIBUTING.md`.
 - **Keep upstream files clean.** Prefer extending via new components/systems rather than editing existing ones.
 - **Sync regularly.** Small, frequent syncs are easier than large, infrequent ones.
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -8,7 +8,7 @@ This document describes the branching strategy for the HonkSquad SS14 fork, desi
 
 Every fork-authored commit must use the `honksquad:` subject prefix. The `commit-prefix` CI job enforces this for authors listed in `Tools/honk/fork_authors.txt`.
 
-If you need to reverse a master-based drift, see `docs/plans/2026-04-16-upstream-stable-resync.md`.
+If release drifts onto a non-stable base, the recovery procedure is a full resync: reclassify every commit as fork-preserve or upstream-drop, replay the fork commits onto a clean `wizden/stable` base, force-push release, and rebase all open PRs with `git rebase --onto origin/release <pre-resync-tag>`.
 
 ## Cross-repository PRs
 


### PR DESCRIPTION
## About the PR

Adds prevention documentation from the upstream-stable resync plan (layers 1 + 2).

## Why / Balance

The 2026-04-16 resync was caused by an undocumented merge of `wizden/master` into staging. These docs make the rules explicit so they're visible before CI even runs.

## Technical details

**BRANCHING.md:**
- New "The upstream rule" section: explicit prohibition on non-stable upstream merges, `honksquad:` prefix requirement, inline recovery procedure summary
- New "Cross-repository PRs" section: documents the `gh pr checkout` workflow for rebasing contributor-fork PRs (learned from the PR #452 incident during Phase 5)
- Updated HONK marker guidance: `//HONK START` / `//HONK END` block markers instead of inline `// honksquad:` tails

**PR template:**
- Two new Requirements checkboxes: upstream-source compliance and commit-prefix compliance

## Media

N/A (docs only)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.