### PR TITLE
honksquad: feat: HONK0007 flag IoCManager.Resolve inside EntitySystem (#545)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkEntitySystemIoCResolveAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkEntitySystemIoCResolveAnalyzerTest.cs
@@ -36,13 +36,20 @@ public sealed class HonkEntitySystemIoCResolveAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/SomeForkSystem.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/SomeSystem.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
         var test = new VerifyCS
         {
             TestState =
             {
-                Sources = { Stubs, code },
+                Sources =
+                {
+                    Stubs,
+                    (filePath, code),
+                },
             },
         };
         test.ExpectedDiagnostics.AddRange(expected);
@@ -66,9 +73,9 @@ public sealed class HonkEntitySystemIoCResolveAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 9, 22, 9, 55)
+                .WithSpan(ForkPath, 9, 22, 9, 55)
                 .WithArguments("MySystem"));
     }
 
@@ -89,9 +96,9 @@ public sealed class HonkEntitySystemIoCResolveAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 9, 22, 9, 64)
+                .WithSpan(ForkPath, 9, 22, 9, 64)
                 .WithArguments("MySystem"));
     }
 
@@ -111,7 +118,7 @@ public sealed class HonkEntitySystemIoCResolveAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -132,7 +139,7 @@ public sealed class HonkEntitySystemIoCResolveAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -154,9 +161,53 @@ public sealed class HonkEntitySystemIoCResolveAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 11, 22, 11, 55)
+                .WithSpan(ForkPath, 11, 22, 11, 55)
                 .WithArguments("FooSystem"));
