### PR TITLE
ci: release base integrity and commit-prefix enforcement

### DIFF
--- a/.github/workflows/check-release-base.yml
+++ b/.github/workflows/check-release-base.yml
@@ -1,0 +1,106 @@
+name: Release base integrity
+
+on:
+  pull_request:
+    branches: [release]
+  push:
+    branches: [release]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  base-integrity:
+    name: Release is based on upstream/stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch upstream/stable mirror
+        run: git fetch --no-tags origin upstream/stable
+
+      - name: Fetch wizden/stable (authoritative)
+        run: |
+          git remote add wizden https://github.com/space-wizards/space-station-14.git || true
+          git fetch --no-tags wizden stable
+
+      - name: Verify mirror matches wizden/stable
+        run: |
+          MIRROR=$(git rev-parse origin/upstream/stable)
+          WIZDEN=$(git rev-parse wizden/stable)
+          if [ "$MIRROR" != "$WIZDEN" ]; then
+            echo "::error::origin/upstream/stable ($MIRROR) does not match wizden/stable ($WIZDEN)"
+            echo "The mirror is stale. Advance it with the check-upstream-stable workflow."
+            exit 1
+          fi
+
+      - name: Verify release merge-base is on upstream/stable
+        run: |
+          BASE=$(git merge-base HEAD origin/upstream/stable)
+          if ! git merge-base --is-ancestor "$BASE" wizden/stable; then
+            echo "::error::release is based on a commit ($BASE) that is not reachable from wizden/stable."
+            echo "This means release has merged wizden/master (or another non-stable branch)."
+            exit 1
+          fi
+
+      - name: Reject red-flag merge subjects
+        run: |
+          RANGE="origin/upstream/stable..HEAD"
+          BAD=$(git log --format="%H %s" $RANGE | \
+            grep -iE "upstream/master|wizden/master|stable ->? master|into staging.*master" || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::Commit subjects reference wizden/master. Release must only merge wizden/stable."
+            echo "$BAD"
+            exit 1
+          fi
+
+  commit-prefix:
+    name: "honksquad: prefix on fork commits"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch upstream/stable
+        run: git fetch --no-tags origin upstream/stable
+
+      - name: Check every new commit for honksquad: prefix
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          RANGE="${BASE}..HEAD"
+
+          FAILED=0
+          while IFS=$'\t' read -r sha subject; do
+            # Exempt merge commits
+            if [[ "$subject" =~ ^Merge\ (pull\ request|branch|remote-tracking) ]]; then
+              continue
+            fi
+
+            # Exempt upstream commits (reachable from upstream/stable)
+            if git merge-base --is-ancestor "$sha" origin/upstream/stable 2>/dev/null; then
+              continue
+            fi
+
+            # Everything else is a fork commit and must have the prefix
+            if ! [[ "$subject" =~ ^honksquad: ]]; then
+              AUTHOR=$(git log -1 --format="%an" "$sha")
+              echo "::error::Commit $sha by \"$AUTHOR\" is missing the honksquad: prefix."
+              echo "  Subject: $subject"
+              echo "  Fix: git rebase -i $BASE and prepend 'honksquad: ' to this commit's subject."
+              FAILED=1
+            fi
+          done < <(git log --format="%H%x09%s" $RANGE)
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "Every fork-authored commit must start with 'honksquad:' (e.g., 'honksquad: feat: add feature')."
+            echo "Upstream commits (reachable from origin/upstream/stable) are automatically exempt."
+          fi
+
+          exit $FAILED

--- a/.github/workflows/check-upstream-stable.yml
+++ b/.github/workflows/check-upstream-stable.yml
@@ -6,8 +6,12 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
-  check-upstream:
+  sync-mirror:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -28,81 +32,76 @@ jobs:
           REMOTE_SHA=$(git rev-parse wizden/stable)
 
           if [ "$LOCAL_SHA" = "$REMOTE_SHA" ]; then
-            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
-          else
+            echo "status=current" >> "$GITHUB_OUTPUT"
+          elif git merge-base --is-ancestor "$LOCAL_SHA" wizden/stable; then
             BEHIND_COUNT=$(git rev-list --count origin/upstream/stable..wizden/stable)
-            LATEST_COMMITS=$(git log --oneline origin/upstream/stable..wizden/stable | head -20)
-            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+            echo "status=behind" >> "$GITHUB_OUTPUT"
             echo "behind_count=$BEHIND_COUNT" >> "$GITHUB_OUTPUT"
             echo "local_sha=$LOCAL_SHA" >> "$GITHUB_OUTPUT"
             echo "remote_sha=$REMOTE_SHA" >> "$GITHUB_OUTPUT"
-            {
-              echo "latest_commits<<COMMITS_EOF"
-              echo "$LATEST_COMMITS"
-              echo "COMMITS_EOF"
-            } >> "$GITHUB_OUTPUT"
+          else
+            echo "status=diverged" >> "$GITHUB_OUTPUT"
+            echo "local_sha=$LOCAL_SHA" >> "$GITHUB_OUTPUT"
+            echo "remote_sha=$REMOTE_SHA" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check for existing open issue
-        if: steps.compare.outputs.up_to_date == 'false'
-        id: existing
+      - name: Auto-advance mirror (fast-forward)
+        if: steps.compare.outputs.status == 'behind'
+        run: |
+          git push origin wizden/stable:upstream/stable
+          echo "Advanced origin/upstream/stable by ${{ steps.compare.outputs.behind_count }} commits"
+          echo "  ${{ steps.compare.outputs.local_sha }} -> ${{ steps.compare.outputs.remote_sha }}"
+
+      - name: Close resolved sync issues
+        if: steps.compare.outputs.status == 'behind' || steps.compare.outputs.status == 'current'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ISSUE=$(gh issue list --label "upstream-sync" --state open --json number --jq '.[0].number // empty')
-          echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
+          ISSUES=$(gh issue list --label "upstream-sync" --state open --json number --jq '.[].number')
+          for num in $ISSUES; do
+            gh issue close "$num" --comment "Mirror auto-advanced to wizden/stable. Closing."
+          done
 
-      - name: Create or update issue
-        if: steps.compare.outputs.up_to_date == 'false' && steps.existing.outputs.issue_number == ''
+      - name: Open issue on divergence (wizden force-pushed)
+        if: steps.compare.outputs.status == 'diverged'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue create \
-            --title "Upstream stable has ${{ steps.compare.outputs.behind_count }} new commits" \
-            --label "upstream-sync" \
-            --body "$(cat <<'EOF'
-          Wizden \`stable\` has moved ahead of our \`upstream/stable\` branch.
+          EXISTING=$(gh issue list --label "upstream-sync" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$(cat <<EOF
+          Mirror still diverged from wizden/stable. Automatic fast-forward is not possible.
 
-          **Behind by:** ${{ steps.compare.outputs.behind_count }} commits
           **Our SHA:** \`${{ steps.compare.outputs.local_sha }}\`
           **Wizden SHA:** \`${{ steps.compare.outputs.remote_sha }}\`
 
-          ### Recent upstream commits
-          ```
-          ${{ steps.compare.outputs.latest_commits }}
-          ```
-
-          ### To sync
-          ```bash
+          This likely means wizden force-pushed stable. A maintainer must manually verify and force-push:
+          \`\`\`bash
           git fetch wizden stable
-          git checkout upstream/stable
-          git reset --hard wizden/stable
-          git push --force origin upstream/stable
-
-          git checkout release
-          git merge upstream/stable
-          # resolve conflicts
-          git push origin release
-          ```
-
-          This issue was created automatically by the [Check Upstream Stable](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow.
+          git push --force origin wizden/stable:upstream/stable
+          \`\`\`
           EOF
           )"
+          else
+            gh issue create \
+              --title "upstream/stable has diverged from wizden/stable (manual intervention needed)" \
+              --label "upstream-sync" \
+              --body "$(cat <<EOF
+          The \`origin/upstream/stable\` mirror cannot be fast-forwarded to \`wizden/stable\`.
+          This means wizden force-pushed their stable branch.
 
-      - name: Update existing issue
-        if: steps.compare.outputs.up_to_date == 'false' && steps.existing.outputs.issue_number != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh issue comment ${{ steps.existing.outputs.issue_number }} \
-            --body "$(cat <<'EOF'
-          Still behind — now **${{ steps.compare.outputs.behind_count }} commits** behind wizden/stable.
-
+          **Our SHA:** \`${{ steps.compare.outputs.local_sha }}\`
           **Wizden SHA:** \`${{ steps.compare.outputs.remote_sha }}\`
 
-          ### Latest upstream commits
-          ```
-          ${{ steps.compare.outputs.latest_commits }}
-          ```
+          A maintainer must manually verify the new wizden/stable tip and force-push:
+          \`\`\`bash
+          git fetch wizden stable
+          git log --oneline origin/upstream/stable..wizden/stable | head -20
+          # verify the commits look correct, then:
+          git push --force origin wizden/stable:upstream/stable
+          \`\`\`
+
+          This issue was created by the [Check Upstream Stable](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow.
           EOF
           )"
+          fi


### PR DESCRIPTION
## About the PR

CI enforcement and mirror automation from the upstream-stable resync prevention plan (layers 3-7).

## Why / Balance

Docs and checkboxes (PR #487) are human-enforced. This PR adds automated enforcement that blocks merges when rules are violated, and auto-advances the upstream mirror so it never goes stale.

## Technical details

**New workflow: `.github/workflows/check-release-base.yml`** (layers 3, 4, 7)

Two jobs:
- **base-integrity** (push + PR to release): verifies mirror matches wizden/stable, merge-base is on stable ancestry, rejects commit subjects referencing wizden/master
- **commit-prefix** (PRs targeting release): requires `honksquad:` prefix on every commit not reachable from `origin/upstream/stable`. No author allow-list needed; upstream vs fork detection is ancestry-based.

**Enhanced: `.github/workflows/check-upstream-stable.yml`** (layer 5)

Replaces the notify-only workflow with auto-fast-forward:
- **current**: mirror matches wizden/stable, close any open upstream-sync issues
- **behind**: auto-advance mirror via fast-forward, close open issues
- **diverged**: wizden force-pushed stable, open issue for manual intervention

Needs `contents: write` permission. Branch protection on `upstream/stable` updated to allow workflow pushes (lock removed, force-push disabled).

**Repo settings applied** (layer 6):
- Release ruleset: added `Release is based on upstream/stable` and `honksquad: prefix on fork commits` as required checks, 1 required reviewer with stale-review dismissal, HellWatcher as bypass actor
- upstream/stable: unlocked (was read-only), force-push disabled. Workflow can fast-forward; maintainers can force-push via admin bypass for divergence recovery.

## Media

N/A (CI only)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

After merge: PRs targeting release that lack the `honksquad:` prefix on fork commits, or that introduce non-stable upstream ancestry, will be blocked by CI. Existing open PRs already rebased during Phase 5 carry the prefix.