### PR TITLE
honksquad: feat: HONK0016 — flag magic numeric literals in fork DataF…

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkMagicNumberAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkMagicNumberAnalyzerTest.cs
@@ -1,0 +1,344 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkMagicNumberAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkMagicNumberAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Serialization.Manager.Attributes
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class DataFieldAttribute : System.Attribute
+            {
+                public DataFieldAttribute() { }
+                public DataFieldAttribute(string tag) { }
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/Example/ExampleComp.cs";
+    private const string HonkPath = "Content.Shared/Medical/HealthAnalyzerSystem.Honk.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/UpstreamComp.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS { TestState = { Sources = { Stubs, (filePath, code) } } };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task NumericLiteralOnDataField_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Modifier = 0.5f;
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 29, 6, 33)
+                .WithArguments("Modifier", "0.5f"));
+    }
+
+    [Test]
+    public async Task NegativeNumericLiteralOnDataField_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Volume = -6f;
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 27, 6, 30)
+                .WithArguments("Volume", "-6f"));
+    }
+
+    [Test]
+    public async Task ZeroLiteralOnDataField_Reports()
+    {
+        // Even `0` / `1` count as magic numbers when they encode a default choice.
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public int Balance = 0;
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 26, 6, 27)
+                .WithArguments("Balance", "0"));
+    }
+
+    [Test]
+    public async Task LiteralOnDataFieldProperty_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Modifier { get; set; } = 1.5f;
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 43, 6, 47)
+                .WithArguments("Modifier", "1.5f"));
+    }
+
+    [Test]
+    public async Task ConstantReferenceOnDataField_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public static class ExampleConstants
+            {
+                public const float DefaultModifier = 0.5f;
+            }
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Modifier = ExampleConstants.DefaultModifier;
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task NoInitializer_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Modifier;
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task StringLiteral_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public string Id = "foo";
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task BoolLiteral_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public bool Enabled = true;
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task NonDataFieldNumericLiteral_DoesNotReport()
+    {
+        const string code = """
+            public sealed class ExampleComp
+            {
+                public float Modifier = 0.5f;
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task UpstreamFileNumericLiteral_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class UpstreamComp
+            {
+                [DataField]
+                public float Modifier = 0.5f;
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
+    }
+
+    [Test]
+    public async Task HonkSuffixFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class HonkComp
+            {
+                [DataField]
+                public float Modifier = 0.5f;
+            }
+            """;
+
+        await Verify(code, HonkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(HonkPath, 6, 29, 6, 33)
+                .WithArguments("Modifier", "0.5f"));
+    }
+
+    [Test]
+    public async Task QualifiedAttributeName_Reports()
+    {
+        const string code = """
+            public sealed class ExampleComp
+            {
+                [Robust.Shared.Serialization.Manager.Attributes.DataField]
+                public float Modifier = 0.5f;
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 4, 29, 4, 33)
+                .WithArguments("Modifier", "0.5f"));
+    }
+
+    [Test]
+    public async Task CollectionExpressionElements_Report()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float[] Thresholds = [1f, 3f, 6f];
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 34, 6, 36)
+                .WithArguments("Thresholds", "1f"),
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 38, 6, 40)
+                .WithArguments("Thresholds", "3f"),
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 42, 6, 44)
+                .WithArguments("Thresholds", "6f"));
+    }
+
+    [Test]
+    public async Task ExplicitArrayCreationElements_Report()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float[] Thresholds = new float[] { 1f, 3f, 6f };
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 47, 6, 49)
+                .WithArguments("Thresholds", "1f"),
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 51, 6, 53)
+                .WithArguments("Thresholds", "3f"),
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 55, 6, 57)
+                .WithArguments("Thresholds", "6f"));
+    }
+
+    [Test]
+    public async Task ImplicitArrayCreationElements_Report()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float[] Thresholds = new[] { 1f, 3f, 6f };
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 41, 6, 43)
+                .WithArguments("Thresholds", "1f"),
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 45, 6, 47)
+                .WithArguments("Thresholds", "3f"),
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 49, 6, 51)
+                .WithArguments("Thresholds", "6f"));
+    }
+
+    [Test]
+    public async Task CollectionExpressionOfConstantReferences_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public static class ExampleConstants
+            {
+                public const float T1 = 1f;
+                public const float T2 = 3f;
+                public const float T3 = 6f;
+            }
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float[] Thresholds = [ExampleConstants.T1, ExampleConstants.T2, ExampleConstants.T3];
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+}

--- a/Content.Analyzers.Honk/HonkMagicNumberAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkMagicNumberAnalyzer.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0016: a fork-owned <c>[DataField]</c> member initialized with a raw
+/// numeric literal bakes the value into source instead of referencing a
+/// named constant. The magic-numbers audit moved every such literal into a
+/// per-system <c>&lt;System&gt;Constants.cs</c> file; this analyzer stops
+/// the regression. Scoped to fork files (path contains <c>/RussStation/</c>
+/// or ends in <c>.Honk.cs</c>).
+///
+/// Covers:
+///   - Direct numeric literal initializers (<c>= 0.5f</c>, <c>= -100f</c>, <c>= 10</c>).
+///   - Numeric literals inside collection/array initializers on the DataField
+///     (<c>= [1f, 3f, 6f]</c>, <c>= new float[] { 1f, 3f, 6f }</c>,
+///     <c>= new[] { 1f, 3f, 6f }</c>).
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkMagicNumberAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0016",
+        title: "Magic numeric literal in [DataField] default",
+        messageFormat: "[DataField] '{0}' is initialized with a raw numeric literal ({1}); move the value to a per-system *Constants.cs and reference it here",
+        category: "Honk.Readability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "DataField defaults are the dominant source of fork magic numbers. Every numeric default must reference a named constant in a per-system constants file so reviewers can trace the value's meaning and retune centrally.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeField, SyntaxKind.FieldDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeProperty, SyntaxKind.PropertyDeclaration);
+    }
+
+    private static void AnalyzeField(SyntaxNodeAnalysisContext context)
+    {
+        var field = (FieldDeclarationSyntax)context.Node;
+
+        if (!IsForkFile(field.SyntaxTree.FilePath))
+            return;
+
+        if (!HasDataFieldAttribute(field.AttributeLists))
+            return;
+
+        foreach (var variable in field.Declaration.Variables)
+        {
+            var initializer = variable.Initializer;
+            if (initializer is null)
+                continue;
+
+            ReportIfMagic(context, variable.Identifier.Text, initializer.Value);
+        }
+    }
+
+    private static void AnalyzeProperty(SyntaxNodeAnalysisContext context)
+    {
+        var property = (PropertyDeclarationSyntax)context.Node;
+
+        if (!IsForkFile(property.SyntaxTree.FilePath))
+            return;
+
+        if (!HasDataFieldAttribute(property.AttributeLists))
+            return;
+
+        var initializer = property.Initializer;
+        if (initializer is null)
+            return;
+
+        ReportIfMagic(context, property.Identifier.Text, initializer.Value);
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool HasDataFieldAttribute(SyntaxList<AttributeListSyntax> attributeLists)
+    {
+        foreach (var list in attributeLists)
+        {
+            foreach (var attr in list.Attributes)
+            {
+                if (IsDataFieldName(attr.Name))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsDataFieldName(NameSyntax name)
+    {
+        var text = name switch
+        {
+            SimpleNameSyntax simple => simple.Identifier.Text,
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            _ => null,
+        };
+
+        return text is "DataField" or "DataFieldAttribute";
+    }
+
+    private static void ReportIfMagic(SyntaxNodeAnalysisContext context, string memberName, ExpressionSyntax value)
+    {
+        // Direct literal or unary-minus literal.
+        if (TryUnwrapNumericLiteral(value) is { } directText)
+        {
+            Report(context, memberName, value, directText);
+            return;
+        }
+
+        // Collection expression: = [1f, 3f, 6f]
+        if (value is CollectionExpressionSyntax collection)
+        {
+            foreach (var element in collection.Elements)
+            {
+                if (element is ExpressionElementSyntax ee
+                    && TryUnwrapNumericLiteral(ee.Expression) is { } elemText)
+                {
+                    Report(context, memberName, ee.Expression, elemText);
+                }
+            }
+            return;
+        }
+
+        // Explicit array creation: = new float[] { 1f, 3f, 6f }
+        if (value is ArrayCreationExpressionSyntax array && array.Initializer is { } arrayInit)
+        {
+            FlagInitializer(context, memberName, arrayInit);
+            return;
+        }
+
+        // Implicit array creation: = new[] { 1f, 3f, 6f }
+        if (value is ImplicitArrayCreationExpressionSyntax implicitArray)
+        {
+            FlagInitializer(context, memberName, implicitArray.Initializer);
+            return;
+        }
+    }
+
+    private static void FlagInitializer(SyntaxNodeAnalysisContext context, string memberName, InitializerExpressionSyntax initializer)
+    {
+        foreach (var expr in initializer.Expressions)
+        {
+            if (TryUnwrapNumericLiteral(expr) is { } text)
+                Report(context, memberName, expr, text);
+        }
+    }
+
+    private static void Report(SyntaxNodeAnalysisContext context, string memberName, ExpressionSyntax location, string literalText)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor,
+            location.GetLocation(),
+            memberName,
+            literalText));
+    }
+
+    internal static string? TryUnwrapNumericLiteral(ExpressionSyntax expr)
+    {
+        switch (expr)
+        {
+            case LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.NumericLiteralExpression):
+                return literal.Token.Text;
+            case PrefixUnaryExpressionSyntax unary when unary.IsKind(SyntaxKind.UnaryMinusExpression)
+                                                       && unary.Operand is LiteralExpressionSyntax inner
+                                                       && inner.IsKind(SyntaxKind.NumericLiteralExpression):
+                return "-" + inner.Token.Text;
+            default:
+                return null;
+        }
+    }
+}


### PR DESCRIPTION
> **Depends on #567** — merge the magic-numbers audit first so the fork has no pre-existing violations to trip on.

## About the PR

DataField defaults are the dominant source of fork magic numbers. The magic-numbers audit (#567) moved every such literal into a per-system `*Constants.cs` file; this analyzer stops the regression so reviewers catch a naked numeric default in CI instead of code review.

### What it flags

Any field or property decorated with `[DataField]` whose initializer is:
- A direct numeric literal (`0.5f`, `-100f`, `10`)
- A unary-minus of a numeric literal
- A collection expression with numeric elements (`[1f, 3f, 6f]`)
- An explicit array creation with numeric elements (`new float[] { 1f, 3f, 6f }`)
- An implicit array creation with numeric elements (`new[] { 1f, 3f, 6f }`)

### What it doesn't flag

- bool / string / null literals
- Uninitialized fields
- Constant references (`TraitsConstants.AlcoholTolerance.BoozeStrengthMultiplier`)
- Method-call initializers (`TimeSpan.FromSeconds(3)` — that's HONK0017's scope)

## Why / Balance

No gameplay effect. Pure CI rule.

## Technical details

- Scope: fork-owned C# (path contains `/RussStation/` or ends in `.Honk.cs`).
- Severity: Warning, promoted to Error by `MSBuild/Content.props`'s `TreatWarningsAsErrors`, matching the rest of the HONK series.
- Auto-registers via `IsRoslynComponent=true`; already referenced with `OutputItemType="Analyzer"` from `Content.Shared/Server/Client` so no workflow changes needed.
- 15 test cases covering every fire path and every silence path, including `.Honk.cs` suffix and qualified attribute names.

## Media

N/A — non-visual.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. Warning-level analyzer scoped to fork files.

**Changelog**

:cl:
- fix: Magic numbers in DataField defaults now fail CI on fork code so they can't sneak into future PRs.