### PR TITLE
chore: gitignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -313,6 +313,7 @@ Resources/MapImages
 # HONK START - Fork-specific ignores
 # AI tooling
 CLAUDE.md
+.claude/
 .serena/
 .prettierignore
 /docs/


### PR DESCRIPTION
## About the PR

Adds `.claude/` to the fork's HONK-marked gitignore block so local Claude Code session files (settings, scheduled task locks) stop showing up in `git status`.

## Why / Balance

Not a gameplay change. `.claude/` is generated by the Claude Code CLI and is purely local tooling state, same category as the existing `CLAUDE.md` and `.serena/` entries already in that block.

## Technical details

One line added to the existing `# HONK START - Fork-specific ignores` block in `.gitignore`.

## Media

N/A, tooling-only.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing changes.