### PR TITLE
honksquad: feat: HONK0002 cap public setters in Honk partials (#520)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkPartialSurfaceAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkPartialSurfaceAnalyzerTest.cs
@@ -1,0 +1,120 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkPartialSurfaceAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkPartialSurfaceAnalyzerTest
+{
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    (filePath, code),
+                },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task HonkPartial_FourSetMethods_Reports()
+    {
+        const string code = """
+            namespace Foo;
+            public abstract partial class SomeSystem
+            {
+                public void SetA() { }
+                public void SetB() { }
+                public void SetC() { }
+                public void SetD() { }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/SomeSystem.Honk.cs",
+            new DiagnosticResult("HONK0002", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/Foo/SomeSystem.Honk.cs", 2, 31, 2, 41)
+                .WithArguments("SomeSystem", 4));
+    }
+
+    [Test]
+    public async Task HonkPartial_ThreeSetMethods_DoesNotReport()
+    {
+        const string code = """
+            namespace Foo;
+            public abstract partial class SomeSystem
+            {
+                public void SetA() { }
+                public void SetB() { }
+                public void SetC() { }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/SomeSystem.Honk.cs");
+    }
+
+    [Test]
+    public async Task HonkPartial_MixedSettersAndMethods_Reports()
+    {
+        const string code = """
+            namespace Foo;
+            public partial class SomeComponent
+            {
+                public int A { get; set; }
+                public int B { get; set; }
+                public void SetC() { }
+                public void ResetD() { }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/SomeComponent.Honk.cs",
+            new DiagnosticResult("HONK0002", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/Foo/SomeComponent.Honk.cs", 2, 22, 2, 35)
+                .WithArguments("SomeComponent", 4));
+    }
+
+    [Test]
+    public async Task NonHonkFile_ManySetMethods_DoesNotReport()
+    {
+        const string code = """
+            namespace Foo;
+            public partial class SomeSystem
+            {
+                public void SetA() { }
+                public void SetB() { }
+                public void SetC() { }
+                public void SetD() { }
+                public void SetE() { }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/SomeSystem.cs");
+    }
+
+    [Test]
+    public async Task HonkPartial_PrivateSetter_DoesNotCount()
+    {
+        const string code = """
+            namespace Foo;
+            public partial class SomeComponent
+            {
+                public int A { get; private set; }
+                public int B { get; private set; }
+                public int C { get; private set; }
+                public int D { get; private set; }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/SomeComponent.Honk.cs");
+    }
+}

--- a/Content.Analyzers.Honk/HonkPartialSurfaceAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkPartialSurfaceAnalyzer.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0002: a `*.Honk.cs` partial class exposing more than three public
+/// mutation entry points (public property setters or `public void SetX()` /
+/// `Reset*` methods) is effectively re-exporting the underlying component.
+/// At that point, the fork should escalate to a HONK-marked
+/// `[Access(typeof(ForkSystem))]` on the upstream component instead of
+/// piling on partial helpers.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkPartialSurfaceAnalyzer : DiagnosticAnalyzer
+{
+    private const int Threshold = 3;
+
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0002",
+        title: "Honk partial exposes too many public setters",
+        messageFormat: "'{0}' exposes {1} public setters or Set*/Reset* methods in a .Honk.cs partial; escalate to a HONK-marked [Access(typeof(ForkSystem))] on the upstream type instead",
+        category: "Honk.Access",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Partial-class setters are a scalpel for one or two fields the fork needs to mutate. Beyond three, they signal that a real [Access] friend is overdue, pushing back against a blob of re-exports growing over time.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var cls = (ClassDeclarationSyntax)context.Node;
+
+        if (!IsHonkPartialFile(cls.SyntaxTree.FilePath))
+            return;
+
+        if (!cls.Modifiers.Any(SyntaxKind.PartialKeyword))
+            return;
+
+        var count = 0;
+        foreach (var member in cls.Members)
+        {
+            if (IsPublicSetterSurface(member))
+                count++;
+        }
+
+        if (count <= Threshold)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, cls.Identifier.GetLocation(), cls.Identifier.ValueText, count));
+    }
+
+    private static bool IsHonkPartialFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        return path!.Replace('\\', '/').EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool IsPublicSetterSurface(MemberDeclarationSyntax member)
+    {
+        if (!member.Modifiers.Any(SyntaxKind.PublicKeyword))
+            return false;
+
+        switch (member)
+        {
+            case PropertyDeclarationSyntax prop:
+                if (prop.AccessorList is null)
+                    return false;
+                foreach (var accessor in prop.AccessorList.Accessors)
+                {
+                    if (!accessor.Keyword.IsKind(SyntaxKind.SetKeyword))
+                        continue;
+                    if (accessor.Modifiers.Any(SyntaxKind.PrivateKeyword)
+                        || accessor.Modifiers.Any(SyntaxKind.InternalKeyword)
+                        || accessor.Modifiers.Any(SyntaxKind.ProtectedKeyword))
+                    {
+                        return false;
+                    }
+                    return true;
+                }
+                return false;
+
+            case MethodDeclarationSyntax method:
+                var name = method.Identifier.ValueText;
+                return name.StartsWith("Set", StringComparison.Ordinal)
+                    || name.StartsWith("Reset", StringComparison.Ordinal);
+
+            default:
+                return false;
+        }
+    }
+}

--- a/HONK-ANALYZERS.md
+++ b/HONK-ANALYZERS.md
@@ -11,6 +11,7 @@ policy. Rules run on every `dotnet build` via the
 | HONK0001 | Error    | `[Access(..., Other = ReadWrite)]` forbidden inside a `// HONK` block.           |
 | HONK0004 | Error    | Unmatched `// HONK START` / `// HONK END` markers in one file.                   |
 | HONK0005 | Error    | `[Access(typeof(ForkSystem))]` on an upstream file must sit inside a HONK block. |
+| HONK0002 | Warning  | `*.Honk.cs` partial exposes more than three public setters / `Set*` methods.     |
 
 ## Suppressing a rule
 


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0002 (Warning) to \`Content.Analyzers.Honk\`. A \`*.Honk.cs\` partial class exposing more than three public property setters or \`Set*\` / \`Reset*\` methods fires the warning.

## Why / Balance

Partial-class setters are a scalpel for one or two fields the fork needs to mutate on an upstream component. Piling on four or more in a \`.Honk.cs\` file is a smell: at that point the fork is effectively re-exporting the component, and a HONK-marked \`[Access(typeof(ForkSystem))]\` on the upstream type is cleaner and rebase-visible.

Severity is Warning, not Error, because the threshold is a heuristic. Teams can \`#pragma warning disable HONK0002\` with a reason when a partial legitimately needs more than three setters.

Current codebase has one \`.Honk.cs\` (\`SharedRadiationSystem.Honk.cs\`) with two \`Set*\` methods, comfortably under the threshold.

## Technical details

- New file: \`Content.Analyzers.Honk/HonkPartialSurfaceAnalyzer.cs\`
- New file: \`Content.Analyzers.Honk.Tests/HonkPartialSurfaceAnalyzerTest.cs\` (5 cases: four \`Set*\` fires, three does not, mixed property+method fires, non-Honk file exempt, \`private set\` doesn't count)
- Doc row added to \`HONK-ANALYZERS.md\`

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.