### PR TITLE
fix: block-wrap HealthAnalyzerControl HONK markers

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
@@ -17,7 +17,9 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
-using Robust.Client.Player; //HONK
+//HONK START - IPlayerManager for local-player filtering
+using Robust.Client.Player;
+//HONK END
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 namespace Content.Client.HealthAnalyzer.UI;
@@ -29,7 +31,9 @@ namespace Content.Client.HealthAnalyzer.UI;
 public sealed partial class HealthAnalyzerControl : BoxContainer
 {
     private readonly IEntityManager _entityManager;
-    private readonly IPlayerManager _player; //HONK
+    //HONK START - local player handle for filtering
+    private readonly IPlayerManager _player;
+    //HONK END
     private readonly SpriteSystem _spriteSystem;
     private readonly IPrototypeManager _prototypes;
     private readonly IResourceCache _cache;
@@ -41,7 +45,9 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
 
         var dependencies = IoCManager.Instance!;
         _entityManager = dependencies.Resolve<IEntityManager>();
-        _player = dependencies.Resolve<IPlayerManager>(); //HONK
+        //HONK START - resolve local player handle
+        _player = dependencies.Resolve<IPlayerManager>();
+        //HONK END
         _spriteSystem = _entityManager.System<SpriteSystem>();
         _prototypes = dependencies.Resolve<IPrototypeManager>();
         _cache = dependencies.Resolve<IResourceCache>();


### PR DESCRIPTION
## About the PR

Converts three inline `// HONK` markers in `HealthAnalyzerControl.xaml.cs` (import, `_player` field, ctor assignment) to `HONK START` / `HONK END` blocks. One entry off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. Drift hygiene only.

## Technical details

- `Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs`: three inline markers replaced with block wrappers around the same lines.

PR-mode audit: "no new upstream C# drift introduced by this PR."

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.