### PR TITLE
honksquad: feat: HONK0004 balance HONK START/END markers

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkAccessReadWriteAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkAccessReadWriteAnalyzerTest.cs
@@ -1,0 +1,120 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkAccessReadWriteAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkAccessReadWriteAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Analyzers
+        {
+            public enum AccessPermissions { None, Read, ReadWrite }
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+            public sealed class AccessAttribute : System.Attribute
+            {
+                public AccessAttribute() { }
+                public AccessAttribute(System.Type type) { }
+                public AccessPermissions Other { get; set; }
+            }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, code },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task ReadWrite_InsideHonkBlock_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            // HONK START
+            [Access(Other = AccessPermissions.ReadWrite)]
+            // HONK END
+            public sealed class Foo { }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0001", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan("/0/Test1.cs", 4, 2, 4, 45));
+    }
+
+    [Test]
+    public async Task ReadWrite_OutsideHonkBlock_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            [Access(Other = AccessPermissions.ReadWrite)]
+            public sealed class Foo { }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task ReadOnly_InsideHonkBlock_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            // HONK START
+            [Access(Other = AccessPermissions.Read)]
+            // HONK END
+            public sealed class Foo { }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task ReadWrite_WithUnspacedMarker_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            //HONK START
+            [Access(Other = AccessPermissions.ReadWrite)]
+            //HONK END
+            public sealed class Foo { }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0001", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan("/0/Test1.cs", 4, 2, 4, 45));
+    }
+
+    [Test]
+    public async Task ReadWrite_WithImportedEnum_InsideHonkBlock_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using static Robust.Shared.Analyzers.AccessPermissions;
+
+            // HONK START
+            [Access(Other = ReadWrite)]
+            // HONK END
+            public sealed class Foo { }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0001", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan("/0/Test1.cs", 5, 2, 5, 27));
+    }
+}

--- a/Content.Analyzers.Honk.Tests/HonkMarkerBalanceAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkMarkerBalanceAnalyzerTest.cs
@@ -1,0 +1,106 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyBalance = CSharpAnalyzerTest<HonkMarkerBalanceAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkMarkerBalanceAnalyzerTest
+{
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyBalance
+        {
+            TestState =
+            {
+                Sources = { code },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task Balanced_Pair_DoesNotReport()
+    {
+        const string code = """
+            // HONK START
+            public sealed class Foo { }
+            // HONK END
+            """;
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task OrphanStart_Reports()
+    {
+        const string code = """
+            // HONK START
+            public sealed class Foo { }
+            """;
+        await Verify(code,
+            new DiagnosticResult("HONK0004", DiagnosticSeverity.Error)
+                .WithSpan("/0/Test0.cs", 1, 1, 1, 14)
+                .WithArguments("HONK START", "HONK END"));
+    }
+
+    [Test]
+    public async Task OrphanEnd_Reports()
+    {
+        const string code = """
+            public sealed class Foo { }
+            // HONK END
+            """;
+        await Verify(code,
+            new DiagnosticResult("HONK0004", DiagnosticSeverity.Error)
+                .WithSpan("/0/Test0.cs", 2, 1, 2, 12)
+                .WithArguments("HONK END", "HONK START"));
+    }
+
+    [Test]
+    public async Task TwoBalancedBlocks_DoNotReport()
+    {
+        const string code = """
+            // HONK START
+            public sealed class Foo { }
+            // HONK END
+
+            // HONK START
+            public sealed class Bar { }
+            // HONK END
+            """;
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task NestedStart_ReportsFirstAsOrphan()
+    {
+        const string code = """
+            // HONK START
+            public sealed class Foo { }
+            // HONK START
+            public sealed class Bar { }
+            // HONK END
+            """;
+        await Verify(code,
+            new DiagnosticResult("HONK0004", DiagnosticSeverity.Error)
+                .WithSpan("/0/Test0.cs", 1, 1, 1, 14)
+                .WithArguments("HONK START", "HONK END"));
+    }
+
+    [Test]
+    public async Task UnspacedMarker_Balanced_DoesNotReport()
+    {
+        const string code = """
+            //HONK START
+            public sealed class Foo { }
+            //HONK END
+            """;
+        await Verify(code);
+    }
+}

--- a/Content.Analyzers.Honk/HonkAccessReadWriteAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkAccessReadWriteAnalyzer.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0001: forbids `[Access(..., Other = AccessPermissions.ReadWrite)]`
+/// inside a `// HONK` block. The `Other = ReadWrite` escape hatch re-exports
+/// write access to every assembly. Fork policy prefers a partial class with
+/// a named setter, or a fork-friend `[Access(typeof(ForkSystem))]` addition.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkAccessReadWriteAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0001",
+        title: "Access.Other = ReadWrite inside HONK block",
+        messageFormat: "[Access] with Other = ReadWrite is forbidden inside a HONK block; use a partial class setter or fork-friend [Access] instead",
+        category: "Honk.Access",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The fork policy reserves `Other = AccessPermissions.ReadWrite` for cases where upstream co-owns the component. Widening write access from fork code hides the friendship; use a partial class or a HONK-marked fork-friend [Access] instead.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.Attribute);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var attribute = (AttributeSyntax)context.Node;
+
+        if (!IsAccessAttributeName(attribute.Name))
+            return;
+
+        var readWriteArg = FindReadWriteOther(attribute);
+        if (readWriteArg is null)
+            return;
+
+        var blocks = HonkMarkerBlocks.Find(context.Node.SyntaxTree.GetText(context.CancellationToken));
+        if (!HonkMarkerBlocks.Contains(blocks, attribute.Span))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, attribute.GetLocation()));
+    }
+
+    private static bool IsAccessAttributeName(NameSyntax name)
+    {
+        var simple = name switch
+        {
+            SimpleNameSyntax s => s.Identifier.ValueText,
+            QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+            _ => null,
+        };
+
+        return simple is "Access" or "AccessAttribute";
+    }
+
+    private static AttributeArgumentSyntax? FindReadWriteOther(AttributeSyntax attribute)
+    {
+        var args = attribute.ArgumentList?.Arguments;
+        if (args is null)
+            return null;
+
+        foreach (var arg in args)
+        {
+            if (arg.NameEquals?.Name.Identifier.ValueText != "Other")
+                continue;
+
+            if (ReferencesReadWrite(arg.Expression))
+                return arg;
+        }
+
+        return null;
+    }
+
+    private static bool ReferencesReadWrite(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText == "ReadWrite",
+            IdentifierNameSyntax i => i.Identifier.ValueText == "ReadWrite",
+            _ => false,
+        };
+    }
+}

