### PR TITLE
refactor: wrap HumanoidCharacterProfile HONK markers in blocks

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -722,7 +722,9 @@ namespace Content.Shared.Preferences
                 // Always valid.
                 if (traitProto.Category == null)
                 {
-                    globalCount = newGlobal; // HONK - Track global spending
+                    //HONK START - Track global spending
+                    globalCount = newGlobal;
+                    //HONK END
                     result.Add(trait);
                     continue;
                 }
@@ -739,7 +741,9 @@ namespace Content.Shared.Preferences
                     continue;
 
                 groups[category.ID] = existing;
-                globalCount = newGlobal; // HONK - Track global spending
+                //HONK START - Track global spending
+                globalCount = newGlobal;
+                //HONK END
                 result.Add(trait);
             }
 


### PR DESCRIPTION
## About the PR

Converts the two inline `// HONK` markers on `globalCount = newGlobal;` inside `GetValidTraits` to `//HONK START/END` blocks. Drops the file off the INLINE-HONK docket so the drift scanner stops flagging it.

## Why / Balance

Marker hygiene. Inline markers get missed during rebase and trip the HONK audit tool.

## Technical details

Two sites wrapped (lines around 725 and 742). No logic change.

## Media

N/A

## Requirements

- [x] Read the contributing guide
- [x] Tested locally (build clean)

## Breaking changes

None.

## Changelog

No player-facing changes.