### PR TITLE
feat: guidebook popout window

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -24,6 +24,13 @@
             <BoxContainer Access="Internal" Name="ReturnContainer" Orientation="Horizontal" HorizontalAlignment="Right" Visible="False">
                 <Button Name="HomeButton" Text="{Loc 'ui-rules-button-home'}" Margin="0 0 10 0"/>
             </BoxContainer>
+            <!-- HONK START - popout button, issue #580 -->
+            <BoxContainer Orientation="Horizontal" HorizontalAlignment="Right" Margin="0 2 10 2">
+                <Button Name="PopoutButton" Access="Public"
+                        Text="{Loc 'honk-guidebook-popout-button'}"
+                        ToolTip="{Loc 'honk-guidebook-popout-button-tooltip'}" />
+            </BoxContainer>
+            <!-- HONK END -->
             <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
                 <Control>
                     <BoxContainer Orientation="Vertical" Name="EntryContainer" Margin="5 5 5 5" Visible="False">

--- a/Content.Client/RussStation/Guidebook/GuidebookPopoutWindow.cs
+++ b/Content.Client/RussStation/Guidebook/GuidebookPopoutWindow.cs
@@ -1,0 +1,36 @@
+// HONK: fork-side OS-window host for the guidebook (issue #580).
+// The docked GuidebookWindow's SplitContainer is reparented into this window
+// while popout mode is active, then returned when the window closes.
+using System;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.RussStation.Guidebook;
+
+public sealed class GuidebookPopoutWindow : OSWindow
+{
+    public GuidebookPopoutWindow()
+    {
+        Title = Loc.GetString("honk-guidebook-popout-title");
+        SetWidth = 900;
+        SetHeight = 700;
+        StartupLocation = WindowStartupLocation.CenterOwner;
+    }
+
+    public void HostContent(Control content)
+    {
+        content.Orphan();
+        AddChild(content);
+    }
+
+    public Control? ReleaseContent()
+    {
+        if (ChildCount == 0)
+            return null;
+
+        var content = GetChild(0);
+        content.Orphan();
+        return content;
+    }
+}

--- a/Content.Client/RussStation/Guidebook/GuidebookWindow.Honk.cs
+++ b/Content.Client/RussStation/Guidebook/GuidebookWindow.Honk.cs
@@ -1,0 +1,9 @@
+// HONK: exposes the private Split container so the popout window can reparent it (issue #580).
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.Guidebook.Controls;
+
+public sealed partial class GuidebookWindow
+{
+    public SplitContainer PopoutContent => Split;
+}

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -4,6 +4,7 @@ using Content.Client.Guidebook;
 using Content.Client.Guidebook.Controls;
 using Content.Client.Lobby;
 using Content.Client.Players.PlayTimeTracking;
+using Content.Client.RussStation.Guidebook; // HONK - popout window
 using Content.Client.UserInterface.Controls;
 using Content.Shared.CCVar;
 using Content.Shared.Guidebook;
@@ -31,6 +32,11 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
     private GuidebookWindow? _guideWindow;
     private MenuButton? GuidebookButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.GuidebookButton;
     private ProtoId<GuideEntryPrototype>? _lastEntry;
