### PR TITLE
feat: group surgery procedures into category submenu

### DIFF
--- a/Content.Client/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Client/RussStation/Surgery/SurgerySystem.cs
@@ -10,6 +10,9 @@ public sealed class SurgerySystem : SharedSurgerySystem
 {
     private SimpleRadialMenu? _menu;
 
+    private static readonly SpriteSpecifier DefaultProcedureIcon = new SpriteSpecifier.Rsi(
+        new ResPath("Objects/Specific/Medical/Surgery/scalpel.rsi"), "scalpel");
+
     public override void Initialize()
     {
         base.Initialize();
@@ -22,8 +25,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
     {
         CloseMenu();
 
-        var buttons = new List<RadialMenuOptionBase>();
-
+        var byCategory = new Dictionary<SurgeryCategory, List<(string Id, SurgeryProcedurePrototype Proto)>>();
         foreach (var procedureId in ev.ProcedureIds)
         {
             if (!ProtoManager.TryIndex<SurgeryProcedurePrototype>(procedureId, out var proto))
@@ -32,29 +34,45 @@ public sealed class SurgerySystem : SharedSurgerySystem
                 continue;
             }
 
-            var id = procedureId;
-            var target = ev.Target;
-            var bedsheet = ev.Bedsheet;
+            if (!byCategory.TryGetValue(proto.Category, out var list))
+                byCategory[proto.Category] = list = new List<(string, SurgeryProcedurePrototype)>();
+            list.Add((procedureId, proto));
+        }
 
-            var icon = proto.Icon
-                ?? new SpriteSpecifier.Rsi(
-                    new ResPath("Objects/Specific/Medical/Surgery/scalpel.rsi"),
-                    "scalpel");
+        var topLevel = new List<RadialMenuOptionBase>();
+        foreach (var category in CategoryDisplayOrder)
+        {
+            if (!byCategory.TryGetValue(category, out var procedures) || procedures.Count == 0)
+                continue;
 
-            buttons.Add(new RadialMenuActionOption<string>(
-                _ => OnProcedureSelected(target, bedsheet, id),
-                id)
+            var nested = new List<RadialMenuOptionBase>();
+            foreach (var (id, proto) in procedures)
             {
-                ToolTip = Loc.GetString(proto.Name),
-                IconSpecifier = RadialMenuIconSpecifier.With(icon),
+                var capturedId = id;
+                var target = ev.Target;
+                var bedsheet = ev.Bedsheet;
+
+                nested.Add(new RadialMenuActionOption<string>(
+                    _ => OnProcedureSelected(target, bedsheet, capturedId),
+                    capturedId)
+                {
+                    ToolTip = Loc.GetString(proto.Name),
+                    IconSpecifier = RadialMenuIconSpecifier.With(proto.Icon ?? DefaultProcedureIcon),
+                });
+            }
+
+            topLevel.Add(new RadialMenuNestedLayerOption(nested)
+            {
+                ToolTip = Loc.GetString(CategoryLocale(category)),
+                IconSpecifier = RadialMenuIconSpecifier.With(CategoryIcon(category)),
             });
         }
 
-        if (buttons.Count == 0)
+        if (topLevel.Count == 0)
             return;
 
         _menu = new SimpleRadialMenu();
-        _menu.SetButtons(buttons);
+        _menu.SetButtons(topLevel);
         _menu.OpenOverMouseScreenPosition();
     }
 
@@ -110,4 +128,34 @@ public sealed class SurgerySystem : SharedSurgerySystem
         _menu?.Close();
         _menu = null;
     }
+
+    private static readonly SurgeryCategory[] CategoryDisplayOrder =
+    {
+        SurgeryCategory.WoundRepair,
+        SurgeryCategory.TendWounds,
+        SurgeryCategory.OrganManipulation,
+        SurgeryCategory.Implants,
+        SurgeryCategory.Advanced,
+    };
+
+    private static string CategoryLocale(SurgeryCategory category) => category switch
+    {
+        SurgeryCategory.WoundRepair => "surgery-category-wound-repair",
+        SurgeryCategory.TendWounds => "surgery-category-tend-wounds",
+        SurgeryCategory.OrganManipulation => "surgery-category-organ-manipulation",
+        SurgeryCategory.Implants => "surgery-category-implants",
+        SurgeryCategory.Advanced => "surgery-category-advanced",
+        _ => category.ToString(),
+    };
+
+    private static SpriteSpecifier CategoryIcon(SurgeryCategory category) => category switch
+    {
+        SurgeryCategory.WoundRepair => new SpriteSpecifier.EntityPrototype("SurgicalDrape"),
+        SurgeryCategory.TendWounds => new SpriteSpecifier.EntityPrototype("Hemostat"),
+        SurgeryCategory.OrganManipulation => new SpriteSpecifier.Rsi(
+            new ResPath("@RussStation/Interface/Surgery/procedures.rsi"), "organmanipulation_icon"),
+        SurgeryCategory.Implants => new SpriteSpecifier.EntityPrototype("Scalpel"),
+        SurgeryCategory.Advanced => new SpriteSpecifier.EntityPrototype("Scalpel"),
+        _ => DefaultProcedureIcon,
+    };
 }

