### PR TITLE
feat: floating chat input anchored above player sprite

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -21,7 +21,6 @@
                 <!-- HONK START - issue #577 floating chat input -->
                 <CheckBox Name="FloatingChatInputCheckBox" Text="{Loc 'ui-options-floating-chat-input'}" />
                 <CheckBox Name="FloatingChatInputRememberChannelCheckBox" Text="{Loc 'ui-options-floating-chat-input-remember-channel'}" Margin="20 0 0 0" />
-                <ui:OptionSlider Name="FloatingChatInputBackgroundOpacitySlider" Title="{Loc 'ui-options-floating-chat-input-background-opacity'}" Margin="20 0 0 0" />
                 <!-- HONK END -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -20,6 +20,7 @@
                 <CheckBox Name="FancyNameBackgroundsCheckBox" Text="{Loc 'ui-options-fancy-name-background'}" />
                 <!-- HONK START - issue #577 floating chat input -->
                 <CheckBox Name="FloatingChatInputCheckBox" Text="{Loc 'ui-options-floating-chat-input'}" />
+                <CheckBox Name="FloatingChatInputRememberChannelCheckBox" Text="{Loc 'ui-options-floating-chat-input-remember-channel'}" />
                 <!-- HONK END -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -20,7 +20,7 @@
                 <CheckBox Name="FancyNameBackgroundsCheckBox" Text="{Loc 'ui-options-fancy-name-background'}" />
                 <!-- HONK START - issue #577 floating chat input -->
                 <CheckBox Name="FloatingChatInputCheckBox" Text="{Loc 'ui-options-floating-chat-input'}" />
-                <CheckBox Name="FloatingChatInputRememberChannelCheckBox" Text="{Loc 'ui-options-floating-chat-input-remember-channel'}" />
+                <CheckBox Name="FloatingChatInputRememberChannelCheckBox" Text="{Loc 'ui-options-floating-chat-input-remember-channel'}" Margin="20 0 0 0" />
                 <!-- HONK END -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -21,6 +21,7 @@
                 <!-- HONK START - issue #577 floating chat input -->
                 <CheckBox Name="FloatingChatInputCheckBox" Text="{Loc 'ui-options-floating-chat-input'}" />
                 <CheckBox Name="FloatingChatInputRememberChannelCheckBox" Text="{Loc 'ui-options-floating-chat-input-remember-channel'}" Margin="20 0 0 0" />
+                <ui:OptionSlider Name="FloatingChatInputBackgroundOpacitySlider" Title="{Loc 'ui-options-floating-chat-input-background-opacity'}" Margin="20 0 0 0" />
                 <!-- HONK END -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -18,6 +18,9 @@
                 <CheckBox Name="ShowLoocAboveHeadCheckBox" Text="{Loc 'ui-options-show-looc-on-head'}" />
                 <CheckBox Name="FancySpeechBubblesCheckBox" Text="{Loc 'ui-options-fancy-speech'}" />
                 <CheckBox Name="FancyNameBackgroundsCheckBox" Text="{Loc 'ui-options-fancy-name-background'}" />
+                <!-- HONK START - issue #577 floating chat input -->
+                <CheckBox Name="FloatingChatInputCheckBox" Text="{Loc 'ui-options-floating-chat-input'}" />
+                <!-- HONK END -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ShowHeldItemCheckBox" Text="{Loc 'ui-options-show-held-item'}" />

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -51,6 +51,9 @@ public sealed partial class MiscTab : Control
         Control.AddOptionCheckBox(CCVars.OpaqueStorageWindow, OpaqueStorageWindowCheckBox);
         Control.AddOptionCheckBox(CCVars.ChatEnableFancyBubbles, FancySpeechBubblesCheckBox);
         Control.AddOptionCheckBox(CCVars.ChatFancyNameBackground, FancyNameBackgroundsCheckBox);
+        //HONK START - issue #577
+        Control.AddOptionCheckBox(CCVars.FloatingChatInput, FloatingChatInputCheckBox);
+        //HONK END
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
 
         Control.Initialize();

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -53,6 +53,7 @@ public sealed partial class MiscTab : Control
         Control.AddOptionCheckBox(CCVars.ChatFancyNameBackground, FancyNameBackgroundsCheckBox);
         //HONK START - issue #577
         Control.AddOptionCheckBox(CCVars.FloatingChatInput, FloatingChatInputCheckBox);
+        Control.AddOptionCheckBox(CCVars.FloatingChatInputRememberChannel, FloatingChatInputRememberChannelCheckBox);
         //HONK END
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
 

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -54,6 +54,7 @@ public sealed partial class MiscTab : Control
         //HONK START - issue #577
         Control.AddOptionCheckBox(CCVars.FloatingChatInput, FloatingChatInputCheckBox);
         Control.AddOptionCheckBox(CCVars.FloatingChatInputRememberChannel, FloatingChatInputRememberChannelCheckBox);
+        Control.AddOptionPercentSlider(CCVars.FloatingChatInputBackgroundOpacity, FloatingChatInputBackgroundOpacitySlider);
         //HONK END
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
 

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -54,7 +54,6 @@ public sealed partial class MiscTab : Control
         //HONK START - issue #577
         Control.AddOptionCheckBox(CCVars.FloatingChatInput, FloatingChatInputCheckBox);
         Control.AddOptionCheckBox(CCVars.FloatingChatInputRememberChannel, FloatingChatInputRememberChannelCheckBox);
-        Control.AddOptionPercentSlider(CCVars.FloatingChatInputBackgroundOpacity, FloatingChatInputBackgroundOpacitySlider);
         //HONK END
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
 

--- a/Content.Client/RussStation/Chat/FloatingChatInputConstants.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputConstants.cs
@@ -14,11 +14,4 @@ internal static class FloatingChatInputConstants
     public const byte BackgroundRed = 30;
     public const byte BackgroundGreen = 30;
     public const byte BackgroundBlue = 34;
-
-    /// <summary>
-    /// Background alpha for the input panel. The anchored HUD chat sits at
-    /// ~221/255; the floating widget overlaps the world, so we push closer
-    /// to opaque to keep typed text legible.
-    /// </summary>
-    public const byte BackgroundAlpha = 245;
 }

