### PR TITLE
honksquad: feat: HONK0012 flag networked component without state mechanism

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateAnalyzerTest.cs
@@ -38,9 +38,12 @@ public sealed class HonkNetworkedComponentStateAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/ForkComp.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/UpstreamComp.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
-        var test = new VerifyCS { TestState = { Sources = { Stubs, code } } };
+        var test = new VerifyCS { TestState = { Sources = { Stubs, (filePath, code) } } };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
     }
@@ -61,9 +64,9 @@ public sealed class HonkNetworkedComponentStateAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0012", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 6, 29, 6, 34)
+                .WithSpan(ForkPath, 6, 29, 6, 34)
                 .WithArguments("Leaky"));
     }
 
@@ -83,7 +86,7 @@ public sealed class HonkNetworkedComponentStateAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -105,7 +108,7 @@ public sealed class HonkNetworkedComponentStateAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -122,7 +125,7 @@ public sealed class HonkNetworkedComponentStateAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -136,6 +139,25 @@ public sealed class HonkNetworkedComponentStateAnalyzerTest
             public sealed partial class Flag : Component { }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task NetworkedWithDataFieldButNoState_InUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            public sealed partial class UpstreamLeaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateAnalyzerTest.cs
@@ -1,0 +1,141 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkNetworkedComponentStateAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkNetworkedComponentStateAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = true)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class AutoGenerateComponentStateAttribute : System.Attribute
+            {
+                public AutoGenerateComponentStateAttribute(bool raiseAfterAutoHandleState = false) { }
+            }
+        }
+        namespace Robust.Shared.Serialization.Manager.Attributes
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class DataFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class AutoNetworkedFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public abstract class Component : IComponent { }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS { TestState = { Sources = { Stubs, code } } };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task NetworkedWithDataFieldButNoState_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            public sealed partial class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0012", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 6, 29, 6, 34)
+                .WithArguments("Leaky"));
+    }
+
+    [Test]
+    public async Task NetworkedWithAutoState_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent, AutoGenerateComponentState]
+            public sealed partial class Fine : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task NetworkedWithManualState_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            public sealed partial class Manual : Component
+            {
+                [DataField]
+                public int Value;
+
+                public void GetComponentState() { }
+                public void HandleComponentState() { }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task NonNetworkedWithDataField_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed partial class Plain : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task NetworkedWithoutDataFields_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+
+            [NetworkedComponent]
+            public sealed partial class Flag : Component { }
+            """;
+
+        await Verify(code);
+    }
+}

--- a/Content.Analyzers.Honk/HonkNetworkedComponentStateAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkNetworkedComponentStateAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -11,7 +12,8 @@ namespace Content.Analyzers.Honk;
 /// <c>[DataField]</c> members but has no <c>[AutoGenerateComponentState]</c>
 /// attribute and no manual <c>GetComponentState</c> / <c>HandleComponentState</c>
 /// override silently fails to replicate its fields. The mutation reaches
-/// only the server.
+/// only the server. Scoped to fork files (path contains <c>/RussStation/</c>
+/// or ends in <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkNetworkedComponentStateAnalyzer : DiagnosticAnalyzer
@@ -38,6 +40,10 @@ public sealed class HonkNetworkedComponentStateAnalyzer : DiagnosticAnalyzer
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         var cls = (ClassDeclarationSyntax)context.Node;
+
+        if (!IsForkFile(cls.SyntaxTree.FilePath))
+            return;
+
         if (context.SemanticModel.GetDeclaredSymbol(cls, context.CancellationToken) is not INamedTypeSymbol symbol)
             return;
 
@@ -54,6 +60,15 @@ public sealed class HonkNetworkedComponentStateAnalyzer : DiagnosticAnalyzer
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, cls.Identifier.GetLocation(), symbol.Name));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool HasAttribute(ISymbol symbol, string name)

--- a/Content.Analyzers.Honk/HonkNetworkedComponentStateAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkNetworkedComponentStateAnalyzer.cs
@@ -1,0 +1,98 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0012: a <c>[NetworkedComponent]</c> class that declares one or more
+/// <c>[DataField]</c> members but has no <c>[AutoGenerateComponentState]</c>
+/// attribute and no manual <c>GetComponentState</c> / <c>HandleComponentState</c>
+/// override silently fails to replicate its fields. The mutation reaches
+/// only the server.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkNetworkedComponentStateAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0012",
+        title: "Networked component declares DataFields but has no state mechanism",
+        messageFormat: "Networked component '{0}' declares [DataField] members but has no [AutoGenerateComponentState] and no GetComponentState/HandleComponentState override; fields silently fail to replicate",
+        category: "Honk.Networking",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A [NetworkedComponent] with [DataField]s needs either auto-state generation or a manual GetComponentState/HandleComponentState pair. Without one, the component announces it is networked but never actually replicates, which is silent at runtime.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var cls = (ClassDeclarationSyntax)context.Node;
+        if (context.SemanticModel.GetDeclaredSymbol(cls, context.CancellationToken) is not INamedTypeSymbol symbol)
+            return;
+
+        if (!HasAttribute(symbol, "NetworkedComponentAttribute"))
+            return;
+
+        if (HasAttribute(symbol, "AutoGenerateComponentStateAttribute"))
+            return;
+
+        if (!HasDataField(symbol))
+            return;
+
+        if (HasStateOverride(symbol))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, cls.Identifier.GetLocation(), symbol.Name));
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string name)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == name)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool HasDataField(INamedTypeSymbol type)
+    {
+        foreach (var member in type.GetMembers())
+        {
+            if (member is IFieldSymbol or IPropertySymbol)
+            {
+                foreach (var attr in member.GetAttributes())
+                {
+                    var attrName = attr.AttributeClass?.Name;
+                    if (attrName == "DataFieldAttribute" || attrName == "AutoNetworkedFieldAttribute")
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static bool HasStateOverride(INamedTypeSymbol type)
+    {
+        foreach (var member in type.GetMembers())
+        {
+            if (member is not IMethodSymbol method)
+                continue;
+            var name = method.Name;
+            if (name is "GetComponentState" or "HandleComponentState")
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds Roslyn analyzer HONK0012 (warning) that flags components marked `[NetworkedComponent]` with `[DataField]` members but no state mechanism, either `[AutoGenerateComponentState]` / `[AutoNetworkedField]` or a manual `GetComponentState`/`HandleComponentState` override.

Closes #550.

## Why / Balance

Networked components that never serialise their fields silently desync from clients. The analyzer catches this at build time rather than during gameplay.

## Technical details

- `HonkNetworkedComponentStateAnalyzer` inspects `ClassDeclarationSyntax` via the semantic model.
- Fires when the type has `[NetworkedComponent]` + at least one `[DataField]`, and lacks both `[AutoGenerateComponentState]` and a `GetComponentState`/`HandleComponentState` override.
- 5 unit tests cover: fires on missing state, passes with auto-generated state, passes with manual state override, passes when not networked, passes when networked but no data fields.

## Media

n/a (analyzer only).

## Requirements

- [x] Tested locally (`dotnet test Content.Analyzers.Honk.Tests`).
- [x] Follows HONK marker conventions for fork-only code.

## Breaking changes

None.

## Changelog

n/a (internal tooling).