+    // HONK START - popout (issue #580)
+    private GuidebookPopoutWindow? _popoutWindow;
+    private bool _suppressPopoutRestore;
+    private bool IsPopoutOpen => _popoutWindow?.IsOpen ?? false;
+    // HONK END
 
     public void OnStateEntered(LobbyState state)
     {
@@ -50,6 +56,9 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         _guideWindow = UIManager.CreateWindow<GuidebookWindow>();
         _guideWindow.OnClose += OnWindowClosed;
         _guideWindow.OnOpen += OnWindowOpen;
+        // HONK START - popout wiring (issue #580)
+        _guideWindow.PopoutButton.OnPressed += _ => OpenPopout();
+        // HONK END
 
         if (state is LobbyState &&
             _jobRequirements.FetchOverallPlaytime() < TimeSpan.FromMinutes(PlaytimeOpenGuidebook))
@@ -83,6 +92,12 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
 
         _guideWindow.OnClose -= OnWindowClosed;
         _guideWindow.OnOpen -= OnWindowOpen;
+
+        // HONK START - teardown popout before disposing docked window (issue #580)
+        ClosePopoutNoRestore();
+        _popoutWindow?.Dispose();
+        _popoutWindow = null;
+        // HONK END
 
         // shutdown
         _guideWindow.Dispose();
@@ -125,6 +140,15 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
     {
         if (_guideWindow == null)
             return;
+
+        // HONK START - popout takes precedence over docked toggle (issue #580)
+        if (IsPopoutOpen)
+        {
+            UIManager.ClickSound();
+            ClosePopoutNoRestore();
+            return;
+        }
+        // HONK END
 
         if (_guideWindow.IsOpen)
         {
@@ -241,12 +265,81 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         if (_guideWindow == null)
             return;
 
+        // HONK START - popout close path (issue #580)
+        if (IsPopoutOpen)
+        {
+            UIManager.ClickSound();
+            ClosePopoutNoRestore();
+            return;
+        }
+        // HONK END
+
         if (_guideWindow.IsOpen)
         {
             UIManager.ClickSound();
             _guideWindow.Close();
         }
     }
+
+    // HONK START - popout helpers (issue #580)
+    private void OpenPopout()
+    {
+        if (_guideWindow == null || IsPopoutOpen)
+            return;
+
+        UIManager.ClickSound();
+
+        if (_guideWindow.IsOpen)
+        {
+            _lastEntry = _guideWindow.LastEntry;
+            _guideWindow.Close();
+        }
+
+        _popoutWindow ??= CreatePopoutWindow();
+        _popoutWindow.HostContent(_guideWindow.PopoutContent);
+        _popoutWindow.Show();
+    }
+
+    private GuidebookPopoutWindow CreatePopoutWindow()
+    {
+        var window = new GuidebookPopoutWindow();
+        window.Closed += OnPopoutClosed;
+        return window;
+    }
+
+    private void OnPopoutClosed()
+    {
+        // Closed fires for both OS-X-button and programmatic Close().
+        // Always return the content to the docked window so state survives.
+        if (_popoutWindow != null && _guideWindow != null)
+        {
+            var content = _popoutWindow.ReleaseContent();
+            if (content != null)
+                _guideWindow.ContentsContainer.AddChild(content);
+        }
+
+        // Only re-open docked when the user closed via OS chrome. Programmatic
+        // close paths (F1 toggle, state exit) set _suppressPopoutRestore first.
+        if (!_suppressPopoutRestore && _guideWindow != null)
+            OpenGuidebook(selected: _lastEntry);
+    }
+
+    private void ClosePopoutNoRestore()
+    {
+        if (_popoutWindow is not { IsOpen: true })
+            return;
+
+        _suppressPopoutRestore = true;
+        try
+        {
+            _popoutWindow.Close();
+        }
+        finally
+        {
+            _suppressPopoutRestore = false;
+        }
+    }
+    // HONK END
 
     private void RecursivelyAddChildren(GuideEntry guide, Dictionary<ProtoId<GuideEntryPrototype>, GuideEntry> guides)
     {

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -4,7 +4,9 @@ using Content.Client.Guidebook;
 using Content.Client.Guidebook.Controls;
 using Content.Client.Lobby;
 using Content.Client.Players.PlayTimeTracking;
-using Content.Client.RussStation.Guidebook; // HONK - popout window
+//HONK START - popout window
+using Content.Client.RussStation.Guidebook;
+//HONK END
 using Content.Client.UserInterface.Controls;
 using Content.Shared.CCVar;
 using Content.Shared.Guidebook;

--- a/Resources/Locale/en-US/@RussStation/guidebook/popout.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/popout.ftl
@@ -1,0 +1,3 @@
+honk-guidebook-popout-title = Guidebook
+honk-guidebook-popout-button = Pop Out
+honk-guidebook-popout-button-tooltip = Detach the guidebook into its own OS window.


### PR DESCRIPTION
Closes #580.

## About the PR

Adds a **Pop Out** button to the guidebook that detaches it into its own OS-level window. Once popped out, the guidebook can be dragged to a second monitor, resized, and kept open alongside gameplay without eating screen space.

## Why / Balance

People keep one guide open for long stretches (chem recipes, surgery steps, engineering reference) and the docked panel either covers the viewport or gets closed and re-opened constantly. An OS-level window solves that without touching anything gameplay-affecting.

## Technical details

Client-only. No shared or server changes.

Rather than extracting the guidebook body into a new content control (which would have been a bigger upstream diff), the `SplitContainer` named `Split` inside `GuidebookWindow` is hot-swapped between the docked `FancyWindow` and the popout's root while popout mode is active. The same tree/scroll/search instance is reused, so state and event wiring survive the toggle.

- `Content.Client/Guidebook/Controls/GuidebookWindow.xaml` — one HONK-marked `Button Name="PopoutButton"` added to the right-pane header.
- `Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs` — HONK-marked popout lifecycle: `OpenPopout` / `OnPopoutClosed` / `ClosePopoutNoRestore`, plus branches in `ToggleGuidebook` and `CloseGuidebook` to route around popout state.
- `Content.Client/RussStation/Guidebook/GuidebookPopoutWindow.cs` — fork-side `OSWindow` subclass with `HostContent` / `ReleaseContent` for the reparent.
- `Content.Client/RussStation/Guidebook/GuidebookWindow.Honk.cs` — partial class that exposes the private `Split` field as `PopoutContent` without touching upstream.
- `Resources/Locale/en-US/@RussStation/guidebook/popout.ftl` — fork-owned `honk-*` loc strings.

`OSWindow.Close()` fires `Closed` synchronously, so the programmatic close paths (F1 toggle, state exit) set a `_suppressPopoutRestore` flag in a try/finally to stop `OnPopoutClosed` from auto-reopening the docked window.

## Media

Draft; media to be attached after in-game verification.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None.

**Changelog**

:cl:
- add: The guidebook now has a Pop Out button that detaches it into its own OS window. You can drag it to a second monitor, resize it, and keep it open alongside the game.