### PR TITLE
honksquad: chore: run analyzer tests in ci-local.sh (#520)

### DIFF
--- a/ci-local.sh
+++ b/ci-local.sh
@@ -102,6 +102,17 @@ fi
 
 # --- Unit Tests ---
 if [ "$SKIP_TESTS" = false ]; then
+    echo "--- Content.Analyzers.Honk.Tests ---"
+    step_start
+    if dotnet test --no-build --configuration DebugOpt Content.Analyzers.Honk.Tests/Content.Analyzers.Honk.Tests.csproj -- NUnit.ConsoleOut=0 2>&1 | tee /dev/stderr | grep -q "Passed!"; then
+        step_end "Analyzer Tests"
+        pass "Content.Analyzers.Honk.Tests" "${STEP_TIMES["Analyzer Tests"]}"
+    else
+        step_end "Analyzer Tests"
+        fail "Content.Analyzers.Honk.Tests" "${STEP_TIMES["Analyzer Tests"]}"
+    fi
+    echo ""
+
     echo "--- Content.Tests ---"
     step_start
     if dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 2>&1 | tee /dev/stderr | grep -q "Passed!"; then
@@ -125,6 +136,7 @@ if [ "$SKIP_TESTS" = false ]; then
     fi
     echo ""
 else
+    skip "Content.Analyzers.Honk.Tests"
     skip "Content.Tests"
     skip "Content.IntegrationTests"
     echo ""
@@ -161,7 +173,7 @@ echo ""
 # Print timing breakdown
 if [ ${#STEP_TIMES[@]} -gt 0 ]; then
     echo "  Timing:"
-    for step in "CRLF Check" "Build" "Unit Tests" "Integration Tests" "YAML Linter"; do
+    for step in "CRLF Check" "Build" "Analyzer Tests" "Unit Tests" "Integration Tests" "YAML Linter"; do
         if [ -n "${STEP_TIMES[$step]+x}" ]; then
             printf "    %-25s %4ss\n" "$step" "${STEP_TIMES[$step]}"
         fi


### PR DESCRIPTION
## About the PR

Adds a `dotnet test` step for `Content.Analyzers.Honk.Tests` to `ci-local.sh` so the HONK Roslyn rules get exercised alongside the standard unit and integration suites when someone runs the local CI script.

## Why / Balance

`ci-local.sh` invokes tests per-csproj rather than letting `dotnet test` discover every suite in the solution. The analyzer test project was added in #538 but never wired into local CI, so rule regressions would only surface in GitHub Actions or if a contributor remembered to run the project by hand. Closes the last checkbox on #520.

## Technical details

- New "Content.Analyzers.Honk.Tests" step runs before `Content.Tests`. Output feeds the same `pass`/`fail` helpers and shows up in the summary timing block as `Analyzer Tests`.
- Step respects `--skip-tests` / `--only-*` like the others.
- Verified locally: `./ci-local.sh --only-tests` executes the analyzer suite and reports 28 passed.

## Media

N/A, script change.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

N/A, internal tooling.