### PR TITLE
feat: PopupCategory enum + categorized popup overloads (#578, PR 1/4)

### DIFF
--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -7,7 +7,9 @@ namespace Content.Shared.Popups
     /// <summary>
     ///     System for displaying small text popups on users' screens.
     /// </summary>
-    public abstract class SharedPopupSystem : EntitySystem
+    //HONK START - partial to allow SharedPopupSystem.Honk.cs to add categorized overloads without touching this file further
+    public abstract partial class SharedPopupSystem : EntitySystem
+    //HONK END
     {
         /// <summary>
         ///     Shows a popup at the local users' cursor. Does nothing on the server.

--- a/Content.Shared/RussStation/Popups/CategorizedPopupRaisedEvent.cs
+++ b/Content.Shared/RussStation/Popups/CategorizedPopupRaisedEvent.cs
@@ -1,0 +1,31 @@
+namespace Content.Shared.RussStation.Popups;
+
+/// <summary>
+/// Broadcast locally when a categorized popup is raised through the fork overloads on <see cref="Content.Shared.Popups.SharedPopupSystem"/>.
+/// Consumers (popup log, chat router, coalescer) subscribe to this instead of intercepting each <c>Popup*</c> overload.
+/// </summary>
+/// <remarks>
+/// This is a local broadcast, not a networked event. A categorized popup raised on the server does not automatically
+/// reach the client through this event; the client receives the underlying <c>PopupEvent</c> via the existing upstream path.
+/// Downstream PRs add networked category plumbing once the log UI exists to consume it.
+/// </remarks>
+public sealed class CategorizedPopupRaisedEvent : EntityEventArgs
+{
+    public string? Message { get; }
+    public PopupCategory Category { get; }
+    public Content.Shared.Popups.PopupType Type { get; }
+
+    /// <summary>
+    /// Source entity for the popup when one exists (PopupEntity / PopupClient / PopupPredicted variants).
+    /// Null for cursor and coordinate variants.
+    /// </summary>
+    public EntityUid? Source { get; }
+
+    public CategorizedPopupRaisedEvent(string? message, PopupCategory category, Content.Shared.Popups.PopupType type, EntityUid? source)
+    {
+        Message = message;
+        Category = category;
+        Type = type;
+        Source = source;
+    }
+}

--- a/Content.Shared/RussStation/Popups/PopupCategory.cs
+++ b/Content.Shared/RussStation/Popups/PopupCategory.cs
@@ -1,0 +1,41 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.Popups;
+
+/// <summary>
+/// Classifies a popup so the client can route it to the floating display, the popup log, or main chat.
+/// Callers pick the category closest to the popup's meaning; Flavor is the default for uncategorized popups.
+/// </summary>
+[Serializable, NetSerializable]
+public enum PopupCategory : byte
+{
+    /// <summary>
+    /// Ambient, cosmetic, or uncategorized. Default when a caller doesn't specify.
+    /// </summary>
+    Flavor = 0,
+
+    /// <summary>
+    /// Damage taken or dealt, miss/dodge notifications, stamina crits.
+    /// </summary>
+    Combat,
+
+    /// <summary>
+    /// Bleeding, pain, status effect onset/offset, medical alerts on self.
+    /// </summary>
+    Medical,
+
+    /// <summary>
+    /// Temperature extremes, low pressure, slips, shocks, gas exposure.
+    /// </summary>
+    Environmental,
+
+    /// <summary>
+    /// "You pick up X", "you can't reach that", action results, tool use feedback.
+    /// </summary>
+    Interaction,
+
+    /// <summary>
+    /// Admin messages and error-like popups ("nothing happens", "something is wrong").
+    /// </summary>
+    System,
+}

--- a/Content.Shared/RussStation/Popups/SharedPopupSystem.Honk.cs
+++ b/Content.Shared/RussStation/Popups/SharedPopupSystem.Honk.cs
@@ -1,0 +1,139 @@
+using Content.Shared.RussStation.Popups;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Shared.Popups;
+
+// HONK - Fork partial adding a PopupCategory-carrying overload for every public Popup* method
+// on SharedPopupSystem. Each overload forwards to the existing upstream method and broadcasts
+// a local CategorizedPopupRaisedEvent so downstream fork systems (popup log, chat router,
+// coalescer) can observe the category without touching each upstream call site. Implemented
+// non-abstract so the fork does not have to patch the client and server subclasses as well.
+// See issue #578 for the full popup categorization roadmap.
+public abstract partial class SharedPopupSystem
+{
+    private void RaiseCategorized(string? message, PopupCategory category, PopupType type, EntityUid? source)
+    {
+        RaiseLocalEvent(new CategorizedPopupRaisedEvent(message, category, type, source));
+    }
+
+    public void PopupCursor(string? message, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCursor(message, type);
+        RaiseCategorized(message, category, type, null);
+    }
+
+    public void PopupCursor(string? message, ICommonSession recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCursor(message, recipient, type);
+        RaiseCategorized(message, category, type, null);
+    }
+
+    public void PopupCursor(string? message, EntityUid recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCursor(message, recipient, type);
+        RaiseCategorized(message, category, type, recipient);
+    }
+
+    public void PopupPredictedCursor(string? message, ICommonSession recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupPredictedCursor(message, recipient, type);
+        RaiseCategorized(message, category, type, null);
+    }
+
+    public void PopupPredictedCursor(string? message, EntityUid recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupPredictedCursor(message, recipient, type);
+        RaiseCategorized(message, category, type, recipient);
+    }
+
+    public void PopupCoordinates(string? message, EntityCoordinates coordinates, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCoordinates(message, coordinates, type);
+        RaiseCategorized(message, category, type, null);
+    }
+
+    public void PopupCoordinates(string? message, EntityCoordinates coordinates, Filter filter, bool recordReplay, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCoordinates(message, coordinates, filter, recordReplay, type);
+        RaiseCategorized(message, category, type, null);
+    }
+
+    public void PopupCoordinates(string? message, EntityCoordinates coordinates, EntityUid recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCoordinates(message, coordinates, recipient, type);
+        RaiseCategorized(message, category, type, recipient);
+    }
+
+    public void PopupCoordinates(string? message, EntityCoordinates coordinates, ICommonSession recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupCoordinates(message, coordinates, recipient, type);
+        RaiseCategorized(message, category, type, null);
+    }
+
+    public void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupPredictedCoordinates(message, coordinates, recipient, type);
+        RaiseCategorized(message, category, type, recipient);
+    }
+
+    public void PopupEntity(string? message, EntityUid uid, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupEntity(message, uid, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupEntity(string? message, EntityUid uid, EntityUid recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupEntity(message, uid, recipient, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupEntity(string? message, EntityUid uid, ICommonSession recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupEntity(message, uid, recipient, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupEntity(string? message, EntityUid uid, Filter filter, bool recordReplay, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupEntity(message, uid, filter, recordReplay, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupClient(string? message, EntityUid? recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupClient(message, recipient, type);
+        RaiseCategorized(message, category, type, recipient);
+    }
+
+    public void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupClient(message, uid, recipient, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupClient(message, coordinates, recipient, type);
+        RaiseCategorized(message, category, type, recipient);
+    }
+
+    public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupPredicted(message, uid, recipient, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, Filter filter, bool recordReplay, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupPredicted(message, uid, recipient, filter, recordReplay, type);
+        RaiseCategorized(message, category, type, uid);
+    }
+
+    public void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupCategory category, PopupType type = PopupType.Small)
+    {
+        PopupPredicted(recipientMessage, othersMessage, uid, recipient, type);
+        RaiseCategorized(recipientMessage ?? othersMessage, category, type, uid);
+    }
+}


### PR DESCRIPTION
## About the PR

First PR in the issue #578 stack. Adds a `PopupCategory` enum and category-carrying overloads to every public `Popup*` method on `SharedPopupSystem`, so callers can classify popups as Combat, Medical, Environmental, Interaction, Flavor, or System. No existing call sites change. No UI or routing yet, that lands in later PRs.

## Why / Balance

Popups are ephemeral and overlap, critical info gets lost in a flurry of flavor text. The long-term goal is a scrollback log window plus per-category routing to main chat. None of that is possible without a category signal on each popup, which this PR provides.

No gameplay change lands here, the overloads are opt-in and default to `Flavor`.

## Technical details

- `Content.Shared/RussStation/Popups/PopupCategory.cs`, new enum, `[NetSerializable]` so future PRs can send it across the wire.
- `Content.Shared/RussStation/Popups/CategorizedPopupRaisedEvent.cs`, local broadcast event raised whenever a fork overload fires. The upcoming log window subscribes to this instead of touching every call site.
- `Content.Shared/RussStation/Popups/SharedPopupSystem.Honk.cs`, fork partial that adds a category-accepting overload for every public `Popup*` method. Each overload forwards to the upstream method, then raises the broadcast event.
- `Content.Shared/Popups/SharedPopupSystem.cs`, one-word upstream touch (`abstract class` to `abstract partial class`), wrapped in HONK markers, so the fork partial can share its CLR identity.

## Media

Foundation PR with no player-visible change. Media on later PRs in the stack.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None. Existing `Popup*` signatures are untouched, the new overloads are additive.