### PR TITLE
feat: mirror popups into a Popup chat tab (#578, PR 2/4)

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -89,6 +89,10 @@ namespace Content.Client.Popups
                     _replayRecording.RecordClientMessage(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)));
             }
 
+            //HONK START - every displayed world popup goes through here; mirror into the popup chat log
+            RaiseLocalEvent(new Content.Shared.RussStation.Popups.CategorizedPopupRaisedEvent(message, null, type, entity));
+            //HONK END
+
             var popupData = new WorldPopupData(message, type, coordinates, entity);
             if (_aliveWorldLabels.TryGetValue(popupData, out var existingLabel))
             {
@@ -136,6 +140,10 @@ namespace Content.Client.Popups
 
             if (recordReplay && _replayRecording.IsRecording)
                 _replayRecording.RecordClientMessage(new PopupCursorEvent(message, type));
+
+            //HONK START - every displayed cursor popup goes through here; mirror into the popup chat log
+            RaiseLocalEvent(new Content.Shared.RussStation.Popups.CategorizedPopupRaisedEvent(message, null, type, null));
+            //HONK END
 
             var popupData = new CursorPopupData(message, type);
             if (_aliveCursorLabels.TryGetValue(popupData, out var existingLabel))

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -27,25 +27,10 @@ public sealed class PopupLogSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeNetworkEvent<PopupCursorEvent>(OnPopupCursor);
-        SubscribeNetworkEvent<PopupCoordinatesEvent>(OnPopupCoordinates);
-        SubscribeNetworkEvent<PopupEntityEvent>(OnPopupEntity);
+        // Single source: the client-side PopupSystem raises a CategorizedPopupRaisedEvent from
+        // PopupMessage / PopupCursorInternal (HONK blocks), so network-sent popups, client-predicted
+        // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
-    }
-
-    private void OnPopupCursor(PopupCursorEvent ev)
-    {
-        LogMirroredPopup(ev.Message, NetEntity.Invalid, null);
-    }
-
-    private void OnPopupCoordinates(PopupCoordinatesEvent ev)
-    {
-        LogMirroredPopup(ev.Message, NetEntity.Invalid, null);
-    }
-
-    private void OnPopupEntity(PopupEntityEvent ev)
-    {
-        LogMirroredPopup(ev.Message, ev.Uid, null);
     }
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -40,9 +40,12 @@ public sealed class PopupLogSystem : EntitySystem
     {
         // Filter out popups the player shouldn't be able to perceive. Server PVS may ship popups
         // for entities outside the player's line of sight (proximity filters, broad broadcast);
-        // gate those behind the same visibility rule the examine system uses.
+        // gate those behind the same visibility rule the examine system uses. Self-sourced popups
+        // (combat mode, spit, ActionGun text) and popups that don't carry an entity source always
+        // log since those are directly addressed to the local player.
         if (ev.Source is { } sourceUid
             && _player.LocalEntity is { } examiner
+            && sourceUid != examiner
             && !_examine.CanExamine(examiner, sourceUid))
         {
             return;

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,7 +1,9 @@
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
+using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Shared.Utility;
 
@@ -12,14 +14,15 @@ namespace Content.Client.RussStation.Popups;
 /// through text that otherwise disappears with the floating display.
 /// </summary>
 /// <remarks>
-/// Subscribes to the three popup network events plus the fork's <see cref="CategorizedPopupRaisedEvent"/>.
-/// Category-tagged mirrors only appear for fork-side categorized calls; server-originated popups arrive
-/// here through the network path and are logged without a category. A future PR will network the category
-/// alongside the popup to close that gap.
+/// Popups for entities the local player can't examine (out of range, occluded, wrong map) are dropped
+/// so the log doesn't leak information the player shouldn't have. Cursor / coordinate-only popups with
+/// no source entity always log since those are typically addressed directly to the local player.
 /// </remarks>
 public sealed class PopupLogSystem : EntitySystem
 {
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
 
     private ChatUIController? _chat;
     private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
@@ -35,6 +38,16 @@ public sealed class PopupLogSystem : EntitySystem
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
     {
+        // Filter out popups the player shouldn't be able to perceive. Server PVS may ship popups
+        // for entities outside the player's line of sight (proximity filters, broad broadcast);
+        // gate those behind the same visibility rule the examine system uses.
+        if (ev.Source is { } sourceUid
+            && _player.LocalEntity is { } examiner
+            && !_examine.CanExamine(examiner, sourceUid))
+        {
+            return;
+        }
+
         var source = ev.Source is { } uid ? GetNetEntity(uid) : NetEntity.Invalid;
         LogMirroredPopup(ev.Message, source, ev.Category);
     }

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,0 +1,76 @@
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.Chat;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Popups;
+using Robust.Client.UserInterface;
+using Robust.Shared.Utility;
+
+namespace Content.Client.RussStation.Popups;
+
+/// <summary>
+/// Mirrors every popup the local client sees into a dedicated chat channel so players can scroll back
+/// through text that otherwise disappears with the floating display.
+/// </summary>
+/// <remarks>
+/// Subscribes to the three popup network events plus the fork's <see cref="CategorizedPopupRaisedEvent"/>.
+/// Category-tagged mirrors only appear for fork-side categorized calls; server-originated popups arrive
+/// here through the network path and are logged without a category. A future PR will network the category
+/// alongside the popup to close that gap.
+/// </remarks>
+public sealed class PopupLogSystem : EntitySystem
+{
+    [Dependency] private readonly IUserInterfaceManager _ui = default!;
+
+    private ChatUIController? _chat;
+    private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<PopupCursorEvent>(OnPopupCursor);
+        SubscribeNetworkEvent<PopupCoordinatesEvent>(OnPopupCoordinates);
+        SubscribeNetworkEvent<PopupEntityEvent>(OnPopupEntity);
+        SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
+    }
+
+    private void OnPopupCursor(PopupCursorEvent ev)
+    {
+        LogMirroredPopup(ev.Message, NetEntity.Invalid, null);
+    }
+
+    private void OnPopupCoordinates(PopupCoordinatesEvent ev)
+    {
+        LogMirroredPopup(ev.Message, NetEntity.Invalid, null);
+    }
+
+    private void OnPopupEntity(PopupEntityEvent ev)
+    {
+        LogMirroredPopup(ev.Message, ev.Uid, null);
+    }
+
+    private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
+    {
+        var source = ev.Source is { } uid ? GetNetEntity(uid) : NetEntity.Invalid;
+        LogMirroredPopup(ev.Message, source, ev.Category);
+    }
+
+    private void LogMirroredPopup(string? message, NetEntity source, PopupCategory? category)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return;
+
+        var escaped = FormattedMessage.EscapeText(message);
+        var wrapped = category is { } cat
+            ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
+            : escaped;
+
+        var mirror = new ChatMessage(
+            ChatChannel.Popup,
+            message,
+            wrapped,
+            source,
+            senderKey: null);
+
+        Chat.ProcessChatMessage(mirror, speechBubble: false);
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -859,6 +859,22 @@ public sealed partial class ChatUIController : UIController
             }
         }
 
+        //HONK START - HideChat emotes (gasp, sleeping snores, etc.) produce a floating speech bubble
+        // but never enter chat history, so the popup log is the only place they can be scrolled back.
+        // Route them through the same CategorizedPopupRaisedEvent pipeline so the examine visibility
+        // filter and self-bypass in PopupLogSystem apply.
+        if (msg.HideChat && msg.Channel == ChatChannel.Emotes)
+        {
+            var source = _ent.GetEntity(msg.SenderEntity);
+            _ent.EventBus.RaiseEvent(EventSource.Local,
+                new Content.Shared.RussStation.Popups.CategorizedPopupRaisedEvent(
+                    msg.Message,
+                    null,
+                    Content.Shared.Popups.PopupType.Small,
+                    source == default ? null : source));
+        }
+        //HONK END
+
         // Log all incoming chat to repopulate when filter is un-toggled
         if (!msg.HideChat)
         {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -535,6 +535,10 @@ public sealed partial class ChatUIController : UIController
         // can always hear server (nobody can actually send server messages).
         FilterableChannels |= ChatChannel.Server;
 
+        // HONK START - popup mirror is always filterable (issue #578)
+        FilterableChannels |= ChatChannel.Popup;
+        // HONK END
+
         if (_state.CurrentState is GameplayStateBase)
         {
             // can always hear local / radio / emote / notifications when in the game

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -861,10 +861,21 @@ public sealed partial class ChatUIController : UIController
 
         //HONK START - let HideChat emotes (gasp, snore, etc.) land in the Emotes filter alongside
         // typed emotes. Upstream set HideChat=true on these so they wouldn't enter chat history, but
-        // the chat log is the only scrollback path for transient visuals. Other HideChat channels
-        // (range-faded Local/Whisper, etc.) stay suppressed.
+        // the chat log is the only scrollback path for transient visuals. The server broadcasts
+        // to everyone in voice range without a line-of-sight check, so gate on whether the local
+        // player can actually examine the source (same rule as the popup log). Self-sourced and
+        // sourceless emotes always pass. Other HideChat channels stay suppressed entirely.
         if (msg.HideChat && msg.Channel == ChatChannel.Emotes)
-            msg.HideChat = false;
+        {
+            var honkSource = _ent.GetEntity(msg.SenderEntity);
+            var honkExaminer = _player.LocalEntity;
+            var honkVisible = honkSource == default
+                || honkExaminer is null
+                || honkSource == honkExaminer.Value
+                || _ent.System<Content.Shared.Examine.ExamineSystemShared>().CanExamine(honkExaminer.Value, honkSource);
+            if (honkVisible)
+                msg.HideChat = false;
+        }
         //HONK END
 
         // Log all incoming chat to repopulate when filter is un-toggled

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -859,20 +859,12 @@ public sealed partial class ChatUIController : UIController
             }
         }
 
-        //HONK START - HideChat emotes (gasp, sleeping snores, etc.) produce a floating speech bubble
-        // but never enter chat history, so the popup log is the only place they can be scrolled back.
-        // Route them through the same CategorizedPopupRaisedEvent pipeline so the examine visibility
-        // filter and self-bypass in PopupLogSystem apply.
+        //HONK START - let HideChat emotes (gasp, snore, etc.) land in the Emotes filter alongside
+        // typed emotes. Upstream set HideChat=true on these so they wouldn't enter chat history, but
+        // the chat log is the only scrollback path for transient visuals. Other HideChat channels
+        // (range-faded Local/Whisper, etc.) stay suppressed.
         if (msg.HideChat && msg.Channel == ChatChannel.Emotes)
-        {
-            var source = _ent.GetEntity(msg.SenderEntity);
-            _ent.EventBus.RaiseEvent(EventSource.Local,
-                new Content.Shared.RussStation.Popups.CategorizedPopupRaisedEvent(
-                    msg.Message,
-                    null,
-                    Content.Shared.Popups.PopupType.Small,
-                    source == default ? null : source));
-        }
+            msg.HideChat = false;
         //HONK END
 
         // Log all incoming chat to repopulate when filter is un-toggled

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -20,7 +20,9 @@ public sealed partial class ChannelFilterPopup : Popup
         ChatChannel.Emotes,
         ChatChannel.Radio,
         ChatChannel.Notifications,
-        ChatChannel.Popup, // HONK - popup mirror (issue #578)
+        //HONK START - popup mirror (issue #578)
+        ChatChannel.Popup,
+        //HONK END
         ChatChannel.LOOC,
         ChatChannel.OOC,
         ChatChannel.Dead,

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class ChannelFilterPopup : Popup
         ChatChannel.Emotes,
         ChatChannel.Radio,
         ChatChannel.Notifications,
+        ChatChannel.Popup, // HONK - popup mirror (issue #578)
         ChatChannel.LOOC,
         ChatChannel.OOC,
         ChatChannel.Dead,

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -85,6 +85,13 @@ namespace Content.Shared.Chat
         /// </summary>
         Unspecified = 1 << 14,
 
+        // HONK START - dedicated channel for mirrored popups (issue #578). Synthesized client-side, never received from the server.
+        /// <summary>
+        ///     Mirrored popups shown in the chat tab so players can scroll back.
+        /// </summary>
+        Popup = 1 << 15,
+        // HONK END
+
         /// <summary>
         ///     Channels considered to be IC.
         /// </summary>

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -2,9 +2,18 @@
 // Without this, FTL-reparenting one side of a joint (e.g. arrivals grid
 // returning from the FTL map) leaves the joint cross-map, which trips
 // the engine's cross-map joint assert during client prediction.
-// Covers pulling, carrying, buckle relay, grappling gun — any JointComponent.
+// Covers pulling, carrying, buckle relay, grappling gun - any JointComponent.
+//
+// Also mirrors the check via PullerComponent/PullableComponent, because
+// the pull joint can be pending in SharedJointSystem.AddedJoints (or a
+// state rollback) before it lands in JointComponent.Joints, in which
+// case the JointComponent-only path misses the transition (e.g. a
+// pullable walking into a portal while the joint is mid-init).
 using System.Collections.Generic;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Physics.Systems;
@@ -15,16 +24,19 @@ public sealed class PullMapGuardSystem : EntitySystem
 {
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly PullingSystem _pulling = default!;
 
     private readonly List<Joint> _toBreak = new();
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<JointComponent, EntParentChangedMessage>(OnParentChanged);
+        SubscribeLocalEvent<JointComponent, EntParentChangedMessage>(OnJointParentChanged);
+        SubscribeLocalEvent<PullerComponent, EntParentChangedMessage>(OnPullerParentChanged);
+        SubscribeLocalEvent<PullableComponent, EntParentChangedMessage>(OnPullableParentChanged);
     }
 
-    private void OnParentChanged(Entity<JointComponent> ent, ref EntParentChangedMessage args)
+    private void OnJointParentChanged(Entity<JointComponent> ent, ref EntParentChangedMessage args)
     {
         if (ent.Comp.GetJoints.Count == 0)
             return;
@@ -45,5 +57,35 @@ public sealed class PullMapGuardSystem : EntitySystem
             _joints.RemoveJoint(joint);
 
         _toBreak.Clear();
+    }
+
+    private void OnPullerParentChanged(Entity<PullerComponent> ent, ref EntParentChangedMessage args)
+    {
+        if (ent.Comp.Pulling is not { } pullable)
+            return;
+
+        if (!MapsDiverged(ent.Owner, pullable))
+            return;
+
+        if (TryComp<PullableComponent>(pullable, out var pullableComp))
+            _pulling.TryStopPull(pullable, pullableComp);
+    }
+
+    private void OnPullableParentChanged(Entity<PullableComponent> ent, ref EntParentChangedMessage args)
+    {
+        if (ent.Comp.Puller is not { } puller)
+            return;
+
+        if (!MapsDiverged(ent.Owner, puller))
+            return;
+
+        _pulling.TryStopPull(ent.Owner, ent.Comp);
+    }
+
+    private bool MapsDiverged(EntityUid a, EntityUid b)
+    {
+        var mapA = _transform.GetMapId(a);
+        var mapB = _transform.GetMapId(b);
+        return mapA != mapB && mapA != MapId.Nullspace && mapB != MapId.Nullspace;
     }
 }

