### PR TITLE
HONK0015: cap Honk partial count per target type

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkPartialProliferationAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkPartialProliferationAnalyzerTest.cs
@@ -1,0 +1,134 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkPartialProliferationAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkPartialProliferationAnalyzerTest
+{
+    private const string Base = """
+        namespace Content.Shared.Upstream
+        {
+            public partial class Target { }
+            public partial class OtherTarget { }
+        }
+        """;
+
+    private static Task Verify(params (string Path, string Code)[] files)
+    {
+        var test = new VerifyCS();
+        test.TestState.Sources.Add(Base);
+        foreach (var (path, code) in files)
+            test.TestState.Sources.Add((path, code));
+        return test.RunAsync();
+    }
+
+    private static Task VerifyWith(DiagnosticResult[] expected, params (string Path, string Code)[] files)
+    {
+        var test = new VerifyCS();
+        test.TestState.Sources.Add(Base);
+        foreach (var (path, code) in files)
+            test.TestState.Sources.Add((path, code));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    private const string PartialA = """
+        namespace Content.Shared.Upstream;
+        public partial class Target { public int A; }
+        """;
+
+    private const string PartialB = """
+        namespace Content.Shared.Upstream;
+        public partial class Target { public int B; }
+        """;
+
+    private const string PartialC = """
+        namespace Content.Shared.Upstream;
+        public partial class Target { public int C; }
+        """;
+
+    private const string PartialD = """
+        namespace Content.Shared.Upstream;
+        public partial class Target { public int D; }
+        """;
+
+    [Test]
+    public async Task TwoHonkPartials_DoNotReport()
+    {
+        await Verify(
+            ("Content.Shared/Upstream/Target.A.Honk.cs", PartialA),
+            ("Content.Shared/Upstream/Target.B.Honk.cs", PartialB));
+    }
+
+    [Test]
+    public async Task ThreeHonkPartials_ReportThird()
+    {
+        const string third = "Content.Shared/Upstream/Target.C.Honk.cs";
+
+        await VerifyWith(
+            new[]
+            {
+                new DiagnosticResult("HONK0015", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                    .WithSpan(third, 2, 22, 2, 28)
+                    .WithArguments("global::Content.Shared.Upstream.Target", 3),
+            },
+            ("Content.Shared/Upstream/Target.A.Honk.cs", PartialA),
+            ("Content.Shared/Upstream/Target.B.Honk.cs", PartialB),
+            (third, PartialC));
+    }
+
+    [Test]
+    public async Task FourHonkPartials_ReportThirdAndFourth()
+    {
+        const string third = "Content.Shared/Upstream/Target.C.Honk.cs";
+        const string fourth = "Content.Shared/Upstream/Target.D.Honk.cs";
+
+        await VerifyWith(
+            new[]
+            {
+                new DiagnosticResult("HONK0015", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                    .WithSpan(third, 2, 22, 2, 28)
+                    .WithArguments("global::Content.Shared.Upstream.Target", 3),
+                new DiagnosticResult("HONK0015", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                    .WithSpan(fourth, 2, 22, 2, 28)
+                    .WithArguments("global::Content.Shared.Upstream.Target", 4),
+            },
+            ("Content.Shared/Upstream/Target.A.Honk.cs", PartialA),
+            ("Content.Shared/Upstream/Target.B.Honk.cs", PartialB),
+            (third, PartialC),
+            (fourth, PartialD));
+    }
+
+    [Test]
+    public async Task DifferentTargets_DoNotCrossContaminate()
+    {
+        const string otherA = """
+            namespace Content.Shared.Upstream;
+            public partial class OtherTarget { public int A; }
+            """;
+        const string otherB = """
+            namespace Content.Shared.Upstream;
+            public partial class OtherTarget { public int B; }
+            """;
+
+        await Verify(
+            ("Content.Shared/Upstream/Target.A.Honk.cs", PartialA),
+            ("Content.Shared/Upstream/Target.B.Honk.cs", PartialB),
+            ("Content.Shared/Upstream/OtherTarget.A.Honk.cs", otherA),
+            ("Content.Shared/Upstream/OtherTarget.B.Honk.cs", otherB));
+    }
+
+    [Test]
+    public async Task NonHonkPartials_DoNotCount()
+    {
+        await Verify(
+            ("Content.Shared/Upstream/Target.A.Honk.cs", PartialA),
+            ("Content.Shared/Upstream/Target.B.Honk.cs", PartialB),
+            ("Content.Shared/Upstream/Target.Plain.cs", PartialC));
+    }
+}

--- a/Content.Analyzers.Honk/HonkPartialProliferationAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkPartialProliferationAnalyzer.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0015: fires when three or more <c>*.Honk.cs</c> files declare a
+/// <c>partial</c> class for the same upstream target type. The fork's
+/// documented escalation rule (see <c>CLAUDE.md</c> "Access Analyzer
+/// Policy") is that two or three Honk partials is the ceiling; past that,
+/// ownership of the subsystem has effectively migrated to the fork and the
+/// right move is a HONK-marked <c>[Access(typeof(ForkSystem))]</c> on the
+/// upstream component, not another setter file. The diagnostic reports the
+/// third-and-subsequent partial declarations so each excess file gets
+/// flagged until the author consolidates.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkPartialProliferationAnalyzer : DiagnosticAnalyzer
+{
+    private const int Threshold = 3;
+
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0015",
+        title: "Too many Honk partials target the same type",
+        messageFormat: "Target type '{0}' now has {1} Honk partials; consolidate into a HONK-marked [Access] addition on the upstream component",
+        category: "Honk.Access",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Two or three *.Honk.cs partials per target is the escalation ceiling. Beyond that the fork is re-exporting the component through setter surface, which fragments ownership and makes rebases harder than one centralised [Access] allowlist line would.",
+        customTags: new[] { WellKnownDiagnosticTags.CompilationEnd });
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var groups = new Dictionary<string, List<(string FilePath, Location Location)>>(StringComparer.Ordinal);
+        var gate = new object();
+
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            var cls = (ClassDeclarationSyntax)ctx.Node;
+
+            var path = cls.SyntaxTree.FilePath;
+            if (!IsHonkPartialFile(path))
+                return;
+
+            if (!cls.Modifiers.Any(SyntaxKind.PartialKeyword))
+                return;
+
+            if (ctx.SemanticModel.GetDeclaredSymbol(cls, ctx.CancellationToken) is not INamedTypeSymbol symbol)
+                return;
+
+            var key = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            var entry = (FilePath: NormalizePath(path), Location: cls.Identifier.GetLocation());
+
+            lock (gate)
+            {
+                if (!groups.TryGetValue(key, out var list))
+                {
+                    list = new List<(string, Location)>();
+                    groups[key] = list;
+                }
+                list.Add(entry);
+            }
+        }, SyntaxKind.ClassDeclaration);
+
+        context.RegisterCompilationEndAction(ctx =>
+        {
+            foreach (var pair in groups)
+            {
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                var ordered = new List<(string FilePath, Location Location)>(pair.Value);
+                ordered.Sort((a, b) => string.CompareOrdinal(a.FilePath, b.FilePath));
+
+                var distinctCount = 0;
+                foreach (var entry in ordered)
+                {
+                    if (!seen.Add(entry.FilePath))
+                        continue;
+
+                    distinctCount++;
+                    if (distinctCount < Threshold)
+                        continue;
+
+                    ctx.ReportDiagnostic(Diagnostic.Create(
+                        Descriptor,
+                        entry.Location,
+                        pair.Key,
+                        distinctCount));
+                }
+            }
+        });
+    }
+
+    private static bool IsHonkPartialFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        return NormalizePath(path!).EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static string NormalizePath(string path) => path.Replace('\\', '/');
+}


### PR DESCRIPTION
## About the PR

Adds `HonkPartialProliferationAnalyzer` (HONK0015). Warns on the third-and-subsequent `*.Honk.cs` files declaring a `partial` class for the same upstream target type.

Closes #553.

## Why / Balance

The fork's Access Analyzer Policy sets 2-3 Honk partials per target as the escalation ceiling. Past that, ownership of the subsystem has migrated to the fork and the right move is a HONK-marked `[Access(typeof(ForkSystem))]` on the upstream component, not yet another setter file. HONK0002 caps setter count per file; this rule is orthogonal, capping partial file count per target so the author sees the escalation signal before the partials sprawl further.

## Technical details

- `CompilationStartAction` collects partial class declarations in `*.Honk.cs` files, grouped by the symbol's fully-qualified name.
- `CompilationEndAction` dedupes by file path, sorts for determinism, reports starting on the third distinct file.
- Descriptor carries the `CompilationEnd` custom tag (RS1037).
- Upstream RA has no concept of Honk partials, so this is fork-only.

Tests cover: two partials pass, third fires, fourth also fires with updated count, different targets do not cross-contaminate, non-`.Honk.cs` partials do not count toward the threshold.

## Media

Analyzer-only, no in-game surface.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.