### PR TITLE
feat: action bar layout customization (#579 part 1)

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -14,6 +14,8 @@
                 <ui:OptionSlider Name="SpeechBubbleTextOpacitySlider" Title="{Loc 'ui-options-speech-bubble-text-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleSpeakerOpacitySlider" Title="{Loc 'ui-options-speech-bubble-speaker-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleBackgroundOpacitySlider" Title="{Loc 'ui-options-speech-bubble-background-opacity'}" />
+                <!-- HONK - action bar button background opacity lives here next to the other UI opacity sliders -->
+                <ui:OptionSlider Name="ActionBarButtonBackgroundAlphaSlider" Title="{Loc 'ui-options-action-bar-button-background-alpha'}" />
                 <CheckBox Name="AutoFillHighlightsCheckBox" Text="{Loc 'ui-options-auto-fill-highlights'}" />
                 <ui:OptionColorSlider Name="HighlightsColorSlider"
                     Title="{Loc 'ui-options-highlights-color'}"

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -28,6 +28,15 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleTextOpacity, SpeechBubbleTextOpacitySlider);
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleSpeakerOpacity, SpeechBubbleSpeakerOpacitySlider);
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleBackgroundOpacity, SpeechBubbleBackgroundOpacitySlider);
+        //HONK START - action bar button background opacity sits with the other UI opacity sliders
+        Control.AddOption(new OptionSliderFloatCVar(
+            Control,
+            IoCManager.Resolve<IConfigurationManager>(),
+            CCVars.HonkActionBarButtonBackgroundAlpha,
+            ActionBarButtonBackgroundAlphaSlider,
+            0f, 1f, 1f,
+            (_, value) => $"{(int)(value * 100)}%"));
+        //HONK END
         Control.AddOptionCheckBox(CCVars.ChatAutoFillHighlights, AutoFillHighlightsCheckBox);
         Control.AddOptionColorSlider(CCVars.ChatHighlightsColor, HighlightsColorSlider);
 

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -37,7 +37,6 @@
                 <ui:OptionSlider Name="ActionBarRowsSlider" Title="{Loc 'ui-options-action-bar-rows'}" />
                 <ui:OptionSlider Name="ActionBarSlotsPerRowSlider" Title="{Loc 'ui-options-action-bar-slots-per-row'}" />
                 <ui:OptionSlider Name="ActionBarSlotSpacingSlider" Title="{Loc 'ui-options-action-bar-slot-spacing'}" />
-                <ui:OptionSlider Name="ActionBarButtonBackgroundAlphaSlider" Title="{Loc 'ui-options-action-bar-button-background-alpha'}" />
                 <CheckBox Name="ActionBarShowKeybindLabel" Text="{Loc 'ui-options-action-bar-show-keybind-label'}" />
                 <CheckBox Name="ActionBarShowEmptySlots" Text="{Loc 'ui-options-action-bar-show-empty-slots'}" />
                 <!-- HONK END -->

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -35,8 +35,11 @@
                 <Label Text="{Loc 'ui-options-action-bar-header'}"
                        StyleClasses="LabelKeyText"/>
                 <ui:OptionSlider Name="ActionBarRowsSlider" Title="{Loc 'ui-options-action-bar-rows'}" />
+                <ui:OptionSlider Name="ActionBarSlotsPerRowSlider" Title="{Loc 'ui-options-action-bar-slots-per-row'}" />
                 <ui:OptionSlider Name="ActionBarSlotSpacingSlider" Title="{Loc 'ui-options-action-bar-slot-spacing'}" />
+                <ui:OptionSlider Name="ActionBarButtonBackgroundAlphaSlider" Title="{Loc 'ui-options-action-bar-button-background-alpha'}" />
                 <CheckBox Name="ActionBarShowKeybindLabel" Text="{Loc 'ui-options-action-bar-show-keybind-label'}" />
+                <CheckBox Name="ActionBarShowEmptySlots" Text="{Loc 'ui-options-action-bar-show-empty-slots'}" />
                 <!-- HONK END -->
             </BoxContainer>
         </ScrollContainer>

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -31,6 +31,13 @@
                 <CheckBox Name="OpaqueStorageWindowCheckBox" Text="{Loc 'ui-options-opaque-storage-window'}" />
                 <CheckBox Name="StaticStorageUI" Text="{Loc 'ui-options-static-storage-ui'}" />
                 <!-- <CheckBox Name="ToggleWalk" Text="{Loc 'ui-options-hotkey-toggle-walk'}" /> -->
+                <!-- HONK START - Action bar customization -->
+                <Label Text="{Loc 'ui-options-action-bar-header'}"
+                       StyleClasses="LabelKeyText"/>
+                <ui:OptionSlider Name="ActionBarRowsSlider" Title="{Loc 'ui-options-action-bar-rows'}" />
+                <ui:OptionSlider Name="ActionBarSlotSpacingSlider" Title="{Loc 'ui-options-action-bar-slot-spacing'}" />
+                <CheckBox Name="ActionBarShowKeybindLabel" Text="{Loc 'ui-options-action-bar-show-keybind-label'}" />
+                <!-- HONK END -->
             </BoxContainer>
         </ScrollContainer>
         <ui:OptionsTabControlRow Name="Control" Access="Public" />

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -57,6 +57,17 @@ public sealed partial class MiscTab : Control
         //HONK END
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
 
