### PR TITLE
fix: restore upstream whitespace on two drift-only files

### DIFF
--- a/Content.Shared/Traits/TraitCategoryPrototype.cs
+++ b/Content.Shared/Traits/TraitCategoryPrototype.cs
@@ -25,5 +25,4 @@ public sealed partial class TraitCategoryPrototype : IPrototype
     /// </summary>
     [DataField]
     public int? MaxTraitPoints;
-
 }

--- a/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
@@ -38,3 +38,4 @@ public sealed class ActionGunSystem : EntitySystem
             _gun.AttemptShoot(ent, (ent.Comp.Gun.Value, gun), args.Target);
     }
 }
+


### PR DESCRIPTION
## About the PR

`TraitCategoryPrototype.cs` and `ActionGunSystem.cs` each had a one-line whitespace drift from upstream (stray blank line / missing trailing newline). Restores upstream formatting on both so the drift scanner classifies them as IDENTICAL.

## Why / Balance

Marker hygiene, clears the REFORMAT-ONLY category from the drift audit.

## Technical details

One blank line removed in each file. Build clean.

Refs #528.

## Media

N/A

## Requirements

- [x] Read the contributing guide
- [x] Tested locally (build clean, audit clean)

## Breaking changes

None.

## Changelog

No player-facing changes.