### PR TITLE
fix: block-wrap SharedStrippableSystem disabled-subscribe HONK marker

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -56,8 +56,9 @@ public abstract class SharedStrippableSystem : EntitySystem
         SubscribeLocalEvent<StrippingComponent, CanDropTargetEvent>(OnCanDropOn);
         SubscribeLocalEvent<StrippableComponent, CanDropDraggedEvent>(OnCanDrop);
         SubscribeLocalEvent<StrippableComponent, DragDropDraggedEvent>(OnDragDrop);
-        // HONK - Click-to-strip disabled: inconsistent interaction behavior. Use drag-to-strip or verb instead.
+        //HONK START - Click-to-strip disabled: inconsistent interaction behavior. Use drag-to-strip or verb instead.
         // SubscribeLocalEvent<StrippableComponent, ActivateInWorldEvent>(OnActivateInWorld);
+        //HONK END
     }
 
     private void AddStripVerb(EntityUid uid, StrippableComponent component, GetVerbsEvent<Verb> args)


### PR DESCRIPTION
## About the PR

Converts the inline `// HONK` on the disabled `ActivateInWorldEvent` subscribe in `SharedStrippableSystem` to a `HONK START` / `HONK END` block. One entry off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. The click-to-strip handler stays disabled for the same reason the fork disabled it: inconsistent interaction behavior, drag-to-strip and the verb are the supported paths.

## Technical details

- `Content.Shared/Strip/SharedStrippableSystem.cs`: inline `// HONK - Click-to-strip disabled...` + commented-out subscribe line replaced with a 3-line block wrapping the commented-out subscribe.

PR-mode audit: "no new upstream C# drift introduced by this PR." File moves from INLINE-HONK to MIXED (classifier rule), but MIXED with zero newly-added drift lines does not trigger the report.

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.