+        //HONK START - Action bar customization
+        var cfg = IoCManager.Resolve<Robust.Shared.Configuration.IConfigurationManager>();
+        Control.AddOption(new OptionSliderIntCVar(
+            Control, cfg, CCVars.HonkActionBarRows, ActionBarRowsSlider, 1, 4,
+            (_, value) => value.ToString()));
+        Control.AddOption(new OptionSliderIntCVar(
+            Control, cfg, CCVars.HonkActionBarSlotSpacing, ActionBarSlotSpacingSlider, 0, 16,
+            (_, value) => $"{value}px"));
+        Control.AddOptionCheckBox(CCVars.HonkActionBarShowKeybindLabel, ActionBarShowKeybindLabel);
+        //HONK END
+
         Control.Initialize();
     }
 }

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -63,9 +63,16 @@ public sealed partial class MiscTab : Control
             Control, cfg, CCVars.HonkActionBarRows, ActionBarRowsSlider, 1, 4,
             (_, value) => value.ToString()));
         Control.AddOption(new OptionSliderIntCVar(
+            Control, cfg, CCVars.HonkActionBarSlotsPerRow, ActionBarSlotsPerRowSlider, 1, 10,
+            (_, value) => value.ToString()));
+        Control.AddOption(new OptionSliderIntCVar(
             Control, cfg, CCVars.HonkActionBarSlotSpacing, ActionBarSlotSpacingSlider, 0, 16,
             (_, value) => $"{value}px"));
+        Control.AddOption(new OptionSliderFloatCVar(
+            Control, cfg, CCVars.HonkActionBarButtonBackgroundAlpha, ActionBarButtonBackgroundAlphaSlider, 0f, 1f, 1f,
+            (_, value) => $"{(int)(value * 100)}%"));
         Control.AddOptionCheckBox(CCVars.HonkActionBarShowKeybindLabel, ActionBarShowKeybindLabel);
+        Control.AddOptionCheckBox(CCVars.HonkActionBarShowEmptySlots, ActionBarShowEmptySlots);
         //HONK END
 
         Control.Initialize();

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -68,9 +68,6 @@ public sealed partial class MiscTab : Control
         Control.AddOption(new OptionSliderIntCVar(
             Control, cfg, CCVars.HonkActionBarSlotSpacing, ActionBarSlotSpacingSlider, 0, 16,
             (_, value) => $"{value}px"));
-        Control.AddOption(new OptionSliderFloatCVar(
-            Control, cfg, CCVars.HonkActionBarButtonBackgroundAlpha, ActionBarButtonBackgroundAlphaSlider, 0f, 1f, 1f,
-            (_, value) => $"{(int)(value * 100)}%"));
         Control.AddOptionCheckBox(CCVars.HonkActionBarShowKeybindLabel, ActionBarShowKeybindLabel);
         Control.AddOptionCheckBox(CCVars.HonkActionBarShowEmptySlots, ActionBarShowEmptySlots);
         //HONK END

--- a/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
@@ -1,0 +1,86 @@
+using Content.Client.Gameplay;
+using Content.Client.UserInterface.Systems.Actions.Controls;
+using Content.Client.UserInterface.Systems.Actions.Widgets;
+using Content.Shared.CCVar;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Shared.Configuration;
+
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Fork UIController that applies user-tunable layout settings to the
+// upstream action bar widget. Reads CVars registered in CCVars.ActionBar.cs
+// and re-applies them whenever any of them change, so settings take effect
+// the moment the user clicks Apply in the options menu. Also re-applies on
+// gameplay state entry since the ActionsBar widget only exists then.
+public sealed class ActionBarCustomizationController : UIController, IOnStateEntered<GameplayState>
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private int _rows;
+    private int _slotSpacing;
+    private bool _showKeybindLabel;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _rows = _cfg.GetCVar(CCVars.HonkActionBarRows);
+        _slotSpacing = _cfg.GetCVar(CCVars.HonkActionBarSlotSpacing);
+        _showKeybindLabel = _cfg.GetCVar(CCVars.HonkActionBarShowKeybindLabel);
+
+        _cfg.OnValueChanged(CCVars.HonkActionBarRows, OnRowsChanged, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarSlotSpacing, OnSlotSpacingChanged, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarShowKeybindLabel, OnShowKeybindLabelChanged, true);
+    }
+
+    private void OnRowsChanged(int value)
+    {
+        _rows = Math.Clamp(value, 1, 4);
+        ApplyLayout();
+    }
+
+    private void OnSlotSpacingChanged(int value)
+    {
+        _slotSpacing = Math.Clamp(value, 0, 16);
+        ApplyLayout();
+    }
+
+    private void OnShowKeybindLabelChanged(bool value)
+    {
+        _showKeybindLabel = value;
+        ApplyLabels();
+    }
+
+    private ActionButtonContainer? GetContainer()
+    {
+        var bar = UIManager.GetActiveUIWidgetOrNull<ActionsBar>();
+        return bar?.ActionsContainer;
+    }
+
+    private void ApplyLayout()
+    {
+        if (GetContainer() is not { } container)
+            return;
+
+        container.Rows = _rows;
+        container.HSeparationOverride = _slotSpacing;
+        container.VSeparationOverride = _slotSpacing;
+    }
+
+    private void ApplyLabels()
+    {
+        if (GetContainer() is not { } container)
+            return;
+
+        foreach (var button in container.GetButtons())
+        {
+            button.Label.Visible = _showKeybindLabel;
+        }
+    }
+
+    public void OnStateEntered(GameplayState state)
+    {
+        ApplyLayout();
+        ApplyLabels();
+    }
+}

--- a/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
@@ -2,6 +2,7 @@ using Content.Client.Gameplay;
 using Content.Client.UserInterface.Systems.Actions;
 using Content.Client.UserInterface.Systems.Actions.Controls;
 using Content.Client.UserInterface.Systems.Actions.Widgets;
+using Content.Client.UserInterface.Systems.Actions.Windows;
 using Content.Shared.CCVar;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Shared.Configuration;
@@ -146,6 +147,16 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         UIManager.GetUIController<ActionUIController>().HonkRefreshHotbar();
         // Padding may have added buttons; labels must be re-applied to the new ones.
         ApplyLabels();
+    }
+
+    // Wires the lock + auto-add toggle checkboxes on the actions window, called from
+    // the upstream LoadGui (HONK) each time the window is (re)created.
+    public void HonkBindWindow(ActionsWindow window)
+    {
+        window.LockButton.Pressed = LockActions;
+        window.AutoAddButton.Pressed = AutoAddActions;
+        window.LockButton.OnToggled += a => _cfg.SetCVar(CCVars.HonkActionBarLock, a.Pressed);
+        window.AutoAddButton.OnToggled += a => _cfg.SetCVar(CCVars.HonkActionBarAutoAddActions, a.Pressed);
     }
 
     // Called from the upstream ActionUIController (HONK) once the action bar widget