--- a/Content.Shared/RussStation/Popups/CategorizedPopupRaisedEvent.cs
+++ b/Content.Shared/RussStation/Popups/CategorizedPopupRaisedEvent.cs
@@ -12,7 +12,12 @@ namespace Content.Shared.RussStation.Popups;
 public sealed class CategorizedPopupRaisedEvent : EntityEventArgs
 {
     public string? Message { get; }
-    public PopupCategory Category { get; }
+
+    /// <summary>
+    /// Null for non-categorized calls (most upstream popup paths). Set only when a fork caller
+    /// used one of the <see cref="PopupCategory"/>-carrying overloads on SharedPopupSystem.
+    /// </summary>
+    public PopupCategory? Category { get; }
     public Content.Shared.Popups.PopupType Type { get; }
 
     /// <summary>
@@ -21,7 +26,7 @@ public sealed class CategorizedPopupRaisedEvent : EntityEventArgs
     /// </summary>
     public EntityUid? Source { get; }
 
-    public CategorizedPopupRaisedEvent(string? message, PopupCategory category, Content.Shared.Popups.PopupType type, EntityUid? source)
+    public CategorizedPopupRaisedEvent(string? message, PopupCategory? category, Content.Shared.Popups.PopupType type, EntityUid? source)
     {
         Message = message;
         Category = category;

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -31,6 +31,7 @@ hud-chatbox-channel-Server = Server
 hud-chatbox-channel-Visual = Actions
 hud-chatbox-channel-Damage = Damage
 hud-chatbox-channel-Unspecified = Unspecified
+hud-chatbox-channel-Popup = Popup
 
 hud-chatbox-highlights = Highlights:
 hud-chatbox-highlights-button = Submit


### PR DESCRIPTION
## About the PR

Second PR in the issue #578 stack, stacked on #582. Adds a new `Popup` chat channel/tab and mirrors every popup the local client sees into it, so players can scroll back through the floating text after it fades.

## Why / Balance

Popups are ephemeral and overlap. Combat spam, pain messages, and environmental alerts vanish before you can read them. This PR gives the player a persistent transcript in a tab they can hide or unhide like any other channel.

No gameplay change, purely an additive UI surface. Existing tabs and channels behave exactly as before.

## Technical details

- `Content.Client/RussStation/Popups/PopupLogSystem.cs`, new client system that subscribes to the three popup network events plus PR 1's `CategorizedPopupRaisedEvent`. For each popup it synthesizes a `ChatMessage` with `Channel = ChatChannel.Popup` and hands it to `ChatUIController.ProcessChatMessage(..., speechBubble: false)`. The chat widget's own history list serves as the ring buffer, no parallel storage.
- Categorized popups carry their category through as a `[Category]` prefix. Server-originated popups arrive via the network event and log without a category; a later PR will network category alongside the popup event to close the gap.
- Upstream touches, all HONK-wrapped:
  - `Content.Shared/Chat/ChatChannel.cs`, adds `Popup = 1 << 15` (fits in the existing `ushort`).
  - `Content.Client/UserInterface/Systems/Chat/ChatUIController.cs`, includes `Popup` in `FilterableChannels`.
  - `Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs`, inserts `Popup` into `ChannelFilterOrder`.
  - `Resources/Locale/en-US/chat/ui/chat-box.ftl`, adds the `Popup` channel label.

## Media

Needs in-game verification, draft for now.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None. `ChatChannel` is additive and the new system observes existing events rather than intercepting them.

**Changelog**

:cl:
- add: Popups now mirror into a dedicated Popup chat tab so you can scroll back through floating text.