### PR TITLE
honksquad: feat: HONK0014 flag ProtoId<T> refs to [TestPrototypes]-declared ids

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkTestPrototypeRefStyleAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkTestPrototypeRefStyleAnalyzerTest.cs
@@ -1,0 +1,154 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkTestPrototypeRefStyleAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkTestPrototypeRefStyleAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Prototypes
+        {
+            public readonly struct ProtoId<T> where T : class, IPrototype
+            {
+                public readonly string Id;
+                public ProtoId(string id) { Id = id; }
+                public static implicit operator ProtoId<T>(string id) => new(id);
+            }
+            public interface IPrototype { }
+            public sealed class TagPrototype : IPrototype { }
+        }
+        namespace Robust.UnitTesting
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field)]
+            public sealed class TestPrototypesAttribute : System.Attribute { }
+        }
+        """;
+
+    private static Task Verify(string code, string assemblyName, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, code } },
+        };
+        test.TestState.AdditionalReferences.Clear();
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId)!;
+            return solution.WithProjectAssemblyName(projectId, assemblyName);
+        });
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task TestProtoId_FieldWithTestPrototypeId_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                private const string MyTag = "MyTagDummy";
+
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: {MyTag}";
+
+                public ProtoId<TagPrototype> MyRef = "MyTagDummy";
+            }
+            """;
+
+        await Verify(code, "Content.IntegrationTests",
+            new DiagnosticResult("HONK0014", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 11, 42, 11, 54)
+                .WithArguments("MyTagDummy"));
+    }
+
+    [Test]
+    public async Task TestProtoId_ConstString_DoesNotReport()
+    {
+        const string code = """
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                private const string MyTag = "MyTagDummy";
+
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: {MyTag}";
+            }
+            """;
+
+        await Verify(code, "Content.IntegrationTests");
+    }
+
+    [Test]
+    public async Task ProductionAssembly_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                private const string MyTag = "MyTagDummy";
+
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: {MyTag}";
+
+                public ProtoId<TagPrototype> MyRef = "MyTagDummy";
+            }
+            """;
+
+        await Verify(code, "Content.Shared");
+    }
+
+    [Test]
+    public async Task UnrelatedProtoId_InTestAssembly_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                private const string MyTag = "MyTagDummy";
+
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: {MyTag}";
+
+                public ProtoId<TagPrototype> RealOne = "SomeRealTag";
+            }
+            """;
+
+        await Verify(code, "Content.IntegrationTests");
+    }
+
+    [Test]
+    public async Task LiteralIdInYaml_ProtoIdMatch_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: DirectDummy";
+
+                public ProtoId<TagPrototype> MyRef = "DirectDummy";
+            }
+            """;
+
+        await Verify(code, "Content.IntegrationTests",
+            new DiagnosticResult("HONK0014", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan("/0/Test1.cs", 9, 42, 9, 55)
+                .WithArguments("DirectDummy"));
+    }
+}

--- a/Content.Analyzers.Honk.Tests/HonkTestPrototypeRefStyleAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkTestPrototypeRefStyleAnalyzerTest.cs
@@ -30,25 +30,25 @@ public sealed class HonkTestPrototypeRefStyleAnalyzerTest
         }
         """;
 
-    private static Task Verify(string code, string assemblyName, params DiagnosticResult[] expected)
+    private static Task Verify(string path, string code, string assemblyName, params DiagnosticResult[] expected)
     {
         var test = new VerifyCS
         {
-            TestState = { Sources = { Stubs, code } },
+            TestState =
+            {
+                Sources = { Stubs, (path, code) },
+            },
         };
-        test.TestState.AdditionalReferences.Clear();
         test.SolutionTransforms.Add((solution, projectId) =>
-        {
-            var project = solution.GetProject(projectId)!;
-            return solution.WithProjectAssemblyName(projectId, assemblyName);
-        });
+            solution.WithProjectAssemblyName(projectId, assemblyName));
         test.ExpectedDiagnostics.AddRange(expected);
         return test.RunAsync();
     }
 
     [Test]
