### PR TITLE
honksquad: feat: HONK0013 flag StatusEffectAppliedEvent handlers missing ApplyingState guard

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkStatusEffectAppliedIdempotencyAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkStatusEffectAppliedIdempotencyAnalyzerTest.cs
@@ -38,11 +38,14 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, params DiagnosticResult[] expected)
+    private const string ForkPath = "Content.Shared/RussStation/ForkSystem.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/Sys.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
     {
         var test = new VerifyCS
         {
-            TestState = { Sources = { Stubs, code } },
+            TestState = { Sources = { Stubs, (filePath, code) } },
         };
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
@@ -75,7 +78,7 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -101,9 +104,9 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0013", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 10, 69, 10, 78)
+                .WithSpan(ForkPath, 10, 69, 10, 78)
                 .WithArguments("OnApplied"));
     }
 
@@ -125,9 +128,9 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
             }
             """;
 
-        await Verify(code,
+        await Verify(code, ForkPath,
             new DiagnosticResult("HONK0013", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 10, 69, 10, 102)
+                .WithSpan(ForkPath, 10, 69, 10, 102)
                 .WithArguments("<lambda>"));
     }
 
@@ -154,7 +157,7 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
     }
 
     [Test]
@@ -184,6 +187,32 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
             }
             """;
 
