### PR TITLE
honksquad: fix: unnest HONK markers in HumanoidProfileEditor.Traits.cs

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -67,7 +67,7 @@ public sealed partial class HumanoidProfileEditor
             }
         }
 
-        //HONK START - Build conflict map: blocked trait → list of blocking trait names
+        // Build conflict map: blocked trait → list of blocking trait names
         var selectedTraits = Profile?.TraitPreferences ?? new HashSet<ProtoId<TraitPrototype>>();
 
         // Map each excluded tag back to the selected trait(s) that exclude it
@@ -153,7 +153,6 @@ public sealed partial class HumanoidProfileEditor
                 }
             }
         }
-        //HONK END
 
         var globalAvailable = globalMax - globalSpent;
 


### PR DESCRIPTION
## About the PR

Removes the nested `HONK START` / `HONK END` pair at lines 70 and 156 of `HumanoidProfileEditor.Traits.cs`. The outer block starting at line 55 already encloses the whole fork-added section (trait point budget display + conflict map + column layout), so the inner pair was redundant and tripped the C# drift audit as `MALFORMED-HONK`.

Closes the single `MALFORMED-HONK` entry flagged in #484.

## Why / Balance

No gameplay impact — comment-only change to pass the drift audit.

## Technical details

- `Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs`: dropped the inner `//HONK START` (line 70) and matching `//HONK END` (line 156).

Verified locally with `python Tools/honk/cs_audit.py --fork-ref HEAD --upstream-ref origin/upstream/stable` — `MALFORMED-HONK` count goes from 1 to 0. Client build passes.

## Media

N/A, no in-game change.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.