### PR TITLE
honksquad: feat: HONK0009 flag SubscribeLocalEvent outside Initialize() (#547)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkSubscribeOutsideInitializeAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkSubscribeOutsideInitializeAnalyzerTest.cs
@@ -39,11 +39,14 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/SomeForkSystem.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/SomeSystem.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
         var test = new VerifyCS
         {
-            TestState = { Sources = { Stubs, code } },
+            TestState = { Sources = { Stubs, (filePath, code) } },
         };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
@@ -67,7 +70,7 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -93,9 +96,9 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0009", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 13, 9, 13, 62)
+                .WithSpan(ForkPath, 13, 9, 13, 62)
                 .WithArguments("SubscribeLocalEvent"));
     }
 
@@ -124,7 +127,7 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -144,9 +147,9 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0009", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 7, 9, 7, 49)
+                .WithSpan(ForkPath, 7, 9, 7, 49)
                 .WithArguments("SubscribeNetworkEvent"));
     }
 
@@ -168,7 +171,7 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -190,9 +193,29 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0009", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 9, 9, 9, 62)
+                .WithSpan(ForkPath, 9, 9, 9, 62)
                 .WithArguments("SubscribeLocalEvent"));
+    }
+
+    [Test]
+    public async Task SubscribeInUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class UpstreamSystem : EntitySystem
+            {
+                public override void Update(float frameTime)
+                {
+                    SubscribeLocalEvent<SomeComponent, SomeEvent>(OnSome);
+                }
+
+                private void OnSome(System.Guid uid, SomeComponent comp, SomeEvent args) { }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkSubscribeOutsideInitializeAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkSubscribeOutsideInitializeAnalyzerTest.cs
@@ -1,0 +1,198 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkSubscribeOutsideInitializeAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkSubscribeOutsideInitializeAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class EntitySystem
+            {
+                public virtual void Initialize() { }
+                public virtual void Update(float frameTime) { }
+                protected void SubscribeLocalEvent<TComp, TEvent>(ComponentEventHandler<TComp, TEvent> handler)
+                    where TComp : IComponent
+                    where TEvent : notnull
+                { }
+                protected void SubscribeNetworkEvent<TEvent>(EventHandler<TEvent> handler)
+                    where TEvent : notnull
+                { }
+                protected void SubscribeAllEvent<TEvent>(EventHandler<TEvent> handler)
+                    where TEvent : notnull
+                { }
+            }
+            public interface IComponent { }
+            public delegate void ComponentEventHandler<TComp, TEvent>(System.Guid uid, TComp comp, TEvent args)
+                where TComp : IComponent
+                where TEvent : notnull;
+            public delegate void EventHandler<TEvent>(TEvent args) where TEvent : notnull;
+            public sealed class SomeComponent : IComponent { }
+            public sealed class SomeEvent { }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, code } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task SubscribeInInitialize_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public override void Initialize()
+                {
+                    base.Initialize();
+                    SubscribeLocalEvent<SomeComponent, SomeEvent>(OnSome);
+                }
+
+                private void OnSome(System.Guid uid, SomeComponent comp, SomeEvent args) { }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task SubscribeInArbitraryHelper_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public override void Initialize()
+                {
+                    base.Initialize();
+                    WireUp();
+                }
+
+                private void WireUp()
+                {
+                    SubscribeLocalEvent<SomeComponent, SomeEvent>(OnSome);
+                }
+
+                private void OnSome(System.Guid uid, SomeComponent comp, SomeEvent args) { }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0009", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 13, 9, 13, 62)
+                .WithArguments("SubscribeLocalEvent"));
+    }
+
+    [Test]
+    public async Task SubscribeInInitializeXxxPartialHelper_DoesNotReport()
+    {
+        // Upstream convention: Initialize() chains to InitializeBuckle(),
+        // InitializeStrap(), etc. in partial files.
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public override void Initialize()
+                {
+                    base.Initialize();
+                    InitializeBuckle();
+                }
+
+                private void InitializeBuckle()
+                {
+                    SubscribeLocalEvent<SomeComponent, SomeEvent>(OnSome);
+                }
+
+                private void OnSome(System.Guid uid, SomeComponent comp, SomeEvent args) { }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task SubscribeNetworkEventInUpdate_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public override void Update(float frameTime)
+                {
+                    SubscribeNetworkEvent<SomeEvent>(OnSome);
+                }
+
+                private void OnSome(SomeEvent args) { }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0009", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 7, 9, 7, 49)
+                .WithArguments("SubscribeNetworkEvent"));
+    }
+
+    [Test]
+    public async Task SubscribeOutsideEntitySystem_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class NotASystem
+            {
+                public void DoThing()
+                {
+                    // Lookalike method, not the EntitySystem one.
+                    SubscribeLocalEvent();
+                }
+
+                private void SubscribeLocalEvent() { }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task SubscribeInTransitivelyDerivedSystem_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public abstract class SharedFooSystem : EntitySystem { }
+
+            public sealed class FooSystem : SharedFooSystem
+            {
+                private void Helper()
+                {
+                    SubscribeLocalEvent<SomeComponent, SomeEvent>(OnSome);
+                }
+
+                private void OnSome(System.Guid uid, SomeComponent comp, SomeEvent args) { }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0009", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 9, 9, 9, 62)
+                .WithArguments("SubscribeLocalEvent"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkSubscribeOutsideInitializeAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkSubscribeOutsideInitializeAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -12,6 +13,8 @@ namespace Content.Analyzers.Honk;
 /// <c>Initialize</c> or an <c>InitializeXxx</c> partial helper invoked by
 /// it. Subscribing later registers handlers after earlier events have
 /// already fired, and the failure mode is invisible at runtime.
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkSubscribeOutsideInitializeAnalyzer : DiagnosticAnalyzer
@@ -38,6 +41,9 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzer : DiagnosticAnalyzer
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
 
         var name = GetInvokedName(invocation);
         if (name is not ("SubscribeLocalEvent" or "SubscribeNetworkEvent" or "SubscribeAllEvent"))
@@ -84,6 +90,15 @@ public sealed class HonkSubscribeOutsideInitializeAnalyzer : DiagnosticAnalyzer
             MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
             _ => null,
         };
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool IsEntitySystemMember(INamedTypeSymbol? type)

--- a/Content.Analyzers.Honk/HonkSubscribeOutsideInitializeAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkSubscribeOutsideInitializeAnalyzer.cs
@@ -1,0 +1,101 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0009: <c>SubscribeLocalEvent</c>, <c>SubscribeNetworkEvent</c>, and
+/// <c>SubscribeAllEvent</c> on <c>EntitySystem</c> must be called from
+/// <c>Initialize</c> or an <c>InitializeXxx</c> partial helper invoked by
+/// it. Subscribing later registers handlers after earlier events have
+/// already fired, and the failure mode is invisible at runtime.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkSubscribeOutsideInitializeAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0009",
+        title: "EntitySystem event subscription outside Initialize()",
+        messageFormat: "'{0}' is called outside Initialize(); move the subscription into Initialize() or an InitializeXxx helper invoked by it",
+        category: "Honk.EntitySystem",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "EntitySystem event subscriptions must be registered from Initialize(). Subscribing later means earlier events are lost and the failure is silent.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        var name = GetInvokedName(invocation);
+        if (name is not ("SubscribeLocalEvent" or "SubscribeNetworkEvent" or "SubscribeAllEvent"))
+            return;
+
+        // Ignore subscriptions made via the SubscribeLocalEvent subscribers helper
+        // (the inner builder passed to `Subscribes(builder => { ... })`), which is
+        // a legitimate Initialize-time pattern reached through a lambda.
+        var method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (method is null)
+            return;
+
+        // Allow the widespread setup-helper naming conventions that upstream
+        // partials use to chain work out of Initialize(): InitializeXxx
+        // (SharedBuckleSystem.Buckle.cs), InitXxx (ExplosionSystem.Visuals.cs
+        // InitVisuals, RadiationSystem.Blockers.cs InitRadBlocking),
+        // SubscribeXxx (MobStateSystem.Subscribers.cs SubscribeEvents).
+        var methodName = method.Identifier.ValueText;
+        if (methodName.StartsWith("Init") || methodName.StartsWith("Subscribe"))
+            return;
+
+        // Verify this subscription resolves to an EntitySystem member, not
+        // a lookalike on an unrelated type.
+        var symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
+        if (symbol is not IMethodSymbol methodSymbol)
+            return;
+
+        if (!IsEntitySystemMember(methodSymbol.ContainingType))
+            return;
+
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType is null || !IsEntitySystemMember(containingType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation(), name));
+    }
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+            _ => null,
+        };
+    }
+
+    private static bool IsEntitySystemMember(INamedTypeSymbol? type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "EntitySystem" &&
+                current.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0009 (Warning) to `Content.Analyzers.Honk`. Inside a type deriving from `Robust.Shared.GameObjects.EntitySystem`, any `SubscribeLocalEvent` / `SubscribeNetworkEvent` / `SubscribeAllEvent` call made from a method not named `Initialize`, `Init*`, or `Subscribe*` fires the warning.

Closes #547.

## Why / Balance

`EntitySystem` subscriptions must be registered during `Initialize()`. Subscribing later means earlier events have already fired and won't reach the handler; subscribing from a method that is never called means the handler silently does nothing. Neither failure shows up at runtime — the bug is the absence of a log line.

The allowlist covers the upstream naming conventions for setup helpers:
- `Initialize` and `InitializeXxx` (partial chain: `SharedBuckleSystem.Buckle.cs` `InitializeBuckle`, `BodySystem.Relay.cs` `InitializeRelay`, etc.)
- `InitXxx` (e.g. `ExplosionSystem.Visuals.cs` `InitVisuals`, `RadiationSystem.Blockers.cs` `InitRadBlocking`)
- `SubscribeXxx` (e.g. `MobStateSystem.Subscribers.cs` `SubscribeEvents`)

Severity is Warning so the remaining few outliers (XenoArchaeology `XATSubscribeDirectEvent` / `XATRelayLocalEvent`) can be addressed via rename or `#pragma warning disable HONK0009` with justification, rather than gating this rule on a refactor.

## Technical details

- New file: `Content.Analyzers.Honk/HonkSubscribeOutsideInitializeAnalyzer.cs`. Syntax action on `InvocationExpression`; matches identifier name, ancestors the containing `MethodDeclaration`, allows `Init*` / `Subscribe*` names, then confirms both the invoked symbol and the containing type are `EntitySystem` members via semantic model.
- New file: `Content.Analyzers.Honk.Tests/HonkSubscribeOutsideInitializeAnalyzerTest.cs` (6 cases: Initialize passes, arbitrary helper fires, `Update` override fires, `SubscribeNetworkEvent` in `Update` fires, non-`EntitySystem` lookalike doesn't fire, transitively-derived system fires, `InitializeXxx` helper passes).
- Doc row added to `HONK-ANALYZERS.md`.
- Current codebase surfaces 4 hits, both in `Content.Shared/Xenoarchaeology/Artifact/`; handleable as rename-to-Subscribe-prefix or pragma suppression in a follow-up.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.