### PR TITLE
chore: gitignore Tools/honk/local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,6 +317,7 @@ CLAUDE.md
 .serena/
 .prettierignore
 /docs/
+Tools/honk/local/
 
 # Deploy
 deploy.sh


### PR DESCRIPTION
## About the PR

Adds `Tools/honk/local/` to the fork's HONK-zone gitignore block.

## Why / Balance

Local-only scratch directory for fork tooling. Nothing there is meant to be tracked.

## Technical details

One-line addition to the `# HONK START` block in `.gitignore`.

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing changes.