### PR TITLE
honksquad: fix: ignore duplicate StorageBoundUserInterface.Open from BUI queue

### DIFF
--- a/Content.Client/Storage/StorageBoundUserInterface.cs
+++ b/Content.Client/Storage/StorageBoundUserInterface.cs
@@ -21,6 +21,13 @@ public sealed class StorageBoundUserInterface : BoundUserInterface
 
     protected override void Open()
     {
+        // HONK START - Guard against duplicate Open() from _queuedBuis draining
+        // the same BUI twice (e.g. reconnect: OnUserInterfaceStartup queues an
+        // open, then an actor re-open queues a second). Without this, we call
+        // CreateStorageWindow -> RegisterControl twice and the engine asserts.
+        if (_window != null)
+            return;
+        // HONK END
         base.Open();
 
         _window = IoCManager.Resolve<IUserInterfaceManager>()


### PR DESCRIPTION
## About the PR

Guards `StorageBoundUserInterface.Open()` with a `_window != null` early-return so a duplicate drain from the engine's `_queuedBuis` becomes a no-op.

## Why / Balance

Reproduced as a hard client crash on reconnect when a storage BUI was open at disconnect (e.g. pulling a janitor trolley with its storage window still up). Locks the player out of the server because the assert fires during initial game-state apply.

Stack (abridged):

```
DebugAssertException
  at UserInterfaceSystem.RegisterControl (.../UserInterfaceSystem.cs:53)
  at StorageUIController.CreateStorageWindow (.../StorageUIController.cs:175)
  at StorageBoundUserInterface.Open (.../StorageBoundUserInterface.cs:26)
  at SharedUserInterfaceSystem.Update (.../SharedUserInterfaceSystem.cs:1111)
```

Root cause: `_queuedBuis` can carry two `(bui, open=true)` entries for the same instance, one enqueued by `OnUserInterfaceStartup` iterating `ClientOpenInterfaces`, another by `EnsureClientBui` when the server re-pushes the actor open in the same frame. `AddQueued` does not dedupe. Second drain calls `Open()` on the already-opened BUI, `CreateStorageWindow` runs twice, the engine's `_registeredControls` ContainsKey assert trips.

Proper fix is engine-side (dedupe `_queuedBuis` in `AddQueued`). This is the fork-side workaround until that lands upstream.

## Technical details

- Touched `Content.Client/Storage/StorageBoundUserInterface.cs` only.
- One HONK-marked guard at the top of `Open()`.
- Side-effects: a legitimate second Open on the same instance was already leaking the first window (assigned over `_window`); the guard preserves the first window instead.

## Media

N/A, crash fix.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed a client crash on reconnect when a storage UI (e.g. janitor trolley) was open at disconnect.