--- a/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
@@ -1,4 +1,5 @@
 using Content.Client.Gameplay;
+using Content.Client.UserInterface.Systems.Actions;
 using Content.Client.UserInterface.Systems.Actions.Controls;
 using Content.Client.UserInterface.Systems.Actions.Widgets;
 using Content.Shared.CCVar;
@@ -17,26 +18,73 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private int _rows;
+    private int _slotsPerRow;
     private int _slotSpacing;
     private bool _showKeybindLabel;
+
+    // Read by ActionButton.UpdateBackground (HONK block) on every frame so empty
+    // slots can render a faint outline. A static keeps the hot path free of a
+    // UIController lookup per button per frame.
+    public static bool ShowEmptySlots { get; private set; }
+
+    // Read by ActionUIController.OnActionAdded (HONK guard) so newly granted actions
+    // can skip auto-population when the user wants a curated bar layout.
+    public static bool AutoAddActions { get; private set; } = true;
+
+    // Read by ActionUIController drag / right-click paths (HONK guards) to keep
+    // the bar immutable when the player has locked the layout.
+    public static bool LockActions { get; private set; }
+
+    // Read by the gameplay-screen resize handlers (HONK guards) to keep them from
+    // calling MaxGridHeight/MaxGridWidth, which would flip the grid into size-limit
+    // mode and silently overwrite the user's explicit row count on resize.
+    public const bool OverridesRowLayout = true;
+
+    // Base 0.0-1.0 alpha applied to every action button's slot background. Read each
+    // frame by ActionButton.UpdateBackground (HONK block). The empty-slot fade scales
+    // proportionally so the relative contrast stays consistent.
+    public static float ButtonBackgroundAlpha { get; private set; } = 150f / 255f;
+
+    // Flipped by ActionUIController drag hooks so empty drop targets are padded into the
+    // container even when the persistent show-empty toggle is off.
+    public static bool IsDragActive { get; private set; }
 
     public override void Initialize()
     {
         base.Initialize();
 
         _rows = _cfg.GetCVar(CCVars.HonkActionBarRows);
+        _slotsPerRow = _cfg.GetCVar(CCVars.HonkActionBarSlotsPerRow);
         _slotSpacing = _cfg.GetCVar(CCVars.HonkActionBarSlotSpacing);
         _showKeybindLabel = _cfg.GetCVar(CCVars.HonkActionBarShowKeybindLabel);
+        ShowEmptySlots = _cfg.GetCVar(CCVars.HonkActionBarShowEmptySlots);
+        AutoAddActions = _cfg.GetCVar(CCVars.HonkActionBarAutoAddActions);
+        LockActions = _cfg.GetCVar(CCVars.HonkActionBarLock);
+        ButtonBackgroundAlpha = Math.Clamp(_cfg.GetCVar(CCVars.HonkActionBarButtonBackgroundAlpha), 0f, 1f);
 
         _cfg.OnValueChanged(CCVars.HonkActionBarRows, OnRowsChanged, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarSlotsPerRow, OnSlotsPerRowChanged, true);
         _cfg.OnValueChanged(CCVars.HonkActionBarSlotSpacing, OnSlotSpacingChanged, true);
         _cfg.OnValueChanged(CCVars.HonkActionBarShowKeybindLabel, OnShowKeybindLabelChanged, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarShowEmptySlots, OnShowEmptySlotsChanged, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarAutoAddActions, v => AutoAddActions = v, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarLock, v => LockActions = v, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarButtonBackgroundAlpha,
+            v => ButtonBackgroundAlpha = Math.Clamp(v, 0f, 1f), true);
     }
 
     private void OnRowsChanged(int value)
     {
         _rows = Math.Clamp(value, 1, 4);
         ApplyLayout();
+        RefreshHotbar();
+    }
+
+    private void OnSlotsPerRowChanged(int value)
+    {
+        _slotsPerRow = Math.Clamp(value, 1, 10);
+        ApplyLayout();
+        RefreshHotbar();
     }
 
     private void OnSlotSpacingChanged(int value)
@@ -51,6 +99,13 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         ApplyLabels();
     }
 
+    private void OnShowEmptySlotsChanged(bool value)
+    {
+        ShowEmptySlots = value;
+        ApplyLayout();
+        RefreshHotbar();
+    }
+
     private ActionButtonContainer? GetContainer()
     {
         var bar = UIManager.GetActiveUIWidgetOrNull<ActionsBar>();
@@ -62,9 +117,12 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         if (GetContainer() is not { } container)
             return;
 
-        container.Rows = _rows;
+        // Setting Columns (not Rows) makes the grid fill row-by-row, so hotkeys 1..0 land
+        // in row 1 and 2 lands on row 2's leftmost slot rather than column-major flow.
+        container.Columns = _slotsPerRow;
         container.HSeparationOverride = _slotSpacing;
         container.VSeparationOverride = _slotSpacing;
+        container.HonkMinSlotCount = ShowEmptySlots || IsDragActive ? _rows * _slotsPerRow : 0;
     }
 
     private void ApplyLabels()
@@ -72,15 +130,50 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         if (GetContainer() is not { } container)
             return;
 
+        // Only reveal labels on slots that actually hold an action; empty buttons
+        // shouldn't display a keybind that does nothing. Empty slots also show
+        // labels during a drag so the player can see which slot maps to which key.
         foreach (var button in container.GetButtons())
         {
-            button.Label.Visible = _showKeybindLabel;
+            button.Label.Visible = _showKeybindLabel && (button.Action != null || IsDragActive);
         }