--- a/Content.Client/RussStation/Chat/FloatingChatInputConstants.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputConstants.cs
@@ -1,0 +1,24 @@
+// HONK — constants for the floating chat input widget. See issue #577.
+
+namespace Content.Client.RussStation.Chat;
+
+internal static class FloatingChatInputConstants
+{
+    /// <summary>World-space vertical offset above the anchor entity's origin.</summary>
+    public const float EntityVerticalOffset = 0.6f;
+
+    /// <summary>Minimum width of the input panel in pixels.</summary>
+    public const int InputMinWidth = 320;
+
+    /// <summary>Background RGB for the input panel — dark, cool-neutral.</summary>
+    public const byte BackgroundRed = 30;
+    public const byte BackgroundGreen = 30;
+    public const byte BackgroundBlue = 34;
+
+    /// <summary>
+    /// Background alpha for the input panel. The anchored HUD chat sits at
+    /// ~221/255; the floating widget overlaps the world, so we push closer
+    /// to opaque to keep typed text legible.
+    /// </summary>
+    public const byte BackgroundAlpha = 245;
+}

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -1,0 +1,111 @@
+// HONK — Floating chat input widget anchored above the local player entity.
+// Positioning mirrors Content.Client/Chat/UI/SpeechBubble.cs. See issue #577.
+
+using System.Numerics;
+using Content.Client.UserInterface.Systems.Chat.Controls;
+using Content.Shared.Chat;
+using Content.Shared.Input;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Input;
+using Robust.Shared.Timing;
+using static Robust.Client.UserInterface.Controls.LineEdit;
+
+namespace Content.Client.RussStation.Chat;
+
+/// <summary>
+/// Floating chat input that follows the local player's sprite on screen. Created on demand by
+/// <see cref="FloatingChatInputController"/> when the focus-chat keybind fires and the
+/// <c>honk.chat.floating_input</c> CVar is enabled.
+/// </summary>
+public sealed class FloatingChatInputControl : Control
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+
+    private readonly SharedTransformSystem _transform;
+
+    /// <summary>World-space vertical offset applied above the entity's origin.</summary>
+    private const float EntityVerticalOffset = 0.6f;
+
+    public readonly ChatInputBox InputBox;
+
+    private EntityUid _anchorEntity;
+    private Vector2 _contentSize;
+
+    public event Action<string, ChatSelectChannel>? OnSubmit;
+    public event Action? OnCancel;
+
+    public FloatingChatInputControl()
+    {
+        IoCManager.InjectDependencies(this);
+        _transform = _entManager.System<SharedTransformSystem>();
+
+        InputBox = new ChatInputBox
+        {
+            MinWidth = 320,
+        };
+        AddChild(InputBox);
+
+        InputBox.Input.OnTextEntered += OnTextEntered;
+        InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
+    }
+
+    public void Attach(EntityUid entity)
+    {
+        _anchorEntity = entity;
+        Measure(Vector2Helpers.Infinity);
+        _contentSize = DesiredSize;
+    }
+
+    public void FocusInput()
+    {
+        InputBox.Input.IgnoreNext = true;
+        InputBox.Input.GrabKeyboardFocus();
+    }
+
+    private void OnTextEntered(LineEditEventArgs args)
+    {
+        var text = args.Text;
+        var channel = (ChatSelectChannel) InputBox.ChannelSelector.SelectedChannel;
+        OnSubmit?.Invoke(text, channel);
+    }
+
+    private void OnInputKeyBindDown(GUIBoundKeyEventArgs args)
+    {
+        if (args.Function == EngineKeyFunctions.TextReleaseFocus)
+        {
+            args.Handle();
+            OnCancel?.Invoke();
+        }
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        if (!_entManager.TryGetComponent<TransformComponent>(_anchorEntity, out var xform)
+            || xform.MapID != _eyeManager.CurrentEye.Position.MapId)
+        {
+            Visible = false;
+            return;
+        }
+
+        Visible = true;
+
+        // Recompute content size each frame in case the input resizes as the player types.
+        Measure(Vector2Helpers.Infinity);
+        _contentSize = DesiredSize;
+
+        var offset = (-_eyeManager.CurrentEye.Rotation).ToWorldVec() * -EntityVerticalOffset;
+        var worldPos = _transform.GetWorldPosition(xform) + offset;
+
+        var anchor = _eyeManager.WorldToScreen(worldPos) / UIScale;
+        var screenPos = anchor - new Vector2(_contentSize.X / 2f, _contentSize.Y);
+        screenPos = (screenPos * 2).Rounded() / 2;
+        LayoutContainer.SetPosition(this, screenPos);
+    }
+
+}

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -31,9 +31,6 @@ public sealed class FloatingChatInputControl : Control
 
     private readonly SharedTransformSystem _transform;
 
-    /// <summary>World-space vertical offset applied above the entity's origin.</summary>
-    private const float EntityVerticalOffset = 0.6f;
-
     public readonly ChatInputBox InputBox;
 
     private EntityUid _anchorEntity;
@@ -61,7 +58,15 @@ public sealed class FloatingChatInputControl : Control
 
         InputBox = new ChatInputBox
         {
-            MinWidth = 320,
+            MinWidth = FloatingChatInputConstants.InputMinWidth,
+            // Thicker background than the anchored chat panel — the floating
+            // widget overlaps the game world, so a near-opaque fill keeps
+            // typed text legible against busy scenes.
+            PanelOverride = new StyleBoxFlat(new Color(
+                FloatingChatInputConstants.BackgroundRed,
+                FloatingChatInputConstants.BackgroundGreen,
+                FloatingChatInputConstants.BackgroundBlue,
+                FloatingChatInputConstants.BackgroundAlpha)),
         };
         // Channel filter button is noise for an ephemeral floating input.
         InputBox.FilterButton.Visible = false;
@@ -220,7 +225,7 @@ public sealed class FloatingChatInputControl : Control
         Measure(Vector2Helpers.Infinity);
         _contentSize = DesiredSize;
 
-        var offset = (-_eyeManager.CurrentEye.Rotation).ToWorldVec() * -EntityVerticalOffset;
+        var offset = (-_eyeManager.CurrentEye.Rotation).ToWorldVec() * -FloatingChatInputConstants.EntityVerticalOffset;
         var worldPos = _transform.GetWorldPosition(xform) + offset;
 
         var anchor = _eyeManager.WorldToScreen(worldPos) / UIScale;

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -6,6 +6,7 @@ using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
 using Content.Shared.Input;
+using Content.Shared.Radio;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
@@ -41,6 +42,18 @@ public sealed class FloatingChatInputControl : Control
     public event Action<string, ChatSelectChannel>? OnSubmit;
     public event Action? OnCancel;
 
+    private RadioChannelPrototype? _pendingRadioChannel;
+    private bool _suppressPendingClear;
+
+    /// <summary>
+    /// Specific radio channel to route to when the widget submits on
+    /// <see cref="ChatSelectChannel.Radio"/> without a typed prefix.
+    /// Cleared automatically when the user picks a channel via dropdown
+    /// or cycle hotkey; use <see cref="RestoreChannel"/> to seed it at
+    /// open time.
+    /// </summary>
+    public RadioChannelPrototype? PendingRadioChannel => _pendingRadioChannel;
+
     public FloatingChatInputControl()
     {
         IoCManager.InjectDependencies(this);
@@ -57,7 +70,38 @@ public sealed class FloatingChatInputControl : Control
         InputBox.Input.OnTextEntered += OnTextEntered;
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
         InputBox.Input.OnTextChanged += OnInputTextChanged;
-        InputBox.ChannelSelector.OnChannelSelect += _ => RefreshChannelLabel();
+        InputBox.ChannelSelector.OnChannelSelect += OnChannelSelectorChanged;
+    }
+
+    private void OnChannelSelectorChanged(ChatSelectChannel channel)
+    {
+        // User interaction (dropdown or cycle) overrides any restored radio
+        // target. Programmatic restore via RestoreChannel suppresses this.
+        if (!_suppressPendingClear)
+            _pendingRadioChannel = null;
+
+        RefreshChannelLabel();
+    }
+
+    /// <summary>
+    /// Open-time channel seed. Selects the channel and, when it is Radio,
+    /// stores the pending radio prototype so both the button label and
+    /// submit routing address it.
+    /// </summary>
+    public void RestoreChannel(ChatSelectChannel channel, RadioChannelPrototype? pendingRadio)
+    {
+        _suppressPendingClear = true;
+        try
+        {
+            InputBox.ChannelSelector.Select(channel);
+        }
+        finally
+        {
+            _suppressPendingClear = false;
+        }
+
+        _pendingRadioChannel = channel == ChatSelectChannel.Radio ? pendingRadio : null;
+        RefreshChannelLabel();
     }
 
     private void OnInputTextChanged(LineEditEventArgs args)
