### PR TITLE
fix: block-wrap HealthAnalyzerScannedUserMessage HONK markers

### DIFF
--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,4 +1,6 @@
-using Content.Shared.RussStation.Wounds; //HONK
+//HONK START - WoundDisplayInfo for wound list payload
+using Content.Shared.RussStation.Wounds;
+//HONK END
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.MedicalScanner;
@@ -29,11 +31,15 @@ public struct HealthAnalyzerUiState
     public bool? ScanMode;
     public bool? Bleeding;
     public bool? Unrevivable;
-    public List<WoundDisplayInfo>? Wounds; //HONK
+    //HONK START - wound list payload
+    public List<WoundDisplayInfo>? Wounds;
+    //HONK END
 
     public HealthAnalyzerUiState() {}
 
-    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, List<WoundDisplayInfo>? wounds = null) //HONK
+    //HONK START - wounds parameter for ctor
+    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, List<WoundDisplayInfo>? wounds = null)
+    //HONK END
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -41,6 +47,8 @@ public struct HealthAnalyzerUiState
         ScanMode = scanMode;
         Bleeding = bleeding;
         Unrevivable = unrevivable;
-        Wounds = wounds; //HONK
+        //HONK START - assign wounds
+        Wounds = wounds;
+        //HONK END
     }
 }


### PR DESCRIPTION
## About the PR

Converts four inline `// HONK` markers in `HealthAnalyzerScannedUserMessage.cs` (import, `Wounds` field, ctor signature extension, `Wounds` assignment) to `HONK START` / `HONK END` blocks. One entry off the INLINE-HONK drift list (#484).

## Why / Balance

No gameplay change. Drift hygiene only.

## Technical details

- `Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs`: four inline markers replaced with block wrappers.

PR-mode audit: "no new upstream C# drift introduced by this PR."

## Media

Not applicable, refactor only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than origin/upstream/stable or fork branches.
- [x] Every fork-authored commit in this PR uses the honksquad: subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.