### PR TITLE
fix: drape renders over prone mobs when dropped

### DIFF
--- a/Resources/Prototypes/@RussStation/Surgery/surgical_drape.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/surgical_drape.yml
@@ -7,6 +7,7 @@
     - type: Sprite
       sprite: "@RussStation/Objects/Medical/surgicaldrape.rsi"
       state: drape
+      drawdepth: OverMobs
     - type: Item
       size: Small
       sprite: "@RussStation/Objects/Medical/surgicaldrape.rsi"


### PR DESCRIPTION
## About the PR

Bumps `SurgicalDrape`'s sprite drawdepth from the default `Items` to `OverMobs`, so a dropped drape stays visible when a patient is lying on the same tile.

## Why / Balance

During surgery it's common to drop the drape on the floor next to the patient. With the default item drawdepth the prone patient fully obscured it, making the drape easy to lose track of mid-procedure.

`DrawDepth` has no downed-mob layer (prone and standing mobs share `Mobs`), so `OverMobs` is the cleanest option available. Trade-off: standing mobs who walk across the dropped drape also render under it. For a flat cloth on the floor that reads fine, but flagging it since there isn't a layer that threads the gap.

## Technical details

One-line YAML change in `@RussStation/Surgery/surgical_drape.yml` adding `drawdepth: OverMobs` to the `Sprite` component.

## Media

Will attach after in-game test.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None.

**Changelog**

:cl:
- fix: A dropped surgical drape now renders above patients lying on the same tile.