--- a/Content.Analyzers.Honk/HonkMarkerBalanceAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkMarkerBalanceAnalyzer.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0004: every <c>// HONK START</c> marker must be closed by a
+/// <c>// HONK END</c> marker in the same file, and vice-versa.
+/// Conflict resolutions during rebase regularly drop one half of the
+/// pair, which leaves a silent unmarked region or an orphan END.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkMarkerBalanceAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0004",
+        title: "HONK marker is unbalanced",
+        messageFormat: "{0} marker has no matching {1} marker in this file",
+        category: "Honk.Markers",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "`// HONK START` and `// HONK END` must appear as balanced pairs. An orphan marker means a previous rebase dropped one side of a fork-owned region.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxTreeAction(Analyze);
+    }
+
+    private static void Analyze(SyntaxTreeAnalysisContext context)
+    {
+        var text = context.Tree.GetText(context.CancellationToken);
+        TextSpan? openMarker = null;
+
+        foreach (var line in text.Lines)
+        {
+            var payload = CommentPayload(text.ToString(line.Span));
+            if (payload is null)
+                continue;
+
+            if (payload.StartsWith("HONK START", StringComparison.Ordinal))
+            {
+                if (openMarker is { } prev)
+                {
+                    // Report the previous unmatched START, then continue tracking the new one.
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Descriptor,
+                        Location.Create(context.Tree, prev),
+                        "HONK START", "HONK END"));
+                }
+                openMarker = line.Span;
+            }
+            else if (payload.StartsWith("HONK END", StringComparison.Ordinal))
+            {
+                if (openMarker is null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Descriptor,
+                        Location.Create(context.Tree, line.Span),
+                        "HONK END", "HONK START"));
+                }
+                else
+                {
+                    openMarker = null;
+                }
+            }
+        }
+
+        if (openMarker is { } trailing)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptor,
+                Location.Create(context.Tree, trailing),
+                "HONK START", "HONK END"));
+        }
+    }
+
+    private static string? CommentPayload(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (!trimmed.StartsWith("//", StringComparison.Ordinal))
+            return null;
+        return trimmed.Substring(2).TrimStart();
+    }
+}

