### PR TITLE
fix: block-wrap StorageWindow HONK markers

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs
@@ -16,7 +16,9 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Collections;
 using Robust.Shared.Containers;
-using Robust.Client.Player; //HONK
+//HONK START - IPlayerManager for local-player filtering
+using Robust.Client.Player;
+//HONK END
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -25,7 +27,9 @@ namespace Content.Client.UserInterface.Systems.Storage.Controls;
 public sealed class StorageWindow : BaseWindow
 {
     [Dependency] private readonly IEntityManager _entity = default!;
-    [Dependency] private readonly IPlayerManager _player = default!; //HONK
+    //HONK START - local player handle for filtering
+    [Dependency] private readonly IPlayerManager _player = default!;
+    //HONK END
     private readonly StorageUIController _storageController;
 
     public EntityUid? StorageEntity;


### PR DESCRIPTION
## About the PR

Converts two inline `// HONK` markers in `StorageWindow.cs` (import, `_player` dependency) to `HONK START` / `HONK END` blocks. One entry off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. Drift hygiene only.

## Technical details

- `Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs`: two inline markers replaced with block wrappers.

PR-mode audit: "no new upstream C# drift introduced by this PR."

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.