### PR TITLE
honksquad: feat: HONK0017 — flag magic numeric literals in layout/time constructor arguments

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkLayoutMagicNumberAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkLayoutMagicNumberAnalyzerTest.cs
@@ -1,0 +1,307 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkLayoutMagicNumberAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkLayoutMagicNumberAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Maths
+        {
+            public readonly struct Thickness
+            {
+                public Thickness(float uniform) { }
+                public Thickness(float horizontal, float vertical) { }
+                public Thickness(float left, float top, float right, float bottom) { }
+            }
+            public readonly struct UIBox2
+            {
+                public UIBox2(float left, float top, float right, float bottom) { }
+            }
+            public readonly struct Color
+            {
+                public Color(float r, float g, float b, float a) { }
+            }
+        }
+        namespace System.Numerics
+        {
+            public readonly struct Vector2
+            {
+                public Vector2(float x, float y) { }
+            }
+            public readonly struct Vector3
+            {
+                public Vector3(float x, float y, float z) { }
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/Example/Example.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/Upstream.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS { TestState = { Sources = { Stubs, (filePath, code) } } };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task ThicknessWithNumericArgs_ReportsPerArgument()
+    {
+        const string code = """
+            using Robust.Shared.Maths;
+
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var margin = new Thickness(0, 8, 0, 0);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 40, 7, 41)
+                .WithArguments("Thickness", "0", 1),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 43, 7, 44)
+                .WithArguments("Thickness", "8", 2),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 46, 7, 47)
+                .WithArguments("Thickness", "0", 3),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 49, 7, 50)
+                .WithArguments("Thickness", "0", 4));
+    }
+
+    [Test]
+    public async Task Vector2WithNumericArgs_Reports()
+    {
+        const string code = """
+            using System.Numerics;
+
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var pos = new Vector2(16f, 16f);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 35, 7, 38)
+                .WithArguments("Vector2", "16f", 1),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 40, 7, 43)
+                .WithArguments("Vector2", "16f", 2));
+    }
+
+    [Test]
+    public async Task TimeSpanFromSecondsWithNumericLiteral_Reports()
+    {
+        const string code = """
+            using System;
+
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var delay = TimeSpan.FromSeconds(3);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 42, 7, 43)
+                .WithArguments("TimeSpan.FromSeconds", "3", 1));
+    }
+
+    [Test]
+    public async Task ThicknessWithNamedConstants_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Maths;
+
+            public static class Layout
+            {
+                public const int TopMargin = 8;
+                public const int ZeroMargin = 0;
+            }
+
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var margin = new Thickness(Layout.ZeroMargin, Layout.TopMargin, Layout.ZeroMargin, Layout.ZeroMargin);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task TimeSpanInsideStaticReadonly_DoesNotReport()
+    {
+        // The constants file itself is where TimeSpan.FromSeconds(N) IS the named value.
+        const string code = """
+            using System;
+
+            public static class LayoutConstants
+            {
+                public static readonly TimeSpan Interval = TimeSpan.FromSeconds(3);
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task ThicknessInsideConstField_DoesNotReport()
+    {
+        // `const` field — this is the defining site, so literals are allowed.
+        const string code = """
+            using Robust.Shared.Maths;
+
+            public static class LayoutConstants
+            {
+                public const int SideMargin = 8;
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task UpstreamFileLiteralArgs_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Maths;
+
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var margin = new Thickness(0, 8, 0, 0);
+                    var delay = System.TimeSpan.FromSeconds(3);
+                }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
+    }
+
+    [Test]
+    public async Task QualifiedTypeName_Reports()
+    {
+        // Matches by rightmost identifier so `Robust.Shared.Maths.Thickness` still fires.
+        const string code = """
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var margin = new Robust.Shared.Maths.Thickness(0, 8, 0, 0);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 56, 5, 57)
+                .WithArguments("Thickness", "0", 1),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 59, 5, 60)
+                .WithArguments("Thickness", "8", 2),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 62, 5, 63)
+                .WithArguments("Thickness", "0", 3),
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 65, 5, 66)
+                .WithArguments("Thickness", "0", 4));
+    }
+
+    [Test]
+    public async Task UnrelatedTypeName_DoesNotReport()
+    {
+        // `Thickness` is the only heuristic — other types with numeric ctors are out of scope.
+        const string code = """
+            public readonly struct SomeOtherType
+            {
+                public SomeOtherType(int a, int b) { }
+            }
+
+            public sealed class Widget
+            {
+                public void Build()
+                {
+                    var x = new SomeOtherType(1, 2);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task TimeSpanFromTicksInsideMethod_Reports()
+    {
+        const string code = """
+            using System;
+
+            public sealed class Widget
+            {
+                public TimeSpan Delay() => TimeSpan.FromTicks(100);
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 51, 5, 54)
+                .WithArguments("TimeSpan.FromTicks", "100", 1));
+    }
+
+    [Test]
+    public async Task TimeSpanFromSecondsWithExpression_DoesNotReport()
+    {
+        // Not a raw literal — variable, computation, constant reference all pass.
+        const string code = """
+            using System;
+
+            public sealed class Widget
+            {
+                public TimeSpan Delay(int seconds) => TimeSpan.FromSeconds(seconds);
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task NonTimeSpanFromSecondsLookalike_DoesNotReport()
+    {
+        // Only `TimeSpan.From*` is in scope; same method name on a different type passes.
+        const string code = """
+            public static class NotTimeSpan
+            {
+                public static int FromSeconds(int n) => n;
+            }
+
+            public sealed class Widget
+            {
+                public int Delay() => NotTimeSpan.FromSeconds(3);
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+}

--- a/Content.Analyzers.Honk/HonkLayoutMagicNumberAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkLayoutMagicNumberAnalyzer.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0017: a fork-owned call site passing a raw numeric literal to a known
+/// UI-layout constructor (<c>Thickness</c>, <c>Vector2/3/4</c>, <c>UIBox2</c>,
+/// <c>Box2</c>, <c>Color</c>) or to one of the <c>TimeSpan.FromX</c> factory
+/// methods bakes a layout decision or duration into source instead of
+/// referencing a named constant. Pairs with HONK0016, which covers DataField
+/// default values; this rule covers the call-site-argument case that appears
+/// everywhere UI widgets, coordinate offsets, and durations are constructed.
+///
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>). Exempts call sites inside a <c>const</c> or
+/// <c>static readonly</c> field initializer — those declarations *are* the
+/// named constant, so the literal at the defining site is allowed.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkLayoutMagicNumberAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0017",
+        title: "Magic numeric literal in layout/time constructor argument",
+        messageFormat: "'{0}' is called with a raw numeric literal ({1}) at argument {2}; move the value to a per-system *Constants.cs and reference it here",
+        category: "Honk.Readability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "UI layout decisions (Thickness corners, Vector axes, Color channels, UIBox/Box corners) and durations (TimeSpan.FromX arguments) should live in a per-system constants file so each axis/side/channel is a distinct, retunable named value and reviewers can spot drift across call sites.");
+
+    // Type names that take magic-number-prone constructor arguments. Matched by
+    // the rightmost identifier in the type syntax — so "Thickness" matches
+    // `Thickness`, `Robust.Shared.Maths.Thickness`, `new Thickness(...)`, etc.
+    private static readonly HashSet<string> LayoutTypes = new(StringComparer.Ordinal)
+    {
+        "Thickness",
+        "Vector2", "Vector3", "Vector4",
+        "Vector2i", "Vector3i", "Vector4i",
+        "UIBox2", "UIBox2i",
+        "Box2", "Box2i",
+        "Color",
+    };
+
+    private static readonly HashSet<string> TimeSpanFactories = new(StringComparer.Ordinal)
+    {
+        "FromSeconds", "FromMilliseconds", "FromMinutes", "FromHours", "FromDays", "FromTicks",
+    };
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        var creation = (ObjectCreationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(creation.SyntaxTree.FilePath))
+            return;
+
+        if (IsInsideNamedConstantDeclaration(creation))
+            return;
+
+        var typeName = GetRightmostIdentifier(creation.Type);
+        if (typeName is null || !LayoutTypes.Contains(typeName))
+            return;
+
+        if (creation.ArgumentList is not { } args)
+            return;
+
+        FlagNumericArguments(context, typeName, args);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
+
+        if (IsInsideNamedConstantDeclaration(invocation))
+            return;
+
+        // Match TimeSpan.FromX(...).
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        if (memberAccess.Expression is not IdentifierNameSyntax typeIdent
+            || typeIdent.Identifier.Text != "TimeSpan")
+        {
+            return;
+        }
+
+        var methodName = memberAccess.Name.Identifier.Text;
+        if (!TimeSpanFactories.Contains(methodName))
+            return;
+
+        FlagNumericArguments(context, $"TimeSpan.{methodName}", invocation.ArgumentList);
+    }
+
+    private static void FlagNumericArguments(SyntaxNodeAnalysisContext context, string callName, ArgumentListSyntax args)
+    {
+        for (var i = 0; i < args.Arguments.Count; i++)
+        {
+            var argExpr = args.Arguments[i].Expression;
+            if (TryUnwrapNumericLiteral(argExpr) is not { } literalText)
+                continue;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptor,
+                argExpr.GetLocation(),
+                callName,
+                literalText,
+                // Human-friendly 1-based argument index.
+                i + 1));
+        }
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static string? GetRightmostIdentifier(TypeSyntax type)
+    {
+        return type switch
+        {
+            IdentifierNameSyntax ident => ident.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            QualifiedNameSyntax qualified => GetRightmostIdentifier(qualified.Right),
+            AliasQualifiedNameSyntax aliased => GetRightmostIdentifier(aliased.Name),
+            _ => null,
+        };
+    }
+
+    private static bool IsInsideNamedConstantDeclaration(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is FieldDeclarationSyntax field)
+            {
+                var hasConst = false;
+                var hasStatic = false;
+                var hasReadOnly = false;
+                foreach (var modifier in field.Modifiers)
+                {
+                    if (modifier.IsKind(SyntaxKind.ConstKeyword)) hasConst = true;
+                    else if (modifier.IsKind(SyntaxKind.StaticKeyword)) hasStatic = true;
+                    else if (modifier.IsKind(SyntaxKind.ReadOnlyKeyword)) hasReadOnly = true;
+                }
+                return hasConst || (hasStatic && hasReadOnly);
+            }
+            if (current is MethodDeclarationSyntax or ConstructorDeclarationSyntax
+                or AccessorDeclarationSyntax or LocalFunctionStatementSyntax)
+            {
+                // Escaped field-initializer scope without seeing a const/static-readonly field.
+                return false;
+            }
+        }
+        return false;
+    }
+
+    // Duplicated from HonkMagicNumberAnalyzer so HONK0017 is self-contained —
+    // the two analyzers ship in independent PRs. If both land, the helper can
+    // be factored into a shared internal class in a follow-up.
+    private static string? TryUnwrapNumericLiteral(ExpressionSyntax expr)
+    {
+        switch (expr)
+        {
+            case LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.NumericLiteralExpression):
+                return literal.Token.Text;
+            case PrefixUnaryExpressionSyntax unary when unary.IsKind(SyntaxKind.UnaryMinusExpression)
+                                                       && unary.Operand is LiteralExpressionSyntax inner
+                                                       && inner.IsKind(SyntaxKind.NumericLiteralExpression):
+                return "-" + inner.Token.Text;
+            default:
+                return null;
+        }
+    }
+}


