### PR TITLE
honksquad: feat: HONK0010 flag networked writes without Dirty() (#548)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkMissingDirtyAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkMissingDirtyAnalyzerTest.cs
@@ -56,11 +56,14 @@ public sealed class HonkMissingDirtyAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/NetworkingStuff.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/NetworkingStuff.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
         var test = new VerifyCS
         {
-            TestState = { Sources = { Stubs, code } },
+            TestState = { Sources = { Stubs, (filePath, code) } },
         };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
@@ -82,9 +85,9 @@ public sealed class HonkMissingDirtyAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0010", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 8, 9, 8, 23)
+                .WithSpan(ForkPath, 8, 9, 8, 23)
                 .WithArguments("Value", "NetComp"));
     }
 
@@ -105,7 +108,7 @@ public sealed class HonkMissingDirtyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -125,7 +128,7 @@ public sealed class HonkMissingDirtyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -144,7 +147,7 @@ public sealed class HonkMissingDirtyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -163,6 +166,25 @@ public sealed class HonkMissingDirtyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task WriteWithoutDirty_InUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Value = 5;
+                }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkMissingDirtyAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkMissingDirtyAnalyzerTest.cs
@@ -1,0 +1,168 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkMissingDirtyAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkMissingDirtyAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = true)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class AutoNetworkedFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public abstract class Component : IComponent { }
+            public readonly struct EntityUid { }
+
+            public abstract class EntitySystem
+            {
+                protected void Dirty(EntityUid uid, IComponent comp) { }
+                protected void DirtyField<T>(EntityUid uid, T comp, string field) where T : IComponent { }
+                protected void DirtyFields<T>(EntityUid uid, T comp, params string[] fields) where T : IComponent { }
+                protected void DirtyEntity(EntityUid uid) { }
+            }
+        }
+        namespace Fork.Stubs
+        {
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Analyzers;
+
+            [NetworkedComponent]
+            public sealed class NetComp : Component
+            {
+                public int Value;
+                [AutoNetworkedField]
+                public int Auto;
+            }
+
+            public sealed class PlainComp : Component
+            {
+                public int Value;
+            }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, code } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task WriteWithoutDirty_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Value = 5;
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0010", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 8, 9, 8, 23)
+                .WithArguments("Value", "NetComp"));
+    }
+
+    [Test]
+    public async Task WriteFollowedByDirty_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Value = 5;
+                    Dirty(uid, comp);
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task WriteFollowedByDirtyField_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Value = 5;
+                    DirtyField(uid, comp, nameof(NetComp.Value));
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task AutoNetworkedFieldWrite_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Auto = 5;
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task NonNetworkedComponentWrite_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, PlainComp comp)
+                {
+                    comp.Value = 5;
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+}

--- a/Content.Analyzers.Honk/HonkMissingDirtyAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkMissingDirtyAnalyzer.cs
@@ -1,0 +1,134 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0010: writing a field on a <c>[NetworkedComponent]</c> inside a
+/// method that never calls a dirty-marking API (<c>Dirty</c>,
+/// <c>DirtyField</c>, <c>DirtyFields</c>, <c>DirtyEntity</c>) is the single
+/// most common desync source in content code. The server mutates state,
+/// the client never receives a delta, and the bug only surfaces under
+/// real latency.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkMissingDirtyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0010",
+        title: "Networked component write without Dirty()",
+        messageFormat: "Write to '{0}' on networked component '{1}' without a Dirty/DirtyField/DirtyFields/DirtyEntity call in the same method",
+        category: "Honk.Networking",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Networked components rely on Dirty() to replicate server writes. A mutation with no Dirty call reaches only the server; the client stays stale until some other path dirties the entity.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.SimpleAssignmentExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var assignment = (AssignmentExpressionSyntax)context.Node;
+
+        if (assignment.Left is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        var fieldSymbol = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
+        if (fieldSymbol is not IFieldSymbol && fieldSymbol is not IPropertySymbol)
+            return;
+
+        var containingComponent = fieldSymbol.ContainingType;
+        if (containingComponent is null || !HasNetworkedComponentAttribute(containingComponent))
+            return;
+
+        // Skip fields handled by the source-generated auto-state setter.
+        if (HasAttribute(fieldSymbol, "AutoNetworkedFieldAttribute"))
+            return;
+
+        var methodBody = GetEnclosingMethodBody(assignment);
+        if (methodBody is null)
+            return;
+
+        if (ContainsDirtyCall(methodBody))
+            return;
+
+        var fieldName = fieldSymbol.Name;
+        var componentName = containingComponent.Name;
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, assignment.GetLocation(), fieldName, componentName));
+    }
+
+    private static bool HasNetworkedComponentAttribute(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            foreach (var attr in current.GetAttributes())
+            {
+                if (attr.AttributeClass?.Name == "NetworkedComponentAttribute")
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string attributeName)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == attributeName)
+                return true;
+        }
+        return false;
+    }
+
+    private static SyntaxNode? GetEnclosingMethodBody(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case MethodDeclarationSyntax m:
+                    return (SyntaxNode?)m.Body ?? m.ExpressionBody;
+                case LocalFunctionStatementSyntax lf:
+                    return (SyntaxNode?)lf.Body ?? lf.ExpressionBody;
+                case AccessorDeclarationSyntax a:
+                    return (SyntaxNode?)a.Body ?? a.ExpressionBody;
+                case ConstructorDeclarationSyntax c:
+                    return (SyntaxNode?)c.Body ?? c.ExpressionBody;
+            }
+        }
+        return null;
+    }
+
+    private static bool ContainsDirtyCall(SyntaxNode body)
+    {
+        foreach (var invocation in body.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var name = GetInvokedName(invocation);
+            if (name is "Dirty" or "DirtyField" or "DirtyFields" or "DirtyEntity")
+                return true;
+        }
+        return false;
+    }
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+            _ => null,
+        };
+    }
+}

