### PR TITLE
honksquad: feat: HONK0006 require partial counterpart for .Honk.cs (#520)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkPartialCounterpartAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkPartialCounterpartAnalyzerTest.cs
@@ -1,0 +1,105 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkPartialCounterpartAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkPartialCounterpartAnalyzerTest
+{
+    [Test]
+    public async Task HonkPartial_WithCounterpart_DoesNotReport()
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    ("Content.Shared/Foo/Bar.cs", """
+                        namespace Foo;
+                        public partial class Bar { }
+                        """),
+                    ("Content.Shared/Foo/Bar.Honk.cs", """
+                        namespace Foo;
+                        public partial class Bar { }
+                        """),
+                },
+            },
+        };
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task HonkPartial_MissingCounterpart_Reports()
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    ("Content.Shared/Foo/Bar.Honk.cs", """
+                        namespace Foo;
+                        public partial class Bar { }
+                        """),
+                },
+                ExpectedDiagnostics =
+                {
+                    new DiagnosticResult("HONK0006", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                        .WithSpan("Content.Shared/Foo/Bar.Honk.cs", 2, 22, 2, 25)
+                        .WithArguments("Bar", "has no non-Honk counterpart declaration"),
+                },
+            },
+        };
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task HonkFile_NonPartialClass_Reports()
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    ("Content.Shared/Foo/Bar.Honk.cs", """
+                        namespace Foo;
+                        public class Bar { }
+                        """),
+                },
+                ExpectedDiagnostics =
+                {
+                    new DiagnosticResult("HONK0006", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                        .WithSpan("Content.Shared/Foo/Bar.Honk.cs", 2, 14, 2, 17)
+                        .WithArguments("Bar", "is not declared partial"),
+                },
+            },
+        };
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task NonHonkFile_NonPartialClass_DoesNotReport()
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    ("Content.Shared/Foo/Bar.cs", """
+                        namespace Foo;
+                        public class Bar { }
+                        """),
+                },
+            },
+        };
+        await test.RunAsync();
+    }
+}

--- a/Content.Analyzers.Honk/HonkPartialCounterpartAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkPartialCounterpartAnalyzer.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0006: every class declared in a `*.Honk.cs` file must be `partial`
+/// and must have at least one declaring file that isn't itself a
+/// `*.Honk.cs` file. This keeps Honk partials anchored to a real upstream
+/// (or fork-owned) definition; a Honk partial with no counterpart is
+/// really just a fork file with a misleading name and should live as a
+/// normal `.cs` file instead.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkPartialCounterpartAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor MissingPartial = new(
+        id: "HONK0006",
+        title: "Honk partial missing partial modifier or counterpart",
+        messageFormat: "'{0}' in a .Honk.cs file {1}; rename the file to plain .cs or declare the counterpart",
+        category: "Honk.Access",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A `.Honk.cs` file is a fork augmentation of an existing type. Classes declared there must be `partial` and must have at least one non-Honk declaration, otherwise the file is a fork addition hiding under the Honk naming convention.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(MissingPartial);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var cls = (ClassDeclarationSyntax)context.Node;
+
+        if (!IsHonkPartialFile(cls.SyntaxTree.FilePath))
+            return;
+
+        if (!cls.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                MissingPartial,
+                cls.Identifier.GetLocation(),
+                cls.Identifier.ValueText,
+                "is not declared partial"));
+            return;
+        }
+
+        if (context.SemanticModel.GetDeclaredSymbol(cls, context.CancellationToken) is not INamedTypeSymbol symbol)
+            return;
+
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (!IsHonkPartialFile(reference.SyntaxTree.FilePath))
+                return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            MissingPartial,
+            cls.Identifier.GetLocation(),
+            cls.Identifier.ValueText,
+            "has no non-Honk counterpart declaration"));
+    }
+
+    private static bool IsHonkPartialFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        return path!.Replace('\\', '/').EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0006 (Error) to \`Content.Analyzers.Honk\`. Classes declared in a \`*.Honk.cs\` file must be \`partial\` and must have at least one declaring file that isn't itself a \`.Honk.cs\`.

## Why / Balance

A \`.Honk.cs\` file is a fork augmentation of an existing type. If the class only exists inside \`.Honk.cs\`, the file is really a new fork definition hiding under the Honk naming convention, which is the wrong layer for fork drift tooling to audit. This rule keeps the convention honest.

Current codebase has one \`.Honk.cs\` (\`SharedRadiationSystem.Honk.cs\`) with its counterpart in \`SharedRadiationSystem.cs\`, compiles clean.

## Technical details

- New file: \`Content.Analyzers.Honk/HonkPartialCounterpartAnalyzer.cs\` (checks both the \`partial\` modifier and \`ISymbol.DeclaringSyntaxReferences\` for a non-Honk file).
- New file: \`Content.Analyzers.Honk.Tests/HonkPartialCounterpartAnalyzerTest.cs\` (4 cases: paired partial passes, unpaired partial errors, non-partial class in a Honk file errors, non-Honk file unaffected).
- Doc row added to \`HONK-ANALYZERS.md\`.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.