--- a/Content.Shared/RussStation/Surgery/SurgeryCategory.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryCategory.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared.RussStation.Surgery;
+
+/// <summary>
+/// Top-level grouping for surgery procedures in the selection radial menu.
+/// </summary>
+public enum SurgeryCategory : byte
+{
+    WoundRepair,
+    TendWounds,
+    OrganManipulation,
+    Implants,
+    Advanced,
+}

--- a/Content.Shared/RussStation/Surgery/SurgeryProcedurePrototype.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryProcedurePrototype.cs
@@ -110,4 +110,10 @@ public sealed partial class SurgeryProcedurePrototype : IPrototype
     /// </summary>
     [DataField]
     public SurgeryDifficulty Difficulty = SurgeryDifficulty.Standard;
+
+    /// <summary>
+    /// Top-level category the procedure is grouped under in the selection radial menu.
+    /// </summary>
+    [DataField]
+    public SurgeryCategory Category = SurgeryCategory.WoundRepair;
 }

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -71,3 +71,10 @@ surgery-procedure-tend-wounds-burn = Tend Wounds (Burn)
 surgery-procedure-organ-manipulation = Organ Manipulation
 surgery-procedure-wound-repair-fracture = Set Fractures
 surgery-procedure-wound-repair-burn = Treat Burns
+
+## Procedure Categories
+surgery-category-wound-repair = Wound Repair
+surgery-category-tend-wounds = Tend Wounds
+surgery-category-organ-manipulation = Organ Manipulation
+surgery-category-implants = Implants
+surgery-category-advanced = Advanced

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/organ_manipulation.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/organ_manipulation.yml
@@ -5,6 +5,7 @@
   icon:
     sprite: "@RussStation/Interface/Surgery/procedures.rsi"
     state: organmanipulation_icon
+  category: OrganManipulation
   difficulty: Major
   steps:
     - quality: Slicing

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_brute.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_brute.yml
@@ -5,6 +5,7 @@
   icon:
     sprite: "@RussStation/Interface/Alerts/wounds.rsi"
     state: brute_icon
+  category: TendWounds
   difficulty: Minor
   steps:
     - quality: Slicing

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_burn.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_burn.yml
@@ -5,6 +5,7 @@
   icon:
     sprite: "@RussStation/Interface/Alerts/wounds.rsi"
     state: burn_icon
+  category: TendWounds
   difficulty: Minor
   steps:
     - quality: Slicing

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_burn.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_burn.yml
@@ -5,6 +5,7 @@
   icon:
     sprite: "@RussStation/Interface/Alerts/wounds.rsi"
     state: burn_icon
+  category: WoundRepair
   difficulty: Minor
   steps:
     - quality: Cauterizing

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_fracture.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_fracture.yml
@@ -5,6 +5,7 @@
   icon:
     sprite: "@RussStation/Interface/Alerts/wounds.rsi"
     state: brute_icon
+  category: WoundRepair
   difficulty: Minor
   steps:
     - quality: BoneSetting


### PR DESCRIPTION
## About the PR

Adds a top-level category layer to the surgery procedure radial. The drape now opens Wound Repair / Tend Wounds / Organ Manipulation as the outer ring, with the existing procedures nested one layer in.

## Why / Balance

With 5 procedures already and Organ Manipulation, Implants, and Advanced on the roadmap, a single flat radial becomes a guessing game. Categories match SS13's mental model: Wound Repair clears a specific `WoundCategory`, Tend Wounds is the tiered hemostat grind for raw damage numbers, Organ Manipulation is its own thing. Implants and Advanced are reserved slots, hidden until a procedure lands in them.

## Technical details

- `SurgeryCategory` enum (`WoundRepair`, `TendWounds`, `OrganManipulation`, `Implants`, `Advanced`) on `SurgeryProcedurePrototype`.
- Client `SurgerySystem` groups by category and uses `RadialMenuNestedLayerOption` so the engine handles back/forward navigation, no custom state.
- Empty categories are filtered out of the top-level list.
- Category icons: surgical drape for Wound Repair, hemostat for Tend Wounds, existing procedures.rsi sprite for Organ Manipulation.
- Server protocol unchanged, category grouping is purely client-side.

## Media

Will attach after in-game test.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None. Existing procedures default to `WoundRepair` if the `category` field is omitted.

**Changelog**

:cl:
- add: Surgery procedures are now grouped into categories in the drape radial menu.