### PR TITLE
fix: block-wrap vending UI import HONK markers

### DIFF
--- a/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
+++ b/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
@@ -1,6 +1,8 @@
 using Content.Client.UserInterface.Controls;
 using Content.Client.VendingMachines.UI;
-using Content.Shared.RussStation.Economy.Components; //HONK
+//HONK START - VendingPricesComponent for price display
+using Content.Shared.RussStation.Economy.Components;
+//HONK END
 using Content.Shared.VendingMachines;
 using Robust.Client.UserInterface;
 using Robust.Shared.Input;

--- a/Content.Client/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Client/VendingMachines/VendingMachineSystem.cs
@@ -1,5 +1,7 @@
 using System.Linq;
-using Content.Shared.RussStation.Economy.Components; //HONK
+//HONK START - VendingPricesComponent sync handler
+using Content.Shared.RussStation.Economy.Components;
+//HONK END
 using Content.Shared.VendingMachines;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;


### PR DESCRIPTION
## About the PR

Converts inline `// HONK` on the `VendingPricesComponent` import in `VendingMachineBoundUserInterface.cs` and `VendingMachineSystem.cs` to `HONK START` / `HONK END` blocks. Two entries off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. Drift hygiene only. Batched together because both are the same one-line import fix for the same feature.

## Technical details

- `Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs`: inline marker on the RussStation.Economy import replaced with block.
- `Content.Client/VendingMachines/VendingMachineSystem.cs`: same treatment.

PR-mode audit: "no new upstream C# drift introduced by this PR."

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.