-    public async Task TestProtoId_FieldWithTestPrototypeId_Reports()
+    public async Task TestProtoId_InForkFile_Reports()
     {
+        const string path = "/0/RussStation/FooTest.cs";
         const string code = """
             using Robust.Shared.Prototypes;
             using Robust.UnitTesting;
@@ -64,15 +64,38 @@ public sealed class HonkTestPrototypeRefStyleAnalyzerTest
             }
             """;
 
-        await Verify(code, "Content.IntegrationTests",
+        await Verify(path, code, "Content.IntegrationTests",
             new DiagnosticResult("HONK0014", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 11, 42, 11, 54)
+                .WithSpan(path, 11, 42, 11, 54)
                 .WithArguments("MyTagDummy"));
+    }
+
+    [Test]
+    public async Task TestProtoId_InUpstreamFile_DoesNotReport()
+    {
+        const string path = "/0/Test1.cs";
+        const string code = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                private const string MyTag = "MyTagDummy";
+
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: {MyTag}";
+
+                public ProtoId<TagPrototype> MyRef = "MyTagDummy";
+            }
+            """;
+
+        await Verify(path, code, "Content.IntegrationTests");
     }
 
     [Test]
     public async Task TestProtoId_ConstString_DoesNotReport()
     {
+        const string path = "/0/RussStation/FooTest.cs";
         const string code = """
             using Robust.UnitTesting;
 
@@ -85,12 +108,13 @@ public sealed class HonkTestPrototypeRefStyleAnalyzerTest
             }
             """;
 
-        await Verify(code, "Content.IntegrationTests");
+        await Verify(path, code, "Content.IntegrationTests");
     }
 
     [Test]
     public async Task ProductionAssembly_DoesNotReport()
     {
+        const string path = "/0/RussStation/FooTest.cs";
         const string code = """
             using Robust.Shared.Prototypes;
             using Robust.UnitTesting;
@@ -106,12 +130,13 @@ public sealed class HonkTestPrototypeRefStyleAnalyzerTest
             }
             """;
 
-        await Verify(code, "Content.Shared");
+        await Verify(path, code, "Content.Shared");
     }
 
     [Test]
-    public async Task UnrelatedProtoId_InTestAssembly_DoesNotReport()
+    public async Task UnrelatedProtoId_InForkTest_DoesNotReport()
     {
+        const string path = "/0/RussStation/FooTest.cs";
         const string code = """
             using Robust.Shared.Prototypes;
             using Robust.UnitTesting;
@@ -127,12 +152,13 @@ public sealed class HonkTestPrototypeRefStyleAnalyzerTest
             }
             """;
 
-        await Verify(code, "Content.IntegrationTests");
+        await Verify(path, code, "Content.IntegrationTests");
     }
 
     [Test]
-    public async Task LiteralIdInYaml_ProtoIdMatch_Reports()
+    public async Task LiteralIdInYaml_ForkProtoIdMatch_Reports()
     {
+        const string path = "/0/RussStation/FooTest.cs";
         const string code = """
             using Robust.Shared.Prototypes;
             using Robust.UnitTesting;
