### PR TITLE
fix: block-wrap strippable menu title fork edit

### DIFF
--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -81,7 +81,9 @@ namespace Content.Client.Inventory
 
             _strippingMenu = this.CreateWindowCenteredLeft<StrippingMenu>();
             _strippingMenu.OnDirty += UpdateMenu;
+            //HONK START - identity-aware title: show owner's identity from the viewer's perspective
             _strippingMenu.Title = Loc.GetString("strippable-bound-user-interface-stripping-menu-title", ("ownerName", Identity.Name(Owner, EntMan, _player.LocalEntity)));
+            //HONK END
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
## About the PR

The fork passes `_player.LocalEntity` as the viewer arg to `Identity.Name` in `StrippableBoundUserInterface.Open()`, so the stripping menu title reflects the local player's perspective. That change sat without HONK markers. Wraps it so the drift scanner can track it.

## Why / Balance

Marker hygiene. No behavior change.

## Technical details

Block-wrapped a single modified line. Audit drops the file from CONTENT-NO-HONK.

Refs #528.

## Media

N/A

## Requirements

- [x] Read the contributing guide
- [x] Tested locally (build clean, audit clean)

## Breaking changes

None.

## Changelog

No player-facing changes.