### PR TITLE
balance: lower dead-end plant mutation odds

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -96,10 +96,12 @@ public sealed class MutationSystem : EntitySystem
 
         // Hybrids have a high chance of being seedless. Balances very
         // effective hybrid crossings.
-        if (a.Name != result.Name && Random(0.7f))
+        //HONK START - 0.7f guaranteed seedless on most hybrids, which made cross-breeding a dead end. Disabled.
+        if (a.Name != result.Name && Random(0f))
         {
             result.Seedless = true;
         }
+        //HONK END
 
         return result;
     }

--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -24,7 +24,9 @@
       effect: !type:PlantMutateSpeciesChange
       persists: false
     - name: Unviable
-      baseOdds: 0.109
+      # HONK START - Unviable was 3x the odds of any other stat mutation. Knock it down to match.
+      baseOdds: 0.036
+      # HONK END
       persists: false
       effect: !type:PlantChangeStat
         targetValue: Viable
@@ -149,7 +151,9 @@
         maxValue: 100
         steps: 5
     - name: ChangeSeedless
-      baseOdds: 0.036
+      # HONK START - Seedless requires hard-to-source chems to fix. Halved odds.
+      baseOdds: 0.018
+      # HONK END
       persists: false
       effect: !type:PlantChangeStat
         targetValue: Seedless
@@ -159,7 +163,9 @@
       effect: !type:PlantChangeStat
         targetValue: Ligneous
     - name: Kudzufication
-      baseOdds: 0.036
+      # HONK START - Kudzu is permanent, unfixable, and kills the tray. Quartered odds.
+      baseOdds: 0.009
+      # HONK END
       persists: false
       effect: !type:PlantChangeStat
         targetValue: TurnIntoKudzu

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -120,9 +120,9 @@
     - !type:PlantAdjustPests
       probability: 0.025
       amount: 1
-    # HONK START - Default threshold is 30 (out of 50 cap), so any RH pump guarantees Seedless. Push it to near-cap so the trait is a tradeoff for maxing potency, not a certainty.
+    # HONK START - Default threshold is 30 (out of 50 cap), so any RH pump guarantees Seedless. Raise above cap so RH no longer forces seedless - the random mutation is the sole seedless source.
     - !type:RobustHarvest
-        potencySeedlessThreshold: 49
+        potencySeedlessThreshold: 51
     # HONK END
   metabolisms:
     Bloodstream:

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -120,7 +120,10 @@
     - !type:PlantAdjustPests
       probability: 0.025
       amount: 1
-    - !type:RobustHarvest {}
+    # HONK START - Default threshold is 30 (out of 50 cap), so any RH pump guarantees Seedless. Push it to near-cap so the trait is a tradeoff for maxing potency, not a certainty.
+    - !type:RobustHarvest
+        potencySeedlessThreshold: 49
+    # HONK END
   metabolisms:
     Bloodstream:
       effects:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Rebalances the plant mutation odds on the 'dead-end' outcomes (Unviable, Seedless, Kudzu) and strips two extra layers of forced Seedless that were stacking on top of the random mutation.

## Why / Balance

Botanist feedback: Unviable / Seedless / Kudzu almost always landed during a mutation run, and fixes are either chemist-gated (Seedless, Unviable) or impossible (Kudzu). Unviable was particularly egregious at `0.109` baseOdds, three times every other stat mutation.

Two extra systems were also forcing Seedless regardless of the random roll. Seedless already exists as both a mutation and a potency-based outcome; didn't need the extra automatic triggers on top:

- `RobustHarvest` reagent defaulted to `PotencySeedlessThreshold = 30` out of a `50` potency cap. Any meaningful RH usage locked seedless in.
- `MutationSystem.Cross` flipped seedless to `true` with a flat `0.7f` probability any time two different species cross-pollinated. Made hybrid hunting a dead end.

New values:

| Source                                              | Before | After | Rationale |
| --------------------------------------------------- | ------ | ----- | ---- |
| Random mutation `Unviable`                          | 0.109  | 0.036 | Match other stat mutations. |
| Random mutation `Seedless`                          | 0.036  | 0.018 | Half as often. Fix needs chemist chems. |
| Random mutation `Kudzufication`                     | 0.036  | 0.009 | Permanent, unfixable, kills the tray. |
| `RobustHarvest.potencySeedlessThreshold`            | 30     | 51    | Above the 50 cap, so RH never forces seedless. |
| Hybrid cross forced-seedless probability            | 0.7f   | 0f    | Same-species still propagates via normal CrossBool. Hybrids no longer auto-punished. |

## Technical details

- `Resources/Prototypes/Hydroponics/randomMutations.yml` — three HONK-wrapped `baseOdds` edits.
- `Resources/Prototypes/Reagents/botany.yml` — HONK-wrapped override on the `RobustHarvest` plant effect setting `potencySeedlessThreshold: 51`.
- `Content.Server/Botany/Systems/MutationSystem.cs` — HONK-wrapped edit changing the hybrid seedless probability from `0.7f` to `0f`.

## Media

_Tuning change, no new assets._

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches. (See \`BRANCHING.md\`.)
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix. (See \`CONTRIBUTING.md\`.)

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Unviable, Seedless, and Kudzu plant mutations now fire less often during mutation rolls. RobustHarvest no longer locks plants as seedless, and cross-pollinating different species no longer automatically produces seedless hybrids.