### PR TITLE
fix: block-wrap construction step locale double-lookup fixes

### DIFF
--- a/Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs
@@ -23,7 +23,9 @@ namespace Content.Shared.Construction.Steps
             return new ConstructionGuideEntry
             {
                 Localization = "construction-presenter-arbitrary-step",
+                //HONK START - locale double-lookup fix: presenter already localizes, don't pre-resolve
                 Arguments = new (string, object)[]{("name", Name.ToString())},
+                //HONK END
                 Icon = Icon,
             };
         }

--- a/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
@@ -45,7 +45,9 @@ namespace Content.Shared.Construction.Steps
             return new ConstructionGuideEntry()
             {
                 Localization = "construction-presenter-material-step",
+                //HONK START - locale double-lookup fix: presenter already localizes, don't pre-resolve
                 Arguments = new (string, object)[]{("amount", Amount), ("material", material.Name)},
+                //HONK END
                 Icon = material.Icon,
             };
         }


### PR DESCRIPTION
## About the PR

`ArbitraryInsertConstructionGraphStep` and `MaterialConstructionGraphStep` skip the pre-resolve `Loc.GetString` in `GenerateGuideEntry` because the presenter's Fluent template already localizes the name argument. Pre-resolving caused a double-lookup bug on the crafting menu (bd05dc920d). The fork-modified lines sat without HONK markers, so the drift scanner flagged both as CONTENT-NO-HONK. Wraps them.

## Why / Balance

Marker hygiene. No behavior change.

## Technical details

One line wrapped in each file.

Refs #528.

## Media

N/A

## Requirements

- [x] Read the contributing guide
- [x] Build clean, audit clean

## Breaking changes

None.

## Changelog

No player-facing changes.