### PR TITLE
fix: block-wrap UIFragment.Setup docstring

### DIFF
--- a/Content.Client/UserInterface/Fragments/UIFragment.cs
+++ b/Content.Client/UserInterface/Fragments/UIFragment.cs
@@ -18,6 +18,7 @@ public abstract partial class UIFragment
 {
     public abstract Control GetUIFragmentRoot();
 
+    //HONK START - document idempotency requirement learned from PDA fragment regressions
     /// <summary>
     /// Called when the cartridge UI is activated. May be called multiple times for the
     /// same program (e.g. PdaUpdateState inherits CartridgeLoaderUiState, so any PDA
@@ -26,6 +27,7 @@ public abstract partial class UIFragment
     /// Creating a new control here without re-attaching it to the UI tree causes the
     /// displayed fragment and the updated fragment to diverge silently.
     /// </summary>
+    //HONK END
     public abstract void Setup(BoundUserInterface userInterface, EntityUid? fragmentOwner);
 
     public abstract void UpdateState(BoundUserInterfaceState state);


### PR DESCRIPTION
## About the PR

Wraps the fork-added docstring on `UIFragment.Setup` in a `//HONK START/END` block so the drift scanner classifies the addition. No code change.

## Why / Balance

Marker hygiene.

## Technical details

Two marker lines added around the docstring. Audit drops the file from CONTENT-NO-HONK.

Refs #528.

## Media

N/A

## Requirements

- [x] Read the contributing guide
- [x] Build clean, audit clean

## Breaking changes

None.

## Changelog

No player-facing changes.