### PR TITLE
honksquad: fix: convert inline HONK comments to block form in 7 files

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -4,7 +4,9 @@ using Content.Client.Stylesheets;
 using Content.Shared.CCVar;
 using Content.Shared.Traits;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.Prototypes; //HONK
+//HONK START - ProtoId lookups for category cap display
+using Robust.Shared.Prototypes;
+//HONK END
 using Robust.Shared.Utility;
 
 namespace Content.Client.Lobby.UI;
@@ -200,7 +202,9 @@ public sealed partial class HumanoidProfileEditor
             {
                 category = _prototypeManager.Index<TraitCategoryPrototype>(categoryId);
                 // Label
-                column.AddChild(new Label // HONK - Changed from TraitsList to column
+                //HONK START - add to column instead of TraitsList
+                column.AddChild(new Label
+                //HONK END
                 {
                     Text = Loc.GetString(category.Name),
                     Margin = new Thickness(0, 0, 0, 0),
@@ -252,8 +256,9 @@ public sealed partial class HumanoidProfileEditor
 
             // HONK END
 
-            // HONK - 2-column grid for trait selectors within each category
+            //HONK START - 2-column grid for trait selectors within each category
             var traitGrid = new GridContainer
+            //HONK END
             {
                 Columns = 2,
                 HorizontalExpand = true,
@@ -280,7 +285,9 @@ public sealed partial class HumanoidProfileEditor
 
             column.AddChild(traitGrid);
 
-            columnsContainer.AddChild(column); // HONK - Add to columns
+            //HONK START - append category column to columns container
+            columnsContainer.AddChild(column);
+            //HONK END
         }
     }
 }


### PR DESCRIPTION
## About the PR

Converts the remaining inline `//HONK` comments flagged by `cs_audit.py` into the block `//HONK START/END` form across 7 files. No behavior change, comment-only.

Touches: `HealthAnalyzerControl.xaml.cs`, `StorageWindow.cs`, `VendingMachineMenu.xaml.cs`, `HealthAnalyzerScannedUserMessage.cs`, `SharedStrippableSystem.cs`, `BeforeThrowEvent.cs`, `HumanoidProfileEditor.Traits.cs`.

## Why / Balance

Part of #528. Inline `//HONK` markers aren't accepted by the drift scanner and surface as `INLINE-HONK` findings on every run. Converting them to block form wraps the fork-owned lines so the scanner's strip pass removes them from the diff.

## Technical details

Each inline marker is replaced with a block wrap. Where the marker sat on an upstream-modified line (parameter added, accessor changed), the block wraps the single modified line; where it tagged a fork-added line or declaration, the block wraps that declaration. Inline comments on fork-added usings became block-wrapped using groups with a short reason on the START.

## Media

n/a, no gameplay change.

## Requirements

- [x] Verified with `python Tools/honk/cs_audit.py --pr-mode origin/release`, no new drift.
- [x] Commits prefixed `honksquad:`.

## Breaking changes

None.

## Changelog

No player-facing change.