@@ -76,10 +120,15 @@ public sealed class FloatingChatInputControl : Control
         var chatUi = _uiManager.GetUIController<ChatUIController>();
         var (prefixChannel, _, radioChannel) = chatUi.SplitInputContents(InputBox.Input.Text.ToLower());
 
-        if (prefixChannel == ChatSelectChannel.None)
-            InputBox.ChannelSelector.UpdateChannelSelectButton(InputBox.ChannelSelector.SelectedChannel, null);
-        else
+        if (prefixChannel != ChatSelectChannel.None)
+        {
             InputBox.ChannelSelector.UpdateChannelSelectButton(prefixChannel, radioChannel);
+            return;
+        }
+
+        var selected = InputBox.ChannelSelector.SelectedChannel;
+        var radio = selected == ChatSelectChannel.Radio ? _pendingRadioChannel : null;
+        InputBox.ChannelSelector.UpdateChannelSelectButton(selected, radio);
     }
 
     private void CycleChannel(bool forward)

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -81,7 +81,22 @@ public sealed class FloatingChatInputControl : Control
         InputBox.Input.OnTextChanged += OnInputTextChanged;
         InputBox.ChannelSelector.OnChannelSelect += OnChannelSelectorChanged;
 
+        // Pick up the accessibility text-opacity knob too so the typed text
+        // fades in sync with in-world bubble text.
+        ApplyTextOpacity(_config.GetCVar(CCVars.SpeechBubbleTextOpacity));
+
         _config.OnValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
+        _config.OnValueChanged(CCVars.SpeechBubbleTextOpacity, OnTextOpacityChanged);
+    }
+
+    private void ApplyTextOpacity(float alpha)
+    {
+        InputBox.Input.ModulateSelfOverride = Color.White.WithAlpha(Math.Clamp(alpha, 0f, 1f));
+    }
+
+    private void OnTextOpacityChanged(float newAlpha)
+    {
+        ApplyTextOpacity(newAlpha);
     }
 
     private static Color BuildBackgroundColor(float alpha)
@@ -101,7 +116,10 @@ public sealed class FloatingChatInputControl : Control
     {
         base.Dispose(disposing);
         if (disposing)
+        {
             _config.UnsubValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
+            _config.UnsubValueChanged(CCVars.SpeechBubbleTextOpacity, OnTextOpacityChanged);
+        }
     }
 
     private void OnChannelSelectorChanged(ChatSelectChannel channel)

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -167,17 +167,26 @@ public sealed class FloatingChatInputControl : Control
     private void RefreshChannelLabel()
     {
         var chatUi = _uiManager.GetUIController<ChatUIController>();
-        var (prefixChannel, _, radioChannel) = chatUi.SplitInputContents(InputBox.Input.Text.ToLower());
-
-        if (prefixChannel != ChatSelectChannel.None)
-        {
-            InputBox.ChannelSelector.UpdateChannelSelectButton(prefixChannel, radioChannel);
-            return;
-        }
-
+        var (prefixChannel, _, prefixRadio) = chatUi.SplitInputContents(InputBox.Input.Text.ToLower());
         var selected = InputBox.ChannelSelector.SelectedChannel;
-        var radio = selected == ChatSelectChannel.Radio ? _pendingRadioChannel : null;
-        InputBox.ChannelSelector.UpdateChannelSelectButton(selected, radio);
+
+        var source = FloatingChatInputRouting.ResolveLabelSource(
+            selected,
+            _pendingRadioChannel != null,
+            prefixChannel);
+
+        switch (source)
+        {
+            case FloatingChatInputRouting.LabelSource.Prefix:
+                InputBox.ChannelSelector.UpdateChannelSelectButton(prefixChannel, prefixRadio);
+                break;
+            case FloatingChatInputRouting.LabelSource.PendingRadio:
+                InputBox.ChannelSelector.UpdateChannelSelectButton(ChatSelectChannel.Radio, _pendingRadioChannel);
+                break;
+            default:
+                InputBox.ChannelSelector.UpdateChannelSelectButton(selected, null);
+                break;
+        }
     }
 
     private void CycleChannel(bool forward)

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -2,6 +2,7 @@
 // Positioning mirrors Content.Client/Chat/UI/SpeechBubble.cs. See issue #577.
 
 using System.Numerics;
+using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
 using Content.Shared.Input;
@@ -10,6 +11,7 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
+using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using static Robust.Client.UserInterface.Controls.LineEdit;
 
@@ -24,6 +26,7 @@ public sealed class FloatingChatInputControl : Control
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
 
     private readonly SharedTransformSystem _transform;
 
@@ -53,6 +56,48 @@ public sealed class FloatingChatInputControl : Control
 
         InputBox.Input.OnTextEntered += OnTextEntered;
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
+        InputBox.Input.OnTextChanged += OnInputTextChanged;
+        InputBox.ChannelSelector.OnChannelSelect += _ => RefreshChannelLabel();
+    }
+
+    private void OnInputTextChanged(LineEditEventArgs args)
+    {
+        RefreshChannelLabel();
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="ChatUIController.UpdateSelectedChannel"/>. The button
+    /// text is only refreshed here; <see cref="ChannelSelectorButton.Select"/>
+    /// short-circuits on same-channel and neither it nor the dropdown's
+    /// OnChannelSelect handler repaints the label.
+    /// </summary>
+    private void RefreshChannelLabel()
+    {
+        var chatUi = _uiManager.GetUIController<ChatUIController>();
+        var (prefixChannel, _, radioChannel) = chatUi.SplitInputContents(InputBox.Input.Text.ToLower());
+
+        if (prefixChannel == ChatSelectChannel.None)
+            InputBox.ChannelSelector.UpdateChannelSelectButton(InputBox.ChannelSelector.SelectedChannel, null);
+        else
+            InputBox.ChannelSelector.UpdateChannelSelectButton(prefixChannel, radioChannel);
+    }
+
+    private void CycleChannel(bool forward)
+    {
+        var chatUi = _uiManager.GetUIController<ChatUIController>();
+        var order = ChannelSelectorPopup.ChannelSelectorOrder;
+        var idx = Array.IndexOf(order, InputBox.ChannelSelector.SelectedChannel);
+        do
+        {
+            idx += forward ? 1 : -1;
+            idx = MathHelper.Mod(idx, order.Length);
+        } while ((chatUi.SelectableChannels & order[idx]) == 0);
+
+        var target = chatUi.MapLocalIfGhost(order[idx]);
+        if ((chatUi.SelectableChannels & target) == 0)
+            return;
+
+        InputBox.ChannelSelector.Select(target);
     }
 
     /// <summary>
@@ -92,6 +137,20 @@ public sealed class FloatingChatInputControl : Control
         {
             args.Handle();
             OnCancel?.Invoke();
+            return;
+        }
+
+        if (args.Function == ContentKeyFunctions.CycleChatChannelForward)
+        {
+            CycleChannel(true);
+            args.Handle();
+            return;
+        }
+
+        if (args.Function == ContentKeyFunctions.CycleChatChannelBackward)
+        {
+            CycleChannel(false);
+            args.Handle();
         }
     }
 

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -53,7 +53,17 @@ public sealed class FloatingChatInputControl : Control
 
         InputBox.Input.OnTextEntered += OnTextEntered;
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
-        InputBox.Input.OnFocusExit += _ => OnCancel?.Invoke();
+    }
+
+    /// <summary>
+    /// Engine invokes this when the widget is popped from the modal stack
+    /// (Escape via CloseModals, or a click outside the widget). Route that
+    /// back to the controller so it can tear down exactly once.
+    /// </summary>
+    protected override void ModalRemoved()
+    {
+        base.ModalRemoved();
+        OnCancel?.Invoke();
     }
 
     public void Attach(EntityUid entity)

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -4,6 +4,7 @@
 using System.Numerics;
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.UserInterface.Systems.Chat.Controls;
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Input;
 using Content.Shared.Radio;
