### PR TITLE
honksquad: feat: HONK0005 fork [Access] friend must sit inside HONK block (#520)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkAccessForkFriendAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkAccessForkFriendAnalyzerTest.cs
@@ -1,0 +1,127 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkAccessForkFriendAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkAccessForkFriendAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+            public sealed class AccessAttribute : System.Attribute
+            {
+                public AccessAttribute() { }
+                public AccessAttribute(System.Type type) { }
+                public AccessAttribute(System.Type a, System.Type b) { }
+            }
+        }
+        namespace Content.Shared.RussStation.Traits
+        {
+            public sealed class BloodDeficiencySystem { }
+        }
+        namespace Content.Shared.Body.Systems
+        {
+            public sealed class SharedBloodstreamSystem { }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    Stubs,
+                    (filePath, code),
+                },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task ForkFriend_InUpstreamFile_OutsideHonkBlock_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            [Access(typeof(BloodDeficiencySystem))]
+            public sealed class BloodstreamComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/Body/Components/BloodstreamComponent.cs",
+            new DiagnosticResult("HONK0005", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan("Content.Shared/Body/Components/BloodstreamComponent.cs", 4, 2, 4, 39)
+                .WithArguments("BloodDeficiencySystem"));
+    }
+
+    [Test]
+    public async Task ForkFriend_InUpstreamFile_InsideHonkBlock_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+            using Content.Shared.Body.Systems;
+
+            // HONK START
+            [Access(typeof(SharedBloodstreamSystem), typeof(BloodDeficiencySystem))]
+            // HONK END
+            public sealed class BloodstreamComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/Body/Components/BloodstreamComponent.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFriend_InUpstreamFile_OutsideHonkBlock_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.Body.Systems;
+
+            [Access(typeof(SharedBloodstreamSystem))]
+            public sealed class BloodstreamComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/Body/Components/BloodstreamComponent.cs");
+    }
+
+    [Test]
+    public async Task ForkFriend_InForkFile_OutsideHonkBlock_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            [Access(typeof(BloodDeficiencySystem))]
+            public sealed class SomeForkComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Traits/SomeForkComponent.cs");
+    }
+
+    [Test]
+    public async Task ForkFriend_InHonkPartialFile_OutsideHonkBlock_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            [Access(typeof(BloodDeficiencySystem))]
+            public sealed class BloodstreamComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/Body/Components/BloodstreamComponent.Honk.cs");
+    }
+}

--- a/Content.Analyzers.Honk/HonkAccessForkFriendAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkAccessForkFriendAnalyzer.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0005: an `[Access(typeof(X))]` attribute where X is a fork-owned
+/// system (namespace contains `RussStation`) must sit inside a `// HONK`
+/// block when the containing file is upstream. Fork-owned files (path
+/// contains `/RussStation/` or filename ends in `.Honk.cs`) are exempt,
+/// the whole file is fork drift there.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkAccessForkFriendAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0005",
+        title: "[Access] typeof fork system must sit inside a HONK block",
+        messageFormat: "[Access] references fork system '{0}' from an upstream file; wrap the attribute in // HONK START / // HONK END so rebase can see the fork-specific friend",
+        category: "Honk.Access",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Adding a fork system as an [Access] friend on an upstream component drifts from upstream. Wrap the attribute in a HONK block so the rebase auditor can find and preserve it.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.Attribute);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var attribute = (AttributeSyntax)context.Node;
+        if (!IsAccessAttributeName(attribute.Name))
+            return;
+
+        if (IsForkFile(attribute.SyntaxTree.FilePath))
+            return;
+
+        var args = attribute.ArgumentList?.Arguments;
+        if (args is null)
+            return;
+
+        foreach (var arg in args.Value)
+        {
+            if (arg.Expression is not TypeOfExpressionSyntax typeofExpr)
+                continue;
+
+            if (context.SemanticModel.GetSymbolInfo(typeofExpr.Type, context.CancellationToken).Symbol is not INamedTypeSymbol symbol)
+                continue;
+
+            if (!IsForkType(symbol))
+                continue;
+
+            var blocks = HonkMarkerBlocks.Find(context.Node.SyntaxTree.GetText(context.CancellationToken));
+            if (HonkMarkerBlocks.Contains(blocks, attribute.Span))
+                return;
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, attribute.GetLocation(), symbol.Name));
+            return;
+        }
+    }
+
+    private static bool IsAccessAttributeName(NameSyntax name)
+    {
+        var simple = name switch
+        {
+            SimpleNameSyntax s => s.Identifier.ValueText,
+            QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+            _ => null,
+        };
+        return simple is "Access" or "AccessAttribute";
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var norm = path!.Replace('\\', '/');
+        return norm.Contains("/RussStation/") || norm.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool IsForkType(INamedTypeSymbol symbol)
+    {
+        for (var ns = symbol.ContainingNamespace; ns is { IsGlobalNamespace: false }; ns = ns.ContainingNamespace)
+        {
+            if (ns.Name == "RussStation")
+                return true;
+        }
+        return false;
+    }
+}

--- a/HONK-ANALYZERS.md
+++ b/HONK-ANALYZERS.md
@@ -6,10 +6,11 @@ policy. Rules run on every `dotnet build` via the
 
 ## Rules
 
-| ID       | Severity | Summary                                                                |
-| -------- | -------- | ---------------------------------------------------------------------- |
-| HONK0001 | Error    | `[Access(..., Other = ReadWrite)]` forbidden inside a `// HONK` block. |
-| HONK0004 | Error    | Unmatched `// HONK START` / `// HONK END` markers in one file.         |
+| ID       | Severity | Summary                                                                          |
+| -------- | -------- | -------------------------------------------------------------------------------- |
+| HONK0001 | Error    | `[Access(..., Other = ReadWrite)]` forbidden inside a `// HONK` block.           |
+| HONK0004 | Error    | Unmatched `// HONK START` / `// HONK END` markers in one file.                   |
+| HONK0005 | Error    | `[Access(typeof(ForkSystem))]` on an upstream file must sit inside a HONK block. |
 
 ## Suppressing a rule
 


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0005 to `Content.Analyzers.Honk`. Flags `[Access(typeof(ForkSystem))]` on upstream files when the attribute isn't inside a `// HONK START` / `// HONK END` block. Fork-owned files (path contains `/RussStation/` or filename ending in `.Honk.cs`) are exempt.

## Why / Balance

When the fork adds a fork system as an `[Access]` friend on an upstream component, the rebase auditor needs HONK markers to preserve the drift through upstream syncs. Without the markers the friend line looks identical to an upstream edit and gets blown away on merge.

Real example the rule protects: `Content.Shared/Body/Components/BloodstreamComponent.cs` wraps `[Access(typeof(SharedBloodstreamSystem), typeof(BloodDeficiencySystem))]` in `// HONK START` / `// HONK END` today. HONK0005 makes that pattern enforceable going forward.

Detection uses the semantic model to walk the `typeof()` target's namespace chain looking for a `RussStation` segment.

## Technical details

- New file: `Content.Analyzers.Honk/HonkAccessForkFriendAnalyzer.cs`
- New file: `Content.Analyzers.Honk.Tests/HonkAccessForkFriendAnalyzerTest.cs` (5 cases: upstream-file outside/inside HONK block, upstream-friend unaffected, fork-file exempt, `.Honk.cs` exempt)
- Doc row added to `HONK-ANALYZERS.md`

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.