### PR TITLE
honksquad: feat: HONK0003 flag direct writes to upstream components (#520)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkUpstreamFieldWriteAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkUpstreamFieldWriteAnalyzerTest.cs
@@ -1,0 +1,140 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkUpstreamFieldWriteAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkUpstreamFieldWriteAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Content.Shared.Body.Components
+        {
+            public sealed class BloodstreamComponent
+            {
+                public float BloodLevel;
+                public int MaxBlood { get; set; }
+            }
+        }
+        namespace Content.Shared.RussStation.Wounds
+        {
+            public sealed class WoundComponent
+            {
+                public string? BleedSourceDamageType;
+            }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task WriteUpstreamField_FromForkFile_Reports()
+    {
+        const string code = """
+            using Content.Shared.Body.Components;
+
+            public static class T
+            {
+                public static void Run(BloodstreamComponent comp)
+                {
+                    comp.BloodLevel = 1.0f;
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs",
+            new DiagnosticResult("HONK0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs", 7, 14, 7, 24)
+                .WithArguments("BloodstreamComponent", "BloodLevel"));
+    }
+
+    [Test]
+    public async Task WriteUpstreamProperty_FromForkFile_Reports()
+    {
+        const string code = """
+            using Content.Shared.Body.Components;
+
+            public static class T
+            {
+                public static void Run(BloodstreamComponent comp)
+                {
+                    comp.MaxBlood = 500;
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs",
+            new DiagnosticResult("HONK0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs", 7, 14, 7, 22)
+                .WithArguments("BloodstreamComponent", "MaxBlood"));
+    }
+
+    [Test]
+    public async Task WriteForkComponent_FromForkFile_DoesNotReport()
+    {
+        const string code = """
+            using Content.Shared.RussStation.Wounds;
+
+            public static class T
+            {
+                public static void Run(WoundComponent comp)
+                {
+                    comp.BleedSourceDamageType = "Slash";
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Wounds/Systems/WoundDisplaySystem.cs");
+    }
+
+    [Test]
+    public async Task WriteUpstreamField_FromUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Content.Shared.Body.Components;
+
+            public static class T
+            {
+                public static void Run(BloodstreamComponent comp)
+                {
+                    comp.BloodLevel = 1.0f;
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Body/Systems/SharedBloodstreamSystem.cs");
+    }
+
+    [Test]
+    public async Task WriteUpstreamField_FromHonkPartial_DoesNotReport()
+    {
+        const string code = """
+            using Content.Shared.Body.Components;
+
+            public static class T
+            {
+                public static void Run(BloodstreamComponent comp)
+                {
+                    comp.BloodLevel = 1.0f;
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Traits/BloodDeficiencySystem.Honk.cs");
+    }
+}

--- a/Content.Analyzers.Honk/HonkUpstreamFieldWriteAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkUpstreamFieldWriteAnalyzer.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0003: a direct write to an upstream component field/property from a
+/// fork file under `*/RussStation/**` drifts silently past rebase. Writes
+/// that need to happen should either go through a HONK-marked
+/// `[Access(typeof(ForkSystem))]` friend on the upstream type, a partial
+/// `*.Honk.cs` setter on the owning upstream system, or an inline
+/// `#pragma warning disable HONK0003` with a reason.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkUpstreamFieldWriteAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0003",
+        title: "Direct write to upstream component from fork file",
+        messageFormat: "Direct write to upstream member '{0}.{1}' from a fork file; add a HONK-marked [Access] friend or move to a .Honk.cs partial instead",
+        category: "Honk.Access",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The fork leans on partial-class setters and [Access] friends to keep drift visible to the rebase auditor. A bare `comp.Field = value` in a RussStation file hides that drift and is hard to preserve through upstream syncs.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.SimpleAssignmentExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var assignment = (AssignmentExpressionSyntax)context.Node;
+
+        var path = assignment.SyntaxTree.FilePath;
+        if (!IsForkFile(path) || IsHonkPartialFile(path))
+            return;
+
+        if (assignment.Left is not MemberAccessExpressionSyntax member)
+            return;
+
+        var symbol = context.SemanticModel.GetSymbolInfo(member, context.CancellationToken).Symbol;
+        if (symbol is null)
+            return;
+
+        if (symbol is not IFieldSymbol && symbol is not IPropertySymbol)
+            return;
+
+        var containing = symbol.ContainingType;
+        if (containing is null)
+            return;
+
+        if (!containing.Name.EndsWith("Component", StringComparison.Ordinal))
+            return;
+
+        if (IsForkType(containing))
+            return;
+
+        if (!IsContentType(containing))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor,
+            member.Name.GetLocation(),
+            containing.Name,
+            symbol.Name));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        return path!.Replace('\\', '/').Contains("/RussStation/");
+    }
+
+    private static bool IsHonkPartialFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        return path!.Replace('\\', '/').EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool IsForkType(INamedTypeSymbol symbol)
+    {
+        for (var ns = symbol.ContainingNamespace; ns is { IsGlobalNamespace: false }; ns = ns.ContainingNamespace)
+        {
+            if (ns.Name == "RussStation")
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsContentType(INamedTypeSymbol symbol)
+    {
+        for (var ns = symbol.ContainingNamespace; ns is { IsGlobalNamespace: false }; ns = ns.ContainingNamespace)
+        {
+            if (ns.Name == "Content" && ns.ContainingNamespace is { IsGlobalNamespace: true })
+                return true;
+        }
+        return false;
+    }
+}

--- a/Content.Server/RussStation/Traits/SkittishSystem.cs
+++ b/Content.Server/RussStation/Traits/SkittishSystem.cs
@@ -66,7 +66,9 @@ public sealed class SkittishSystem : EntitySystem
 
         // Block the internal-movement handler from immediately re-opening the storage due to the
         // lingering movement input that triggered this collision.
+#pragma warning disable HONK0003 // EntityStorageComponent field guards re-entry on skittish collision; reviewed drift, upstream has no equivalent helper.
         storageComp.NextInternalOpenAttempt = _timing.CurTime + TimeSpan.FromSeconds(1.0);
+#pragma warning restore HONK0003
         Dirty(other, storageComp);
 
         // Lock the container after entering.

--- a/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencySystem.cs
@@ -39,7 +39,9 @@ public sealed class BloodDeficiencySystem : EntitySystem
         if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
             return;
 
+#pragma warning disable HONK0003 // BloodstreamComponent grants this system as an [Access] friend (HONK-marked on the upstream file); write is sanctioned fork drift.
         bloodstream.BloodRefreshAmount = -component.BloodLossPerTick;
+#pragma warning restore HONK0003
 
         if (!_net.IsServer)
             return;


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0003 (Warning) to \`Content.Analyzers.Honk\`. Fires on a direct assignment to a field or property of an upstream \`*Component\` type when the assignment lives in a file under \`*/RussStation/**\`. \`.Honk.cs\` partials and fork-owned components are exempt.

## Why / Balance

The fork leans on partial-class setters and \`[Access]\` friends to keep upstream-component mutations visible to the rebase auditor. A bare \`comp.Field = value\` in a RussStation file hides that drift and is hard to preserve through upstream syncs.

Scope was narrowed to \`*Component\` types specifically, to avoid noise from writing event-struct fields (\`ev.Handled = true\`, \`ev.CanDrop = ...\`), which is normal interop.

Two existing sites are real fork drift and get inline \`#pragma warning disable HONK0003\` with a one-line reason:

- \`BloodDeficiencySystem\` writing \`BloodstreamComponent.BloodRefreshAmount\` (already sanctioned via HONK-marked \`[Access]\` friend on \`BloodstreamComponent\`).
- \`SkittishSystem\` writing \`EntityStorageComponent.NextInternalOpenAttempt\` (reviewed drift, upstream has no equivalent helper).

## Technical details

- New file: \`Content.Analyzers.Honk/HonkUpstreamFieldWriteAnalyzer.cs\` (semantic model; walks containing namespace for a \`RussStation\` segment to decide fork-vs-upstream).
- New file: \`Content.Analyzers.Honk.Tests/HonkUpstreamFieldWriteAnalyzerTest.cs\` (5 cases: upstream field/property from fork file reports, fork component doesn't, upstream file doesn't, \`.Honk.cs\` doesn't).
- Two inline \`#pragma\` suppressions with one-line justifications.
- Doc row added to \`HONK-ANALYZERS.md\`.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.