@@ -11,6 +12,7 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
@@ -28,8 +30,10 @@ public sealed class FloatingChatInputControl : Control
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     private readonly SharedTransformSystem _transform;
+    private readonly StyleBoxFlat _backgroundStyle;
 
     public readonly ChatInputBox InputBox;
 
@@ -56,17 +60,16 @@ public sealed class FloatingChatInputControl : Control
         IoCManager.InjectDependencies(this);
         _transform = _entManager.System<SharedTransformSystem>();
 
+        // Thicker background than the anchored chat panel — the floating
+        // widget overlaps the game world, so a more opaque fill keeps typed
+        // text legible against busy scenes. Alpha is user-tunable via the
+        // accessibility option below.
+        _backgroundStyle = new StyleBoxFlat(BuildBackgroundColor(_config.GetCVar(CCVars.FloatingChatInputBackgroundOpacity)));
+
         InputBox = new ChatInputBox
         {
             MinWidth = FloatingChatInputConstants.InputMinWidth,
-            // Thicker background than the anchored chat panel — the floating
-            // widget overlaps the game world, so a near-opaque fill keeps
-            // typed text legible against busy scenes.
-            PanelOverride = new StyleBoxFlat(new Color(
-                FloatingChatInputConstants.BackgroundRed,
-                FloatingChatInputConstants.BackgroundGreen,
-                FloatingChatInputConstants.BackgroundBlue,
-                FloatingChatInputConstants.BackgroundAlpha)),
+            PanelOverride = _backgroundStyle,
         };
         // Channel filter button is noise for an ephemeral floating input.
         InputBox.FilterButton.Visible = false;
@@ -76,6 +79,28 @@ public sealed class FloatingChatInputControl : Control
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
         InputBox.Input.OnTextChanged += OnInputTextChanged;
         InputBox.ChannelSelector.OnChannelSelect += OnChannelSelectorChanged;
+
+        _config.OnValueChanged(CCVars.FloatingChatInputBackgroundOpacity, OnBackgroundOpacityChanged);
+    }
+
+    private static Color BuildBackgroundColor(float alpha)
+    {
+        return new Color(
+            FloatingChatInputConstants.BackgroundRed,
+            FloatingChatInputConstants.BackgroundGreen,
+            FloatingChatInputConstants.BackgroundBlue).WithAlpha(Math.Clamp(alpha, 0f, 1f));
+    }
+
+    private void OnBackgroundOpacityChanged(float newAlpha)
+    {
+        _backgroundStyle.BackgroundColor = BuildBackgroundColor(newAlpha);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+            _config.UnsubValueChanged(CCVars.FloatingChatInputBackgroundOpacity, OnBackgroundOpacityChanged);
     }
 
     private void OnChannelSelectorChanged(ChatSelectChannel channel)

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -47,10 +47,13 @@ public sealed class FloatingChatInputControl : Control
         {
             MinWidth = 320,
         };
+        // Channel filter button is noise for an ephemeral floating input.
+        InputBox.FilterButton.Visible = false;
         AddChild(InputBox);
 
         InputBox.Input.OnTextEntered += OnTextEntered;
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
+        InputBox.Input.OnFocusExit += _ => OnCancel?.Invoke();
     }
 
     public void Attach(EntityUid entity)

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -62,9 +62,10 @@ public sealed class FloatingChatInputControl : Control
 
         // Thicker background than the anchored chat panel — the floating
         // widget overlaps the game world, so a more opaque fill keeps typed
-        // text legible against busy scenes. Alpha is user-tunable via the
-        // accessibility option below.
-        _backgroundStyle = new StyleBoxFlat(BuildBackgroundColor(_config.GetCVar(CCVars.FloatingChatInputBackgroundOpacity)));
+        // text legible. Share the accessibility "Speech bubble background
+        // opacity" option rather than adding a duplicate slider; in-world
+        // text surfaces belong to the same knob.
+        _backgroundStyle = new StyleBoxFlat(BuildBackgroundColor(_config.GetCVar(CCVars.SpeechBubbleBackgroundOpacity)));
 
         InputBox = new ChatInputBox
         {
@@ -80,7 +81,7 @@ public sealed class FloatingChatInputControl : Control
         InputBox.Input.OnTextChanged += OnInputTextChanged;
         InputBox.ChannelSelector.OnChannelSelect += OnChannelSelectorChanged;
 
-        _config.OnValueChanged(CCVars.FloatingChatInputBackgroundOpacity, OnBackgroundOpacityChanged);
+        _config.OnValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
     }
 
     private static Color BuildBackgroundColor(float alpha)
@@ -100,7 +101,7 @@ public sealed class FloatingChatInputControl : Control
     {
         base.Dispose(disposing);
         if (disposing)
-            _config.UnsubValueChanged(CCVars.FloatingChatInputBackgroundOpacity, OnBackgroundOpacityChanged);
+            _config.UnsubValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
     }
 
     private void OnChannelSelectorChanged(ChatSelectChannel channel)

