### PR TITLE
honksquad: feat: HONK0008 require [RegisterComponent] on concrete components (#546)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkComponentRegistrationAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkComponentRegistrationAnalyzerTest.cs
@@ -1,0 +1,134 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkComponentRegistrationAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkComponentRegistrationAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class Component { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class RegisterComponentAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class VirtualAttribute : System.Attribute { }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, code } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task ConcreteComponent_WithoutAttribute_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooComponent : Component { }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0008", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 3, 21, 3, 33)
+                .WithArguments("FooComponent"));
+    }
+
+    [Test]
+    public async Task ConcreteComponent_WithAttribute_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            [RegisterComponent]
+            public sealed class FooComponent : Component { }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task AbstractComponent_WithoutAttribute_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public abstract class BaseThingComponent : Component { }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task VirtualComponent_WithoutRegisterAttribute_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Analyzers;
+
+            [Virtual]
+            public class SharedFooComponent : Component { }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task NonComponentClass_WithoutAttribute_DoesNotReport()
+    {
+        const string code = """
+            public sealed class SomeHelper { }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task TransitivelyDerivedComponent_WithoutAttribute_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public abstract class BaseThingComponent : Component { }
+
+            public sealed class DerivedThingComponent : BaseThingComponent { }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0008", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 5, 21, 5, 42)
+                .WithArguments("DerivedThingComponent"));
+    }
+
+    [Test]
+    public async Task TransitivelyDerivedComponent_WithAttribute_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public abstract class BaseThingComponent : Component { }
+
+            [RegisterComponent]
+            public sealed class DerivedThingComponent : BaseThingComponent { }
+            """;
+
+        await Verify(code);
+    }
+}

--- a/Content.Analyzers.Honk/HonkComponentRegistrationAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkComponentRegistrationAnalyzer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0008: a non-abstract, non-<c>[Virtual]</c> class deriving from
+/// <c>Robust.Shared.GameObjects.Component</c> must carry a
+/// <c>[RegisterComponent]</c> attribute. Without it, the component is not
+/// registered with the factory: <c>AddComp</c>/<c>EnsureComp</c> throw at
+/// runtime and prototypes silently fail to attach it.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkComponentRegistrationAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0008",
+        title: "Component subclass missing [RegisterComponent]",
+        messageFormat: "'{0}' derives from Component but is missing [RegisterComponent]; add the attribute, mark the class abstract, or mark it [Virtual]",
+        category: "Honk.Component",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Concrete Component subclasses must be registered via [RegisterComponent]. Missing the attribute means the component cannot be added, ensured, or attached through prototypes at runtime. Abstract classes and upstream [Virtual] base classes are exempt.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(Analyze, SymbolKind.NamedType);
+    }
+
+    private static void Analyze(SymbolAnalysisContext context)
+    {
+        if (context.Symbol is not INamedTypeSymbol type)
+            return;
+
+        if (type.TypeKind != TypeKind.Class || type.IsAbstract)
+            return;
+
+        if (!InheritsComponent(type))
+            return;
+
+        if (HasRegisterComponentAttribute(type))
+            return;
+
+        if (HasVirtualAttribute(type))
+            return;
+
+        foreach (var location in type.Locations)
+        {
+            if (location.IsInSource)
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, type.Name));
+        }
+    }
+
+    private static bool InheritsComponent(INamedTypeSymbol type)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "Component" &&
+                current.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasRegisterComponentAttribute(INamedTypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is null)
+                continue;
+
+            if (attrClass.Name is "RegisterComponentAttribute" or "RegisterComponent" &&
+                attrClass.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasVirtualAttribute(INamedTypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is null)
+                continue;
+
+            if (attrClass.Name is "VirtualAttribute" or "Virtual" &&
+                attrClass.ContainingNamespace?.ToDisplayString() == "Robust.Shared.Analyzers")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/HONK-ANALYZERS.md
+++ b/HONK-ANALYZERS.md
@@ -12,6 +12,7 @@ policy. Rules run on every `dotnet build` via the
 | HONK0004 | Error    | Unmatched `// HONK START` / `// HONK END` markers in one file.                   |
 | HONK0005 | Error    | `[Access(typeof(ForkSystem))]` on an upstream file must sit inside a HONK block. |
 | HONK0002 | Warning  | `*.Honk.cs` partial exposes more than three public setters / `Set*` methods.     |
+| HONK0008 | Warning  | Concrete `Component` subclass missing `[RegisterComponent]`.                     |
 
 ## Suppressing a rule
 


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0008 (Warning) to `Content.Analyzers.Honk`. A non-abstract class deriving from `Robust.Shared.GameObjects.Component` must carry `[RegisterComponent]`; classes marked `[Virtual]` (upstream's "abstract-by-contract" convention) and actual `abstract` classes are exempt.

Closes #546.

## Why / Balance

Missing `[RegisterComponent]` means the factory never registers the type. `AddComp`/`EnsureComp` throw at runtime and prototypes silently fail to attach it, so the bug only surfaces in-game. Upstream's existing component analyzers (RA0021–RA0024, RA0040/0041) cover pause generators and auto-state shape but never check the registration attribute itself.

Severity is Warning to give upstream room to clean up any genuine missing attributes in a follow-up, rather than gating the rule on a refactor. `[Virtual]` skip was necessary because upstream uses it as the marker for non-abstract base classes like `SharedAmeControllerComponent`, which legitimately have no registration.

## Technical details

- New file: `Content.Analyzers.Honk/HonkComponentRegistrationAnalyzer.cs`. Symbol action on `NamedType`, walks base chain for `Robust.Shared.GameObjects.Component`, skips when `IsAbstract`, `[RegisterComponent]`, or `[Virtual]`.
- New file: `Content.Analyzers.Honk.Tests/HonkComponentRegistrationAnalyzerTest.cs` (6 cases: concrete without attribute fires, with attribute passes, abstract passes, `[Virtual]` passes, non-`Component` class passes, transitively-derived with and without attribute).
- Doc row added to `HONK-ANALYZERS.md`.
- Current codebase builds clean: no HONK0008 hits across `Content.Shared`, `Content.Server`, or `Content.Client`.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.
