### PR TITLE
ci: run HONK audits on ready_for_review

### DIFF
--- a/.github/workflows/honk-cs-audit.yml
+++ b/.github/workflows/honk-cs-audit.yml
@@ -2,7 +2,7 @@ name: HONK / C# audit (PR)
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     branches: [release]
 
 jobs:

--- a/.github/workflows/honk-yaml-drift.yml
+++ b/.github/workflows/honk-yaml-drift.yml
@@ -2,7 +2,7 @@ name: HONK / YAML drift (PR)
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     branches: [release]
 
 jobs:


### PR DESCRIPTION
## About the PR

Adds `ready_for_review` to the `pull_request` trigger types for `honk-cs-audit.yml` and `honk-yaml-drift.yml`.

## Why / Balance

Both jobs gate on `github.event.pull_request.draft == false`, so they skip on draft PRs. The workflow only listened for `[opened, reopened, synchronize]`, none of which fire when a draft flips to ready — meaning a PR opened as draft never re-ran the audits on ready-up. You had to push another commit to retrigger.

## Technical details

One-line addition per workflow.

## Media

N/A.

## Requirements

- [x] Read the PR guidelines.
- [x] No in-game showcase needed.
- [x] Based on `release`.
- [x] `honksquad:` commit prefix.

## Breaking changes

None.

**Changelog**

No player-facing changes.