### PR TITLE
fix: restore pull virtual item for reptilians

### DIFF
--- a/Resources/Prototypes/Body/Species/reptilian.yml
+++ b/Resources/Prototypes/Body/Species/reptilian.yml
@@ -119,7 +119,10 @@
   name: Urist McScales
   components:
   - type: Puller
-    needsHands: false
+    # HONK START - Upstream Nubody (#42419) disabled NeedsHands on reptilians,
+    # which also disables the pull virtual item. Restore hand-based pulling.
+    needsHands: true
+    # HONK END
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
## About the PR

Flips `needsHands` back to `true` on `MobReptilian.Puller` so lizards get the hand virtual item while pulling, like every other humanoid.

## Why / Balance

Upstream Nubody (#42419) set `needsHands: false` on MobReptilian as part of a species refactor. Side effect: `PullingSystem.HandlePullStarted` skips `TrySpawnVirtualItemInHand` whenever `NeedsHands` is false, so reptilians had no visible pull item in hand. Players couldn't drop-to-release the pull, and the UX diverged from other species with no apparent intent on upstream's part.

## Technical details

- One-line flip in `Resources/Prototypes/Body/Species/reptilian.yml` wrapped with `# HONK START` / `# HONK END` markers explaining the upstream source and the intent.
- No code changes. Traced via log instrumentation: handler fired, bailed on `NeedsHands=false`. Removing the override restores the upstream spawn path.

## Media

N/A — visible change is the hand glyph appearing while pulling as a lizard, identical to how it already appears on humans.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Reptilians now show the pull hand item while pulling, matching other species.