### PR TITLE
fix: block-wrap BeforeThrowEvent.Direction HONK marker

### DIFF
--- a/Content.Shared/Throwing/BeforeThrowEvent.cs
+++ b/Content.Shared/Throwing/BeforeThrowEvent.cs
@@ -14,7 +14,9 @@ public struct BeforeThrowEvent
     }
 
     public EntityUid ItemUid { get; set; }
-    public Vector2 Direction { get; set; } // HONK - mutable for Weak Arm quirk
+    //HONK START - mutable for Weak Arm quirk
+    public Vector2 Direction { get; set; }
+    //HONK END
     public float ThrowSpeed { get; set;}
     public EntityUid PlayerUid { get; }
 


### PR DESCRIPTION
## About the PR

Converts the inline `// HONK` on `BeforeThrowEvent.Direction`'s mutable setter to a `HONK START` / `HONK END` block wrapper. One entry off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. Drift hygiene only. The Direction setter stays `{ get; set; }` so Weak Arm can still rewrite the throw vector.

## Technical details

- `Content.Shared/Throwing/BeforeThrowEvent.cs`: inline `// HONK - mutable for Weak Arm quirk` replaced with a 3-line block wrapping the property declaration.

PR-mode audit: "no new upstream C# drift introduced by this PR." File moves from INLINE-HONK to MIXED (classifier rule), but MIXED with zero newly-added drift lines is not a report-triggering state.

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.