### PR TITLE
honksquad: fix: block-wrap inline HONK drift in 8 MIXED files

### DIFF
--- a/Content.Client/Stylesheets/Stylesheets/NanotrasenStylesheet.cs
+++ b/Content.Client/Stylesheets/Stylesheets/NanotrasenStylesheet.cs
@@ -31,7 +31,9 @@ public partial class NanotrasenStylesheet : CommonStylesheet
 
     // why? see InterfaceStylesheet.cs
     // ReSharper disable once UseCollectionExpression
+    //HONK START - non-readonly so ForkFontCustomization.Apply can reassign
     private List<(string?, int)> _commonFontSizes = new()
+    //HONK END
     {
         (null, PrimaryFontSize),
         (StyleClass.FontSmall, PrimaryFontSize - FontSizeStep),
@@ -54,7 +56,9 @@ public partial class NanotrasenStylesheet : CommonStylesheet
             // Set up our core rules.
             [
                 // Declare the default font.
+                //HONK START - use customSize so user-selected font size applies
                 Element().Prop(Label.StylePropertyFont, BaseFont.GetFont(customSize)),
+                //HONK END
                 // Branding.
                 Element<TextureRect>()
                     .Class("NTLogoDark")

--- a/Content.Client/Stylesheets/Stylesheets/SystemStylesheet.cs
+++ b/Content.Client/Stylesheets/Stylesheets/SystemStylesheet.cs
@@ -30,7 +30,9 @@ public partial class SystemStylesheet : CommonStylesheet
     // for some GOD FORSAKEN REASON if I use a collection expression here it throws a sandbox error
     // Thanks ReSharper, this was very fun to find in the ~40 files I last committed
     // ReSharper disable once UseCollectionExpression
+    //HONK START - non-readonly so ForkFontCustomization.Apply can reassign
     private List<(string?, int)> _commonFontSizes = new()
+    //HONK END
     {
         (null, PrimaryFontSize),
         (StyleClass.FontSmall, PrimaryFontSize - FontSizeStep),
@@ -53,7 +55,9 @@ public partial class SystemStylesheet : CommonStylesheet
             // Set up our core rules.
             [
                 // Declare the default font.
+                //HONK START - use customSize so user-selected font size applies
                 Element().Prop(Label.StylePropertyFont, BaseFont.GetFont(customSize)),
+                //HONK END
             ],
             // Finally, load all the other sheetlets.
             GetAllSheetletRules<PalettedStylesheet, CommonSheetletAttribute>(man),

--- a/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml.cs
+++ b/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml.cs
@@ -18,7 +18,9 @@ namespace Content.Client.UserInterface.Controls;
 [GenerateTypedNameReferences]
 public sealed partial class SimpleRadialMenu : RadialMenu
 {
+    //HONK START - shared button size constant for pixel-aware icon fit
     private const float ButtonSize = 64f;
+    //HONK END
 
     private EntityUid? _attachMenuToEntity;
 
@@ -129,7 +131,9 @@ public sealed partial class SimpleRadialMenu : RadialMenu
         var button = settings.UseSectors
             ? ConvertToButtonWithSector(model, settings)
             : new RadialMenuButton();
+        //HONK START - use shared ButtonSize constant
         button.SetSize = new Vector2(ButtonSize, ButtonSize);
+        //HONK END
         button.ToolTip = model.ToolTip;
         var imageControl = model.IconSpecifier switch
         {

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -672,7 +672,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         RaiseLocalEvent(source, ref voiceRangeEv);
         //HONK END
 
+        //HONK START - use voiceRangeEv.Range (was VoiceRange)
         foreach (var (session, data) in GetRecipients(source, voiceRangeEv.Range))
+        //HONK END
         {
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -269,8 +269,8 @@ public sealed partial class HealthAnalyzerSystem : EntitySystem
             bloodAmount,
             null,
             bleeding,
+            //HONK START - add trailing comma + wounds arg
             unrevivable,
-            //HONK START
             wounds
             //HONK END
         );

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -374,8 +374,8 @@ namespace Content.Shared.Atmos
         WaterVapor = 5,
         Ammonia = 6,
         NitrousOxide = 7,
+        // HONK START - Fork gases (trailing comma added for fork-appended entries)
         Frezon = 8,
-        // HONK START - Fork gases
         Hydrogen = 9,
         Helium = 10,
         BZ = 11,

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -233,7 +233,9 @@ public sealed partial class ClimbSystem : VirtualController
             climbDelay *= freerunning.ClimbDelayMultiplier;
         //HONK END
 
+        //HONK START - use Freerunning-adjusted climbDelay
         var args = new DoAfterArgs(EntityManager, user, climbDelay, new ClimbDoAfterEvent(),
+        //HONK END
             entityToMove,
             target: climbable,
             used: entityToMove)

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -156,9 +156,13 @@ namespace Content.Shared.Examine
                     return CritExamineRange;
 
                 if (TryComp<BlurryVisionComponent>(examiner, out var blurry))
+                    //HONK START - use event-modified range
                     return Math.Clamp(range - blurry.Magnitude * ExamineBlurrinessMult, 2, range);
+                    //HONK END
             }
+            //HONK START - use event-modified range
             return range;
+            //HONK END
         }
 
         /// <summary>


### PR DESCRIPTION
## About the PR

Block-wraps fork-modified upstream lines in `//HONK START ... //HONK END` across 8 files so the drift scanner's strip pass removes them from the diff. No behavior change.

Touches: `NanotrasenStylesheet`, `SystemStylesheet`, `SimpleRadialMenu`, `ChatSystem`, `HealthAnalyzerSystem`, `Atmospherics`, `ClimbSystem`, `ExamineSystemShared`.

## Why / Balance

Part of issue #528. These files were MIXED in the drift scanner because a single-line fork modification of an upstream line was left bare. Scanner's `drift_lines` treats stripped HONK blocks as upstream-equivalent, so wrapping the modified line resolves the flag without editing upstream intent.

## Technical details

Comment-only change. Every edit wraps an already-modified line in a START/END block with a short reason on the START.

## Media

n/a, no gameplay change.

## Requirements

- [x] Verified with `python Tools/honk/cs_audit.py --pr-mode origin/release` ? no new drift.
- [x] Commits prefixed `honksquad:`.

## Breaking changes

None.

## Changelog

No player-facing change.