### PR TITLE
honksquad: feat: HONK0016 code fix, extract magic DataField literal to private const

### DIFF
--- a/Content.Analyzers.Honk.Tests/Content.Analyzers.Honk.Tests.csproj
+++ b/Content.Analyzers.Honk.Tests/Content.Analyzers.Honk.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/Content.Analyzers.Honk.Tests/HonkMagicNumberFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkMagicNumberFixerTest.cs
@@ -1,0 +1,128 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkMagicNumberAnalyzer, HonkMagicNumberFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkMagicNumberFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Serialization.Manager.Attributes
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class DataFieldAttribute : System.Attribute
+            {
+                public DataFieldAttribute() { }
+                public DataFieldAttribute(string tag) { }
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/Example/ExampleComp.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task FloatLiteralOnField_ExtractsConst()
+    {
+        const string before = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Modifier = 0.5f;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                private const float ModifierDefault = 0.5f;
+                [DataField]
+                public float Modifier = ModifierDefault;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 29, 6, 33)
+                .WithArguments("Modifier", "0.5f"));
+    }
+
+    [Test]
+    public async Task NegativeLiteralOnProperty_ExtractsConst()
+    {
+        const string before = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public float Volume { get; set; } = -6f;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                private const float VolumeDefault = -6f;
+
+                [DataField]
+                public float Volume { get; set; } = VolumeDefault;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 41, 6, 44)
+                .WithArguments("Volume", "-6f"));
+    }
+
+    [Test]
+    public async Task IntLiteralOnField_ExtractsConst()
+    {
+        const string before = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                [DataField]
+                public int MaxStack = 30;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            public sealed class ExampleComp
+            {
+                private const int MaxStackDefault = 30;
+                [DataField]
+                public int MaxStack = MaxStackDefault;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0016", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 27, 6, 29)
+                .WithArguments("MaxStack", "30"));
+    }
+}

--- a/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateFixerTest.cs
@@ -1,0 +1,119 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkNetworkedComponentStateAnalyzer, HonkNetworkedComponentStateFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkNetworkedComponentStateFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = true)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class AutoGenerateComponentStateAttribute : System.Attribute
+            {
+                public AutoGenerateComponentStateAttribute(bool raiseAfterAutoHandleState = false) { }
+            }
+        }
+        namespace Robust.Shared.Serialization.Manager.Attributes
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class DataFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public abstract class Component : IComponent { }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/ForkComp.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task AddsAttributeAndPartialAndUsing_WhenAllMissing()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            public sealed class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            [AutoGenerateComponentState]
+            public sealed partial class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0012", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 21, 6, 26)
+                .WithArguments("Leaky"));
+    }
+
+    [Test]
+    public async Task AddsUsing_WhenGameStatesMissing()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [Robust.Shared.GameStates.NetworkedComponent]
+            public sealed class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization.Manager.Attributes;
+            using Robust.Shared.GameStates;
+
+            [Robust.Shared.GameStates.NetworkedComponent]
+            [AutoGenerateComponentState]
+            public sealed partial class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0012", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 21, 5, 26)
+                .WithArguments("Leaky"));
+    }
+}