--- a/Content.Client/RussStation/Chat/FloatingChatInputController.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputController.cs
@@ -1,0 +1,93 @@
+// HONK — Owns the floating chat input widget lifecycle. See issue #577.
+
+using Content.Client.Chat.Managers;
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.Chat;
+using Robust.Client.Player;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.RussStation.Chat;
+
+/// <summary>
+/// Spawns and tears down <see cref="FloatingChatInputControl"/> in response to the
+/// focus-chat keybind when the floating-input CVar is enabled. Routes submissions to
+/// the shared chat manager (same path as the anchored chat box).
+/// </summary>
+public sealed class FloatingChatInputController : UIController
+{
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    private FloatingChatInputControl? _active;
+
+    public bool IsActive => _active != null;
+
+    public void Show(ChatSelectChannel? channel = null)
+    {
+        if (_active != null)
+        {
+            // Already showing — just refocus.
+            _active.FocusInput();
+            return;
+        }
+
+        if (_player.LocalEntity is not { } entity)
+            return;
+
+        var root = UIManager.ActiveScreen?.FindControl<LayoutContainer>("ViewportContainer");
+        if (root == null)
+            return;
+
+        _active = new FloatingChatInputControl();
+        _active.OnSubmit += HandleSubmit;
+        _active.OnCancel += HandleCancel;
+
+        root.AddChild(_active);
+        _active.Attach(entity);
+
+        if (channel.HasValue)
+            _active.InputBox.ChannelSelector.Select(channel.Value);
+
+        _active.FocusInput();
+    }
+
+    private void HandleSubmit(string text, ChatSelectChannel channel)
+    {
+        Close();
+
+        if (string.IsNullOrWhiteSpace(text))
+            return;
+
+        var chatUi = UIManager.GetUIController<ChatUIController>();
+        (var prefixChannel, text, _) = chatUi.SplitInputContents(text);
+
+        if (prefixChannel != ChatSelectChannel.None)
+            channel = prefixChannel;
+        else if (channel == ChatSelectChannel.Radio)
+        {
+            // Radio routes through `say` with the common-radio prefix.
+            text = $";{text}";
+        }
+
+        _chatManager.SendMessage(text, channel);
+    }
+
+    private void HandleCancel()
+    {
+        Close();
+    }
+
+    public void Close()
+    {
+        if (_active == null)
+            return;
+
+        _active.OnSubmit -= HandleSubmit;
+        _active.OnCancel -= HandleCancel;
+        _active.InputBox.Input.ReleaseKeyboardFocus();
+        _active.Orphan();
+        _active = null;
+    }
+}

--- a/Content.Client/RussStation/Chat/FloatingChatInputController.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputController.cs
@@ -90,17 +90,11 @@ public sealed class FloatingChatInputController : UIController
 
     private ChatSelectChannel ResolveDefaultChannel()
     {
-        if (!_config.GetCVar(CCVars.FloatingChatInputRememberChannel))
-            return ChatSelectChannel.Local;
-
-        var stored = (ChatSelectChannel) _config.GetCVar(CCVars.FloatingChatInputLastChannel);
         var chatUi = UIManager.GetUIController<ChatUIController>();
-        // Only restore if the channel is currently selectable (e.g. Dead is
-        // gone once the player is alive again). Fall back to Local otherwise.
-        if (stored != ChatSelectChannel.None && (chatUi.SelectableChannels & stored) != 0)
-            return stored;
-
-        return ChatSelectChannel.Local;
+        return FloatingChatInputRouting.ResolveDefaultChannel(
+            _config.GetCVar(CCVars.FloatingChatInputRememberChannel),
+            _config.GetCVar(CCVars.FloatingChatInputLastChannel),
+            chatUi.SelectableChannels);
     }
 
     private void HandleSubmit(string text, ChatSelectChannel channel)
@@ -127,10 +121,7 @@ public sealed class FloatingChatInputController : UIController
             // No typed prefix — route via the restored pending radio channel if
             // we still have one, otherwise fall back to common radio.
             effectiveRadio = widgetPendingRadio;
-            var keycode = effectiveRadio?.KeyCode ?? '\0';
-            text = keycode != '\0'
-                ? $"{SharedChatSystem.RadioChannelPrefix}{keycode} {text}"
-                : $"{SharedChatSystem.RadioCommonPrefix}{text}";
+            text = FloatingChatInputRouting.BuildRadioPrefixedText(text, effectiveRadio?.KeyCode);
         }
 
         if (_config.GetCVar(CCVars.FloatingChatInputRememberChannel))

--- a/Content.Client/RussStation/Chat/FloatingChatInputController.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputController.cs
@@ -2,11 +2,13 @@
 
 using Content.Client.Chat.Managers;
 using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Configuration;
 
 namespace Content.Client.RussStation.Chat;
 
@@ -19,6 +21,7 @@ public sealed class FloatingChatInputController : UIController
 {
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     private FloatingChatInputControl? _active;
 
@@ -60,7 +63,7 @@ public sealed class FloatingChatInputController : UIController
         root.AddChild(_active);
         _active.Attach(entity);
 
-        var selected = channel ?? ChatSelectChannel.Local;
+        var selected = channel ?? ResolveDefaultChannel();
         _active.InputBox.ChannelSelector.Select(selected);
         // Select() is a no-op when the target channel already matches the
         // freshly-constructed default, so the label can be blank. Force a
@@ -72,6 +75,21 @@ public sealed class FloatingChatInputController : UIController
         UIManager.PushModal(_active);
 
         _active.FocusInput();
+    }
+
+    private ChatSelectChannel ResolveDefaultChannel()
+    {
+        if (!_config.GetCVar(CCVars.FloatingChatInputRememberChannel))
+            return ChatSelectChannel.Local;
+
+        var stored = (ChatSelectChannel) _config.GetCVar(CCVars.FloatingChatInputLastChannel);
+        var chatUi = UIManager.GetUIController<ChatUIController>();
+        // Only restore if the channel is currently selectable (e.g. Dead is
+        // gone once the player is alive again). Fall back to Local otherwise.
+        if (stored != ChatSelectChannel.None && (chatUi.SelectableChannels & stored) != 0)
+            return stored;
+
+        return ChatSelectChannel.Local;
     }
 
     private void HandleSubmit(string text, ChatSelectChannel channel)
@@ -91,6 +109,9 @@ public sealed class FloatingChatInputController : UIController
             // Radio routes through `say` with the common-radio prefix.
             text = $";{text}";
         }
+
+        if (_config.GetCVar(CCVars.FloatingChatInputRememberChannel))
+            _config.SetCVar(CCVars.FloatingChatInputLastChannel, (int) channel);
 
         _chatManager.SendMessage(text, channel);
     }

--- a/Content.Client/RussStation/Chat/FloatingChatInputController.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputController.cs
@@ -24,6 +24,19 @@ public sealed class FloatingChatInputController : UIController
 
     public bool IsActive => _active != null;
 
