### PR TITLE
fix: guard carrying shutdown handlers against mutual recursion

### DIFF
--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -420,8 +420,11 @@ public abstract class SharedCarryingSystem : EntitySystem
         var carrier = component.Carrier;
 
         // Remove the symmetric carrier-side marker first. Skip if the carrier is itself
-        // terminating — its own component shutdown is already running the symmetric path.
-        if (!Terminating(carrier) && HasComp<ActiveCarrierComponent>(carrier))
+        // terminating, or if its marker is already in shutdown — HasComp stays true during
+        // ComponentShutdown, so without the LifeStage guard the two handlers recurse.
+        if (!Terminating(carrier)
+            && TryComp<ActiveCarrierComponent>(carrier, out var activeComp)
+            && activeComp.LifeStage < ComponentLifeStage.Stopping)
             RemComp<ActiveCarrierComponent>(carrier);
 
         if (Exists(carrier) && !Terminating(carrier))
@@ -470,10 +473,12 @@ public abstract class SharedCarryingSystem : EntitySystem
     private void OnActiveCarrierShutdown(EntityUid uid, ActiveCarrierComponent component, ComponentShutdown args)
     {
         var target = component.Target;
-        // Skip if the target is itself terminating — its BeingCarriedComponent is either
-        // already in shutdown (we're being called from it) or will be when the deletion
-        // walk reaches it.
-        if (!Terminating(target) && HasComp<BeingCarriedComponent>(target))
+        // Skip if the target is itself terminating, or if its marker is already in shutdown.
+        // HasComp stays true during ComponentShutdown, so without the LifeStage guard the
+        // two handlers recurse when the teardown enters via BeingCarried first.
+        if (!Terminating(target)
+            && TryComp<BeingCarriedComponent>(target, out var carriedComp)
+            && carriedComp.LifeStage < ComponentLifeStage.Stopping)
             RemComp<BeingCarriedComponent>(target);
     }
 


### PR DESCRIPTION
## About the PR

Fixes a stack overflow crash triggered during teardown of a carrying relationship (for example buckling or deleting while one entity is carrying another).

## Why / Balance

`ActiveCarrierComponent` and `BeingCarriedComponent` are mirrored markers, one on the carrier, one on the target. Each handler's `ComponentShutdown` removed the other marker. The guard was `HasComp`, which stays true throughout `ComponentShutdown` (the component is not unregistered until the shutdown event returns), so removing one side re-entered the other side's handler, which re-removed the first, and so on until the stack blew up.

## Technical details

Both handlers now check `LifeStage < ComponentLifeStage.Stopping` via `TryComp` on the mirror component before calling `RemComp`. Once the mirror has entered its own shutdown, the cascade stops.

Touched only `Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs`. Two small edits, symmetric on both handlers.

## Media

N/A, crash fix with no visible change.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [X] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed a crash when a carrying relationship ended (for instance buckling while being carried).