### PR TITLE
honksquad: docs: HONK-mark vanilla HealthAnalyzer BUI title omission

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerBoundUserInterface.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerBoundUserInterface.cs
@@ -19,6 +19,10 @@ namespace Content.Client.HealthAnalyzer.UI
             base.Open();
 
             _window = this.CreateWindow<HealthAnalyzerWindow>();
+            // HONK START - upstream sets _window.Title here; the fork's HandheldHealthAnalyzer proto
+            // wires to HealthAnalyzerTabbedBoundUserInterface, which titles its own window. This
+            // class is kept lean for upstream parity but never opens at runtime.
+            // HONK END
         }
 
         protected override void ReceiveMessage(BoundUserInterfaceMessage message)


### PR DESCRIPTION
## About the PR

Wraps the missing window-title assignment in `HealthAnalyzerBoundUserInterface.Open()` with a HONK block explaining why the line is intentionally absent.

## Why / Balance

The fork's `HandheldHealthAnalyzer` proto wires to `HealthAnalyzerTabbedBoundUserInterface` (added in the tabbed-UI refactor #465), which titles its own window via `ToTitleCase(EntityName)`. The vanilla upstream BUI in this file is kept for upstream parity but never opens at runtime, so the omitted line was a deliberate consequence of the refactor, not a regression.

Without a HONK marker the CONTENT-NO-HONK audit (#528) flags this file as undocumented drift. The marker classifies it correctly and gives future merge conflicts on this line the missing context.

## Technical details

- Pure documentation: no behavioural change.
- Vanilla `HealthAnalyzerBoundUserInterface` is unreachable from the fork's prototypes; only `HealthAnalyzerTabbedBoundUserInterface` runs at runtime.

Refs #528.

## Media

N/A (no runtime change).

## Requirements

- [x] Read the contributing guide
- [x] Build clean, audit clean

## Breaking changes

None.

## Changelog

(no player-facing change)