### PR TITLE
honksquad: fix: break cross-map joints on parent change

### DIFF
--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -1,0 +1,47 @@
+// HONK - Break pulls when the two endpoints end up on different maps.
+// Without this, FTL-reparenting the pullee (e.g. arrivals grid returning
+// from the FTL map) leaves the pulling distance joint cross-map, which
+// trips the engine's cross-map joint assert during client prediction.
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.RussStation.Physics;
+
+public sealed class PullMapGuardSystem : EntitySystem
+{
+    [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PullableComponent, EntParentChangedMessage>(OnPullableParentChanged);
+        SubscribeLocalEvent<PullerComponent, EntParentChangedMessage>(OnPullerParentChanged);
+    }
+
+    private void OnPullableParentChanged(Entity<PullableComponent> ent, ref EntParentChangedMessage args)
+    {
+        if (ent.Comp.Puller is not { } puller)
+            return;
+
+        if (_transform.GetMapId(ent.Owner) == _transform.GetMapId(puller))
+            return;
+
+        _pulling.TryStopPull(ent.Owner, ent.Comp);
+    }
+
+    private void OnPullerParentChanged(Entity<PullerComponent> ent, ref EntParentChangedMessage args)
+    {
+        if (ent.Comp.Pulling is not { } pullable)
+            return;
+
+        if (_transform.GetMapId(ent.Owner) == _transform.GetMapId(pullable))
+            return;
+
+        if (!TryComp<PullableComponent>(pullable, out var pullableComp))
+            return;
+
+        _pulling.TryStopPull(pullable, pullableComp);
+    }
+}

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -1,47 +1,49 @@
-// HONK - Break pulls when the two endpoints end up on different maps.
-// Without this, FTL-reparenting the pullee (e.g. arrivals grid returning
-// from the FTL map) leaves the pulling distance joint cross-map, which
-// trips the engine's cross-map joint assert during client prediction.
-using Content.Shared.Movement.Pulling.Components;
-using Content.Shared.Movement.Pulling.Systems;
+// HONK - Break any joint whose endpoints end up on different maps.
+// Without this, FTL-reparenting one side of a joint (e.g. arrivals grid
+// returning from the FTL map) leaves the joint cross-map, which trips
+// the engine's cross-map joint assert during client prediction.
+// Covers pulling, carrying, buckle relay, grappling gun — any JointComponent.
+using System.Collections.Generic;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Dynamics.Joints;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.RussStation.Physics;
 
 public sealed class PullMapGuardSystem : EntitySystem
 {
-    [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private readonly List<Joint> _toBreak = new();
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<PullableComponent, EntParentChangedMessage>(OnPullableParentChanged);
-        SubscribeLocalEvent<PullerComponent, EntParentChangedMessage>(OnPullerParentChanged);
+        SubscribeLocalEvent<JointComponent, EntParentChangedMessage>(OnParentChanged);
     }
 
-    private void OnPullableParentChanged(Entity<PullableComponent> ent, ref EntParentChangedMessage args)
+    private void OnParentChanged(Entity<JointComponent> ent, ref EntParentChangedMessage args)
     {
-        if (ent.Comp.Puller is not { } puller)
+        if (ent.Comp.GetJoints.Count == 0)
             return;
 
-        if (_transform.GetMapId(ent.Owner) == _transform.GetMapId(puller))
+        var map = _transform.GetMapId(ent.Owner);
+
+        foreach (var joint in ent.Comp.GetJoints.Values)
+        {
+            var other = joint.BodyAUid == ent.Owner ? joint.BodyBUid : joint.BodyAUid;
+            if (_transform.GetMapId(other) != map)
+                _toBreak.Add(joint);
+        }
+
+        if (_toBreak.Count == 0)
             return;
 
-        _pulling.TryStopPull(ent.Owner, ent.Comp);
-    }
+        foreach (var joint in _toBreak)
+            _joints.RemoveJoint(joint);
 
-    private void OnPullerParentChanged(Entity<PullerComponent> ent, ref EntParentChangedMessage args)
-    {
-        if (ent.Comp.Pulling is not { } pullable)
-            return;
-
-        if (_transform.GetMapId(ent.Owner) == _transform.GetMapId(pullable))
-            return;
-
-        if (!TryComp<PullableComponent>(pullable, out var pullableComp))
-            return;
-
-        _pulling.TryStopPull(pullable, pullableComp);
+        _toBreak.Clear();
     }
 }


### PR DESCRIPTION
## About the PR

Adds `PullMapGuardSystem` (fork-side, shared). It subscribes `EntParentChangedMessage` on `JointComponent` and breaks any joint whose two endpoints are on different maps after the reparent.

## Why / Balance

Client prediction was dying with `DebugAssertException: Attempted to initialize cross-map joint` during arrivals FTL. The trigger is arrivals grid reparenting between the FTL map and the station map while a joint (pull, carry relay, buckle relay, grappling gun) still straddles the two sides. The engine asserts in `SharedJointSystem.InitJoint`.

Guarding at the `JointComponent` layer covers every joint source in one place rather than patching each relationship system.

## Technical details

- New file: `Content.Shared/RussStation/Physics/PullMapGuardSystem.cs`
- Subscribes `EntParentChangedMessage` on `JointComponent`
- Walks `GetJoints`, compares `MapId` of each endpoint, calls `SharedJointSystem.RemoveJoint` on any mismatch
- No upstream files touched

Known caveats:
- Unreproduced in a controlled test; reasoned from the stack trace.
- Same-tick race possible if `JointSystem.Update` runs before the reparent handler drains. Monitor after merge.

## Media

N/A, code-only fix.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed a client crash during arrivals FTL when a pull, carry, or buckle relay straddled the FTL and station maps.