--- a/Content.Analyzers.Honk/HonkMissingDirtyAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkMissingDirtyAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -13,7 +14,8 @@ namespace Content.Analyzers.Honk;
 /// <c>DirtyField</c>, <c>DirtyFields</c>, <c>DirtyEntity</c>) is the single
 /// most common desync source in content code. The server mutates state,
 /// the client never receives a delta, and the bug only surfaces under
-/// real latency.
+/// real latency. Scoped to fork files (path contains <c>/RussStation/</c>
+/// or ends in <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkMissingDirtyAnalyzer : DiagnosticAnalyzer
@@ -41,6 +43,9 @@ public sealed class HonkMissingDirtyAnalyzer : DiagnosticAnalyzer
     {
         var assignment = (AssignmentExpressionSyntax)context.Node;
 
+        if (!IsForkFile(assignment.SyntaxTree.FilePath))
+            return;
+
         if (assignment.Left is not MemberAccessExpressionSyntax memberAccess)
             return;
 
@@ -66,6 +71,15 @@ public sealed class HonkMissingDirtyAnalyzer : DiagnosticAnalyzer
         var fieldName = fieldSymbol.Name;
         var componentName = containingComponent.Name;
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, assignment.GetLocation(), fieldName, componentName));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool HasNetworkedComponentAttribute(INamedTypeSymbol type)


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0010 (Warning) to `Content.Analyzers.Honk`. Assignments to a field or property of a `[NetworkedComponent]` type fire the warning when the enclosing method contains no `Dirty` / `DirtyField` / `DirtyFields` / `DirtyEntity` call. Writes to `[AutoNetworkedField]` members are skipped: the generated state setter path handles dirtying itself.

Closes #548.

## Why / Balance

Missing `Dirty()` is the single most common desync source in content code. The server mutates a networked field, the client never receives a delta, and the failure only reproduces under real latency. Nothing at runtime flags it. Catching it at compile time closes the loop before the bug ever reaches a playtest.

The scope is deliberately conservative per the issue: the analyzer only looks for *any* `Dirty` variant invocation in the same method body. That's a shallow check but covers the canonical pattern (mutate, call `Dirty`) and avoids the false-positive rate of a full call-graph traversal. Helper-wrapper cases are one line of `#pragma warning disable HONK0010` with a justification, which is the shape of guidance the rule is meant to impose anyway.

Severity starts at Warning so the rule can land without gating on a pre-existing audit pass.

## Technical details

- New file: `Content.Analyzers.Honk/HonkMissingDirtyAnalyzer.cs`. Syntax action on `SimpleAssignmentExpression`; resolves the left-hand member to a field or property symbol, checks the containing type for `[NetworkedComponent]` (walks the inheritance chain), skips `[AutoNetworkedField]` members, finds the enclosing method / accessor / constructor / local-function body, and scans its descendants for any invocation whose invoked name matches `Dirty` / `DirtyField` / `DirtyFields` / `DirtyEntity`.
- New file: `Content.Analyzers.Honk.Tests/HonkMissingDirtyAnalyzerTest.cs`. Five cases: write without Dirty fires, write followed by `Dirty(uid, comp)` passes, write followed by `DirtyField` passes, `[AutoNetworkedField]` write passes, non-networked component write passes.
- No touches to non-analyzer code; rule will emit warnings in existing content when a rebase includes HONK0010, which is the intended audit signal.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.