### PR TITLE
honksquad: feat: HONK0011 flag unguarded Comp<T>() on args.* (#549)

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs
@@ -38,9 +38,12 @@ public sealed class HonkUnguardedCompAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/ForkSystem.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/Sys.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
-        var test = new VerifyCS { TestState = { Sources = { Stubs, code } } };
+        var test = new VerifyCS { TestState = { Sources = { Stubs, (filePath, code) } } };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
     }
@@ -61,9 +64,9 @@ public sealed class HonkUnguardedCompAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 8, 17, 8, 46)
+                .WithSpan(ForkPath, 8, 17, 8, 46)
                 .WithArguments("TargetComp", "args.Target"));
     }
 
@@ -85,7 +88,7 @@ public sealed class HonkUnguardedCompAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -107,7 +110,7 @@ public sealed class HonkUnguardedCompAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -127,7 +130,7 @@ public sealed class HonkUnguardedCompAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -148,9 +151,9 @@ public sealed class HonkUnguardedCompAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 10, 17, 10, 46)
+                .WithSpan(ForkPath, 10, 17, 10, 46)
                 .WithArguments("TargetComp", "args.Target"));
     }
 
@@ -171,6 +174,25 @@ public sealed class HonkUnguardedCompAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task UnguardedCompInUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class UpstreamSys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var c = Comp<TargetComp>(args.Target);
+                }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs
@@ -1,0 +1,176 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkUnguardedCompAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkUnguardedCompAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public readonly struct EntityUid { }
+
+            public abstract class EntitySystem
+            {
+                protected T Comp<T>(EntityUid uid) where T : IComponent => default!;
+                protected bool HasComp<T>(EntityUid uid) where T : IComponent => false;
+                protected bool TryComp<T>(EntityUid uid, out T? comp) where T : IComponent
+                { comp = default; return false; }
+            }
+        }
+        namespace Fork.Stubs
+        {
+            using Robust.Shared.GameObjects;
+            public sealed class TargetComp : IComponent { }
+            public sealed class OtherComp : IComponent { }
+            public sealed class SomeEvent
+            {
+                public EntityUid Target;
+                public EntityUid User;
+                public EntityUid OtherEntity;
+            }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS { TestState = { Sources = { Stubs, code } } };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task UnguardedCompOnArgsTarget_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var c = Comp<TargetComp>(args.Target);
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 8, 17, 8, 46)
+                .WithArguments("TargetComp", "args.Target"));
+    }
+
+    [Test]
+    public async Task HasCompGuard_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    if (!HasComp<TargetComp>(args.Target))
+                        return;
+                    var c = Comp<TargetComp>(args.Target);
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task TryCompGuard_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    if (!TryComp<TargetComp>(args.Target, out _))
+                    {
+                        var c = Comp<TargetComp>(args.Target);
+                    }
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task CompOnLocalUid_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var local = args.Target;
+                    var c = Comp<TargetComp>(local);
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task DifferentComponentGuard_StillReports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    if (!HasComp<OtherComp>(args.Target))
+                        return;
+                    var c = Comp<TargetComp>(args.Target);
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 10, 17, 10, 46)
+                .WithArguments("TargetComp", "args.Target"));
+    }
+
+    [Test]
+    public async Task NonEntitySystem_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Plain
+            {
+                public T Comp<T>(EntityUid uid) where T : IComponent => default!;
+                public void OnIt(SomeEvent args)
+                {
+                    var c = Comp<TargetComp>(args.Target);
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+}

--- a/Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -13,6 +14,8 @@ namespace Content.Analyzers.Honk;
 /// handler with no preceding <c>HasComp&lt;T&gt;</c> / <c>TryComp&lt;T&gt;</c>
 /// guard in the same method body. <c>Comp&lt;T&gt;</c> throws on miss;
 /// server-side that kills the handler for the rest of the tick.
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
@@ -40,6 +43,9 @@ public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
 
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
+
         var invokedName = GetGenericName(invocation);
         if (invokedName is null || invokedName.Identifier.ValueText != "Comp")
             return;
@@ -64,6 +70,15 @@ public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation(), typeArgText, uidText));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static GenericNameSyntax? GetGenericName(InvocationExpressionSyntax invocation)

