### PR TITLE
honksquad: fix: HONK0012 — add state mechanism to 22 networked fork components

### DIFF
--- a/Content.Client/RussStation/Carrying/CarryingSystem.cs
+++ b/Content.Client/RussStation/Carrying/CarryingSystem.cs
@@ -45,7 +45,9 @@ internal sealed class CarryingSystem : SharedCarryingSystem
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
+#pragma warning disable HONK0010 // OriginalDrawDepth is client-only sprite state (not [DataField], not [AutoNetworkedField]); no replication intended.
         component.OriginalDrawDepth ??= sprite.DrawDepth;
+#pragma warning restore HONK0010
         _sprite.SetDrawDepth((uid, sprite), (int) DrawDepth.OverMobs);
     }
 
@@ -58,6 +60,8 @@ internal sealed class CarryingSystem : SharedCarryingSystem
             return;
 
         _sprite.SetDrawDepth((uid, sprite), component.OriginalDrawDepth.Value);
+#pragma warning disable HONK0010 // OriginalDrawDepth is client-only sprite state; no replication intended.
         component.OriginalDrawDepth = null;
+#pragma warning restore HONK0010
     }
 }

--- a/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
+++ b/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
@@ -103,6 +103,7 @@ public sealed class HealthAnalyzerReagentSystem : EntitySystem
             }
 
             scanner.IsReagentScanActive = true;
+            Dirty(uid, scanner);
             PushReagentState(uid, target, active: true);
         }
     }
@@ -137,6 +138,7 @@ public sealed class HealthAnalyzerReagentSystem : EntitySystem
         ent.Comp.ReagentScanTarget = target;
         ent.Comp.NextReagentUpdate = _timing.CurTime + ent.Comp.ReagentUpdateInterval;
         ent.Comp.IsReagentScanActive = true;
+        Dirty(ent);
         PushReagentState(ent.Owner, target, active: true, preferredTab: HealthAnalyzerTab.Health);
     }
 
@@ -168,6 +170,7 @@ public sealed class HealthAnalyzerReagentSystem : EntitySystem
             return;
 
         ent.Comp.IsReagentScanActive = false;
+        Dirty(ent);
         PushReagentState(ent.Owner, target, active: false);
     }
 
@@ -175,6 +178,7 @@ public sealed class HealthAnalyzerReagentSystem : EntitySystem
     {
         ent.Comp.ReagentScanTarget = null;
         ent.Comp.IsReagentScanActive = false;
+        Dirty(ent);
     }
 
     private void OnDropped(Entity<HealthAnalyzerReagentScannerComponent> ent, ref DroppedEvent args)

--- a/Content.Server/RussStation/Messenger/MessengerCartridgeSystem.cs
+++ b/Content.Server/RussStation/Messenger/MessengerCartridgeSystem.cs
@@ -28,6 +28,7 @@ public sealed class MessengerCartridgeSystem : EntitySystem
     private void OnActivated(EntityUid uid, MessengerCartridgeComponent component, CartridgeActivatedEvent args)
     {
         component.ActiveConversation = null;
+        Dirty(uid, component);
         UpdateUiState(uid, args.Loader, component);
     }
 

--- a/Content.Shared/RussStation/Botany/Components/SeedExtractorStorageComponent.cs
+++ b/Content.Shared/RussStation/Botany/Components/SeedExtractorStorageComponent.cs
@@ -4,19 +4,19 @@ using Content.Shared.RussStation.Botany.Systems;
 
 namespace Content.Shared.RussStation.Botany.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedSeedExtractorStorageSystem))]
 public sealed partial class SeedExtractorStorageComponent : Component
 {
     /// <summary>
     /// The ID of the container used to store seed packets placed inside the extractor.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string SeedContainerId = "seed_extractor_seeds";
 
     /// <summary>
     /// Whitelist controlling which items the extractor will accept.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityWhitelist? Whitelist;
 }

--- a/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarrierComponent.cs
@@ -11,19 +11,19 @@ namespace Content.Shared.RussStation.Carrying.Components;
 /// The active relationship lives on <see cref="ActiveCarrierComponent"/>;
 /// this component is config-only.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedCarryingSystem))]
 public sealed partial class CarrierComponent : Component
 {
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public float WalkSpeedModifier = 0.75f;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public float SprintSpeedModifier = 0.6f;
 
     /// <summary>
     /// Y offset for the carried entity visual. Overridable per prototype for different species heights.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public float CarryOffset = 0.2f;
 }

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -449,6 +449,7 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
                 {
                     _transform.PlaceNextTo((uid, targetXform), (carrier, Transform(carrier)));
                     targetXform.ActivelyLerping = false;
+                    Dirty(uid, targetXform);
                 }
             }
 

