### PR TITLE
test: regression tests for carry shutdown, cross-map joints, cross-map pulls

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryShutdownRecursionTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryShutdownRecursionTest.cs
@@ -1,0 +1,112 @@
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Systems;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Carrying;
+
+/// <summary>
+/// Regression test for the mutual-recursion crash in paired carry markers.
+/// <see cref="ActiveCarrierComponent"/> and <see cref="BeingCarriedComponent"/> each
+/// reference the other in their shutdown handler. Before the fix, both handlers used
+/// <c>HasComp</c>, which stays true throughout <c>ComponentShutdown</c>, so removing
+/// one side re-entered the other's handler and stack-overflowed. The fix gates the
+/// mirror removal on <c>LifeStage &lt; Stopping</c>.
+///
+/// Only the target-side entry point is exercised here. The carrier-side entry point
+/// would also be valuable, but its teardown calls <c>PlaceNextTo</c> which debug-asserts
+/// on the synthetic test fixtures — unrelated to the recursion guard itself.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SharedCarryingSystem))]
+public sealed class CarryShutdownRecursionTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CarryRecursionCarrier
+  components:
+  - type: Carrier
+  - type: Carriable
+  - type: Hands
+  - type: ComplexInteraction
+  - type: InputMover
+  - type: Physics
+    bodyType: KinematicController
+  - type: Puller
+  - type: StandingState
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: Damageable
+    damageContainer: Biological
+  - type: Body
+    prototype: Human
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.35
+
+- type: entity
+  id: CarryRecursionTarget
+  components:
+  - type: Carriable
+  - type: Physics
+    bodyType: KinematicController
+  - type: StandingState
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: Damageable
+    damageContainer: Biological
+  - type: Body
+    prototype: Human
+  - type: Pullable
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.35
+";
+
+    /// <summary>
+    /// Remove the target-side marker directly. The carrier-side handler must clean up
+    /// without re-entering the target handler. Before the fix this stack-overflowed.
+    /// </summary>
+    [Test]
+    public async Task RemoveBeingCarriedDropsActiveCarrierWithoutRecursion()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var carrier = entityManager.SpawnEntity("CarryRecursionCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryRecursionTarget", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+            carrying.Carry(carrier, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True);
+
+            Assert.DoesNotThrow(() => entityManager.RemoveComponent<BeingCarriedComponent>(target));
+
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False);
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "Carrier-side marker should have been cleaned up by the shutdown cascade");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Physics/CrossMapJointGuardTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Physics/CrossMapJointGuardTest.cs
@@ -1,0 +1,167 @@
+using Content.Shared.RussStation.Physics;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.IntegrationTests.Tests.RussStation.Physics;
+
+/// <summary>
+/// Regression tests for <see cref="PullMapGuardSystem"/>. Engine asserts in
+/// <c>SharedJointSystem.InitJoint</c> when a joint ends up spanning two different
+/// maps (typical cause: arrivals FTL reparenting a body while it's still joined
+/// to something on the station map). The guard watches <c>EntParentChangedMessage</c>
+/// on <see cref="JointComponent"/> and breaks any joint whose endpoints aren't on
+/// the same map anymore. These tests cover the positive case (joint broken),
+/// same-map reparents (no-op), and multiple joints where only the cross-map ones
+/// should be dropped.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(PullMapGuardSystem))]
+public sealed class CrossMapJointGuardTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: JointGuardBody
+  components:
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.25
+";
+
+    /// <summary>
+    /// Reparenting one endpoint of a joint to a different map must cause the guard
+    /// to remove that joint before the next physics tick tries to initialize it.
+    /// </summary>
+    [Test]
+    public async Task JointBreaksWhenEndpointCrossesMaps()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var joints = entMan.System<SharedJointSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapA);
+            mapSys.CreateMap(out var mapB);
+
+            var a = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(0, 0, mapA));
+            var b = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(0, 0, mapA));
+
+            var joint = joints.CreateDistanceJoint(a, b, id: "cross-map-test");
+            Assert.That(entMan.TryGetComponent<JointComponent>(a, out var aJoints));
+            Assert.That(aJoints!.GetJoints, Has.Count.EqualTo(1),
+                "Joint should exist on same-map spawn");
+
+            var mapBEnt = mapSys.GetMap(mapB);
+            xformSys.SetParent(b, mapBEnt);
+
+            // Guard subscribes to EntParentChangedMessage and runs synchronously
+            // in the same event chain, so the joint should already be gone.
+            entMan.TryGetComponent<JointComponent>(a, out var aJointsAfter);
+            var aCount = aJointsAfter?.GetJoints.Count ?? 0;
+            entMan.TryGetComponent<JointComponent>(b, out var bJointsAfter);
+            var bCount = bJointsAfter?.GetJoints.Count ?? 0;
+
+            Assert.That(aCount, Is.Zero, "Cross-map joint should have been removed from endpoint A");
+            Assert.That(bCount, Is.Zero, "Cross-map joint should have been removed from endpoint B");
+
+            // Cleanup: the test map pool is picky about leftover maps.
+            entMan.DeleteEntity(mapSys.GetMap(mapA));
+            entMan.DeleteEntity(mapBEnt);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Reparenting within the same map must not disturb the joint. This locks in
+    /// that the guard's MapId check is load-bearing and doesn't over-fire.
+    /// </summary>
+    [Test]
+    public async Task JointSurvivesSameMapReparent()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var joints = entMan.System<SharedJointSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapA);
+
+            var a = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(0, 0, mapA));
+            var b = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(1, 0, mapA));
+            var holder = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(2, 0, mapA));
+
+            joints.CreateDistanceJoint(a, b, id: "same-map-test");
+
+            xformSys.SetParent(b, holder);
+
+            Assert.That(entMan.TryGetComponent<JointComponent>(a, out var aJoints));
+            Assert.That(aJoints!.GetJoints, Has.Count.EqualTo(1),
+                "Joint should still exist after same-map reparent");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapA));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// When an entity holds multiple joints and only some cross maps after reparent,
+    /// only the cross-map ones should be dropped. Protects against a regression that
+    /// nukes all joints on any reparent.
+    /// </summary>
+    [Test]
+    public async Task OnlyCrossMapJointsAreBroken()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var joints = entMan.System<SharedJointSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapA);
+            mapSys.CreateMap(out var mapB);
+
+            // center holds joints to same-map partner and cross-map partner.
+            var center = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(0, 0, mapA));
+            var sameMap = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(1, 0, mapA));
+            var crossMap = entMan.SpawnEntity("JointGuardBody", new MapCoordinates(0, 0, mapA));
+
+            joints.CreateDistanceJoint(center, sameMap, id: "same");
+            joints.CreateDistanceJoint(center, crossMap, id: "cross");
+
+            Assert.That(entMan.GetComponent<JointComponent>(center).GetJoints, Has.Count.EqualTo(2));
+
+            xformSys.SetParent(crossMap, mapSys.GetMap(mapB));
+
+            var centerJoints = entMan.GetComponent<JointComponent>(center).GetJoints;
+            Assert.That(centerJoints, Has.Count.EqualTo(1),
+                "Only the cross-map joint should be removed; the same-map joint must survive");
+            Assert.That(centerJoints.ContainsKey("same"), Is.True,
+                "Same-map joint should still be present by id");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapA));
+            entMan.DeleteEntity(mapSys.GetMap(mapB));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Physics/CrossMapPullGuardTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Physics/CrossMapPullGuardTest.cs
@@ -1,0 +1,113 @@
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.IntegrationTests.Tests.RussStation.Physics;
+
+/// <summary>
+/// End-to-end regression for the same failure class as <see cref="CrossMapJointGuardTest"/>,
+/// but routed through <see cref="PullingSystem"/>. Pulls use a distance joint under the hood,
+/// so when arrivals FTL reparents a puller or pullable across maps, the joint guard breaks
+/// the joint — but the pull's higher-level state (<see cref="PullerComponent.Pulling"/> and
+/// <see cref="PullableComponent.Puller"/>) has to clean up from the <c>JointRemovedEvent</c>
+/// cascade, or we leak a dangling relationship.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(PullingSystem))]
+public sealed class CrossMapPullGuardTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CrossMapPullBody
+  components:
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.25
+  - type: Puller
+    needsHands: false
+  - type: Pullable
+";
+
+    /// <summary>
+    /// Start a pull, then reparent the pullable to a different map. The joint guard
+    /// breaks the joint; pulling state must follow it down rather than dangle.
+    /// </summary>
+    [Test]
+    public async Task PullStateClearsWhenPullableCrossesMaps()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var pulling = entMan.System<PullingSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapA);
+            mapSys.CreateMap(out var mapB);
+
+            var puller = entMan.SpawnEntity("CrossMapPullBody", new MapCoordinates(0, 0, mapA));
+            var pullable = entMan.SpawnEntity("CrossMapPullBody", new MapCoordinates(0.5f, 0, mapA));
+
+            Assert.That(pulling.TryStartPull(puller, pullable), Is.True, "Pull should start on same-map entities");
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.EqualTo(pullable));
+            Assert.That(entMan.GetComponent<PullableComponent>(pullable).Puller, Is.EqualTo(puller));
+
+            xformSys.SetParent(pullable, mapSys.GetMap(mapB));
+
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.Null,
+                "Puller-side pull state should clear after cross-map reparent");
+            Assert.That(entMan.GetComponent<PullableComponent>(pullable).Puller, Is.Null,
+                "Pullable-side pull state should clear after cross-map reparent");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapA));
+            entMan.DeleteEntity(mapSys.GetMap(mapB));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Symmetric: reparent the puller across maps instead. The joint lives on the
+    /// pullable via <c>JointComponent</c>, so the guard path differs slightly.
+    /// </summary>
+    [Test]
+    public async Task PullStateClearsWhenPullerCrossesMaps()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var pulling = entMan.System<PullingSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapA);
+            mapSys.CreateMap(out var mapB);
+
+            var puller = entMan.SpawnEntity("CrossMapPullBody", new MapCoordinates(0, 0, mapA));
+            var pullable = entMan.SpawnEntity("CrossMapPullBody", new MapCoordinates(0.5f, 0, mapA));
+
+            Assert.That(pulling.TryStartPull(puller, pullable), Is.True);
+
+            xformSys.SetParent(puller, mapSys.GetMap(mapB));
+
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.Null);
+            Assert.That(entMan.GetComponent<PullableComponent>(pullable).Puller, Is.Null);
+
+            entMan.DeleteEntity(mapSys.GetMap(mapA));
+            entMan.DeleteEntity(mapSys.GetMap(mapB));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
## About the PR

Adds three integration test classes covering recent crash fixes and related failure classes.

- `CarryShutdownRecursionTest` — paired-marker shutdown recursion (matches fix 2702ad6e01).
- `CrossMapJointGuardTest` — joint breaks cleanly on cross-map reparent (matches fix 5163323d53).
- `CrossMapPullGuardTest` — end-to-end pull cleanup when endpoints land on different maps.

## Why / Balance

Both recent crashes were hard to reproduce by hand. Locking the behavior in as tests so regressions surface in CI rather than at runtime.

## Technical details

- Synthetic prototypes only, kept minimal. The carry test targets one side of the shutdown cascade (target-side removal); the carrier-side removal path tripped an unrelated `PlaceNextTo` debug-assert on the synthetic fixtures, noted in the file comment.
- `CrossMapPullGuardTest` is a behavior test, not a guard-specific test. With the fork's `PullMapGuardSystem` disabled the tests still pass because the engine's `RecursiveMapUpdate` clears joints on physics-map change. The test locks in the observable cleanup so either path breaking surfaces as a failure.
- No production code touched.

## Media

N/A (test-only).

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing changes.