@@ -146,9 +172,9 @@ public sealed class HonkTestPrototypeRefStyleAnalyzerTest
             }
             """;
 
-        await Verify(code, "Content.IntegrationTests",
+        await Verify(path, code, "Content.IntegrationTests",
             new DiagnosticResult("HONK0014", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
-                .WithSpan("/0/Test1.cs", 9, 42, 9, 55)
+                .WithSpan(path, 9, 42, 9, 55)
                 .WithArguments("DirectDummy"));
     }
 }

--- a/Content.Analyzers.Honk/HonkTestPrototypeRefStyleAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkTestPrototypeRefStyleAnalyzer.cs
@@ -1,0 +1,202 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0014: inside <c>Content.IntegrationTests</c>, a <c>ProtoId&lt;T&gt;</c>
+/// field or property must not use a string literal whose value is declared
+/// as a prototype id inside a <c>[TestPrototypes]</c> YAML block. The YAML
+/// linter never sees <c>[TestPrototypes]</c> prototypes, so the compilation
+/// passes but CI fails with <c>Unknown prototype</c>. Use
+/// <c>private const string Foo = "Foo";</c> + <c>protoMan.Index&lt;T&gt;(Foo)</c> instead.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0014",
+        title: "ProtoId<T> field refers to [TestPrototypes]-declared id",
+        messageFormat: "'{0}' is declared in a [TestPrototypes] YAML block; store it as 'private const string' and resolve through protoMan.Index<T>() instead of ProtoId<T>",
+        category: "Honk.TestPrototypes",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The YAML linter does not load [TestPrototypes] YAML blocks, so ProtoId<T> fields pointing at those ids fail CI with 'Unknown prototype'. Use a private const string threaded through IPrototypeManager.Index<T>() to dodge both the linter and upstream's [ForbidLiteral] RA0033.",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    private static readonly Regex IdRegex = new(@"id:\s*(?:\{(?<name>\w+)\}|(?<lit>\w+))", RegexOptions.Compiled);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private sealed class State
+    {
+        public readonly ConcurrentDictionary<string, string> ConstValues = new();
+        public readonly ConcurrentBag<string> TestPrototypeYaml = new();
+        public readonly ConcurrentBag<(string Value, Location Location)> ProtoIdLiterals = new();
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var assembly = context.Compilation.AssemblyName ?? string.Empty;
+        if (!assembly.StartsWith("Content.IntegrationTests", System.StringComparison.Ordinal))
+            return;
+
+        var state = new State();
+
+        context.RegisterSemanticModelAction(ctx => Collect(ctx, state));
+        context.RegisterCompilationEndAction(ctx => Report(ctx, state));
+    }
+
+    private static void Collect(SemanticModelAnalysisContext context, State state)
+    {
+        var root = context.SemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
+        var model = context.SemanticModel;
+
+        foreach (var field in root.DescendantNodes().OfType<FieldDeclarationSyntax>())
+        {
+            var hasTestProto = HasTestPrototypesAttribute(field, model, context.CancellationToken);
+
+            if (IsConstString(field))
+            {
+                foreach (var declarator in field.Declaration.Variables)
+                {
+                    if (declarator.Initializer?.Value is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
+                    {
+                        state.ConstValues[declarator.Identifier.ValueText] = lit.Token.ValueText;
+                    }
+                }
+            }
+
+            if (hasTestProto)
+            {
+                foreach (var declarator in field.Declaration.Variables)
+                {
+                    var raw = ExtractRawText(declarator.Initializer?.Value);
+                    if (raw is not null)
+                        state.TestPrototypeYaml.Add(raw);
+                }
+            }
+
+            CollectProtoIdFromField(field, model, state, context.CancellationToken);
+        }
+
+        foreach (var prop in root.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+        {
+            CollectProtoIdFromProperty(prop, model, state, context.CancellationToken);
+        }
+    }
+
+    private static void CollectProtoIdFromField(FieldDeclarationSyntax field, SemanticModel model, State state, System.Threading.CancellationToken ct)
+    {
+        if (!IsProtoIdType(field.Declaration.Type, model, ct))
+            return;
+        foreach (var declarator in field.Declaration.Variables)
+        {
+            if (declarator.Initializer?.Value is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                state.ProtoIdLiterals.Add((lit.Token.ValueText, lit.GetLocation()));
+            }
+        }
+    }
+
+    private static void CollectProtoIdFromProperty(PropertyDeclarationSyntax prop, SemanticModel model, State state, System.Threading.CancellationToken ct)
+    {
+        if (!IsProtoIdType(prop.Type, model, ct))
+            return;
+        if (prop.Initializer?.Value is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            state.ProtoIdLiterals.Add((lit.Token.ValueText, lit.GetLocation()));
+        }
+    }
+
+    private static void Report(CompilationAnalysisContext context, State state)
+    {
+        var testIds = new HashSet<string>(System.StringComparer.Ordinal);
+        foreach (var raw in state.TestPrototypeYaml)
+        {
+            foreach (Match match in IdRegex.Matches(raw))
+            {
+                var name = match.Groups["name"].Value;
+                if (!string.IsNullOrEmpty(name))
+                {
+                    if (state.ConstValues.TryGetValue(name, out var value))
+                        testIds.Add(value);
+                }
+                else
+                {
+                    testIds.Add(match.Groups["lit"].Value);
+                }
+            }
+        }
+
+        if (testIds.Count == 0)
+            return;
+
+        foreach (var (value, location) in state.ProtoIdLiterals)
+        {
+            if (testIds.Contains(value))
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, value));
+        }
+    }
+
+    private static bool IsConstString(FieldDeclarationSyntax field)
+    {
+        var isConst = false;
+        foreach (var modifier in field.Modifiers)
+        {
+            if (modifier.IsKind(SyntaxKind.ConstKeyword))
+                isConst = true;
+        }
+        if (!isConst)
+            return false;
+
+        return field.Declaration.Type is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.StringKeyword);
+    }
+
+    private static bool HasTestPrototypesAttribute(FieldDeclarationSyntax field, SemanticModel model, System.Threading.CancellationToken ct)
+    {
+        foreach (var list in field.AttributeLists)
+        {
+            foreach (var attr in list.Attributes)
+            {
+                var type = model.GetTypeInfo(attr, ct).Type;
+                if (type?.Name == "TestPrototypesAttribute" || type?.Name == "TestPrototypes")
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static string? ExtractRawText(ExpressionSyntax? expr)
+    {
+        return expr switch
+        {
+            LiteralExpressionSyntax lit when lit.IsKind(SyntaxKind.StringLiteralExpression) => lit.Token.ValueText,
+            InterpolatedStringExpressionSyntax interp => interp.ToString(),
+            _ => expr?.ToString(),
+        };
+    }
+
+    private static bool IsProtoIdType(TypeSyntax? typeSyntax, SemanticModel model, System.Threading.CancellationToken ct)
+    {
+        if (typeSyntax is null)
+            return false;
+        var type = model.GetTypeInfo(typeSyntax, ct).Type;
+        return type?.Name == "ProtoId";
+    }
+}

--- a/Content.Analyzers.Honk/HonkTestPrototypeRefStyleAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkTestPrototypeRefStyleAnalyzer.cs
@@ -149,9 +149,20 @@ public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
 
         foreach (var (value, location) in state.ProtoIdLiterals)
         {
-            if (testIds.Contains(value))
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, value));
+            if (!testIds.Contains(value))
+                continue;
+            if (!IsForkFile(location.SourceTree?.FilePath))
+                continue;
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, value));
         }
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var norm = path!.Replace('\\', '/');
+        return norm.Contains("/RussStation/") || norm.EndsWith(".Honk.cs", System.StringComparison.Ordinal);
     }
 
     private static bool IsConstString(FieldDeclarationSyntax field)


### PR DESCRIPTION
## About the PR

Adds Roslyn analyzer HONK0014 (warning), active only inside the `Content.IntegrationTests` assembly. It flags `ProtoId<T>` field or property initializers whose literal value matches a prototype id declared inside a `[TestPrototypes]` YAML block.

Closes #552.

## Why / Balance

The YAML linter does not load `[TestPrototypes]` YAML, so a `ProtoId<T>` field pointing at a test-only id compiles fine but fails CI with `Unknown prototype`. The `Content.IntegrationTests/Tests/Tag/TagTest.cs` pattern threads the needle: `private const string Foo = "Foo";` + `protoMan.Index<T>(Foo)`. The linter only inspects `ProtoId<T>` fields, and `[ForbidLiteral]` / RA0033 only fires on inline literals, so the const-and-Index approach dodges both. The analyzer catches the mistake in the IDE instead of in CI.

## Technical details

- `HonkTestPrototypeRefStyleAnalyzer` only activates when `AssemblyName` starts with `Content.IntegrationTests`.
- Uses `CompilationStartAction` + `SemanticModelAction` per tree to collect: all `const string` field values, all `[TestPrototypes]` YAML payloads (raw text), and all `ProtoId<T>` literal initializers with their locations. Reports on `CompilationEndAction` (descriptor is tagged `WellKnownDiagnosticTags.CompilationEnd`).
- YAML id extraction is a regex (`id:\s*(?:\{(?<name>\w+)\}|(?<lit>\w+))`) matching both `id: {ConstName}` and `id: DirectLiteral`. Interpolated names resolve through the collected const-string map.
- 5 unit tests: `ProtoId<T>` with interpolated test id fires, const-string with same id passes, production assembly name passes, unrelated `ProtoId<T>` in a test assembly passes, direct-literal id in YAML matched by `ProtoId<T>` fires.

## Media

n/a (analyzer only).

## Requirements

- [x] Tested locally (`dotnet test Content.Analyzers.Honk.Tests`).

## Breaking changes

None. Warning severity.

## Changelog

n/a (internal tooling).