### PR TITLE
fix: block-wrap VendingMachineMenu HONK markers

### DIFF
--- a/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
+++ b/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
@@ -91,11 +91,14 @@ namespace Content.Client.VendingMachines.UI
         /// Populates the list of available items on the vending machine interface
         /// and sets icons based on their prototypes
         /// </summary>
-        //HONK - Added prices parameter
+        //HONK START - Added prices parameter
         public void Populate(List<VendingMachineInventoryEntry> inventory, bool enabled, Dictionary<string, int>? prices = null)
+        //HONK END
         {
             _enabled = enabled;
-            _prices = prices; //HONK
+            //HONK START - track prices for display
+            _prices = prices;
+            //HONK END
             _listItems.Clear();
             _amounts.Clear();
 
@@ -165,11 +168,14 @@ namespace Content.Client.VendingMachines.UI
         /// <summary>
         /// Updates text entries for vending data in place without modifying the list controls.
         /// </summary>
-        //HONK - Added prices parameter
+        //HONK START - Added prices parameter
         public void UpdateAmounts(List<VendingMachineInventoryEntry> cachedInventory, bool enabled, Dictionary<string, int>? prices = null)
+        //HONK END
         {
             _enabled = enabled;
-            _prices = prices; //HONK
+            //HONK START - track prices for display
+            _prices = prices;
+            //HONK END
 
             foreach (var proto in _dummies.Keys)
             {


### PR DESCRIPTION
## About the PR

Converts four inline `// HONK` markers in `VendingMachineMenu.xaml.cs` (signature notes and `_prices` assignments inside `Populate` and `UpdateAmounts`) to `HONK START` / `HONK END` blocks. One entry off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. Drift hygiene only.

## Technical details

- `Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs`: each of the four inline markers wrapped in a block, around the extended method signature and the `_prices = prices` assignment in both methods.

PR-mode audit: "no new upstream C# drift introduced by this PR."

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.