### PR TITLE
fix: HONK drift scanner false positives

### DIFF
--- a/Tools/honk/common.py
+++ b/Tools/honk/common.py
@@ -25,7 +25,7 @@ FORK_OWNED = re.compile(
 
 HONK_START = re.compile(r"HONK\s*START", re.IGNORECASE)
 HONK_END = re.compile(r"HONK\s*END", re.IGNORECASE)
-HONK_LINE = re.compile(r"//\s*HONK\b|#\s*HONK\b", re.IGNORECASE)
+HONK_LINE = re.compile(r"//\s*HONK\b|#\s*HONK\b")
 
 DRIFT_CATEGORIES = ("REFORMAT-ONLY", "MIXED", "CONTENT-NO-HONK")
 

--- a/Tools/honk/cs_audit.py
+++ b/Tools/honk/cs_audit.py
@@ -25,6 +25,7 @@ from common import (
     DRIFT_CATEGORIES,
     HONK_START,
     balanced_honk,
+    drift_lines,
     git_show,
     inline_honk_lines,
     is_fork_owned,
@@ -32,7 +33,6 @@ from common import (
     pr_new_inline,
     sh,
     strip_honk_blocks,
-    whitespace_normalize,
 )
 
 DEFAULT_FORK_REF = "origin/release"
@@ -112,10 +112,8 @@ def classify(path: str, fork_ref: str, upstream_ref: str) -> Result:
     has_honk = bool(HONK_START.search(release))
 
     stripped_release = strip_honk_blocks(release)
-    norm_stripped = whitespace_normalize(stripped_release)
-    norm_upstream = whitespace_normalize(upstream)
 
-    if norm_stripped == norm_upstream:
+    if not drift_lines(stripped_release, upstream):
         if has_honk:
             return Result(path, "HONK-ONLY")
         return Result(path, "REFORMAT-ONLY")


### PR DESCRIPTION
## About the PR

Two small fixes to `Tools/honk/cs_audit.py` and `Tools/honk/common.py` that remove a pair of false-positive classes the audit kept flagging.

## Why / Balance

Running the scanner over the fork surfaced noise rather than real drift:

- Files where an upstream line was modified *inside* a HONK block got classified as MIXED "drift outside HONK", because `classify()` compared the HONK-stripped fork to upstream with whitespace-normalized equality. The stripped fork was shorter than upstream (the modified line vanished with the block), so equality failed even though set-subtraction showed zero unwrapped drift.
- `HONK_LINE` was case-insensitive, so upstream joke comments like `// honk!!!!!` in `MechSoundboardSystem.cs:51` triggered INLINE-HONK.

Neither case was real drift, and both showed up in PR checks, so the signal-to-noise of the audit was dropping.

## Technical details

1. `classify()` now uses `not drift_lines(stripped_release, upstream)` instead of whitespace-normalized equality. `drift_lines` is `set(fork_lines) - set(upstream_lines)`, which is the same comparison the PR-mode scanner already uses, and it's robust to stripped lines that leave the fork shorter than upstream.
2. `HONK_LINE` drops `re.IGNORECASE`. `HONK_START` and `HONK_END` keep theirs, so `// honk start` and `// HONK START` both still parse, but lowercase `honk` in prose no longer counts as an inline marker.

## Media

N/A (tooling only).

## Requirements

- [x] Ran `python Tools/honk/cs_audit.py` before and after, confirmed MechSoundboard dropped out of INLINE-HONK.

## Breaking changes

None.

## Changelog

No player-facing changes.