### PR TITLE
honksquad: feat: Escape cancels active DoAfters (#513)

### DIFF
--- a/Content.Client/RussStation/DoAfterCancel/DoAfterCancelRequestSystem.cs
+++ b/Content.Client/RussStation/DoAfterCancel/DoAfterCancelRequestSystem.cs
@@ -1,0 +1,43 @@
+using Content.Shared.DoAfter;
+using Content.Shared.RussStation.DoAfterCancel;
+using Robust.Client.Player;
+
+namespace Content.Client.RussStation.DoAfterCancel;
+
+/// <summary>
+/// Client hook for honksquad #513. <see cref="TryRequestCancel"/> checks
+/// whether the local player has any active DoAfters and, if so, asks the
+/// server to cancel them all; the server is authoritative and broadcasts
+/// the result. Returns true when a request was sent so callers (the
+/// Escape key handler) can consume the input.
+/// </summary>
+public sealed class DoAfterCancelRequestSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    public bool TryRequestCancel()
+    {
+        if (_player.LocalEntity is not { } player)
+            return false;
+
+        if (!TryComp<DoAfterComponent>(player, out var comp))
+            return false;
+
+        var hasActive = false;
+        foreach (var doAfter in comp.DoAfters.Values)
+        {
+            if (doAfter.Cancelled || doAfter.Completed)
+                continue;
+            if (doAfter.Args.User != player)
+                continue;
+            hasActive = true;
+            break;
+        }
+
+        if (!hasActive)
+            return false;
+
+        RaiseNetworkEvent(new CancelAllDoAftersEvent());
+        return true;
+    }
+}

--- a/Content.Client/UserInterface/Systems/EscapeMenu/EscapeContextUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/EscapeContextUIController.cs
@@ -34,14 +34,14 @@ public sealed class EscapeContextUIController : UIController
         if (_closeRecentWindowUIController.HasClosableWindow())
         {
             _closeRecentWindowUIController.CloseMostRecentWindow();
-            return;
         }
-
-        // HONK START - honksquad #513: cancel active DoAfters before opening the escape menu
-        if (_entityManager.System<DoAfterCancelRequestSystem>().TryRequestCancel())
-            return;
-        // HONK END
-
-        _escapeUIController.ToggleWindow();
+        else
+        {
+            // HONK START - honksquad #513: cancel active DoAfters before opening the escape menu
+            if (_entityManager.System<DoAfterCancelRequestSystem>().TryRequestCancel())
+                return;
+            // HONK END
+            _escapeUIController.ToggleWindow();
+        }
     }
 }

--- a/Content.Client/UserInterface/Systems/EscapeMenu/EscapeContextUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/EscapeContextUIController.cs
@@ -1,4 +1,7 @@
 ﻿using Content.Client.UserInterface.Systems.Info;
+// HONK START - honksquad #513: Escape cancels active DoAfters before falling through to window/menu
+using Content.Client.RussStation.DoAfterCancel;
+// HONK END
 using Content.Shared.Input;
 using JetBrains.Annotations;
 using Robust.Client.Input;
@@ -16,6 +19,9 @@ public sealed class EscapeContextUIController : UIController
 
     [Dependency] private readonly CloseRecentWindowUIController _closeRecentWindowUIController = default!;
     [Dependency] private readonly EscapeUIController _escapeUIController = default!;
+    // HONK START - honksquad #513
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    // HONK END
 
     public override void Initialize()
     {
@@ -28,10 +34,14 @@ public sealed class EscapeContextUIController : UIController
         if (_closeRecentWindowUIController.HasClosableWindow())
         {
             _closeRecentWindowUIController.CloseMostRecentWindow();
+            return;
         }
-        else
-        {
-            _escapeUIController.ToggleWindow();
-        }
+
+        // HONK START - honksquad #513: cancel active DoAfters before opening the escape menu
+        if (_entityManager.System<DoAfterCancelRequestSystem>().TryRequestCancel())
+            return;
+        // HONK END
+
+        _escapeUIController.ToggleWindow();
     }
 }

