### PR TITLE
honksquad: refactor: extract PairedMarkerSystem helpers for carry shutdown

### DIFF
--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.RussStation.EscalatedGrab;
 using Content.Shared.RussStation.EscalatedGrab.Systems;
+using Content.Shared.RussStation.Shared;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -29,7 +30,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.RussStation.Carrying.Systems;
 
-public abstract class SharedCarryingSystem : EntitySystem
+public abstract class SharedCarryingSystem : PairedMarkerSystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedEscalatedGrabSystem _grab = default!;
@@ -401,10 +402,9 @@ public abstract class SharedCarryingSystem : EntitySystem
         if (Terminating(uid))
             return;
 
-        // PlaceNextTo inside OnBeingCarriedShutdown fires a parent change mid-teardown.
-        // At that point this component is already Stopping; re-entering Drop would call
-        // RemComp on the Stopping ActiveCarrierComponent and trip LifeShutdown's assert.
-        if (component.LifeStage >= ComponentLifeStage.Stopping)
+        // PlaceNextTo inside OnBeingCarriedShutdown fires a parent change mid-teardown;
+        // bail so we don't re-enter Drop on an already-Stopping component.
+        if (IsShuttingDown(component))
             return;
 
         if (Transform(uid).ParentUid != component.Carrier)
@@ -425,13 +425,10 @@ public abstract class SharedCarryingSystem : EntitySystem
     {
         var carrier = component.Carrier;
 
-        // Remove the symmetric carrier-side marker first. Skip if the carrier is itself
-        // terminating, or if its marker is already in shutdown — HasComp stays true during
-        // ComponentShutdown, so without the LifeStage guard the two handlers recurse.
-        if (!Terminating(carrier)
-            && TryComp<ActiveCarrierComponent>(carrier, out var activeComp)
-            && activeComp.LifeStage < ComponentLifeStage.Stopping)
-            RemComp<ActiveCarrierComponent>(carrier);
+        // Remove the symmetric carrier-side marker. TryRemovePaired skips if the carrier
+        // is terminating or its marker is already shutting down — without that guard the
+        // two handlers recurse (HasComp stays true during ComponentShutdown).
+        TryRemovePaired<ActiveCarrierComponent>(carrier);
 
         if (Exists(carrier) && !Terminating(carrier))
         {
@@ -478,14 +475,10 @@ public abstract class SharedCarryingSystem : EntitySystem
     /// </summary>
     private void OnActiveCarrierShutdown(EntityUid uid, ActiveCarrierComponent component, ComponentShutdown args)
     {
-        var target = component.Target;
-        // Skip if the target is itself terminating, or if its marker is already in shutdown.
-        // HasComp stays true during ComponentShutdown, so without the LifeStage guard the
-        // two handlers recurse when the teardown enters via BeingCarried first.
-        if (!Terminating(target)
-            && TryComp<BeingCarriedComponent>(target, out var carriedComp)
-            && carriedComp.LifeStage < ComponentLifeStage.Stopping)
-            RemComp<BeingCarriedComponent>(target);
+        // TryRemovePaired skips if the target is terminating or its marker is already
+        // shutting down — without that guard the two handlers recurse when teardown
+        // enters via BeingCarried first.
+        TryRemovePaired<BeingCarriedComponent>(component.Target);
     }
 
     private void OnDropHandItems(EntityUid uid, ActiveCarrierComponent component, DropHandItemsEvent args)

--- a/Content.Shared/RussStation/Shared/PairedMarkerSystem.cs
+++ b/Content.Shared/RussStation/Shared/PairedMarkerSystem.cs
@@ -1,0 +1,38 @@
+namespace Content.Shared.RussStation.Shared;
+
+/// <summary>
+/// Base class for systems that manage a pair of marker components whose shutdown
+/// handlers remove each other symmetrically (e.g. ActiveCarrier &lt;-&gt; BeingCarried).
+/// Symmetric removal is recursion-prone: without a guard, each shutdown handler
+/// re-enters the other and eventually calls RemComp on an already-Stopping component,
+/// which trips LifeShutdown's debug assert. The two helpers below encode the guard
+/// as the only supported way to perform the removal or respond to a structural
+/// event during teardown, so the recursion class is unreachable by construction.
+///
+/// See #502 and #511 for the two bugs this class exists to prevent from recurring.
+/// </summary>
+public abstract class PairedMarkerSystem : EntitySystem
+{
+    /// <summary>
+    /// Remove a paired marker from <paramref name="target"/> if and only if the
+    /// removal is safe: the entity isn't terminating and the component isn't
+    /// already in its own shutdown. Returns true if a removal was performed.
+    /// </summary>
+    protected bool TryRemovePaired<T>(EntityUid target) where T : IComponent
+    {
+        if (Terminating(target))
+            return false;
+        if (!TryComp<T>(target, out var comp) || comp.LifeStage >= ComponentLifeStage.Stopping)
+            return false;
+        RemComp<T>(target);
+        return true;
+    }
+
+    /// <summary>
+    /// True if the component is at or past <see cref="ComponentLifeStage.Stopping"/>.
+    /// Call at the top of reactive handlers (EntParentChangedMessage, container
+    /// events, etc.) whose own component may re-enter teardown mid-shutdown.
+    /// </summary>
+    protected static bool IsShuttingDown(IComponent component)
+        => component.LifeStage >= ComponentLifeStage.Stopping;
+}


### PR DESCRIPTION
## About the PR

Pulls the LifeStage + Terminating guard that #502 and #511 each hand-rolled into a tiny reusable base class, so any future paired-marker system picks up the same protection without needing to rediscover the pattern.

## Why / Balance

No gameplay change. This is a code-hygiene follow-up to the carry crash fixes. Both bugs stemmed from paired marker components that remove each other symmetrically during shutdown; without the guard, each shutdown handler re-enters the other and eventually calls `RemComp` on an already-`Stopping` component, which trips `LifeShutdown`'s debug assert. Encoding the guard once in a helper makes the crash class unreachable by construction.

## Technical details

- New `Content.Shared/RussStation/Shared/PairedMarkerSystem.cs`:
  - `TryRemovePaired<T>(target)`: skips if the entity is terminating or the component is already stopping, then `RemComp`s.
  - `IsShuttingDown(component)`: one-liner for reactive handlers (e.g. `EntParentChangedMessage`) that can re-enter teardown mid-shutdown.
- `SharedCarryingSystem` inherits from `PairedMarkerSystem` and its three previously-vulnerable handlers (`OnBeingCarriedShutdown`, `OnActiveCarrierShutdown`, `OnCarriedParentChanged`) now call the helpers instead of open-coding the guard.

Behavior-preserving. The existing `CarryStateValidationTest` suite (which includes the regressions added by #508 and #511) continues to pass locally.

Future paired-marker systems (escalated grab is a plausible candidate) can inherit from `PairedMarkerSystem` and use the same helpers.

## Media

N/A, internal refactor.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. `PairedMarkerSystem` is a new fork-only type.

**Changelog**

No player-facing changes.