+    public override void Initialize()
+    {
+        _player.LocalPlayerAttached += OnLocalPlayerAttached;
+    }
+
+    private void OnLocalPlayerAttached(EntityUid newEntity)
+    {
+        // Keep the widget following whatever entity the session controls now
+        // (death -> ghost, admin respawn, etc.). Without this, the anchor stays
+        // pinned to the prior entity and the new body can't open a fresh box.
+        _active?.Attach(newEntity);
+    }
+
     public void Show(ChatSelectChannel? channel = null)
     {
         if (_active != null)

--- a/Content.Client/RussStation/Chat/FloatingChatInputController.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputController.cs
@@ -4,11 +4,13 @@ using Content.Client.Chat.Managers;
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
+using Content.Shared.Radio;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client.RussStation.Chat;
 
@@ -22,6 +24,7 @@ public sealed class FloatingChatInputController : UIController
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
 
     private FloatingChatInputControl? _active;
 
@@ -64,11 +67,19 @@ public sealed class FloatingChatInputController : UIController
         _active.Attach(entity);
 
         var selected = channel ?? ResolveDefaultChannel();
-        _active.InputBox.ChannelSelector.Select(selected);
-        // Select() is a no-op when the target channel already matches the
-        // freshly-constructed default, so the label can be blank. Force a
-        // repaint of the button text regardless.
-        _active.InputBox.ChannelSelector.UpdateChannelSelectButton(selected, null);
+        RadioChannelPrototype? pendingRadio = null;
+        if (selected == ChatSelectChannel.Radio
+            && _config.GetCVar(CCVars.FloatingChatInputRememberChannel))
+        {
+            var lastRadioId = _config.GetCVar(CCVars.FloatingChatInputLastRadioChannel);
+            if (!string.IsNullOrEmpty(lastRadioId)
+                && _protoManager.TryIndex<RadioChannelPrototype>(lastRadioId, out var proto))
+            {
+                pendingRadio = proto;
+            }
+        }
+
+        _active.RestoreChannel(selected, pendingRadio);
 
         // Make the widget a modal so Escape (CloseModals) and clicks outside
         // dismiss it without needing the LineEdit to hold keyboard focus.
@@ -94,24 +105,41 @@ public sealed class FloatingChatInputController : UIController
 
     private void HandleSubmit(string text, ChatSelectChannel channel)
     {
+        // Snapshot the pending radio before Close() tears the widget down.
+        var widgetPendingRadio = _active?.PendingRadioChannel;
         Close();
 
         if (string.IsNullOrWhiteSpace(text))
             return;
 
         var chatUi = UIManager.GetUIController<ChatUIController>();
-        (var prefixChannel, text, _) = chatUi.SplitInputContents(text);
+        var (prefixChannel, strippedText, prefixRadio) = chatUi.SplitInputContents(text);
 
+        RadioChannelPrototype? effectiveRadio = null;
         if (prefixChannel != ChatSelectChannel.None)
+        {
             channel = prefixChannel;
+            effectiveRadio = prefixRadio;
+            text = strippedText;
+        }
         else if (channel == ChatSelectChannel.Radio)
         {
-            // Radio routes through `say` with the common-radio prefix.
-            text = $";{text}";
+            // No typed prefix — route via the restored pending radio channel if
+            // we still have one, otherwise fall back to common radio.
+            effectiveRadio = widgetPendingRadio;
+            var keycode = effectiveRadio?.KeyCode ?? '\0';
+            text = keycode != '\0'
+                ? $"{SharedChatSystem.RadioChannelPrefix}{keycode} {text}"
+                : $"{SharedChatSystem.RadioCommonPrefix}{text}";
         }
 
         if (_config.GetCVar(CCVars.FloatingChatInputRememberChannel))
+        {
             _config.SetCVar(CCVars.FloatingChatInputLastChannel, (int) channel);
+            _config.SetCVar(
+                CCVars.FloatingChatInputLastRadioChannel,
+                channel == ChatSelectChannel.Radio && effectiveRadio != null ? effectiveRadio.ID : string.Empty);
+        }
 
         _chatManager.SendMessage(text, channel);
     }

--- a/Content.Client/RussStation/Chat/FloatingChatInputController.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputController.cs
@@ -60,8 +60,16 @@ public sealed class FloatingChatInputController : UIController
         root.AddChild(_active);
         _active.Attach(entity);
 
-        if (channel.HasValue)
-            _active.InputBox.ChannelSelector.Select(channel.Value);
+        var selected = channel ?? ChatSelectChannel.Local;
+        _active.InputBox.ChannelSelector.Select(selected);
+        // Select() is a no-op when the target channel already matches the
+        // freshly-constructed default, so the label can be blank. Force a
+        // repaint of the button text regardless.
+        _active.InputBox.ChannelSelector.UpdateChannelSelectButton(selected, null);
+
+        // Make the widget a modal so Escape (CloseModals) and clicks outside
+        // dismiss it without needing the LineEdit to hold keyboard focus.
+        UIManager.PushModal(_active);
 
         _active.FocusInput();
     }
@@ -97,10 +105,15 @@ public sealed class FloatingChatInputController : UIController
         if (_active == null)
             return;
 
-        _active.OnSubmit -= HandleSubmit;
-        _active.OnCancel -= HandleCancel;
-        _active.InputBox.Input.ReleaseKeyboardFocus();
-        _active.Orphan();
+        var widget = _active;
         _active = null;
+
+        // Detach first so the ModalRemoved callback the engine fires while
+        // tearing down has no subscribers left to re-enter Close(). Orphan
+        // pops the widget off the modal stack for us.
+        widget.OnSubmit -= HandleSubmit;
+        widget.OnCancel -= HandleCancel;
+        widget.InputBox.Input.ReleaseKeyboardFocus();
+        widget.Orphan();
     }
 }

