### PR TITLE
fix: block-wrap BloodstreamComponent [Access] HONK marker

### DIFF
--- a/Content.Shared/Body/Components/BloodstreamComponent.cs
+++ b/Content.Shared/Body/Components/BloodstreamComponent.cs
@@ -17,8 +17,10 @@ namespace Content.Shared.Body.Components;
 /// </summary>
 [RegisterComponent, NetworkedComponent,]
 [AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
+//HONK START - Blood Deficiency quirk needs direct field access
 [Access(typeof(SharedBloodstreamSystem),
-    typeof(RussStation.Traits.BloodDeficiencySystem))] // HONK - Blood Deficiency quirk
+    typeof(RussStation.Traits.BloodDeficiencySystem))]
+//HONK END
 public sealed partial class BloodstreamComponent : Component
 {
     public const string DefaultBloodSolutionName = "bloodstream";


### PR DESCRIPTION
## About the PR

Converts the inline `// HONK` on `BloodstreamComponent`'s `[Access]` attribute into a `//HONK START/END` block. Keeps `BloodDeficiencySystem` in the access list, no behavior change.

## Why / Balance

Marker hygiene. The partial-class extension will come later as a follow-up; for now just fix the drift scanner classification.

## Technical details

One attribute block wrapped.

## Media

N/A

## Requirements

- [x] Read the contributing guide
- [x] Tested locally (build clean, audit clean)

## Breaking changes

None.

## Changelog

No player-facing changes.