### PR TITLE
honksquad: feat: wound healing via surgery + slow natural regen (#505)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRegenTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRegenTest.cs
@@ -1,0 +1,119 @@
+using Content.Server.RussStation.Wounds;
+using Content.Shared.RussStation.Wounds;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Wounds;
+
+[TestFixture]
+[TestOf(typeof(WoundRegenSystem))]
+public sealed class WoundRegenTest
+{
+    // Sentinel "well past any tick" time used where the test needs a wound
+    // entry that must not decay during the test window.
+    private static readonly TimeSpan FarFuture = TimeSpan.FromHours(1);
+
+
+    [Test]
+    public async Task DueWoundDropsOneTier()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
+            var comp = entityManager.AddComponent<WoundComponent>(entity);
+
+            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 3) { NextDecayTime = TimeSpan.Zero });
+
+            entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
+
+            Assert.That(comp.ActiveWounds, Has.Count.EqualTo(1));
+            Assert.That(comp.ActiveWounds[0].Tier, Is.EqualTo(2),
+                "Due tier-3 wound should have decayed exactly one tier.");
+            Assert.That(comp.ActiveWounds[0].NextDecayTime, Is.GreaterThan(TimeSpan.Zero),
+                "Next decay time should have been rescheduled.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task NotDueWoundIsUntouched()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
+            var comp = entityManager.AddComponent<WoundComponent>(entity);
+
+            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 3) { NextDecayTime = FarFuture });
+
+            entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
+
+            Assert.That(comp.ActiveWounds[0].Tier, Is.EqualTo(3),
+                "Wound whose NextDecayTime is in the future should not decay.");
+            Assert.That(comp.ActiveWounds[0].NextDecayTime, Is.EqualTo(FarFuture));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task Tier1WoundIsRemovedOnDue()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
+            var comp = entityManager.AddComponent<WoundComponent>(entity);
+
+            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
+
+            entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
+
+            Assert.That(comp.ActiveWounds, Is.Empty,
+                "Tier-1 wound whose decay timer expired should be removed entirely.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ExpiredWoundCoexistsWithHealthySameCategoryWound()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
+            var comp = entityManager.AddComponent<WoundComponent>(entity);
+
+            // One tier-1 Burn due to expire (will be removed) + one tier-3 Burn that stays.
+            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
+            comp.ActiveWounds.Add(new WoundEntry("ColdBurn", 3) { NextDecayTime = FarFuture });
+
+            entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
+
+            Assert.That(comp.ActiveWounds, Has.Count.EqualTo(1),
+                "Expired tier-1 wound should be removed while the healthy one stays.");
+            Assert.That(comp.ActiveWounds[0].WoundTypeId.Id, Is.EqualTo("ColdBurn"),
+                "The surviving wound should be the one whose decay timer had not expired.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
@@ -105,6 +105,10 @@ public sealed partial class SurgerySystem
                 OpenOrganRemovalMenu(surgeon, patient);
                 break;
 
+            case ClearWoundCategoryEffect clear:
+                _wounds.ClearWoundsByCategory(patient, clear.Category);
+                break;
+
             default:
                 Log.Warning($"Unhandled surgery effect type: {effect.GetType().Name} on {ToPrettyString(patient)}");
                 break;

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Popups;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.RussStation.Surgery.Systems;
+using Content.Shared.RussStation.Wounds.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Tag;
 using Content.Shared.Tools;
@@ -34,6 +35,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     [Dependency] private readonly TagSystem _tags = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly SharedWoundSystem _wounds = default!;
 
     [Dependency] private readonly EntityQuery<SurgeryDrapedComponent> _drapedQuery = default!;
     [Dependency] private readonly EntityQuery<ActiveSurgeryComponent> _activeSurgeryQuery = default!;

--- a/Content.Server/RussStation/Wounds/WoundRegenSystem.cs
+++ b/Content.Server/RussStation/Wounds/WoundRegenSystem.cs
@@ -1,0 +1,112 @@
+using Content.Shared.Mobs.Systems;
+using Content.Shared.RussStation.Wounds;
+using Content.Shared.RussStation.Wounds.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server.RussStation.Wounds;
+
+/// <summary>
+/// Server-side natural regen for <see cref="WoundComponent"/>: once per
+/// <see cref="WoundsConstants.RegenTickSeconds"/> interval, walks every
+/// wound whose <see cref="WoundEntry.NextDecayTime"/> has elapsed and drops
+/// its tier by one. Wounds whose tier falls below 1 are removed. Dead mobs
+/// are skipped — rotting flesh does not heal, and this matches the spec's
+/// "untreated wounds resolve over minutes" framing for live patients.
+/// </summary>
+public sealed class WoundRegenSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedWoundSystem _wounds = default!;
+
+    private TimeSpan _nextTick;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _nextTick = _timing.CurTime + TimeSpan.FromSeconds(WoundsConstants.RegenTickSeconds);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_timing.CurTime < _nextTick)
+            return;
+
+        _nextTick = _timing.CurTime + TimeSpan.FromSeconds(WoundsConstants.RegenTickSeconds);
+
+        var query = EntityQueryEnumerator<WoundComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.ActiveWounds.Count == 0)
+                continue;
+
+            if (_mobState.IsDead(uid))
+                continue;
+
+            DecayWounds(uid, comp);
+        }
+    }
+
+    /// <summary>
+    /// Drops every due wound by one tier, removes tier-1 wounds whose timer
+    /// expired, and fires <see cref="WoundsClearedEvent"/> for each category
+    /// that fully empties. Public so integration tests can drive the decay
+    /// step without having to advance sim time past the per-tick throttle.
+    /// </summary>
+    public void DecayWounds(EntityUid uid, WoundComponent comp)
+    {
+        var changed = false;
+        var clearedCategory = false;
+        var now = _timing.CurTime;
+
+        for (var i = comp.ActiveWounds.Count - 1; i >= 0; i--)
+        {
+            var wound = comp.ActiveWounds[i];
+            if (wound.NextDecayTime > now)
+                continue;
+
+            if (wound.Tier <= 1)
+            {
+                comp.ActiveWounds.RemoveAt(i);
+                changed = true;
+                if (IsCategoryCleared(comp, wound))
+                    clearedCategory = true;
+                continue;
+            }
+
+            wound.Tier -= 1;
+            wound.NextDecayTime = now + SharedWoundSystem.GetTierDecayDuration(wound.Tier);
+            changed = true;
+        }
+
+        if (!changed)
+            return;
+
+        Dirty(uid, comp);
+        if (clearedCategory)
+            RaiseLocalEvent(uid, new WoundsClearedEvent());
+    }
+
+    /// <summary>
+    /// True if no remaining wound shares the just-removed entry's category.
+    /// Orphan entries whose prototype is gone are treated as cleared so stale
+    /// state doesn't suppress the refresh event.
+    /// </summary>
+    private bool IsCategoryCleared(WoundComponent comp, WoundEntry removed)
+    {
+        if (!_proto.TryIndex(removed.WoundTypeId, out var removedProto))
+            return true;
+
+        foreach (var wound in comp.ActiveWounds)
+        {
+            if (_proto.TryIndex(wound.WoundTypeId, out var proto) && proto.Category == removedProto.Category)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Server/RussStation/Wounds/WoundRegenSystem.cs
+++ b/Content.Server/RussStation/Wounds/WoundRegenSystem.cs
@@ -19,7 +19,6 @@ public sealed class WoundRegenSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
-    [Dependency] private readonly SharedWoundSystem _wounds = default!;
 
     private TimeSpan _nextTick;
 

--- a/Content.Shared/RussStation/Surgery/Effects/ClearWoundCategoryEffect.cs
+++ b/Content.Shared/RussStation/Surgery/Effects/ClearWoundCategoryEffect.cs
@@ -1,0 +1,17 @@
+using Content.Shared.RussStation.Wounds;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Content.Shared.RussStation.Surgery.Effects;
+
+/// <summary>
+/// Surgery effect: clears every wound in <see cref="Category"/> on the patient
+/// when the step completes. Used by external repair procedures (fracture
+/// setting, burn treatment) that don't need to open the body cavity and
+/// should bypass the tend-wounds damage-healing path.
+/// </summary>
+[DataDefinition]
+public sealed partial class ClearWoundCategoryEffect : ISurgeryEffect
+{
+    [DataField(required: true)]
+    public WoundCategory Category;
+}

--- a/Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs
+++ b/Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs
@@ -113,7 +113,7 @@ public abstract class SharedWoundSystem : EntitySystem
         return tier;
     }
 
-    private static bool ApplyWound(WoundComponent comp, WoundTypePrototype proto, int tier)
+    private bool ApplyWound(WoundComponent comp, WoundTypePrototype proto, int tier)
     {
         // Try to upgrade an existing wound of this type first
         var existingCount = 0;
@@ -127,6 +127,7 @@ public abstract class SharedWoundSystem : EntitySystem
             if (wound.Tier < tier)
             {
                 wound.Tier = tier;
+                wound.NextDecayTime = _timing.CurTime + GetTierDecayDuration(tier);
                 return true;
             }
 
@@ -142,8 +143,27 @@ public abstract class SharedWoundSystem : EntitySystem
             return false;
 
         // Create new wound entry
-        comp.ActiveWounds.Add(new WoundEntry(proto.ID, tier));
+        comp.ActiveWounds.Add(new WoundEntry(proto.ID, tier)
+        {
+            NextDecayTime = _timing.CurTime + GetTierDecayDuration(tier),
+        });
         return true;
+    }
+
+    /// <summary>
+    /// Seconds-until-next-drop budget for a wound at the given tier. Returns
+    /// <see cref="TimeSpan.Zero"/> for invalid tiers so the caller can treat
+    /// them as already-expired.
+    /// </summary>
+    public static TimeSpan GetTierDecayDuration(int tier)
+    {
+        return tier switch
+        {
+            3 => TimeSpan.FromSeconds(WoundsConstants.Tier3DecaySeconds),
+            2 => TimeSpan.FromSeconds(WoundsConstants.Tier2DecaySeconds),
+            1 => TimeSpan.FromSeconds(WoundsConstants.Tier1DecaySeconds),
+            _ => TimeSpan.Zero,
+        };
     }
 
     /// <summary>

--- a/Content.Shared/RussStation/Wounds/WoundEntry.cs
+++ b/Content.Shared/RussStation/Wounds/WoundEntry.cs
@@ -12,6 +12,15 @@ public sealed partial class WoundEntry
     [DataField]
     public int Tier;
 
+    /// <summary>
+    /// Game time at which this wound's next natural-regen tier drop is due.
+    /// Set by <see cref="Systems.SharedWoundSystem"/> on application or tier
+    /// upgrade and decremented by the server-side regen tick. Replicated so
+    /// the client never lags the actual tier value.
+    /// </summary>
+    [DataField]
+    public TimeSpan NextDecayTime;
+
     public WoundEntry(ProtoId<WoundTypePrototype> woundTypeId, int tier)
     {
         WoundTypeId = woundTypeId;

--- a/Content.Shared/RussStation/Wounds/WoundsConstants.cs
+++ b/Content.Shared/RussStation/Wounds/WoundsConstants.cs
@@ -33,4 +33,25 @@ public static class WoundsConstants
     /// fracture / burn tiers into the alert widget (tier 1 = severity 0).
     /// </summary>
     public const short AlertSeverityTierOffset = 1;
+
+    /// <summary>
+    /// How often the server sweeps <see cref="WoundComponent"/> entries
+    /// to apply natural regen. Coarse by design — tier decay is minute-scale.
+    /// </summary>
+    public const float RegenTickSeconds = 10f;
+
+    /// <summary>
+    /// Seconds an untreated tier-3 wound spends before dropping to tier 2.
+    /// </summary>
+    public const float Tier3DecaySeconds = 120f;
+
+    /// <summary>
+    /// Seconds an untreated tier-2 wound spends before dropping to tier 1.
+    /// </summary>
+    public const float Tier2DecaySeconds = 180f;
+
+    /// <summary>
+    /// Seconds an untreated tier-1 wound spends before being removed.
+    /// </summary>
+    public const float Tier1DecaySeconds = 300f;
 }

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -18,6 +18,8 @@ surgery-step-cauterize = {CAPITALIZE(THE($user))} cauterizes the wound on {THE($
 surgery-step-treat-brute = {CAPITALIZE(THE($user))} repairs physical damage on {THE($target)}.
 surgery-step-treat-burn = {CAPITALIZE(THE($user))} treats burn damage on {THE($target)}.
 surgery-step-remove-organ = {CAPITALIZE(THE($user))} carefully extracts an organ from {THE($target)}.
+surgery-step-set-bones = {CAPITALIZE(THE($user))} sets {POSS-ADJ($target)} broken bones.
+surgery-step-treat-burn-wounds = {CAPITALIZE(THE($user))} dresses and cauterizes {POSS-ADJ($target)} burns.
 
 ## Alerts
 alerts-surgery-draped-name = Surgical Drapes
@@ -67,3 +69,5 @@ tool-quality-draping-tool-name = Drape
 surgery-procedure-tend-wounds-brute = Tend Wounds (Brute)
 surgery-procedure-tend-wounds-burn = Tend Wounds (Burn)
 surgery-procedure-organ-manipulation = Organ Manipulation
+surgery-procedure-wound-repair-fracture = Set Fractures
+surgery-procedure-wound-repair-burn = Treat Burns

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_burn.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_burn.yml
@@ -1,0 +1,14 @@
+- type: surgeryProcedure
+  id: WoundRepairBurn
+  name: surgery-procedure-wound-repair-burn
+  description: Cauterize and dress burn wounds to clear burn damage.
+  icon:
+    sprite: "@RussStation/Interface/Alerts/wounds.rsi"
+    state: burn_icon
+  difficulty: Minor
+  steps:
+    - quality: Cauterizing
+      duration: 6
+      popup: surgery-step-treat-burn-wounds
+      effect: !type:ClearWoundCategoryEffect
+        category: Burn

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_fracture.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_fracture.yml
@@ -1,0 +1,14 @@
+- type: surgeryProcedure
+  id: WoundRepairFracture
+  name: surgery-procedure-wound-repair-fracture
+  description: Manually set broken bones to clear fractures.
+  icon:
+    sprite: "@RussStation/Interface/Alerts/wounds.rsi"
+    state: brute_icon
+  difficulty: Minor
+  steps:
+    - quality: BoneSetting
+      duration: 6
+      popup: surgery-step-set-bones
+      effect: !type:ClearWoundCategoryEffect
+        category: Fracture


### PR DESCRIPTION
Closes #505.

## About the PR

Wounds (fractures, burns) are applied by `SharedWoundSystem.OnDamageChanged` but today only come back down through `RejuvenateEvent`. This PR adds two independently-useful removal paths so a single heavy hit doesn't permanently cripple a patient:

1. **Surgical clearing** — new per-category surgery procedures on the draped patient.
2. **Slow natural regen** — untreated wounds decay one tier at a time over in-game minutes.

## Why / Balance

Closes a one-way ratchet that had been forcing admin intervention or round-end for any stacked tier-3 wound. Natural regen is slow on purpose (2 min tier-3→2, 3 min tier-2→1, 5 min tier-1→cleared) so surgery is still the fast path. Dead mobs are skipped so corpses don't quietly heal.

All four "open questions" in the issue were answered with the conservative default and can be tuned from `WoundsConstants` once playtest data arrives.

## Technical details

**Surgical clearing**

- `ClearWoundCategoryEffect : ISurgeryEffect` carrying a `WoundCategory` field.
- `SurgerySystem.HandleEffect` gains a branch calling `SharedWoundSystem.ClearWoundsByCategory(patient, clear.Category)`.
- Two new single-step procedures — `WoundRepairFracture` (BoneSetting quality) and `WoundRepairBurn` (Cauterizing quality) — reusing existing tool qualities. Fixed 6s duration per step; tier-scaled duration is out of scope.

**Natural regen**

- `WoundEntry` gains `NextDecayTime`. `SharedWoundSystem.ApplyWound` sets it on creation and on tier upgrade to `now + GetTierDecayDuration(tier)`. Replicated via the existing `ActiveWounds` `[AutoNetworkedField]`, so client tiers track server state.
- `WoundRegenSystem.Update` runs every `RegenTickSeconds` (10s throttle), walks every `WoundComponent`, and for each due wound either drops its tier by one and reschedules, or (at tier 1) removes the entry. Dead mobs skipped via `MobStateSystem.IsDead`.
- `WoundsClearedEvent` fires only when a category fully empties, so the alert / display systems refresh at the right moment.

**Scope filter**

- No bleed or medbed gating. No new reagents. Existing `BreakOnMove` / distance rules on other DoAfters untouched (surgery already uses the shared surgery DoAfter flow).
- No upstream files edited — all changes live under `Content.*/RussStation/`, the shared wound types, or `Resources/Prototypes/@RussStation/`.

**Files**

New: `ClearWoundCategoryEffect.cs`, `WoundRegenSystem.cs`, `WoundRegenTest.cs`, `wound_repair_fracture.yml`, `wound_repair_burn.yml`.
Modified: `SurgerySystem.cs` (one dep + using), `SurgerySystem.Healing.cs` (one switch arm), `SharedWoundSystem.cs` (set `NextDecayTime` on apply/upgrade, new `GetTierDecayDuration` helper), `WoundEntry.cs` (new field), `WoundsConstants.cs` (4 new intervals), `surgery.ftl` (step popups + procedure names).

## Media

N/A — mechanics are visible via the existing wound alerts and health analyzer, both of which refresh automatically on `WoundsClearedEvent`.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. Additive surgery procedures + server-side regen tick. `WoundEntry` gains one optional field; existing entries load with default `TimeSpan.Zero` which the regen system treats as immediately-due, but the first regen sweep will simply drop them one tier — intended behavior for in-flight wounds after deploy.

## Test plan

Integration coverage in `WoundRegenTest`:
- [x] Tier-3 wound with expired `NextDecayTime` drops to tier 2 and reschedules.
- [x] Wound whose `NextDecayTime` is in the future is untouched.
- [x] Tier-1 wound with expired timer is removed entirely.
- [x] Expired wound is removed while a same-category healthy wound stays intact.

Manual / in-game checks:
- [x] Damage a patient to tier-3 fracture; run `WoundRepairFracture` with a bonesetter on a draped patient; fracture alert clears.
- [x] Damage a patient to tier-3 burn; run `WoundRepairBurn` with a cautery; burn alert clears.
- [x] Leave a patient idle with a tier-2 fracture; after ~3 min it drops to tier 1; after another ~5 min the alert clears entirely.
- [ ] Kill a mob mid-regen; confirm no further decay ticks apply.

**Changelog**

:cl:
- add: Doctors can now clear fractures with bonesetting surgery and burns with cautery surgery on a draped patient.
- add: Untreated wounds now slowly heal on their own over several minutes — tier-3 down to tier-2 in ~2 min, all the way cleared in ~10 min. Dead bodies don't regenerate.