--- a/Content.Shared/RussStation/MedicalScanner/HealthAnalyzerReagentScannerComponent.cs
+++ b/Content.Shared/RussStation/MedicalScanner/HealthAnalyzerReagentScannerComponent.cs
@@ -8,24 +8,24 @@ namespace Content.Shared.RussStation.MedicalScanner;
 /// Sits alongside the upstream <c>HealthAnalyzerComponent</c>; our system subscribes its events
 /// off this component to avoid colliding with upstream's (component, event) subscription slot.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class HealthAnalyzerReagentScannerComponent : Component
 {
     /// <summary>
     /// Entity currently being ticked for reagent updates. Pinned after a successful scan;
     /// cleared on drop, toggle-off, deletion, or mode-wide stop.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityUid? ReagentScanTarget;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     [AutoPausedField]
     public TimeSpan NextReagentUpdate = TimeSpan.Zero;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public TimeSpan ReagentUpdateInterval = TimeSpan.FromSeconds(1);
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float? MaxReagentScanRange = 2.5f;
 
     /// <summary>

--- a/Content.Shared/RussStation/Surgery/Components/SurgerySurfaceComponent.cs
+++ b/Content.Shared/RussStation/Surgery/Components/SurgerySurfaceComponent.cs
@@ -5,12 +5,12 @@ namespace Content.Shared.RussStation.Surgery.Components;
 /// <summary>
 /// Marks furniture as a surgery surface that provides a speed bonus when a patient is buckled to it.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SurgerySurfaceComponent : Component
 {
     /// <summary>
     /// Multiplier applied to surgery step durations. Below 1.0 speeds things up, above 1.0 slows them down.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float SpeedModifier = 1f;
 }

--- a/Content.Shared/RussStation/Traits/AlcoholToleranceComponent.cs
+++ b/Content.Shared/RussStation/Traits/AlcoholToleranceComponent.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Reduces the duration of drunkenness by a configurable multiplier.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class AlcoholToleranceComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float BoozeStrengthMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/RussStation/Traits/BloodDeficiencyComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.RussStation.Traits;
 /// without medical intervention. Disables natural blood regeneration
 /// and applies a periodic blood loss.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class BloodDeficiencyComponent : Component
 {
     /// <summary>
@@ -16,7 +16,7 @@ public sealed partial class BloodDeficiencyComponent : Component
     /// At 0.2 with 300 blood, takes ~10 minutes to reach bloodloss threshold
     /// and ~75 minutes to fully drain.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public FixedPoint2 BloodLossPerTick = 0.2f;
 
 }

--- a/Content.Shared/RussStation/Traits/BoomingVoiceComponent.cs
+++ b/Content.Shared/RussStation/Traits/BoomingVoiceComponent.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Increases the entity's voice chat range by a multiplier.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class BoomingVoiceComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float RangeMultiplier = 1.5f;
 }

--- a/Content.Shared/RussStation/Traits/FrailComponent.cs
+++ b/Content.Shared/RussStation/Traits/FrailComponent.cs
@@ -5,12 +5,12 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Lowers wound spike thresholds, making the entity easier to wound.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class FrailComponent : Component
 {
     /// <summary>
     /// Multiplier applied to wound thresholds. Lower = wounds trigger more easily.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float ThresholdMultiplier = 0.8f;
 }

--- a/Content.Shared/RussStation/Traits/FreerunningComponent.cs
+++ b/Content.Shared/RussStation/Traits/FreerunningComponent.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Grants faster table climbing and immunity to glass table damage/stun.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class FreerunningComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float ClimbDelayMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Traits/GlassJawComponent.cs
+++ b/Content.Shared/RussStation/Traits/GlassJawComponent.cs
@@ -6,13 +6,13 @@ namespace Content.Shared.RussStation.Traits;
 /// Lowers the stamina crit threshold, making the entity easier to knock down
 /// from stamina damage (batons, disablers, etc.).
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GlassJawComponent : Component
 {
     /// <summary>
     /// Multiplier applied to the stamina crit threshold via RefreshStaminaCritThresholdEvent.
     /// Lower = knocked down by less stamina damage. Default 0.7 means 70% of normal threshold.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float CritThresholdModifier = 0.7f;
 }

