### PR TITLE
honksquad: fix: scope HONK0008 to fork files only

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkComponentRegistrationAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkComponentRegistrationAnalyzerTest.cs
@@ -26,11 +26,20 @@ public sealed class HonkComponentRegistrationAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/SomeForkComponent.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
         var test = new VerifyCS
         {
-            TestState = { Sources = { Stubs, code } },
+            TestState =
+            {
+                Sources =
+                {
+                    Stubs,
+                    (filePath, code),
+                },
+            },
         };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
@@ -45,9 +54,9 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public sealed class FooComponent : Component { }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0008", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 3, 21, 3, 33)
+                .WithSpan(ForkPath, 3, 21, 3, 33)
                 .WithArguments("FooComponent"));
     }
 
@@ -61,7 +70,7 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public sealed class FooComponent : Component { }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -73,7 +82,7 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public abstract class BaseThingComponent : Component { }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -87,7 +96,7 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public class SharedFooComponent : Component { }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -97,7 +106,7 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public sealed class SomeHelper { }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -111,9 +120,9 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public sealed class DerivedThingComponent : BaseThingComponent { }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0008", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 5, 21, 5, 42)
+                .WithSpan(ForkPath, 5, 21, 5, 42)
                 .WithArguments("DerivedThingComponent"));
     }
 
@@ -129,6 +138,34 @@ public sealed class HonkComponentRegistrationAnalyzerTest
             public sealed class DerivedThingComponent : BaseThingComponent { }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task UpstreamFile_WithoutAttribute_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class SharedDisposalRouterComponent : Component { }
+            """;
+
+        await Verify(code, "Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs");
+    }
+
+    [Test]
+    public async Task HonkPartial_WithoutAttribute_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed partial class FooComponent : Component { }
+            """;
+
+        const string path = "Content.Shared/Body/Components/FooComponent.Honk.cs";
+        await Verify(code, path,
+            new DiagnosticResult("HONK0008", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(path, 3, 29, 3, 41)
+                .WithArguments("FooComponent"));
     }
 }

--- a/Content.Analyzers.Honk/HonkComponentRegistrationAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkComponentRegistrationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -7,11 +8,13 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Content.Analyzers.Honk;
 
 /// <summary>
-/// HONK0008: a non-abstract, non-<c>[Virtual]</c> class deriving from
+/// HONK0008: a non-abstract, non-<c>[Virtual]</c> fork class deriving from
 /// <c>Robust.Shared.GameObjects.Component</c> must carry a
 /// <c>[RegisterComponent]</c> attribute. Without it, the component is not
 /// registered with the factory: <c>AddComp</c>/<c>EnsureComp</c> throw at
-/// runtime and prototypes silently fail to attach it.
+/// runtime and prototypes silently fail to attach it. Scoped to fork files
+/// (path contains <c>/RussStation/</c> or ends in <c>.Honk.cs</c>) so
+/// upstream-only dead code is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkComponentRegistrationAnalyzer : DiagnosticAnalyzer
@@ -52,11 +55,32 @@ public sealed class HonkComponentRegistrationAnalyzer : DiagnosticAnalyzer
         if (HasVirtualAttribute(type))
             return;
 
+        if (!HasForkDeclaration(type))
+            return;
+
         foreach (var location in type.Locations)
         {
             if (location.IsInSource)
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, type.Name));
         }
+    }
+
+    private static bool HasForkDeclaration(INamedTypeSymbol type)
+    {
+        foreach (var location in type.Locations)
+        {
+            if (location.IsInSource && IsForkFile(location.SourceTree?.FilePath))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var norm = path!.Replace('\\', '/');
+        return norm.Contains("/RussStation/") || norm.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool InheritsComponent(INamedTypeSymbol type)


### PR DESCRIPTION
## About the PR

Restricts HONK0008 to classes with at least one declaration in a fork file (`*/RussStation/**` or `*.Honk.cs`). Upstream-only classes no longer trigger the rule.

## Why / Balance

HONK0008 (merged in #555) started firing on two upstream files, `SharedDisposalRouterComponent` and `SharedDisposalTaggerComponent`, which inherit `Component` but lack `[RegisterComponent]`. They are upstream dead code, not fork drift. Under `TreatWarningsAsErrors` the rule blocked every open PR's CI on unrelated changes, so #557 and the in-flight rule PRs could not turn green.

The HONK family is a fork-drift toolset, so scoping HONK0008 the way HONK0003 and HONK0005 already are (fork-file check) matches the rest of the catalogue. Anything a fork author adds under `/RussStation/` or in a `*.Honk.cs` partial is still covered.

## Technical details

- `HonkComponentRegistrationAnalyzer.Analyze`: adds a `HasForkDeclaration` gate; the rule only reports when at least one of the symbol's declaring locations sits in a fork file.
- `IsForkFile`: mirrors the helper in `HonkAccessForkFriendAnalyzer` (`/RussStation/` path segment or `.Honk.cs` suffix).
- Existing tests updated to pass a fork file path. Two new tests cover the scoping: an upstream-file declaration is silent, and a `.Honk.cs` partial still reports.

## Media

N/A, analyzer-only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

N/A, internal tooling.