-        await Verify(code);
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task HandlerWithoutGuard_InUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Content.Shared.StatusEffectNew;
+
+            public sealed class FooComponent : Component { }
+
+            public sealed class FooSystem : EntitySystem
+            {
+                public void Init()
+                {
+                    SubscribeLocalEvent<FooComponent, StatusEffectAppliedEvent>(OnApplied);
+                }
+
+                private void OnApplied(Microsoft.CodeAnalysis.Testing.EntityUid uid, FooComponent comp, StatusEffectAppliedEvent ev)
+                {
+                    var x = 1;
+                }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkStatusEffectAppliedIdempotencyAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkStatusEffectAppliedIdempotencyAnalyzerTest.cs
@@ -1,0 +1,189 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkStatusEffectAppliedIdempotencyAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkStatusEffectAppliedIdempotencyAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class Component { }
+            public abstract class EntitySystem
+            {
+                public void SubscribeLocalEvent<TComp, TEvent>(System.Action<Microsoft.CodeAnalysis.Testing.EntityUid, TComp, TEvent> handler) where TComp : Component { }
+            }
+        }
+        namespace Microsoft.CodeAnalysis.Testing
+        {
+            public struct EntityUid { }
+        }
+        namespace Content.Shared.StatusEffectNew
+        {
+            public sealed class StatusEffectAppliedEvent { }
+            public sealed class StatusEffectRemovedEvent { }
+        }
+        namespace Robust.Shared.Timing
+        {
+            public interface IGameTiming
+            {
+                bool ApplyingState { get; }
+            }
+        }
+        """;
+
+    private static Task Verify(string code, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, code } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task HandlerWithApplyingStateGuard_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Timing;
+            using Content.Shared.StatusEffectNew;
+
+            public sealed class FooComponent : Component { }
+
+            public sealed class FooSystem : EntitySystem
+            {
+                private IGameTiming _timing = null!;
+
+                public void Init()
+                {
+                    SubscribeLocalEvent<FooComponent, StatusEffectAppliedEvent>(OnApplied);
+                }
+
+                private void OnApplied(Microsoft.CodeAnalysis.Testing.EntityUid uid, FooComponent comp, StatusEffectAppliedEvent ev)
+                {
+                    if (_timing.ApplyingState)
+                        return;
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task HandlerWithoutGuard_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Content.Shared.StatusEffectNew;
+
+            public sealed class FooComponent : Component { }
+
+            public sealed class FooSystem : EntitySystem
+            {
+                public void Init()
+                {
+                    SubscribeLocalEvent<FooComponent, StatusEffectAppliedEvent>(OnApplied);
+                }
+
+                private void OnApplied(Microsoft.CodeAnalysis.Testing.EntityUid uid, FooComponent comp, StatusEffectAppliedEvent ev)
+                {
+                    var x = 1;
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0013", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 10, 69, 10, 78)
+                .WithArguments("OnApplied"));
+    }
+
+    [Test]
+    public async Task LambdaWithoutGuard_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Content.Shared.StatusEffectNew;
+
+            public sealed class FooComponent : Component { }
+
+            public sealed class FooSystem : EntitySystem
+            {
+                public void Init()
+                {
+                    SubscribeLocalEvent<FooComponent, StatusEffectAppliedEvent>((uid, comp, ev) => { var x = 1; });
+                }
+            }
+            """;
+
+        await Verify(code,
+            new DiagnosticResult("HONK0013", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 10, 69, 10, 102)
+                .WithArguments("<lambda>"));
+    }
+
+    [Test]
+    public async Task DifferentEvent_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Content.Shared.StatusEffectNew;
+
+            public sealed class FooComponent : Component { }
+
+            public sealed class FooSystem : EntitySystem
+            {
+                public void Init()
+                {
+                    SubscribeLocalEvent<FooComponent, StatusEffectRemovedEvent>(OnRemoved);
+                }
+
+                private void OnRemoved(Microsoft.CodeAnalysis.Testing.EntityUid uid, FooComponent comp, StatusEffectRemovedEvent ev)
+                {
+                    var x = 1;
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+
+    [Test]
+    public async Task HandlerWithInlineApplyingStateCheck_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Timing;
+            using Content.Shared.StatusEffectNew;
+
+            public sealed class FooComponent : Component { }
+
+            public sealed class FooSystem : EntitySystem
+            {
+                private IGameTiming _timing = null!;
+
+                public void Init()
+                {
+                    SubscribeLocalEvent<FooComponent, StatusEffectAppliedEvent>(OnApplied);
+                }
+
+                private void OnApplied(Microsoft.CodeAnalysis.Testing.EntityUid uid, FooComponent comp, StatusEffectAppliedEvent ev)
+                {
+                    if (_timing.ApplyingState && true) return;
+                    var x = 1;
+                }
+            }
+            """;
+
+        await Verify(code);
+    }
+}

--- a/Content.Analyzers.Honk/HonkStatusEffectAppliedIdempotencyAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkStatusEffectAppliedIdempotencyAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -13,6 +14,8 @@ namespace Content.Analyzers.Honk;
 /// <c>StatusEffectComponent.Applied</c> field is intentionally not networked,
 /// so client state replay re-raises the event every tick; a non-idempotent
 /// handler will run repeatedly instead of once per real application.
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class HonkStatusEffectAppliedIdempotencyAnalyzer : DiagnosticAnalyzer
@@ -39,6 +42,9 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzer : DiagnosticAnaly
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
 
         if (!TryGetSubscribeLocalEventName(invocation, out var nameSyntax))
             return;
@@ -84,6 +90,15 @@ public sealed class HonkStatusEffectAppliedIdempotencyAnalyzer : DiagnosticAnaly
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, handlerExpression.GetLocation(), handlerName));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool TryGetSubscribeLocalEventName(InvocationExpressionSyntax invocation, out GenericNameSyntax? name)

--- a/Content.Analyzers.Honk/HonkStatusEffectAppliedIdempotencyAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkStatusEffectAppliedIdempotencyAnalyzer.cs
@@ -1,0 +1,113 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0013: a <c>SubscribeLocalEvent&lt;TComp, StatusEffectAppliedEvent&gt;</c>
+/// handler must short-circuit on <c>IGameTiming.ApplyingState</c>. The
+/// <c>StatusEffectComponent.Applied</c> field is intentionally not networked,
+/// so client state replay re-raises the event every tick; a non-idempotent
+/// handler will run repeatedly instead of once per real application.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkStatusEffectAppliedIdempotencyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0013",
+        title: "StatusEffectAppliedEvent handler missing ApplyingState guard",
+        messageFormat: "Handler '{0}' for StatusEffectAppliedEvent does not short-circuit on IGameTiming.ApplyingState; it will re-run every time the client re-applies the component's state",
+        category: "Honk.StatusEffect",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "StatusEffectComponent.Applied is not networked, so client state replay re-fires StatusEffectAppliedEvent continuously. Handlers that do non-idempotent work must early-out when IGameTiming.ApplyingState is true. See SleepingSystem for the canonical guard.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!TryGetSubscribeLocalEventName(invocation, out var nameSyntax))
+            return;
+
+        if (nameSyntax!.TypeArgumentList.Arguments.Count < 2)
+            return;
+
+        var eventTypeSyntax = nameSyntax.TypeArgumentList.Arguments[1];
+        var eventType = context.SemanticModel.GetTypeInfo(eventTypeSyntax, context.CancellationToken).Type;
+        if (eventType is null || eventType.Name != "StatusEffectAppliedEvent")
+            return;
+
+        if (invocation.ArgumentList.Arguments.Count == 0)
+            return;
+
+        var handlerExpression = invocation.ArgumentList.Arguments[0].Expression;
+
+        SyntaxNode? body;
+        string handlerName;
+
+        if (handlerExpression is AnonymousFunctionExpressionSyntax anon)
+        {
+            handlerName = "<lambda>";
+            body = anon.Body;
+        }
+        else if (context.SemanticModel.GetSymbolInfo(handlerExpression, context.CancellationToken).Symbol is IMethodSymbol handlerSymbol)
+        {
+            handlerName = handlerSymbol.Name;
+            var reference = handlerSymbol.DeclaringSyntaxReferences.FirstOrDefault();
+            if (reference is null)
+                return;
+            body = reference.GetSyntax(context.CancellationToken);
+        }
+        else
+        {
+            return;
+        }
+
+        if (body is null)
+            return;
+
+        if (BodyReferencesApplyingState(body))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, handlerExpression.GetLocation(), handlerName));
+    }
+
+    private static bool TryGetSubscribeLocalEventName(InvocationExpressionSyntax invocation, out GenericNameSyntax? name)
+    {
+        name = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax ma => ma.Name as GenericNameSyntax,
+            GenericNameSyntax g => g,
+            _ => null,
+        };
+
+        if (name is null)
+            return false;
+
+        return name.Identifier.ValueText == "SubscribeLocalEvent";
+    }
+
+    private static bool BodyReferencesApplyingState(SyntaxNode body)
+    {
+        foreach (var id in body.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (id.Identifier.ValueText == "ApplyingState")
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds Roslyn analyzer HONK0013 (warning) that flags `SubscribeLocalEvent<TComp, StatusEffectAppliedEvent>` registrations whose handler body never references `IGameTiming.ApplyingState`.

Closes #551.

## Why / Balance

`StatusEffectComponent.Applied` is intentionally not networked, so the client re-raises `StatusEffectAppliedEvent` every time state is replayed. Any non-idempotent handler does its work on every tick of state replay instead of once per real application. The canonical guard is the `_timing.ApplyingState` early-return used by `SleepingSystem`. Fork issue #492 tracks the user-visible failure mode (DoAfter / status-effect progress-bar ghosts).

## Technical details

- `HonkStatusEffectAppliedIdempotencyAnalyzer` registers an `InvocationExpression` syntax action.
- Matches `SubscribeLocalEvent<TComp, StatusEffectAppliedEvent>(...)`; the event type is resolved through the semantic model, so namespace variants are handled.
- Resolves the handler: direct method group via `IMethodSymbol.DeclaringSyntaxReferences`, or inline lambda via `AnonymousFunctionExpressionSyntax`.
- Scans the resolved body's descendant `IdentifierNameSyntax` nodes for `ApplyingState`; any reference suffices, matching the issue's "any comparison shape" requirement.
- 5 unit tests: guarded handler passes, unguarded method handler fires, unguarded lambda fires, different event does not fire, inline `_timing.ApplyingState &&` guard passes.

## Media

n/a (analyzer only).

## Requirements

- [x] Tested locally (`dotnet test Content.Analyzers.Honk.Tests`).

## Breaking changes

None. Warning severity; provably idempotent handlers can suppress per-call.

## Changelog

n/a (internal tooling).