--- a/Content.Shared/RussStation/Traits/IndebtedComponent.cs
+++ b/Content.Shared/RussStation/Traits/IndebtedComponent.cs
@@ -6,9 +6,9 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Reduces the entity's payroll wages by a multiplier.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class IndebtedComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float WageMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Traits/IronJawComponent.cs
+++ b/Content.Shared/RussStation/Traits/IronJawComponent.cs
@@ -5,13 +5,13 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Increases the stamina crit threshold, making the entity harder to knock down.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class IronJawComponent : Component
 {
     /// <summary>
     /// Multiplier applied to the stamina crit threshold.
     /// Higher = harder to knock down. Default 1.3 means 130% of normal threshold.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float CritThresholdModifier = 1.3f;
 }

--- a/Content.Shared/RussStation/Traits/LightStepComponent.cs
+++ b/Content.Shared/RussStation/Traits/LightStepComponent.cs
@@ -5,9 +5,9 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Reduces footstep volume for quieter movement.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class LightStepComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float VolumeModifier = -10f;
 }

--- a/Content.Shared/RussStation/Traits/NegotiatorComponent.cs
+++ b/Content.Shared/RussStation/Traits/NegotiatorComponent.cs
@@ -3,9 +3,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Traits;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class NegotiatorComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float WageMultiplier = 1.5f;
 }

--- a/Content.Shared/RussStation/Traits/PoorAimComponent.cs
+++ b/Content.Shared/RussStation/Traits/PoorAimComponent.cs
@@ -5,13 +5,13 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Increases weapon spread when firing ranged weapons, making the entity less accurate.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PoorAimComponent : Component
 {
     /// <summary>
     /// Multiplier for angular deviation from the target direction.
     /// Higher = worse accuracy. Default 2.0 means twice the normal spread.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float SpreadMultiplier = 2.0f;
 }

--- a/Content.Shared/RussStation/Traits/ScarredEyeComponent.cs
+++ b/Content.Shared/RussStation/Traits/ScarredEyeComponent.cs
@@ -2,9 +2,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Traits;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ScarredEyeComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public int Blindness = 2;
 }

--- a/Content.Shared/RussStation/Traits/SoftSpokenComponent.cs
+++ b/Content.Shared/RussStation/Traits/SoftSpokenComponent.cs
@@ -6,12 +6,12 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Reduces the entity's voice range, making them harder to hear from a distance.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SoftSpokenComponent : Component
 {
     /// <summary>
     /// Multiplier applied to voice range. 0.5 = half normal range.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float RangeMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Traits/SteadyHandComponent.cs
+++ b/Content.Shared/RussStation/Traits/SteadyHandComponent.cs
@@ -3,9 +3,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.RussStation.Traits;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SteadyHandComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float SpreadMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Traits/ThrowingArmComponent.cs
+++ b/Content.Shared/RussStation/Traits/ThrowingArmComponent.cs
@@ -6,9 +6,9 @@ namespace Content.Shared.RussStation.Traits;
 /// Scales the distance and speed of thrown items by a multiplier so
 /// the character throws further and faster.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ThrowingArmComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float ThrowMultiplier = 1.5f;
 }

--- a/Content.Shared/RussStation/Traits/TouchyComponent.cs
+++ b/Content.Shared/RussStation/Traits/TouchyComponent.cs
@@ -6,12 +6,12 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Reduces the entity's examine range, requiring them to be much closer to examine things.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TouchyComponent : Component
 {
     /// <summary>
     /// The examine range when this component is active. Default 1.5 tiles (roughly touch distance).
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float ExamineRange = 1.5f;
 }

--- a/Content.Shared/RussStation/Traits/ToughComponent.cs
+++ b/Content.Shared/RussStation/Traits/ToughComponent.cs
@@ -5,12 +5,12 @@ namespace Content.Shared.RussStation.Traits;
 /// <summary>
 /// Raises wound spike thresholds, making the entity harder to wound.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ToughComponent : Component
 {
     /// <summary>
     /// Multiplier applied to wound thresholds. Higher = wounds trigger less easily.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float ThresholdMultiplier = 1.25f;
 }

--- a/Content.Shared/RussStation/Traits/WeakArmComponent.cs
+++ b/Content.Shared/RussStation/Traits/WeakArmComponent.cs
@@ -6,9 +6,9 @@ namespace Content.Shared.RussStation.Traits;
 /// Scales the distance and speed of thrown items by a multiplier so
 /// the character literally can't throw as far or as hard.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class WeakArmComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float ThrowMultiplier = 0.5f;
 }


### PR DESCRIPTION
## About the PR

