### PR TITLE
honksquad: fix: guard carrying parent-change re-entry during shutdown

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
@@ -4,6 +4,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.RussStation.Carrying.Components;
 using Content.Shared.RussStation.Carrying.Systems;
+using Content.Shared.Standing;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Carrying;
@@ -143,6 +144,84 @@ public sealed class CarryStateValidationTest
 
             Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False,
                 "Deleting the carrier must remove the target marker, regardless of component shutdown order");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Dropping a live carry (both entities alive, not terminating) must run the
+    /// teardown cleanly. OnBeingCarriedShutdown calls PlaceNextTo to reparent the
+    /// target away from the carrier, which fires a parent-change message mid-shutdown.
+    /// Without a LifeStage guard on OnCarriedParentChanged that reparent re-enters
+    /// Drop and trips LifeShutdown's debug assert when it tries to RemComp an
+    /// already-Stopping ActiveCarrierComponent.
+    /// </summary>
+    [Test]
+    public async Task DropLiveCarryDoesNotRecurse()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+            carrying.Carry(carrier, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True);
+
+            Assert.DoesNotThrow(() => carrying.Drop(carrier),
+                "Drop on a live carry must not recurse through OnCarriedParentChanged when PlaceNextTo reparents the target mid-shutdown");
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "Carrier marker must be cleared after Drop");
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False,
+                "Target marker must be cleared after Drop");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// A DownedEvent on the carrier (fired e.g. from buckling the carrier into a chair
+    /// via StandingStateSystem.Down) triggers Drop. This exercises the same mid-shutdown
+    /// reparent as the fireman-carry crash path but entered from OnCarrierDowned rather
+    /// than OnVirtualItemDeleted.
+    /// </summary>
+    [Test]
+    public async Task CarrierDownedDropsCarryCleanly()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var standing = server.System<StandingStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+            carrying.Carry(carrier, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+
+            Assert.DoesNotThrow(() => standing.Down(carrier),
+                "Downing the carrier must cleanly drop the carry without recursing through OnCarriedParentChanged");
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -401,6 +401,12 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (Terminating(uid))
             return;
 
+        // PlaceNextTo inside OnBeingCarriedShutdown fires a parent change mid-teardown.
+        // At that point this component is already Stopping; re-entering Drop would call
+        // RemComp on the Stopping ActiveCarrierComponent and trip LifeShutdown's assert.
+        if (component.LifeStage >= ComponentLifeStage.Stopping)
+            return;
+
         if (Transform(uid).ParentUid != component.Carrier)
             Drop(component.Carrier);
     }


### PR DESCRIPTION
## About the PR

Plugs a second recursion path in the carrying system. #502 covered the paired-marker shutdown handlers, but `OnCarriedParentChanged` still had no `LifeStage` guard, so the reparent that `OnBeingCarriedShutdown` performs via `PlaceNextTo` could re-enter `Drop` mid-teardown and trip `LifeShutdown`'s debug assert.

Reproduced two ways on the reptilian pull branch:
- fireman carry, client crashed (entry via `OnVirtualItemDeleted` → `Drop`)
- buckling the carrier into a bed, server crashed (entry via `OnCarrierDowned` from `StandingStateSystem.Down` during buckle)

Both converge on `OnBeingCarriedShutdown`'s `PlaceNextTo` firing a parent-change message while `BeingCarriedComponent` is already `Stopping`, and `OnCarriedParentChanged` re-entering `Drop` which then calls `RemComp` on an already-Stopping `ActiveCarrierComponent`.

## Why / Balance

Crash fix. No behavior change for carries that were already working.

## Technical details

- `Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs` — early-out in `OnCarriedParentChanged` when `component.LifeStage >= ComponentLifeStage.Stopping`. Mirrors the guards added by #502 on the two shutdown handlers.
- `Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs` — two regression tests:
  - `DropLiveCarryDoesNotRecurse`: calls `Drop()` on a live carry (matches the fireman-carry crash).
  - `CarrierDownedDropsCarryCleanly`: `StandingStateSystem.Down(carrier)` (matches the buckle-the-carrier crash; `DownedEvent` is what fires during buckle).

Prior tests only exercised entity-deletion teardown, where the `Terminating(uid)` guard short-circuits before the re-entry path. Both new tests fail without the guard and pass with it (verified by flipping the guard off and rerunning).

## Media

N/A, crash fix with no visible behavior change.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed a crash when dropping someone mid fireman carry, and a related crash when the carrier got buckled into a chair or bed.