+    }
+
+    private void RefreshHotbar()
+    {
+        if (GetContainer() == null)
+            return;
+        UIManager.GetUIController<ActionUIController>().HonkRefreshHotbar();
+        // Padding may have added buttons; labels must be re-applied to the new ones.
+        ApplyLabels();
+    }
+
+    // Called from the upstream ActionUIController (HONK) once the action bar widget
+    // is registered. That's the first point the container reliably exists, so fresh
+    // client starts get the stored layout applied here rather than relying on the
+    // order in which UIControllers receive OnStateEntered.
+    public void HonkOnContainerReady()
+    {
+        ApplyLayout();
+        ApplyLabels();
+        RefreshHotbar();
+    }
+
+    // Called from the action drag hooks so the container can pad in empty drop targets
+    // and then trim them back out once the drop completes.
+    public void HonkSetDragActive(bool active)
+    {
+        if (IsDragActive == active)
+            return;
+        IsDragActive = active;
+        ApplyLayout();
+        RefreshHotbar();
+        ApplyLabels();
     }
 
     public void OnStateEntered(GameplayState state)
     {
-        ApplyLayout();
-        ApplyLabels();
+        // HonkOnContainerReady runs from ActionUIController.LoadGui once the widget is up;
+        // nothing else to do here now that MaxGrid* resizes no longer clobber our Rows.
     }
 }

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -247,6 +247,11 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _actionsSystem?.TriggerAction(action);
     }
 
+    //HONK START - remember which slot an action from a given provider item last occupied, so
+    // hand<->pocket moves (which revoke + regrant the action) don't shuffle the bar layout.
+    private readonly Dictionary<EntityUid, int> _honkLastSlotByProvider = new();
+    //HONK END
+
     private void OnActionAdded(EntityUid actionId)
     {
         if (_actionsSystem?.GetAction(actionId) is not {} action)
@@ -260,6 +265,23 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actions.Contains(action))
             return;
 
+        //HONK START - restore to the previously-held slot if this provider's action was here before
+        if (action.Comp.Container is {} provider
+            && _honkLastSlotByProvider.TryGetValue(provider, out var lastSlot)
+            && lastSlot >= 0
+            && lastSlot < _actions.Count
+            && _actions[lastSlot] == null)
+        {
+            _actions[lastSlot] = action;
+            return;
+        }
+        //HONK END
+
+        //HONK START - fork auto-add toggle lets players curate layouts without new actions butting in
+        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+            return;
+        //HONK END
+
         _actions.Add(action);
     }
 
@@ -271,7 +293,18 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (actionId == SelectingTargetFor)
             StopTargeting();
 
-        _actions.RemoveAll(x => x == actionId);
+        //HONK START - null the slot in place + record provider->slot so re-granted actions return home
+        for (var i = 0; i < _actions.Count; i++)
+        {
+            if (_actions[i] != actionId)
+                continue;
+            if (_actionsSystem?.GetAction(actionId) is {} action && action.Comp.Container is {} provider)
+                _honkLastSlotByProvider[provider] = i;
+            _actions[i] = null;
+        }
+        while (_actions.Count > 0 && _actions[^1] == null)
+            _actions.RemoveAt(_actions.Count - 1);
+        //HONK END
     }
 
     private void OnActionsUpdated()
@@ -281,6 +314,11 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actionsSystem != null)
             _container?.SetActionData(_actionsSystem, _actions.ToArray());
     }
+
+    //HONK START - public entry so the fork controller can force a hotbar rebuild when empty-slot /
+    // slots-per-row / rows CVars change and the padding needs to grow or shrink.
+    public void HonkRefreshHotbar() => OnActionsUpdated();
+    //HONK END
 
     private void ActionButtonPressed(ButtonEventArgs args)
     {
@@ -439,14 +477,24 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             button.ClearData();
             if (_container?.TryGetButtonIndex(button, out position) ?? false)
             {
-                if (_actions.Count > position && position >= 0)
-                    _actions.RemoveAt(position);
+                //HONK START - keep _actions sparse so a cleared middle slot doesn't shift later actions left
+                if (position >= 0 && position < _actions.Count)
+                {
+                    _actions[position] = null;
+                    while (_actions.Count > 0 && _actions[^1] == null)
+                        _actions.RemoveAt(_actions.Count - 1);
+                }
+                //HONK END
             }
         }
         else if (button.TryReplaceWith(actionId.Value, _actionsSystem) &&
             _container != null &&
             _container.TryGetButtonIndex(button, out position))
         {
+            //HONK START - pad with nulls so an action dropped on slot N lands at slot N, not at Count
+            while (_actions.Count < position)
+                _actions.Add(null);
+            //HONK END
             if (position >= _actions.Count)
             {
                 _actions.Add(actionId);
@@ -590,6 +638,8 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private bool OnMenuBeginDrag()
     {
+        //HONK - pad empty drop targets into the bar for the duration of the drag
+        UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkSetDragActive(true);
         // TODO ACTIONS
         // The dragging icon shuld be based on the entity's icon style. I.e. if the action has a large icon texture,
         // and a small item/provider sprite, then the dragged icon should be the big texture, not the provider.
@@ -623,6 +673,8 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnMenuEndDrag()
     {
+        //HONK - trim the drag-only empty slots back out now that the drop is resolved
+        UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkSetDragActive(false);
         _dragShadow.Texture = null;
         _dragShadow.Visible = false;
     }
@@ -668,7 +720,15 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         RegisterActionContainer(ActionsBar.ActionsContainer);
 
+        //HONK - apply fork layout (rows, slots-per-row, spacing, empty preview, min-slot padding)
+        // once the container exists and before LinkAllActions populates it; a second call after
+        // linking re-asserts the layout in case upstream rebuilds the grid during linking.
+        UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkOnContainerReady();
+
         _actionsSystem?.LinkAllActions();
+
+        //HONK - re-apply after the initial action link rebuilds the container children
+        UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkOnContainerReady();
     }
 
     public void RegisterActionContainer(ActionButtonContainer container)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -823,17 +823,27 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         _container?.ClearActionData();
         QueueWindowUpdate();
         StopTargeting();
+        //HONK - reset the first-link flag so next connection gets the default bar populated even if
+        // auto-add is off; within a connection the guard preserves the curated layout on respawn.
+        _honkLoadedDefaultsThisConnection = false;
     }
+
+    //HONK START - track whether defaults have been populated this connection so auto-add off still
+    // gets a sensible initial bar on first server link. Reset on unlink-all-actions (disconnect).
+    private bool _honkLoadedDefaultsThisConnection;
+    //HONK END
 
     private void LoadDefaultActions()
     {
         if (_actionsSystem == null)
             return;
 
-        //HONK START - auto-add off: don't clobber the curated layout when the player's ActionsComponent
-        // re-links (respawn, body swap). New actions still land in the actions menu; bar stays as-is.
-        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+        //HONK START - auto-add off skips the respawn / body-swap repopulate so a curated bar survives,
+        // but first link per connection always loads defaults so a new connect isn't a blank bar.
+        if (_honkLoadedDefaultsThisConnection
+            && !Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
             return;
+        _honkLoadedDefaultsThisConnection = true;
         //HONK END
 
         var actions = _actionsSystem.GetClientActions().Where(action => action.Comp.AutoPopulate).ToList();

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -265,11 +265,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actions.Contains(action))
             return;
 
-        //HONK START - fork auto-add toggle + provider-slot memory. Auto-add off skips ALL new
-        // actions including ones that previously lived on the bar; when on, prefer the remembered
-        // slot for hand/pocket swaps so the layout doesn't reshuffle every toggle.
-        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
-            return;
+        //HONK START - fork auto-add toggle + provider-slot memory. Hand/pocket swaps of an item that
+        // already had a slot always restore to that slot regardless of auto-add (the player accepted
+        // the action onto the bar previously, so a move shouldn't silently drop it). Truly new
+        // providers fall through to the auto-add check.
         if (action.Comp.Container is {} provider
             && _honkLastSlotByProvider.TryGetValue(provider, out var lastSlot)
             && lastSlot >= 0
@@ -279,6 +278,8 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _actions[lastSlot] = action;
             return;
         }
+        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+            return;
         //HONK END
 
         _actions.Add(action);

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -823,9 +823,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         _container?.ClearActionData();
         QueueWindowUpdate();
         StopTargeting();
-        //HONK - reset the first-link flag so next connection gets the default bar populated even if
-        // auto-add is off; within a connection the guard preserves the curated layout on respawn.
+        //HONK START - reset the first-link flag so next connection gets the default bar populated
+        // even if auto-add is off; within a connection the guard preserves the curated layout on respawn.
         _honkLoadedDefaultsThisConnection = false;
+        //HONK END
     }
 
     //HONK START - track whether defaults have been populated this connection so auto-add off still

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -265,7 +265,11 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actions.Contains(action))
             return;
 