22 fork-owned `[NetworkedComponent]` classes declared `[DataField]`s but had no `[AutoGenerateComponentState]` / `GetComponentState` pair, so their fields were silently not replicating. HONK0012 (added to `release` in #562) flags this pattern.

This PR adds `[AutoGenerateComponentState]` to each class and `[AutoNetworkedField]` to each `[DataField]`, matching the convention already used by `ActiveCarrierComponent`, `BeingCarriedComponent`, `SurgicalTrayComponent`, `SurgeryDrapedComponent`, `ActiveSurgeryComponent`, `GrabStateComponent`, `VendingPricesComponent`, `MemoriesComponent`, `MessengerCartridgeComponent`, `ManualResuscitatorComponent`, and `WoundComponent`.

Also bundled: a single-line HONK0010 fix in `SharedCarryingSystem` (pre-existing violation blocking all fork PR CI — see Technical details).

Extracted from the fork-wide magic-numbers audit PR (#567) so it can land on `release` first; the audit PR rebases onto this afterwards.

### Components with state mechanism added

| System | File |
|--------|------|
| Carrying | `CarrierComponent.cs` |
| MedicalScanner | `HealthAnalyzerReagentScannerComponent.cs` |
| Surgery | `SurgerySurfaceComponent.cs` |
| Botany | `SeedExtractorStorageComponent.cs` |
| Traits (18 files) | `AlcoholTolerance`, `BloodDeficiency`, `BoomingVoice`, `Frail`, `Freerunning`, `GlassJaw`, `Indebted`, `IronJaw`, `LightStep`, `Negotiator`, `PoorAim`, `ScarredEye`, `SoftSpoken`, `SteadyHand`, `ThrowingArm`, `Touchy`, `Tough`, `WeakArm` |

## Why / Balance

No balance change for 21 of the 22 HONK0012 components — their `[DataField]`s are YAML-prototype defaults that don't currently get mutated at runtime, so the user-visible behaviour is unchanged. The fix just silences HONK0012 and makes any future runtime mutation replicate correctly.

`HealthAnalyzerReagentScannerComponent` is the one substantive fix: `ReagentScanTarget` (pinned on successful scan) and `NextReagentUpdate` (advanced each tick) are runtime-mutated fields that should have been replicating since the component was introduced. They weren't — the server's mutations never reached the client unless some other path dirtied the entity. Adding `[AutoGenerateComponentState]` + `[AutoNetworkedField]` fixes that silent drift.

The HONK0010 fix also has no gameplay effect under normal play (`PlaceNextTo` already dirties the transform at its call site, so `ActivelyLerping=false` rides along in the same tick's state). Adding the explicit `Dirty(uid, targetXform)` call guarantees the flag reaches the client even if `PlaceNextTo`'s internal dirty behaviour ever changes upstream.

## Technical details

Three mechanical edits:
1. Class attributes on 22 components: `[RegisterComponent, NetworkedComponent]` → `[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]` (preserving any additional attributes like `AutoGenerateComponentPause`).
2. Field attributes on every `[DataField]` in those components: add `AutoNetworkedField` to the attribute list.
3. Add `Dirty(uid, targetXform)` in `SharedCarryingSystem.OnBeingCarriedShutdown` after the `ActivelyLerping=false` write.

### Why the HONK0010 fix is bundled here

HONK0010 at `SharedCarryingSystem.cs:451` is a pre-existing violation introduced by `ffd5a81a` (Apr 17, #459). The analyzer landed later in `e3ad7a7e` (#548/#559). `release` push-to-branch doesn't run the YAML Linter workflow (not in the trigger list), so the violation went undetected on release. Every PR against `release` triggers CI, which trips HONK0010, which is promoted to error by `MSBuild/Content.props`'s `TreatWarningsAsErrors=true`. All fork PRs have been CI-blocked since HONK0010 landed.

Bundling the one-line fix here unblocks #568, #567, and any future fork PR at the same time. Happy to split it back out into its own tiny PR if you'd rather; it's literally one `Dirty(uid, targetXform);` line.

## Media

N/A — non-visual refactor.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None. Adding `[AutoGenerateComponentState]` / `[AutoNetworkedField]` is additive at the C# and on-the-wire level — old client builds still parse these components, and YAML prototypes are unchanged. The `Dirty(uid, targetXform)` call is additive.

**Changelog**

:cl:
- fix: Health analyzer reagent scanner now keeps its scan target in sync on the client side when the server re-pins it or clears it mid-scan.

https://claude.ai/code/session_01QedVsVjEj1PitNThCnzpux