--- a/Content.Client/RussStation/Chat/FloatingChatInputRouting.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputRouting.cs
@@ -1,0 +1,79 @@
+// HONK — pure helpers for the floating chat input. Extracted so the
+// decision logic can be unit-tested without spinning up the widget.
+
+using Content.Shared.Chat;
+
+namespace Content.Client.RussStation.Chat;
+
+public static class FloatingChatInputRouting
+{
+    /// <summary>
+    /// What the channel selector button should display, given the current
+    /// selector state, whether a restored radio channel is still pending,
+    /// and the result of parsing a typed prefix.
+    /// </summary>
+    public enum LabelSource
+    {
+        /// <summary>Paint the currently-selected channel as-is.</summary>
+        Selected,
+
+        /// <summary>Paint the channel derived from the typed prefix.</summary>
+        Prefix,
+
+        /// <summary>Paint the pending (restored) radio channel.</summary>
+        PendingRadio,
+    }
+
+    /// <summary>
+    /// Build the prefixed text a <see cref="ChatSelectChannel.Radio"/> submit
+    /// should send when the user did not type a prefix themselves. Uses the
+    /// pending radio channel's keycode when one is known, otherwise common.
+    /// </summary>
+    public static string BuildRadioPrefixedText(string text, char? pendingKeycode)
+    {
+        if (pendingKeycode is { } kc && kc != '\0')
+            return $"{SharedChatSystem.RadioChannelPrefix}{kc} {text}";
+
+        return $"{SharedChatSystem.RadioCommonPrefix}{text}";
+    }
+
+    /// <summary>
+    /// Decide which channel to seed the floating input with at open time,
+    /// honouring the remember-channel toggle and the currently selectable
+    /// mask so we never restore a channel the player lost access to.
+    /// </summary>
+    public static ChatSelectChannel ResolveDefaultChannel(
+        bool rememberEnabled,
+        int storedRaw,
+        ChatSelectChannel selectable)
+    {
+        if (!rememberEnabled)
+            return ChatSelectChannel.Local;
+
+        var stored = (ChatSelectChannel) storedRaw;
+        if (stored != ChatSelectChannel.None && (selectable & stored) != 0)
+            return stored;
+
+        return ChatSelectChannel.Local;
+    }
+
+    /// <summary>
+    /// Pick which "thing" the channel selector label should render. Keeps
+    /// the upstream <see cref="Controls.ChannelSelectorButton.Select"/>
+    /// same-channel early-return bug (empty Text after construction) from
+    /// biting by making the paint path unconditional on our side.
+    /// </summary>
+    public static LabelSource ResolveLabelSource(
+        ChatSelectChannel selected,
+        bool hasPendingRadio,
+        ChatSelectChannel prefixChannel)
+    {
+        if (prefixChannel != ChatSelectChannel.None)
+            return LabelSource.Prefix;
+
+        if (selected == ChatSelectChannel.Radio && hasPendingRadio)
+            return LabelSource.PendingRadio;
+
+        return LabelSource.Selected;
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -372,6 +372,14 @@ public sealed partial class ChatUIController : UIController
 
     private void FocusChat()
     {
+        // HONK START — issue #577, route to floating input when enabled
+        if (_config.GetCVar(CCVars.FloatingChatInput))
+        {
+            UIManager.GetUIController<Content.Client.RussStation.Chat.FloatingChatInputController>().Show();
+            return;
+        }
+        // HONK END
+
         foreach (var chat in _chats)
         {
             if (!chat.Main)

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -11,4 +11,19 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> FloatingChatInput =
         CVarDef.Create("honk.chat.floating_input", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// When true alongside <see cref="FloatingChatInput"/>, the floating input reopens on
+    /// the channel that was last used instead of defaulting to Local every time.
+    /// </summary>
+    public static readonly CVarDef<bool> FloatingChatInputRememberChannel =
+        CVarDef.Create("honk.chat.floating_input_remember_channel", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Persists the last channel selected from the floating input when
+    /// <see cref="FloatingChatInputRememberChannel"/> is on. Stored as the integer flag
+    /// value of <c>ChatSelectChannel</c>.
+    /// </summary>
+    public static readonly CVarDef<int> FloatingChatInputLastChannel =
+        CVarDef.Create("honk.chat.floating_input_last_channel", 0, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -34,12 +34,4 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> FloatingChatInputLastRadioChannel =
         CVarDef.Create("honk.chat.floating_input_last_radio_channel", string.Empty, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-    /// <summary>
-    /// Alpha of the floating chat input's background panel, 0..1. Higher values
-    /// make typed text more legible over busy scenes; lower values let the game
-    /// world show through.
-    /// </summary>
-    public static readonly CVarDef<float> FloatingChatInputBackgroundOpacity =
-        CVarDef.Create("honk.chat.floating_input_background_opacity", 0.96f, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -26,4 +26,12 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<int> FloatingChatInputLastChannel =
         CVarDef.Create("honk.chat.floating_input_last_channel", 0, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Persists the last <c>RadioChannelPrototype</c> ID used on the Radio channel when
+    /// <see cref="FloatingChatInputRememberChannel"/> is on. Empty means "default/common"
+    /// (or the prototype is missing and the widget falls back to common).
+    /// </summary>
+    public static readonly CVarDef<string> FloatingChatInputLastRadioChannel =
+        CVarDef.Create("honk.chat.floating_input_last_radio_channel", string.Empty, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// When true, pressing the focus-chat keybind opens a floating text input anchored
+    /// above the local player's sprite instead of focusing the HUD-corner chat box.
+    /// Discards typed text on Escape; submits on Enter.
+    /// </summary>
+    public static readonly CVarDef<bool> FloatingChatInput =
+        CVarDef.Create("honk.chat.floating_input", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -34,4 +34,12 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> FloatingChatInputLastRadioChannel =
         CVarDef.Create("honk.chat.floating_input_last_radio_channel", string.Empty, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Alpha of the floating chat input's background panel, 0..1. Higher values
+    /// make typed text more legible over busy scenes; lower values let the game
+    /// world show through.
+    /// </summary>
+    public static readonly CVarDef<float> FloatingChatInputBackgroundOpacity =
+        CVarDef.Create("honk.chat.floating_input_background_opacity", 0.96f, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Tests/Client/RussStation/Chat/FloatingChatInputRoutingTest.cs
+++ b/Content.Tests/Client/RussStation/Chat/FloatingChatInputRoutingTest.cs
@@ -1,0 +1,134 @@
+// HONK — covers the three decision helpers extracted from the floating
+// chat input. The widget itself needs a full UI harness to exercise, so
+// these tests pin the pure logic only. See issue #577.
+
+using Content.Client.RussStation.Chat;
+using Content.Shared.Chat;
+using NUnit.Framework;
+
+namespace Content.Tests.Client.RussStation.Chat;
+
+[TestFixture]
+[TestOf(typeof(FloatingChatInputRouting))]
+public sealed class FloatingChatInputRoutingTest
+{
+    // ---------- BuildRadioPrefixedText ----------
+
+    [Test]
+    public void BuildRadioPrefixedText_NoPending_UsesCommonPrefix()
+    {
+        var output = FloatingChatInputRouting.BuildRadioPrefixedText("hello", null);
+        Assert.That(output, Is.EqualTo(";hello"));
+    }
+
+    [Test]
+    public void BuildRadioPrefixedText_NullKeycodeChar_UsesCommonPrefix()
+    {
+        // Defensive: a prototype exists but exposes no keycode — treat as common.
+        var output = FloatingChatInputRouting.BuildRadioPrefixedText("hello", '\0');
+        Assert.That(output, Is.EqualTo(";hello"));
+    }
+
+    [Test]
+    public void BuildRadioPrefixedText_PendingKeycode_RoutesViaChannelPrefix()
+    {
+        var output = FloatingChatInputRouting.BuildRadioPrefixedText("hello", 'h');
+        Assert.That(output, Is.EqualTo(":h hello"));
+    }
+
+    // ---------- ResolveDefaultChannel ----------
+
+    [Test]
+    public void ResolveDefaultChannel_RememberOff_AlwaysReturnsLocal()
+    {
+        var result = FloatingChatInputRouting.ResolveDefaultChannel(
+            rememberEnabled: false,
+            storedRaw: (int) ChatSelectChannel.Radio,
+            selectable: ChatSelectChannel.Radio | ChatSelectChannel.Local);
+
+        Assert.That(result, Is.EqualTo(ChatSelectChannel.Local));
+    }
+
+    [Test]
+    public void ResolveDefaultChannel_RememberOn_Selectable_RestoresStored()
+    {
+        var result = FloatingChatInputRouting.ResolveDefaultChannel(
+            rememberEnabled: true,
+            storedRaw: (int) ChatSelectChannel.Radio,
+            selectable: ChatSelectChannel.Radio | ChatSelectChannel.Local);
+
+        Assert.That(result, Is.EqualTo(ChatSelectChannel.Radio));
+    }
+
+    [Test]
+    public void ResolveDefaultChannel_RememberOn_NotSelectable_FallsBackToLocal()
+    {
+        // Player had Dead (as a ghost) but is now alive — Dead isn't in the mask.
+        var result = FloatingChatInputRouting.ResolveDefaultChannel(
+            rememberEnabled: true,
+            storedRaw: (int) ChatSelectChannel.Dead,
+            selectable: ChatSelectChannel.Local | ChatSelectChannel.OOC);
+
+        Assert.That(result, Is.EqualTo(ChatSelectChannel.Local));
+    }
+
+    [Test]
+    public void ResolveDefaultChannel_RememberOn_StoredIsNone_FallsBackToLocal()
+    {
+        // Fresh CVar — never submitted, stored value is 0.
+        var result = FloatingChatInputRouting.ResolveDefaultChannel(
+            rememberEnabled: true,
+            storedRaw: 0,
+            selectable: ChatSelectChannel.Local | ChatSelectChannel.Radio);
+
+        Assert.That(result, Is.EqualTo(ChatSelectChannel.Local));
+    }
+
+    // ---------- ResolveLabelSource ----------
+
+    [Test]
+    public void ResolveLabelSource_TypedPrefix_AlwaysWins()
+    {
+        // Even with a pending radio restored, a typed prefix should paint from the prefix.
+        var result = FloatingChatInputRouting.ResolveLabelSource(
+            selected: ChatSelectChannel.Radio,
+            hasPendingRadio: true,
+            prefixChannel: ChatSelectChannel.LOOC);
+
+        Assert.That(result, Is.EqualTo(FloatingChatInputRouting.LabelSource.Prefix));
+    }
+
+    [Test]
+    public void ResolveLabelSource_RadioWithPending_NoPrefix_UsesPendingRadio()
+    {
+        var result = FloatingChatInputRouting.ResolveLabelSource(
+            selected: ChatSelectChannel.Radio,
+            hasPendingRadio: true,
+            prefixChannel: ChatSelectChannel.None);
+
+        Assert.That(result, Is.EqualTo(FloatingChatInputRouting.LabelSource.PendingRadio));
+    }
+
+    [Test]
+    public void ResolveLabelSource_RadioWithoutPending_NoPrefix_UsesSelected()
+    {
+        // After the user overrides restored state via dropdown, pending is cleared.
+        var result = FloatingChatInputRouting.ResolveLabelSource(
+            selected: ChatSelectChannel.Radio,
+            hasPendingRadio: false,
+            prefixChannel: ChatSelectChannel.None);
+
+        Assert.That(result, Is.EqualTo(FloatingChatInputRouting.LabelSource.Selected));
+    }
+
+    [Test]
+    public void ResolveLabelSource_NonRadio_IgnoresPending()
+    {
+        var result = FloatingChatInputRouting.ResolveLabelSource(
+            selected: ChatSelectChannel.Local,
+            hasPendingRadio: true,
+            prefixChannel: ChatSelectChannel.None);
+
+        Assert.That(result, Is.EqualTo(FloatingChatInputRouting.LabelSource.Selected));
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
@@ -1,2 +1,3 @@
 ui-options-floating-chat-input = Float chat input above your character
 ui-options-floating-chat-input-remember-channel = Remember last-used channel across openings
+ui-options-floating-chat-input-background-opacity = Floating chat input background opacity

--- a/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
@@ -1,1 +1,2 @@
 ui-options-floating-chat-input = Float chat input above your character
+ui-options-floating-chat-input-remember-channel = Remember last-used channel across openings

--- a/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
@@ -1,0 +1,1 @@
+ui-options-floating-chat-input = Float chat input above your character

--- a/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl
@@ -1,3 +1,2 @@
 ui-options-floating-chat-input = Float chat input above your character
 ui-options-floating-chat-input-remember-channel = Remember last-used channel across openings
-ui-options-floating-chat-input-background-opacity = Floating chat input background opacity


### PR DESCRIPTION
Closes #577.

## About the PR

Adds an opt-in floating chat input anchored above the local player's sprite. When enabled, pressing the focus-chat keybind opens a text input that floats over the character instead of sending focus to the HUD-corner chat box. Typing, channel selection, radio prefixes, the channel cycle hotkey, and Escape-to-cancel all behave the same as the anchored box. The widget follows the player through death, ghosting, and admin respawn.

Toggle lives in **Options, Misc, "Float chat input above your character"**. Default off.

A sub-option, **"Remember last-used channel across openings"**, persists the last channel (and specific radio channel) the player submitted on so the floating input reopens on it. Both toggles are client-side and archived across sessions.

## Why / Balance

No gameplay impact. Pure UX, addresses long-running feedback that the bottom-right input anchor is awkward to track while keeping eyes on the game world.

## Technical details

**Fork-side additions:**
- `Content.Shared/RussStation/CCVar/CCVars.Chat.cs`, three CLIENTONLY ARCHIVE CVars driving the feature: the on/off toggle, the remember-channel toggle, and two backing stores for the last channel plus the last radio channel prototype ID.
- `Content.Client/RussStation/Chat/FloatingChatInputControl.cs`, the floating widget. A `ChatInputBox` hosted inside a `Control` that anchors itself above the local player's transform each `FrameUpdate` with the same eye-to-screen math `SpeechBubble` uses. Widget registers as a modal via `PushModal` so Escape, click-outside, and any click that moves focus elsewhere dismiss it without relying on the LineEdit holding keyboard focus. The panel background is a flat near-opaque fill (RGB 30/30/34) whose alpha binds to the existing `accessibility.speech_bubble_background_opacity`; typed-text alpha binds to `accessibility.speech_bubble_text_opacity`. Both update live when the player drags the accessibility sliders.
- `Content.Client/RussStation/Chat/FloatingChatInputController.cs`, `UIController` owning the widget lifecycle. Seeds the selector from the remembered channel on open, resolves the pending radio channel from its prototype ID, reanchors the widget to the entity emitted by `LocalPlayerAttached` so death/ghost/respawn transitions keep the widget on the currently-controlled body, and saves the post-prefix channel plus radio channel ID on submit.
- `Content.Client/RussStation/Chat/FloatingChatInputRouting.cs`, pure helpers extracted from the widget so the bug-prone decisions (radio prefix construction, default-channel resolution, label source selection) can be unit-tested without a client harness.
- `Content.Client/RussStation/Chat/FloatingChatInputConstants.cs`, RGB and geometry constants, satisfies HONK0017 over raw literals.
- `Content.Tests/Client/RussStation/Chat/FloatingChatInputRoutingTest.cs`, 11 NUnit cases covering the helpers. Escape handling, focus, and modal-stack behaviour remain manual-verified in-game since they need a live client.
- `Resources/Locale/en-US/@RussStation/chat/floating-chat-input.ftl`, two locale strings for the Misc checkboxes.

**Upstream touches (HONK-marked):**
- `ChatUIController.FocusChat()`, 5-line block checking the CVar and routing to the floating controller when on.
- `SharedDoAfterSystem` unrelated (not in this PR).
- `MiscTab.xaml` and `MiscTab.xaml.cs`, two `<CheckBox>` entries plus an `AddOptionCheckBox` call each.

**Behaviour:**
- Escape and clicks outside the panel discard typed text.
- Enter submits and closes the widget.
- Cycle chat channel forward/back hotkeys work inside the floating input, same order and selectable mask as the anchored box.
- Typing a channel prefix (`;`, `:h`, `/o`, etc.) repaints the selector label to match, then reverts when the prefix is deleted.
- Selecting "Radio" from the dropdown after a remembered specific radio clears the restored channel so the explicit dropdown pick means common radio, not the previously-used channel.
- Widget hides cleanly when the local entity is on a different map or missing.

## Media

_Needs playtest media before merge._

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

:cl:
- add: Added an optional floating chat input that appears above your character. Enable in Options, Misc.
- add: Optional sub-setting remembers the last-used channel, including specific radio channels, across openings.
