### PR TITLE
honksquad: fix: refuse tend-wounds on uninjured patients (#506)

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
@@ -111,6 +111,38 @@ public sealed partial class SurgerySystem
         }
     }
 
+    /// <summary>
+    /// True if any healing step in the procedure has at least one target damage type
+    /// the patient currently carries above a small epsilon. Procedures whose only
+    /// useful effect is healing (tend-wounds) fail this check on an uninjured patient.
+    /// Procedures with no healing steps (e.g. organ manipulation) always pass.
+    /// </summary>
+    private bool ProcedureHasAnythingToTend(EntityUid patient, SurgeryProcedurePrototype proto)
+    {
+        if (!TryComp<DamageableComponent>(patient, out var damageable))
+            return true;
+
+        var hasHealingStep = false;
+        var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
+        const float epsilon = 0.01f;
+
+        foreach (var step in proto.Steps)
+        {
+            if (step.Healing == null)
+                continue;
+
+            hasHealingStep = true;
+
+            foreach (var type in step.Healing.DamageDict.Keys)
+            {
+                if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > FixedPoint2.New(epsilon))
+                    return true;
+            }
+        }
+
+        return !hasHealingStep;
+    }
+
     private bool StepCanStillHeal(EntityUid patient, SurgeryStep step)
     {
         if (step.Healing == null || (step.HealingFlat <= 0 && step.HealingMultiplier <= 0))

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -205,6 +205,13 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             return;
         }
 
+        // Validate: if the procedure only heals and the patient has no matching damage, refuse.
+        if (!ProcedureHasAnythingToTend(target.Value, proto))
+        {
+            _popup.PopupEntity(Loc.GetString("surgery-nothing-to-tend", ("target", target.Value)), target.Value, surgeon);
+            return;
+        }
+
         // Now drape the patient and take the bedsheet/drape
         var draped = EnsureComp<SurgeryDrapedComponent>(target.Value);
         draped.Bedsheet = bedsheet.Value;
@@ -354,13 +361,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         // Apply side effects
         ApplyStepEffects(patient, step);
 
-        // Popup
-        if (!string.IsNullOrEmpty(step.Popup) && args.User is { } user)
-            _popup.PopupEntity(Loc.GetString(step.Popup, ("user", user), ("target", patient)), patient);
-
-        // Trigger effect if this step has one
-        if (step.Effect != null)
-            HandleEffect(args.User, patient, step.Effect);
+        var suppressStepPopup = false;
 
         // Advance step (unless repeatable).
         // Repeatable steps with effects (like organ manipulation) need manual re-use,
@@ -379,8 +380,20 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             args.Repeat = healedSomething && StepCanStillHeal(patient, step);
 
             if (!args.Repeat)
+            {
+                // Swap the step popup for the completion popup so we don't double up.
+                suppressStepPopup = true;
                 _popup.PopupEntity(Loc.GetString("surgery-step-repeat-done"), patient);
+            }
         }
+
+        // Step popup (skipped on the terminal iteration of a repeatable step).
+        if (!suppressStepPopup && !string.IsNullOrEmpty(step.Popup) && args.User is { } user)
+            _popup.PopupEntity(Loc.GetString(step.Popup, ("user", user), ("target", patient)), patient);
+
+        // Trigger effect if this step has one
+        if (step.Effect != null)
+            HandleEffect(args.User, patient, step.Effect);
 
         // Procedure steps exhausted, wait for cautery to close
         if (active.CurrentStep >= proto.Steps.Count)

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -44,6 +44,7 @@ surgery-already-draped = The patient is already draped for surgery.
 surgery-drape-missing = The surgical drape is no longer available.
 surgery-procedure-invalid = The surgical procedure is no longer valid.
 surgery-busy = You are already doing something.
+surgery-nothing-to-tend = {CAPITALIZE(THE($target))} has no wounds that this procedure can treat.
 
 ## Guidebook
 guide-entry-surgery = Surgery


### PR DESCRIPTION
## About the PR

Closes #506.

Two small bugs around the tend-wounds surgery procedures:

- Selecting tend-wounds on a patient with no matching damage still started the procedure, so the surgeon would drape, cut, retract, and clamp for nothing.
- Once the Clamping step finished repeating, two popups fired on the same tick: the step popup ("treats burn damage on Bob") and the completion popup ("the treatment has done all it can").

## Why / Balance

No balance change. The only gameplay effect is that a surgeon who picks the wrong procedure gets told right away instead of running the whole sequence.

## Technical details

- `OnProcedureSelected` now calls `ProcedureHasAnythingToTend` before draping. The helper walks every step of the chosen procedure, collects the damage types any healing step targets, and checks the patient's current positive damage against them. If all of those are below a 0.01 epsilon, the procedure is refused with one `surgery-nothing-to-tend` popup. Procedures with no healing steps (organ manipulation) fall through unchanged.
- `OnStepDoAfter` now emits the step popup and the completion popup as alternatives, not back-to-back. On the terminal iteration of a repeatable healing step (`args.Repeat == false` after the zero-effect check), the step popup is suppressed so only `surgery-step-repeat-done` fires.
- New locale string `surgery-nothing-to-tend` under `Resources/Locale/en-US/@RussStation/surgery/surgery.ftl`.

No prototype changes; the fix is shared by `TendWoundsBrute`, `TendWoundsBurn`, and any future procedure that composes its steps the same way.

## Media

Popup-only change, no media.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches. (See \`BRANCHING.md\`.)
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix. (See \`CONTRIBUTING.md\`.)

## Breaking changes

None.

**Changelog**

:cl:
- fix: Tend-wounds surgery now refuses to start on a patient with no matching damage and no longer emits two overlapping popups at the end of the treatment step.