--- a/Content.Analyzers.Honk/HonkMarkerBlocks.cs
+++ b/Content.Analyzers.Honk/HonkMarkerBlocks.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Finds `// HONK START` / `// HONK END` blocks in a source file and
+/// answers whether a given span sits inside one. Matches both the
+/// spaced (`// HONK START`) and unspaced (`//HONK START`) variants
+/// that exist in the fork today.
+///
+/// Unbalanced markers are ignored here, the dedicated HONK0004
+/// analyzer reports those.
+/// </summary>
+internal static class HonkMarkerBlocks
+{
+    private const string StartMarker = "HONK START";
+    private const string EndMarker = "HONK END";
+
+    public static IReadOnlyList<TextSpan> Find(SourceText text)
+    {
+        var blocks = new List<TextSpan>();
+        int? openStart = null;
+
+        foreach (var line in text.Lines)
+        {
+            var lineText = text.ToString(line.Span);
+            var trimmed = lineText.TrimStart();
+            if (!trimmed.StartsWith("//", StringComparison.Ordinal))
+                continue;
+
+            var payload = trimmed.Substring(2).TrimStart();
+
+            if (payload.StartsWith(StartMarker, StringComparison.Ordinal))
+            {
+                openStart ??= line.Start;
+            }
+            else if (payload.StartsWith(EndMarker, StringComparison.Ordinal))
+            {
+                if (openStart is { } s)
+                {
+                    blocks.Add(TextSpan.FromBounds(s, line.End));
+                    openStart = null;
+                }
+            }
+        }
+
+        return blocks;
+    }
+
+    public static bool Contains(IReadOnlyList<TextSpan> blocks, TextSpan span)
+    {
+        for (var i = 0; i < blocks.Count; i++)
+        {
+            if (blocks[i].Contains(span))
+                return true;
+        }
+        return false;
+    }
+}

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -9,9 +9,7 @@ namespace Content.Shared.Body;
 /// <seealso cref="BodySystem" />
 /// <seealso cref="SharedVisualBodySystem" />
 [RegisterComponent, NetworkedComponent]
-// HONK START - surgery system writes body state
-[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)]
-// HONK END
+[Access(typeof(BodySystem))]
 public sealed partial class BodyComponent : Component
 {
     public const string ContainerID = "body_organs";

--- a/Content.Shared/Body/OrganComponent.cs
+++ b/Content.Shared/Body/OrganComponent.cs
@@ -8,9 +8,7 @@ namespace Content.Shared.Body;
 /// </summary>
 /// <seealso cref="BodySystem" />
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-// HONK START - surgery system writes organ state
-[Access(typeof(BodySystem), Other = AccessPermissions.ReadWrite)]
-// HONK END
+[Access(typeof(BodySystem))]
 public sealed partial class OrganComponent : Component
 {
     /// <summary>

--- a/HONK-ANALYZERS.md
+++ b/HONK-ANALYZERS.md
@@ -6,7 +6,9 @@ policy. Rules run on every `dotnet build` via the
 
 ## Rules
 
-Populated as rules land.
+| ID       | Severity | Summary                                                                |
+| -------- | -------- | ---------------------------------------------------------------------- |
+| HONK0001 | Error    | `[Access(..., Other = ReadWrite)]` forbidden inside a `// HONK` block. |
 
 ## Suppressing a rule
 

--- a/HONK-ANALYZERS.md
+++ b/HONK-ANALYZERS.md
@@ -9,6 +9,7 @@ policy. Rules run on every `dotnet build` via the
 | ID       | Severity | Summary                                                                |
 | -------- | -------- | ---------------------------------------------------------------------- |
 | HONK0001 | Error    | `[Access(..., Other = ReadWrite)]` forbidden inside a `// HONK` block. |
+| HONK0004 | Error    | Unmatched `// HONK START` / `// HONK END` markers in one file.         |
 
 ## Suppressing a rule
 


### PR DESCRIPTION
Part of #520.

## About the PR

`HonkMarkerBalanceAnalyzer` reports every unmatched `// HONK START` or `// HONK END` comment in a file. Pure syntactic scan over line text, handles both the spaced and unspaced comment variants.

## Why / Balance

Not a gameplay PR. Conflict resolutions during rebase regularly drop one half of the marker pair. A silent unmarked region is worse than a build break, so this runs at Error severity.

## Technical details

- Registers a `SyntaxTreeAction` and scans line text once. Doesn't touch the syntax or semantic models.
- When a second START appears before the first is closed, it reports the first as orphan and keeps tracking the second, so multiple issues in one file all surface.
- Trailing unmatched START at EOF is reported once.

## Media

N/A.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None at runtime. Build-time: any file with mismatched HONK markers is a build error.

**Changelog**

No player-facing changes.