+    }
+
+    [Test]
+    public async Task Resolve_InUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.IoC;
+            using Robust.Shared.Timing;
+
+            public sealed class UpstreamSystem : EntitySystem
+            {
+                public void Foo()
+                {
+                    var timing = IoCManager.Resolve<IGameTiming>();
+                }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
+    }
+
+    [Test]
+    public async Task Resolve_InHonkPartial_Reports()
+    {
+        const string honkPath = "Content.Shared/Upstream/SomeSystem.Honk.cs";
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.IoC;
+            using Robust.Shared.Timing;
+
+            public sealed class HonkPartialSystem : EntitySystem
+            {
+                public void Foo()
+                {
+                    var timing = IoCManager.Resolve<IGameTiming>();
+                }
+            }
+            """;
+
+        await Verify(code, honkPath,
+            new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(honkPath, 9, 22, 9, 55)
+                .WithArguments("HonkPartialSystem"));
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkEntitySystemIoCResolveAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkEntitySystemIoCResolveAnalyzerTest.cs
@@ -1,0 +1,162 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkEntitySystemIoCResolveAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkEntitySystemIoCResolveAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class EntitySystem
+            {
+            }
+        }
+        namespace Robust.Shared.IoC
+        {
+            public static class IoCManager
+            {
+                public static T Resolve<T>() => default!;
+                public static IoCProxy Instance { get; } = new();
+                public sealed class IoCProxy
+                {
+                    public T Resolve<T>() => default!;
+                }
+            }
+        }
+        namespace Robust.Shared.Timing
+        {
+            public interface IGameTiming { }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, code },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task Resolve_InsideEntitySystem_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.IoC;
+            using Robust.Shared.Timing;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public void Foo()
+                {
+                    var timing = IoCManager.Resolve<IGameTiming>();
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 9, 22, 9, 55)
+                .WithArguments("MySystem"));
+    }
+
+    [Test]
+    public async Task ResolveViaInstance_InsideEntitySystem_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.IoC;
+            using Robust.Shared.Timing;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public void Foo()
+                {
+                    var timing = IoCManager.Instance.Resolve<IGameTiming>();
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 9, 22, 9, 64)
+                .WithArguments("MySystem"));
+    }
+
+    [Test]
+    public async Task Resolve_OutsideEntitySystem_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.IoC;
+            using Robust.Shared.Timing;
+
+            public sealed class SomeHelper
+            {
+                public void Foo()
+                {
+                    var timing = IoCManager.Resolve<IGameTiming>();
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task EntitySystem_WithoutResolve_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Timing;
+
+            public sealed class MySystem : EntitySystem
+            {
+                private IGameTiming _timing = default!;
+
+                public void Foo()
+                {
+                    _ = _timing;
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task Resolve_InTransitivelyDerivedSystem_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.IoC;
+            using Robust.Shared.Timing;
+
+            public abstract class SharedFooSystem : EntitySystem { }
+
+            public sealed class FooSystem : SharedFooSystem
+            {
+                public void Bar()
+                {
+                    var timing = IoCManager.Resolve<IGameTiming>();
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0007", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 11, 22, 11, 55)
+                .WithArguments("FooSystem"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkEntitySystemIoCResolveAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkEntitySystemIoCResolveAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -12,6 +13,8 @@ namespace Content.Analyzers.Honk;
 /// constructed by the engine with DI available via <c>[Dependency]</c>
 /// field injection. Reaching into the IoC container defeats lifetime
 /// tracking and test substitution, and hides the system's dependency list.
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkEntitySystemIoCResolveAnalyzer : DiagnosticAnalyzer
@@ -38,6 +41,9 @@ public sealed class HonkEntitySystemIoCResolveAnalyzer : DiagnosticAnalyzer
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
 
         if (!IsIoCResolveCall(invocation))
             return;
@@ -77,6 +83,15 @@ public sealed class HonkEntitySystemIoCResolveAnalyzer : DiagnosticAnalyzer
                 || ma.Name.Identifier.ValueText == "IoCManager",
             _ => false,
         };
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool InheritsEntitySystem(INamedTypeSymbol type)

--- a/Content.Analyzers.Honk/HonkEntitySystemIoCResolveAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkEntitySystemIoCResolveAnalyzer.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0007: forbids <c>IoCManager.Resolve&lt;T&gt;()</c> inside any type
+/// deriving from <c>Robust.Shared.GameObjects.EntitySystem</c>. Systems are
+/// constructed by the engine with DI available via <c>[Dependency]</c>
+/// field injection. Reaching into the IoC container defeats lifetime
+/// tracking and test substitution, and hides the system's dependency list.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkEntitySystemIoCResolveAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0007",
+        title: "IoCManager.Resolve inside EntitySystem",
+        messageFormat: "'{0}' uses IoCManager.Resolve inside an EntitySystem; declare a [Dependency] field instead",
+        category: "Honk.EntitySystem",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "EntitySystems receive dependencies via [Dependency] field injection. IoCManager.Resolve bypasses that, hiding the system's dependency list and breaking test substitution.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsIoCResolveCall(invocation))
+            return;
+
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType is null)
+            return;
+
+        if (!InheritsEntitySystem(containingType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation(), containingType.Name));
+    }
+
+    private static bool IsIoCResolveCall(InvocationExpressionSyntax invocation)
+    {
+        // Match IoCManager.Resolve<T>(...) and IoCManager.Instance.Resolve<T>(...).
+        if (invocation.Expression is not MemberAccessExpressionSyntax member)
+            return false;
+
+        if (member.Name is not GenericNameSyntax generic)
+            return false;
+
+        if (generic.Identifier.ValueText != "Resolve")
+            return false;
+
+        return ReceiverIsIoCManager(member.Expression);
+    }
+
+    private static bool ReceiverIsIoCManager(ExpressionSyntax expr)
+    {
+        return expr switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText == "IoCManager",
+            MemberAccessExpressionSyntax ma =>
+                ma.Name.Identifier.ValueText == "Instance" && ReceiverIsIoCManager(ma.Expression)
+                || ma.Name.Identifier.ValueText == "IoCManager",
+            _ => false,
+        };
+    }
+
+    private static bool InheritsEntitySystem(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "EntitySystem" &&
+                current.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0007 (Warning) to `Content.Analyzers.Honk`. Any `IoCManager.Resolve<T>()` or `IoCManager.Instance.Resolve<T>()` call inside a type deriving from `Robust.Shared.GameObjects.EntitySystem` fires the warning.

Closes #545.

## Why / Balance

EntitySystems receive their dependencies via `[Dependency]` field injection. Reaching into the IoC container from a system method defeats lifetime tracking, hides the system's dependency list from anyone scanning for it, and breaks test substitution (the tests can't swap an injected field if the call resolves at runtime).

Severity is Warning, not Error, because upstream itself has a handful of these (`HTNSystem.cs` in `Content.Client/NPC/HTN/` is the current example). That keeps the PR landable and turns the cleanup into a separate follow-up rather than gating the analyzer on a refactor.

## Technical details

- New file: `Content.Analyzers.Honk/HonkEntitySystemIoCResolveAnalyzer.cs`.
- New file: `Content.Analyzers.Honk.Tests/HonkEntitySystemIoCResolveAnalyzerTest.cs` (5 cases: direct `Resolve` in a system fires, `Instance.Resolve` fires, non-system usage doesn't fire, system with no `Resolve` call doesn't fire, transitively-derived system still fires).
- Doc row added to `HONK-ANALYZERS.md`.
- Current codebase surfaces two warnings in `Content.Client/NPC/HTN/HTNSystem.cs`; both are valid hits and appropriate for a separate cleanup PR.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.