### PR DESCRIPTION
> **Depends on #567** — merge the magic-numbers audit first so the fork has no pre-existing violations to trip on. Pairs with #HONK0016 (separate PR) which catches the DataField-default case.

## About the PR

UI layout decisions and duration calls that take numeric literals as constructor or factory-method arguments. `HONK0016` catches the DataField-default case; this one covers the call-site-argument case that appears in widget constructors, system code building offsets, and ad-hoc delays.

### What it flags (per numeric argument)

- `new Thickness(...)`
- `new Vector2/3/4` (and the `*i` integer variants)
- `new UIBox2 / UIBox2i / Box2 / Box2i`
- `new Color(r, g, b, a)` with numeric channels
- `TimeSpan.FromSeconds / FromMilliseconds / FromMinutes / FromHours / FromDays / FromTicks`

### What it doesn't flag

- Call sites inside a `const` or `static readonly` field initializer — those declarations *are* the named constant, so the literal at the defining site is allowed. Per-system `*Constants.cs` files using `public static readonly TimeSpan Interval = TimeSpan.FromSeconds(3);` stay valid.
- Non-literal arguments (variables, constant references, expressions).
- Other types that happen to take numeric constructors — rule is a named allowlist.

## Why / Balance

No gameplay effect. Pure CI rule.

## Technical details

- Scope: fork-owned C# (path contains `/RussStation/` or ends in `.Honk.cs`).
- Severity: Warning, promoted to Error by `MSBuild/Content.props`'s `TreatWarningsAsErrors`.
- `TryUnwrapNumericLiteral` is duplicated inline so this PR is independent of HONK0016's merge order. Once both land, the helper can be factored into a shared internal class in a follow-up.
- 11 test cases covering Thickness/Vector2/TimeSpan fires, qualified type names, static-readonly and const exemptions, upstream-path silence, unrelated-type silence, expression-arg silence, and a `FromSeconds` lookalike on a different type.

## Media

N/A — non-visual.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. Warning-level analyzer scoped to fork files.

**Changelog**

:cl:
- fix: Magic numbers in Thickness/Vector2/Color/UIBox constructors and TimeSpan.FromX calls now fail CI on fork code so they can't sneak into future PRs.