--- a/Content.Server/RussStation/DoAfterCancel/DoAfterCancelSystem.cs
+++ b/Content.Server/RussStation/DoAfterCancel/DoAfterCancelSystem.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Content.Shared.DoAfter;
+using Content.Shared.RussStation.DoAfterCancel;
+
+namespace Content.Server.RussStation.DoAfterCancel;
+
+/// <summary>
+/// Handles <see cref="CancelAllDoAftersEvent"/>. Iterates the sender's
+/// <see cref="DoAfterComponent"/> and cancels every DoAfter where the
+/// sender is <see cref="DoAfterArgs.User"/>, i.e. actions the player
+/// started themselves. Hostile DoAfters where the player is merely the
+/// target live on a different user's component and are untouched.
+/// </summary>
+public sealed class DoAfterCancelSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<CancelAllDoAftersEvent>(OnCancelRequest);
+    }
+
+    private void OnCancelRequest(CancelAllDoAftersEvent ev, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } player)
+            return;
+
+        if (!TryComp<DoAfterComponent>(player, out var comp))
+            return;
+
+        // Cancel() mutates the dictionary via Dirty / state replication,
+        // and InternalCancel can raise events whose handlers may enqueue
+        // more DoAfters; snapshot the pairs first.
+        foreach (var (id, doAfter) in comp.DoAfters.ToArray())
+        {
+            if (doAfter.Cancelled || doAfter.Completed)
+                continue;
+
+            if (doAfter.Args.User != player)
+                continue;
+
+            _doAfter.Cancel(player, id, comp);
+        }
+    }
+}

--- a/Content.Shared/RussStation/DoAfterCancel/CancelAllDoAftersEvent.cs
+++ b/Content.Shared/RussStation/DoAfterCancel/CancelAllDoAftersEvent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.DoAfterCancel;
+
+/// <summary>
+/// Sent client -> server when the local player pressed Escape with no UI
+/// capturing input. The server cancels every active DoAfter where the
+/// sender's attached entity is the DoAfter user; forced DoAfters where
+/// the player is merely the target stay running.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class CancelAllDoAftersEvent : EntityEventArgs;


### PR DESCRIPTION
Closes #513.

## About the PR

One key, one behavior: pressing Escape with no UI in the way cancels every active progress-bar action the local player started. No more getting stuck in an eating/drinking DoAfter that doesn't break on movement.

Server-authoritative — the client sends `CancelAllDoAftersEvent`, the server iterates the sender's `DoAfterComponent` and invokes `SharedDoAfterSystem.Cancel` for each match. The progress bar disappears because the action actually ended, not because the client predicted it away.

## Why / Balance

No balance impact. Escape is an explicit-intent override — it ignores `BreakOnMove` / `BreakOnDamage` / `DistanceThreshold` because the player is saying "stop" directly. Existing break flags on individual DoAfters are untouched.

## Technical details

**Escape flow (unchanged order, one new step):**

1. Closable window open → close it (existing behavior).
2. Else local player has at least one active DoAfter where `Args.User == localEntity` → send `CancelAllDoAftersEvent`, consume the press (new).
3. Else → toggle the escape menu (existing behavior).

UI precedence is already handled by Robust's input-context system: when chat / a text field / a modal is capturing keyboard input, `EscapeContext` isn't active, so this path never runs.

**Scope decision — `Args.User == sender` only.** DoAfters where the player is merely the target (hostile grabs, being stripped, admin-forced) live on a different user's `DoAfterComponent` and aren't touched, matching the spec's "forced actions are not cancellable" rule. Broadening to cover the "willing target" case (e.g. being helped up by a medic) would require a consent flag that `DoAfterArgs` doesn't currently expose — out of scope.

**New files (fork-owned):**
- `Content.Shared/RussStation/DoAfterCancel/CancelAllDoAftersEvent.cs`
- `Content.Server/RussStation/DoAfterCancel/DoAfterCancelSystem.cs`
- `Content.Client/RussStation/DoAfterCancel/DoAfterCancelRequestSystem.cs`

**In-place edit** to `Content.Client/UserInterface/Systems/EscapeMenu/EscapeContextUIController.cs` is wrapped in `// HONK START` / `// HONK END` markers. Adds one `using`, one `[Dependency] IEntityManager`, and one early-return branch in `CloseWindowOrOpenGameMenu`. No other upstream files touched.

## Media

N/A — input-handler behavior, no visuals beyond the progress bar disappearing.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. Additive behavior on Escape; all existing Escape handling (close window, open menu) is preserved in the same order.

**Changelog**

:cl:
- tweak: Escape now cancels any active progress-bar action you started (eating, drinking, channeled actions, etc.), as long as no menu or text field is in the way.