--- a/Content.Analyzers.Honk/Content.Analyzers.Honk.csproj
+++ b/Content.Analyzers.Honk/Content.Analyzers.Honk.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Content.Analyzers.Honk/HonkMagicNumberFixer.cs
+++ b/Content.Analyzers.Honk/HonkMagicNumberFixer.cs
@@ -1,0 +1,210 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0016: extracts a magic numeric literal on a
+/// <c>[DataField]</c> into a sibling <c>private const</c> named
+/// <c>{FieldName}Default</c> and replaces the literal with a reference.
+/// Keeps the fix local to the containing type; moving the constant to a
+/// per-system <c>*Constants.cs</c> file remains a manual follow-up.
+/// Only handles direct numeric literals (including unary-minus); array
+/// and collection initializers still need manual extraction.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkMagicNumberFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("HONK0016");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var literal = node.AncestorsAndSelf()
+                .FirstOrDefault(a => a is LiteralExpressionSyntax or PrefixUnaryExpressionSyntax) as ExpressionSyntax;
+
+            if (literal is null || !IsDirectNumericLiteral(literal))
+                continue;
+
+            var member = literal.FirstAncestorOrSelf<MemberDeclarationSyntax>(m =>
+                m is FieldDeclarationSyntax or PropertyDeclarationSyntax);
+
+            if (member is null)
+                continue;
+
+            if (!TryGetMemberInfo(member, out var memberName, out var memberType))
+                continue;
+
+            // Only rewrite when the flagged literal IS the initializer value itself —
+            // array/collection initializers stay a manual extraction.
+            if (GetInitializerValue(member) != literal)
+                continue;
+
+            var typeDecl = member.Parent as TypeDeclarationSyntax;
+            if (typeDecl is null)
+                continue;
+
+            var constName = memberName + "Default";
+            if (TypeAlreadyHasMember(typeDecl, constName))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Extract to private const '{constName}'",
+                    createChangedDocument: c => ExtractConstAsync(context.Document, typeDecl, member, literal, constName, memberType, c),
+                    equivalenceKey: "HonkExtractConst"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ExtractConstAsync(
+        Document document,
+        TypeDeclarationSyntax typeDecl,
+        MemberDeclarationSyntax dataFieldMember,
+        ExpressionSyntax literal,
+        string constName,
+        TypeSyntax constType,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var constDecl = SyntaxFactory.FieldDeclaration(
+            attributeLists: default,
+            modifiers: SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+                SyntaxFactory.Token(SyntaxKind.ConstKeyword)),
+            declaration: SyntaxFactory.VariableDeclaration(
+                constType.WithoutTrivia(),
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator(
+                        identifier: SyntaxFactory.Identifier(constName),
+                        argumentList: null,
+                        initializer: SyntaxFactory.EqualsValueClause(literal.WithoutTrivia())))))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var replacement = SyntaxFactory.IdentifierName(constName).WithTriviaFrom(literal);
+
+        var editor = new TrackedEditor(root);
+        editor.TrackNodes(dataFieldMember, literal, typeDecl);
+
+        root = editor.ReplaceNode(literal, replacement);
+        root = editor.InsertBefore(dataFieldMember, constDecl);
+
+        return document.WithSyntaxRoot(root);
+    }
+
+    private static bool IsDirectNumericLiteral(ExpressionSyntax expr)
+    {
+        return expr switch
+        {
+            LiteralExpressionSyntax l => l.IsKind(SyntaxKind.NumericLiteralExpression),
+            PrefixUnaryExpressionSyntax u => u.IsKind(SyntaxKind.UnaryMinusExpression)
+                                             && u.Operand is LiteralExpressionSyntax inner
+                                             && inner.IsKind(SyntaxKind.NumericLiteralExpression),
+            _ => false,
+        };
+    }
+
+    private static bool TryGetMemberInfo(MemberDeclarationSyntax member, out string name, out TypeSyntax type)
+    {
+        switch (member)
+        {
+            case FieldDeclarationSyntax field when field.Declaration.Variables.Count == 1:
+                name = field.Declaration.Variables[0].Identifier.Text;
+                type = field.Declaration.Type;
+                return true;
+            case PropertyDeclarationSyntax prop:
+                name = prop.Identifier.Text;
+                type = prop.Type;
+                return true;
+            default:
+                name = string.Empty;
+                type = null!;
+                return false;
+        }
+    }
+
+    private static ExpressionSyntax? GetInitializerValue(MemberDeclarationSyntax member) => member switch
+    {
+        FieldDeclarationSyntax f when f.Declaration.Variables.Count == 1 => f.Declaration.Variables[0].Initializer?.Value,
+        PropertyDeclarationSyntax p => p.Initializer?.Value,
+        _ => null,
+    };
+
+    private static bool TypeAlreadyHasMember(TypeDeclarationSyntax typeDecl, string name)
+    {
+        foreach (var m in typeDecl.Members)
+        {
+            switch (m)
+            {
+                case FieldDeclarationSyntax f:
+                    foreach (var v in f.Declaration.Variables)
+                        if (v.Identifier.Text == name)
+                            return true;
+                    break;
+                case PropertyDeclarationSyntax p:
+                    if (p.Identifier.Text == name)
+                        return true;
+                    break;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Tiny wrapper around <see cref="SyntaxNode.TrackNodes"/> so the two
+    /// edits (replace literal, insert const) can reference the same
+    /// original nodes after the first replacement changes identity.
+    /// </summary>
+    private sealed class TrackedEditor
+    {
+        private SyntaxNode _root;
+
+        public TrackedEditor(SyntaxNode root)
+        {
+            _root = root;
+        }
+
+        public void TrackNodes(params SyntaxNode[] nodes)
+        {
+            _root = _root.TrackNodes(nodes);
+        }
+
+        public SyntaxNode ReplaceNode(SyntaxNode original, SyntaxNode replacement)
+        {
+            var current = _root.GetCurrentNode(original);
+            if (current is null)
+                return _root;
+            _root = _root.ReplaceNode(current, replacement);
+            return _root;
+        }
+
+        public SyntaxNode InsertBefore(SyntaxNode anchor, SyntaxNode toInsert)
+        {
+            var current = _root.GetCurrentNode(anchor);
+            if (current is null)
+                return _root;
+            _root = _root.InsertNodesBefore(current, new[] { toInsert });
+            return _root;
+        }
+    }
+}

--- a/Content.Analyzers.Honk/HonkNetworkedComponentStateFixer.cs
+++ b/Content.Analyzers.Honk/HonkNetworkedComponentStateFixer.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0012: attaches the auto-state scaffolding to a
+/// networked fork component that declares <c>[DataField]</c>s but ships
+/// no state mechanism. Adds <c>[AutoGenerateComponentState]</c>, marks
+/// the class <c>partial</c>, and inserts <c>using Robust.Shared.GameStates;</c>
+/// when absent. Fields still need <c>[AutoNetworkedField]</c> (or a
+/// manual state override) to actually replicate; the analyzer will stop
+/// firing either way, so the remaining networking work is surfaced in
+/// code review rather than by the rule.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkNetworkedComponentStateFixer : CodeFixProvider
+{
+    private const string AutoGenerateAttributeName = "AutoGenerateComponentState";
+    private const string GameStatesNamespace = "Robust.Shared.GameStates";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0012");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var cls = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            if (cls is null)
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Add [AutoGenerateComponentState] and mark partial",
+                    createChangedDocument: c => ApplyFixAsync(context.Document, cls, c),
+                    equivalenceKey: "HonkAddAutoGenerateComponentState"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, ClassDeclarationSyntax cls, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is not CompilationUnitSyntax unit)
+            return document;
+
+        var updatedClass = cls;
+
+        if (!HasAttribute(updatedClass, AutoGenerateAttributeName))
+        {
+            var attribute = SyntaxFactory.Attribute(SyntaxFactory.IdentifierName(AutoGenerateAttributeName));
+            var list = SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(attribute))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            updatedClass = updatedClass.AddAttributeLists(list);
+        }
+
+        if (!updatedClass.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            var partialToken = SyntaxFactory.Token(SyntaxKind.PartialKeyword)
+                .WithTrailingTrivia(SyntaxFactory.Space);
+            updatedClass = updatedClass.WithModifiers(updatedClass.Modifiers.Add(partialToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+        }
+
+        var newUnit = unit.ReplaceNode(cls, updatedClass);
+
+        if (!HasUsing(newUnit, GameStatesNamespace))
+        {
+            var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(GameStatesNamespace))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            newUnit = newUnit.AddUsings(usingDirective);
+        }
+
+        return document.WithSyntaxRoot(newUnit);
+    }
+
+    private static bool HasAttribute(ClassDeclarationSyntax cls, string name)
+    {
+        foreach (var list in cls.AttributeLists)
+        {
+            foreach (var attr in list.Attributes)
+            {
+                var attrName = attr.Name switch
+                {
+                    IdentifierNameSyntax id => id.Identifier.ValueText,
+                    QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+                    _ => null,
+                };
+                if (attrName == name || attrName == name + "Attribute")
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasUsing(CompilationUnitSyntax unit, string ns)
+    {
+        foreach (var u in unit.Usings)
+        {
+            if (u.Name?.ToString() == ns)
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a Roslyn `CodeFixProvider` companion to `HonkMagicNumberAnalyzer`. When HONK0016 flags a raw numeric literal on a fork `[DataField]`, the IDE now offers a lightbulb titled *Extract to private const `{FieldName}Default`*. Invoking it inserts a sibling `private const T {FieldName}Default = <literal>;` into the containing type and rewrites the DataField initializer to reference it.

This is the first fixer to ship alongside a HONK analyzer, so the PR also wires the `Microsoft.CodeAnalysis.CSharp.Workspaces` package into `Content.Analyzers.Honk` and `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing` into the test project.

## Why / Balance

HONK0016 flags a real fork-wide convention (named constants over magic literals), but the fix is mechanical boilerplate repeated per field: think of a const name, add a `private const`, swap the literal. Without a fixer the rule is tedious enough to demote in practice. A CodeFixProvider turns each diagnostic into a one-keystroke extraction and unlocks *Fix all in document* for bulk-cleaning existing offenders.

Not a gameplay change. No content touched.

## Technical details

Scope is deliberately narrow:
- Only direct numeric literals (and unary-minus literals) on single-variable fields or properties. Array and collection initializers still need a manual extraction, the analyzer still flags them.
- The extracted const lands in the **same type**, not the per-system `*Constants.cs` file that the analyzer description points at. Moving the const into the central file stays a manual follow-up; this fixer only enforces the "named constant" half of the rule.
- Idempotent: if the type already has a member named `{FieldName}Default`, no fix is offered, so re-running over the same tree is safe.

Tests cover the three shapes we care about right now: float field, int field, negative-literal property. Run via `dotnet test Content.Analyzers.Honk.Tests/Content.Analyzers.Honk.Tests.csproj --filter HonkMagicNumberFixerTest`.

The two pre-existing `HonkLayoutMagicNumberAnalyzerTest` failures on `origin/release` (`ThicknessWithNumericArgs_ReportsPerArgument`, `Vector2WithNumericArgs_Reports`) are untouched by this PR.

## Media

N/A, developer-only tooling.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. Adds a new CodeFixProvider, does not modify existing analyzer behavior.