-        //HONK START - restore to the previously-held slot if this provider's action was here before
+        //HONK START - fork auto-add toggle + provider-slot memory. Auto-add off skips ALL new
+        // actions including ones that previously lived on the bar; when on, prefer the remembered
+        // slot for hand/pocket swaps so the layout doesn't reshuffle every toggle.
+        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+            return;
         if (action.Comp.Container is {} provider
             && _honkLastSlotByProvider.TryGetValue(provider, out var lastSlot)
             && lastSlot >= 0
@@ -275,11 +279,6 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _actions[lastSlot] = action;
             return;
         }
-        //HONK END
-
-        //HONK START - fork auto-add toggle lets players curate layouts without new actions butting in
-        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
-            return;
         //HONK END
 
         _actions.Add(action);
@@ -830,6 +829,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     {
         if (_actionsSystem == null)
             return;
+
+        //HONK START - auto-add off: don't clobber the curated layout when the player's ActionsComponent
+        // re-links (respawn, body swap). New actions still land in the actions menu; bar stays as-is.
+        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+            return;
+        //HONK END
 
         var actions = _actionsSystem.GetClientActions().Where(action => action.Comp.AutoPopulate).ToList();
         actions.Sort(ActionComparer);

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -267,16 +267,22 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         //HONK START - fork auto-add toggle + provider-slot memory. Hand/pocket swaps of an item that
         // already had a slot always restore to that slot regardless of auto-add (the player accepted
-        // the action onto the bar previously, so a move shouldn't silently drop it). Truly new
-        // providers fall through to the auto-add check.
+        // the action onto the bar previously, so a move shouldn't silently drop it). The trailing-null
+        // trim in OnActionRemoved means the remembered slot can be past _actions.Count by the time
+        // we re-add, so pad up to it (capped at the bound hotbar key count). Truly new providers
+        // fall through to the auto-add check.
         if (action.Comp.Container is {} provider
             && _honkLastSlotByProvider.TryGetValue(provider, out var lastSlot)
             && lastSlot >= 0
-            && lastSlot < _actions.Count
-            && _actions[lastSlot] == null)
+            && lastSlot < ContentKeyFunctions.GetHotbarBoundKeys().Length)
         {
-            _actions[lastSlot] = action;
-            return;
+            while (_actions.Count <= lastSlot)
+                _actions.Add(null);
+            if (_actions[lastSlot] == null)
+            {
+                _actions[lastSlot] = action;
+                return;
+            }
         }
         if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
             return;

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -638,8 +638,9 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private bool OnMenuBeginDrag()
     {
-        //HONK - pad empty drop targets into the bar for the duration of the drag
+        //HONK START - pad empty drop targets into the bar for the duration of the drag
         UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkSetDragActive(true);
+        //HONK END
         // TODO ACTIONS
         // The dragging icon shuld be based on the entity's icon style. I.e. if the action has a large icon texture,
         // and a small item/provider sprite, then the dragged icon should be the big texture, not the provider.
@@ -673,8 +674,9 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnMenuEndDrag()
     {
-        //HONK - trim the drag-only empty slots back out now that the drop is resolved
+        //HONK START - trim the drag-only empty slots back out now that the drop is resolved
         UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkSetDragActive(false);
+        //HONK END
         _dragShadow.Texture = null;
         _dragShadow.Visible = false;
     }
@@ -720,15 +722,17 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         RegisterActionContainer(ActionsBar.ActionsContainer);
 
-        //HONK - apply fork layout (rows, slots-per-row, spacing, empty preview, min-slot padding)
+        //HONK START - apply fork layout (rows, slots-per-row, spacing, empty preview, min-slot padding)
         // once the container exists and before LinkAllActions populates it; a second call after
         // linking re-asserts the layout in case upstream rebuilds the grid during linking.
         UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkOnContainerReady();
+        //HONK END
 
         _actionsSystem?.LinkAllActions();
 
-        //HONK - re-apply after the initial action link rebuilds the container children
+        //HONK START - re-apply after the initial action link rebuilds the container children
         UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkOnContainerReady();
+        //HONK END
     }
 
     public void RegisterActionContainer(ActionButtonContainer container)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -491,9 +491,16 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _container != null &&
             _container.TryGetButtonIndex(button, out position))
         {
-            //HONK START - pad with nulls so an action dropped on slot N lands at slot N, not at Count
+            //HONK START - pad with nulls so an action dropped on slot N lands at slot N, not at Count,
+            // and update provider->slot memory so re-acquiring the item later restores to the new slot
+            // rather than the original auto-populated one.
             while (_actions.Count < position)
                 _actions.Add(null);
+            if (_actionsSystem.GetAction(actionId.Value) is {} placedAction
+                && placedAction.Comp.Container is {} placedProvider)
+            {
+                _honkLastSlotByProvider[placedProvider] = position;
+            }
             //HONK END
             if (position >= _actions.Count)
             {

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -711,7 +711,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         _window.OnOpen += OnWindowOpened;
         _window.OnClose += OnWindowClosed;
-        //HONK - ClearButton removed; right-click the search box to clear it
+        //HONK START - ClearButton removed (right-click the search box instead); wire fork
+        // lock + auto-add checkboxes on the actions window.
+        UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>().HonkBindWindow(_window);
+        //HONK END
         _window.SearchBar.OnTextChanged += OnSearchChanged;
         _window.FilterButton.OnItemSelected += OnFilterSelected;
 

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -572,6 +572,13 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     {
         if (args.Function == EngineKeyFunctions.UIRightClick)
         {
+            //HONK START - locked bars swallow right-click clear so a mis-click can't wipe a slot
+            if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.LockActions)
+            {
+                args.Handle();
+                return;
+            }
+            //HONK END
             SetAction(button, null);
             args.Handle();
             return;
@@ -588,6 +595,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         args.Handle();
         if (button.Action != null)
         {
+            //HONK START - lock blocks drag-rearrange on the bar; clicking an action to fire it still works
+            if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.LockActions)
+                return;
+            //HONK END
             _menuDragHelper.MouseDown(button);
             return;
         }

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -393,8 +393,9 @@ public sealed class ActionButton : Control, IEntityControl
     {
         _controller ??= UserInterfaceManager.GetUIController<ActionUIController>();
         //HONK START - fork empty-slot preview toggle + accessibility button-background alpha.
-        // Also reveal empty slots at full alpha during drag so drop targets are visible
-        // even when the user has the persistent empty-slot toggle off.
+        // Empty slots reveal at full alpha during drag so drop targets are visible even
+        // when the user has the persistent empty-slot toggle off, and the slot background
+        // texture draws in that case so the preview has something to render.
         var honkShowEmpty = Action == null
             && (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ShowEmptySlots
                 || _controller.IsDragging);
@@ -405,8 +406,6 @@ public sealed class ActionButton : Control, IEntityControl
         Button.Modulate = honkShowEmpty && !_controller.IsDragging
             ? new Color(255, 255, 255, honkEmptyAlphaByte)
             : new Color(255, 255, 255, honkAlphaByte);
-        //HONK END
-        //HONK START - draw the slot background texture so the empty preview has something to show
         if (Action != null ||
             _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1
             || honkShowEmpty)

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -406,12 +406,14 @@ public sealed class ActionButton : Control, IEntityControl
             ? new Color(255, 255, 255, honkEmptyAlphaByte)
             : new Color(255, 255, 255, honkAlphaByte);
         //HONK END
+        //HONK START - draw the slot background texture so the empty preview has something to show
         if (Action != null ||
             _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1
-            || honkShowEmpty) //HONK - draw the slot background texture so the empty preview has something to show
+            || honkShowEmpty)
         {
             Button.Texture = _buttonBackgroundTexture;
         }
+        //HONK END
         else
         {
             Button.Texture = null;

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -392,8 +392,23 @@ public sealed class ActionButton : Control, IEntityControl
     public void UpdateBackground()
     {
         _controller ??= UserInterfaceManager.GetUIController<ActionUIController>();
+        //HONK START - fork empty-slot preview toggle + accessibility button-background alpha.
+        // Also reveal empty slots at full alpha during drag so drop targets are visible
+        // even when the user has the persistent empty-slot toggle off.
+        var honkShowEmpty = Action == null
+            && (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ShowEmptySlots
+                || _controller.IsDragging);
+        var honkAlpha = Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ButtonBackgroundAlpha;
+        const float honkEmptyFadeRatio = 0.4f;
+        var honkAlphaByte = (byte) Math.Clamp(honkAlpha * 255f, 0, 255);
+        var honkEmptyAlphaByte = (byte) Math.Clamp(honkAlpha * honkEmptyFadeRatio * 255f, 0, 255);
+        Button.Modulate = honkShowEmpty && !_controller.IsDragging
+            ? new Color(255, 255, 255, honkEmptyAlphaByte)
+            : new Color(255, 255, 255, honkAlphaByte);
+        //HONK END
         if (Action != null ||
-            _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1)
+            _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1
+            || honkShowEmpty) //HONK - draw the slot background texture so the empty preview has something to show
         {
             Button.Texture = _buttonBackgroundTexture;
         }

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -26,10 +26,21 @@ public class ActionButtonContainer : GridContainer
         get => (ActionButton) GetChild(index);
     }
 
+    //HONK START - fork empty-slot preview: pad up to this many slots with nulls so the grid renders
+    // the layout visibly even when the player hasn't filled every slot yet.
+    public int HonkMinSlotCount { get; set; }
+    //HONK END
+
     public void SetActionData(ActionsSystem system, params EntityUid?[] actionTypes)
     {
         var uniqueCount = Math.Min(system.GetClientActions().Count(), actionTypes.Length + 1);
         var keys = ContentKeyFunctions.GetHotbarBoundKeys();
+        //HONK START - honour the caller's sparse layout (drag-to-slot places actions at specific indices)
+        // and pad empties up to the fork-requested minimum, capped at bound hotbar key count.
+        uniqueCount = Math.Max(uniqueCount, actionTypes.Length);
+        if (HonkMinSlotCount > 0)
+            uniqueCount = Math.Max(uniqueCount, Math.Min(HonkMinSlotCount, keys.Length));
+        //HONK END
 
         for (var i = 0; i < uniqueCount; i++)
         {

--- a/Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml
@@ -14,9 +14,15 @@
             <LineEdit Name="SearchBar" Access="Public" StyleClasses="actionSearchBox" HorizontalExpand="True"
                       PlaceHolder="{Loc ui-actionmenu-search-bar-placeholder-text}"/>
         </BoxContainer>
-        <!-- HONK - ClearButton removed; right-click the search box to clear it -->
-        <!-- HONK - FilterContainer hosts the inline HonkFilterPanel body when expanded -->
+        <!-- HONK START - ClearButton removed (right-click the search box), plus fork toggles
+             for bar lock and auto-add-new-actions, and FilterContainer hosts the inline
+             HonkFilterPanel body when expanded -->
+        <BoxContainer Orientation="Horizontal" SeparationOverride="8">
+            <CheckBox Name="LockButton" Access="Public" Text="{Loc ui-actionmenu-lock-button}"/>
+            <CheckBox Name="AutoAddButton" Access="Public" Text="{Loc ui-actionmenu-auto-add-button}"/>
+        </BoxContainer>
         <BoxContainer Name="FilterContainer" Access="Public" Orientation="Vertical"/>
+        <!-- HONK END -->
         <Label Name="FilterLabel" Access="Public"/>
         <ScrollContainer VerticalExpand="True" HorizontalExpand="True">
             <GridContainer Name="ResultsGrid" Access="Public" MaxGridWidth="300"/>

--- a/Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// Number of rows the action bar's hotbar page is laid out over.
+    /// The 10 hotbar slots reflow across this many rows; values outside
+    /// 1-4 are clamped by the options UI.
+    /// </summary>
+    public static readonly CVarDef<int> HonkActionBarRows =
+        CVarDef.Create("honk.action_bar.rows", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Pixel gap between adjacent action bar slots, applied as both
+    /// horizontal and vertical separation on the hotbar container.
+    /// </summary>
+    public static readonly CVarDef<int> HonkActionBarSlotSpacing =
+        CVarDef.Create("honk.action_bar.slot_spacing", 0, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether to show the per-slot keybind label in the corner of each action button.
+    /// </summary>
+    public static readonly CVarDef<bool> HonkActionBarShowKeybindLabel =
+        CVarDef.Create("honk.action_bar.show_keybind_label", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs
@@ -13,6 +13,14 @@ public sealed partial class CCVars
         CVarDef.Create("honk.action_bar.rows", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
+    /// Slots displayed per row. Combined with <see cref="HonkActionBarRows"/>
+    /// this also determines how many empty slots get drawn when the empty-slot
+    /// toggle is on; total is capped at the number of hotbar key bindings (20).
+    /// </summary>
+    public static readonly CVarDef<int> HonkActionBarSlotsPerRow =
+        CVarDef.Create("honk.action_bar.slots_per_row", 10, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
     /// Pixel gap between adjacent action bar slots, applied as both
     /// horizontal and vertical separation on the hotbar container.
     /// </summary>
@@ -24,4 +32,38 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> HonkActionBarShowKeybindLabel =
         CVarDef.Create("honk.action_bar.show_keybind_label", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether to draw a faint outline on empty action bar slots so the layout
+    /// is visible without every slot being populated. Empty slots go fully
+    /// opaque while an action is being dragged so the drop targets stand out.
+    /// </summary>
+    public static readonly CVarDef<bool> HonkActionBarShowEmptySlots =
+        CVarDef.Create("honk.action_bar.show_empty_slots", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether newly granted actions auto-populate the action bar. Off leaves the
+    /// action available in the actions menu but keeps the bar layout untouched,
+    /// so players curating a specific loadout don't have to re-remove every
+    /// implant/species action that gets handed to them.
+    /// </summary>
+    public static readonly CVarDef<bool> HonkActionBarAutoAddActions =
+        CVarDef.Create("honk.action_bar.auto_add_actions", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// When set, blocks drag-rearrangement and right-click-clear on the action bar
+    /// so a curated layout can't be nudged by mis-clicks. Toggled from the actions
+    /// window header button.
+    /// </summary>
+    public static readonly CVarDef<bool> HonkActionBarLock =
+        CVarDef.Create("honk.action_bar.lock", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Base opacity of the slot background on each action bar button (0.0-1.0).
+    /// Default matches the upstream hard-coded 150/255. Lower values make the
+    /// bar fade into the background for low-vision or minimalist HUD preferences.
+    /// The empty-slot preview fade scales from this value.
+    /// </summary>
+    public static readonly CVarDef<float> HonkActionBarButtonBackgroundAlpha =
+        CVarDef.Create("honk.action_bar.button_background_alpha", 150f / 255f, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl
@@ -1,0 +1,4 @@
+ui-options-action-bar-header = Action Bar
+ui-options-action-bar-rows = Rows
+ui-options-action-bar-slot-spacing = Slot spacing
+ui-options-action-bar-show-keybind-label = Show keybind label

--- a/Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl
@@ -1,4 +1,9 @@
 ui-options-action-bar-header = Action Bar
 ui-options-action-bar-rows = Rows
+ui-options-action-bar-slots-per-row = Slots per row
 ui-options-action-bar-slot-spacing = Slot spacing
 ui-options-action-bar-show-keybind-label = Show keybind label
+ui-options-action-bar-show-empty-slots = Show empty slots (faint)
+ui-options-action-bar-button-background-alpha = Action bar button background alpha
+ui-actionmenu-lock-button = Lock bar
+ui-actionmenu-auto-add-button = Auto-add new actions


### PR DESCRIPTION
## About the PR

First slice of #579. Adds an Action Bar section to Settings → Misc and an inline header strip on the actions window so players can size, dim, and curate the bar. Eight CVars total, all client-only and per-account.

Settings → Misc → Action Bar:

- Rows (1–4)
- Slots per row (1–10)
- Slot spacing (0–16 px)
- Show keybind label
- Show empty slots (faint). Empty tiles render at a low alpha so the bar's shape is visible without every slot being populated, and they jump to full alpha during a drag so drop targets are obvious.

Settings → Accessibility:

- Action bar button background alpha (0–100%). Sits with the other UI opacity sliders.

Actions window header CheckBoxes:

- Lock. Freezes the bar against right-click clear and drag rearrange. Click-to-fire still works.
- Auto-add. When off, server-granted actions don't auto-populate the bar (still listed in the actions menu). Items the player has previously placed on the bar still restore to their last slot on hand/pocket swap.

## Why / Balance

Follow-up to #579. The action bar was fixed at 1×10 with no opacity, density, or visibility knobs, and a new action being granted (pickup, implant, species innate) always pushed onto the bar regardless of player preference. Verb bindings depend on a configurable bar before the verb-as-button flag can ship, so this lands first. No gameplay balance impact, pure UI.

## Technical details

New files:

- `Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs`. Eight `honk.action_bar.*` CVars (rows, slots_per_row, slot_spacing, show_keybind_label, show_empty_slots, auto_add_actions, lock, button_background_alpha).
- `Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs`. UIController that reads the CVars, subscribes to `IConfigurationManager.OnValueChanged`, and exposes static accessors (`ShowEmptySlots`, `AutoAddActions`, `LockActions`, `ButtonBackgroundAlpha`, `IsDragActive`) consumed on hot paths. Owns `HonkOnContainerReady`, `HonkSetDragActive`, `HonkRefreshHotbar`, and `HonkBindWindow`.
- `Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl`. Strings.

Upstream touches (HONK-wrapped):

- `Content.Client/Options/UI/Tabs/MiscTab.xaml` / `.xaml.cs`. Action Bar section with two sliders and two checkboxes wired through `OptionSliderIntCVar` and `AddOptionCheckBox`.
- `Content.Client/Options/UI/Tabs/AccessibilityTab.xaml` / `.xaml.cs`. Single `OptionSliderFloatCVar` for the button background alpha, placed next to the existing chat / speech bubble opacity sliders.
- `Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs`. New `HonkMinSlotCount` property and a `SetActionData` pass that pads up to `rows × slots_per_row` (capped at the bound hotbar key count) so empty slots actually render.
- `Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs`. `UpdateBackground` HONK block applies the background-alpha CVar, fades empty slots while showing the toggle, and force-draws the slot texture during drag-reveal.
- `Content.Client/UserInterface/Systems/Actions/ActionUIController.cs`:
  - `_honkLastSlotByProvider` dict + `OnActionRemoved` records (provider, position) and nulls the slot in place (with trailing-null trim) instead of `RemoveAll` shifting everything left.
  - `OnActionAdded` restores a re-acquired action to its remembered slot regardless of auto-add (player accepted it previously). Pads `_actions` up to the remembered slot since the trim can collapse trailing nulls between drop and re-acquire.
  - `SetAction` (drag drop) updates the provider→slot map so a drag, then pocket, then unpocket restores to the new slot rather than the auto-populated original.
  - `LoadDefaultActions` populates defaults on first link per connection regardless of auto-add (so a new connect isn't a blank bar) and skips on subsequent re-links (respawn, body swap) when auto-add is off.
  - `OnActionPressed` / `HandleActionPressed` honour `LockActions` for right-click-clear and drag-rearrange. Click-to-fire still works because `HandleActionUnpressed` runs the trigger regardless of whether `_menuDragHelper.MouseDown` was called.
  - `OnMenuBeginDrag` / `OnMenuEndDrag` toggle `HonkSetDragActive(true/false)` so empty slot padding kicks in for the duration of the drag.
  - `LoadGui` calls `HonkOnContainerReady()` before and after `LinkAllActions` so fresh client starts get the stored layout applied even if upstream rebuilds the grid during linking.
- `Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml`. Lock and Auto-add checkboxes inline above the existing `HonkFilterPanel` body.

Layout note: `ApplyLayout` sets `container.Columns = _slotsPerRow` rather than `Rows`, so the grid fills row-major (slots 1..5 on row 1, 6..0 on row 2 with `slots_per_row=5, rows=2`) instead of the upstream column-major flow that would put 1, 3, 5, 7, 9 on row 1.

## Scope trimmed (out to follow-ups)

- Click-to-rebind keybind on action slot. Filed as #603.
- Movable bar with preset window (drag-to-reposition, save/load layouts, reset, lock moved into the window). Filed as #604.
- Icon size, text scale, action-name labels. Need `ActionButton` layout rework, will follow with verb-bindings work.

## Media

Pending, will attach before merge gates clear.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None for default settings. Auto-add defaults to on, lock defaults to off, show empty slots defaults to off, button background alpha defaults to the upstream `150/255`. A player who never opens the new options sees the same bar they always did.

**Changelog**

:cl:
- add: Action bar layout is now customisable in Settings → Misc → Action Bar. Row count, slots per row, slot spacing, show empty slots, show keybind label.
- add: Action bar button background opacity is in Settings → Accessibility next to the other UI opacity sliders.
- add: Lock and Auto-add checkboxes on the actions window header. Lock blocks right-click clear and drag rearrange. Auto-add off keeps server-granted actions out of the bar (still in the menu).
- tweak: Empty action slots now render at a low alpha when shown, jump to full alpha while dragging an action so drop targets are visible.
- fix: Hand/pocket swapping an item now restores its action to the same slot it sat in before, not whichever slot the auto-populate happened to choose.