--- a/Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs
@@ -1,0 +1,141 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0011: <c>Comp&lt;T&gt;(args.Target)</c> / <c>Comp&lt;T&gt;(args.User)</c>
+/// / <c>Comp&lt;T&gt;(args.OtherEntity)</c> in an <see cref="EntitySystem"/>
+/// handler with no preceding <c>HasComp&lt;T&gt;</c> / <c>TryComp&lt;T&gt;</c>
+/// guard in the same method body. <c>Comp&lt;T&gt;</c> throws on miss;
+/// server-side that kills the handler for the rest of the tick.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0011",
+        title: "Unguarded Comp<T>() on args.*",
+        messageFormat: "Comp<{0}>({1}) has no HasComp<{0}>/TryComp<{0}> guard in the enclosing method; a missing component throws mid-tick",
+        category: "Honk.EntitySystem",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Comp<T> throws when the component is absent. On args.Target / args.User / args.OtherEntity the absence is routine, and the throw wipes out the rest of the handler. Pair with HasComp<T> or TryComp<T> first.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        var invokedName = GetGenericName(invocation);
+        if (invokedName is null || invokedName.Identifier.ValueText != "Comp")
+            return;
+
+        if (invocation.ArgumentList.Arguments.Count < 1)
+            return;
+
+        var uidArg = invocation.ArgumentList.Arguments[0].Expression;
+        if (!IsArgsMemberAccess(uidArg, out var uidText))
+            return;
+
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType is null || !InheritsEntitySystem(containingType))
+            return;
+
+        var methodBody = GetEnclosingMethodBody(invocation);
+        if (methodBody is null)
+            return;
+
+        var typeArgText = invokedName.TypeArgumentList.Arguments[0].ToString();
+        if (HasGuardCall(methodBody, typeArgText))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation(), typeArgText, uidText));
+    }
+
+    private static GenericNameSyntax? GetGenericName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            GenericNameSyntax gn => gn,
+            MemberAccessExpressionSyntax m => m.Name as GenericNameSyntax,
+            _ => null,
+        };
+    }
+
+    private static bool IsArgsMemberAccess(ExpressionSyntax expr, out string text)
+    {
+        text = string.Empty;
+        if (expr is not MemberAccessExpressionSyntax member)
+            return false;
+
+        if (member.Expression is not IdentifierNameSyntax root || root.Identifier.ValueText != "args")
+            return false;
+
+        var name = member.Name.Identifier.ValueText;
+        if (name != "Target" && name != "User" && name != "OtherEntity")
+            return false;
+
+        text = $"args.{name}";
+        return true;
+    }
+
+    private static bool InheritsEntitySystem(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "EntitySystem" &&
+                current.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static SyntaxNode? GetEnclosingMethodBody(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case MethodDeclarationSyntax m:
+                    return (SyntaxNode?)m.Body ?? m.ExpressionBody;
+                case LocalFunctionStatementSyntax lf:
+                    return (SyntaxNode?)lf.Body ?? lf.ExpressionBody;
+            }
+        }
+        return null;
+    }
+
+    private static bool HasGuardCall(SyntaxNode body, string typeArgText)
+    {
+        foreach (var inv in body.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var generic = GetGenericName(inv);
+            if (generic is null)
+                continue;
+            var name = generic.Identifier.ValueText;
+            if (name != "HasComp" && name != "TryComp")
+                continue;
+            if (generic.TypeArgumentList.Arguments.Count == 0)
+                continue;
+            if (generic.TypeArgumentList.Arguments[0].ToString() == typeArgText)
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds Roslyn rule HONK0011 (Warning) to `Content.Analyzers.Honk`. Inside a type deriving from `EntitySystem`, any `Comp<T>(args.Target)` / `Comp<T>(args.User)` / `Comp<T>(args.OtherEntity)` call fires the warning when the same method body has no matching `HasComp<T>` or `TryComp<T>` guard for the same type argument.

Closes #549.

## Why / Balance

`Comp<T>` throws when the component is absent. On an uid sourced from an event's `Target` / `User` / `OtherEntity`, absence is routine (any entity that happens to walk into the handler without that component), and the throw wipes out the rest of the handler for that tick. The documented idiom is to pair with `HasComp` or `TryComp` first. Catching the missed pairing at compile time keeps the convention honest.

The scope is intentionally conservative per the issue: only `args.Target` / `args.User` / `args.OtherEntity`, and only same-method-body textual presence of a guard with the matching type argument. No flow analysis, no call-graph crawling, no local-uid tracking. Legitimate "already guarded by the caller" cases can suppress with `#pragma warning disable HONK0011` and a reason; false positives from that shape are preferable to letting the scope balloon on v1.

Severity is Warning so the rule lands without gating on a preexisting audit.

## Technical details

- New file: `Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs`. Syntax action on `InvocationExpression`; matches the invoked generic name, parses the first argument as a `MemberAccessExpression` rooted at the identifier `args` with a name in `{Target, User, OtherEntity}`, confirms the enclosing type is an `EntitySystem`, then walks the method body's invocations for a `HasComp<T>` / `TryComp<T>` whose first type-argument syntax text matches the flagged `Comp<T>`.
- New file: `Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs` (6 cases: unguarded fires, `HasComp` passes, `TryComp` passes, locally-bound uid doesn't fire (conservative scope), a guard with a *different* type argument still fires, non-`EntitySystem` lookalike doesn't fire).
- Comparison of the type-argument text is syntactic, so fully-qualified vs short-name references will not match across a single method. That's acceptable for v1, content-side style is already consistent and the false-positive shape is obvious to the author.

## Media

N/A, CI-only rule.

## Requirements

- [x] I have tested all added content.
- [x] I have added changelog entries for additions players will notice. N/A, internal analyzer.
- [x] All added sprites have appropriate licenses. N/A.

## Breaking changes

None.

## Changelog

N/A, internal tooling.