### PR TITLE
honksquad: feat: HONK0012 code fix, add AutoGenerateComponentState + partial

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkNetworkedComponentStateFixerTest.cs
@@ -1,0 +1,119 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkNetworkedComponentStateAnalyzer, HonkNetworkedComponentStateFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkNetworkedComponentStateFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = true)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class AutoGenerateComponentStateAttribute : System.Attribute
+            {
+                public AutoGenerateComponentStateAttribute(bool raiseAfterAutoHandleState = false) { }
+            }
+        }
+        namespace Robust.Shared.Serialization.Manager.Attributes
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class DataFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public abstract class Component : IComponent { }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/ForkComp.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task AddsAttributeAndPartialAndUsing_WhenAllMissing()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            public sealed class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [NetworkedComponent]
+            [AutoGenerateComponentState]
+            public sealed partial class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0012", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 6, 21, 6, 26)
+                .WithArguments("Leaky"));
+    }
+
+    [Test]
+    public async Task AddsUsing_WhenGameStatesMissing()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            [Robust.Shared.GameStates.NetworkedComponent]
+            public sealed class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization.Manager.Attributes;
+            using Robust.Shared.GameStates;
+
+            [Robust.Shared.GameStates.NetworkedComponent]
+            [AutoGenerateComponentState]
+            public sealed partial class Leaky : Component
+            {
+                [DataField]
+                public int Value;
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0012", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 21, 5, 26)
+                .WithArguments("Leaky"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkNetworkedComponentStateFixer.cs
+++ b/Content.Analyzers.Honk/HonkNetworkedComponentStateFixer.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0012: attaches the auto-state scaffolding to a
+/// networked fork component that declares <c>[DataField]</c>s but ships
+/// no state mechanism. Adds <c>[AutoGenerateComponentState]</c>, marks
+/// the class <c>partial</c>, and inserts <c>using Robust.Shared.GameStates;</c>
+/// when absent. Fields still need <c>[AutoNetworkedField]</c> (or a
+/// manual state override) to actually replicate; the analyzer will stop
+/// firing either way, so the remaining networking work is surfaced in
+/// code review rather than by the rule.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkNetworkedComponentStateFixer : CodeFixProvider
+{
+    private const string AutoGenerateAttributeName = "AutoGenerateComponentState";
+    private const string GameStatesNamespace = "Robust.Shared.GameStates";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0012");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var cls = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            if (cls is null)
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Add [AutoGenerateComponentState] and mark partial",
+                    createChangedDocument: c => ApplyFixAsync(context.Document, cls, c),
+                    equivalenceKey: "HonkAddAutoGenerateComponentState"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, ClassDeclarationSyntax cls, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is not CompilationUnitSyntax unit)
+            return document;
+
+        var updatedClass = cls;
+
+        if (!HasAttribute(updatedClass, AutoGenerateAttributeName))
+        {
+            var attribute = SyntaxFactory.Attribute(SyntaxFactory.IdentifierName(AutoGenerateAttributeName));
+            var list = SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(attribute))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            updatedClass = updatedClass.AddAttributeLists(list);
+        }
+
+        if (!updatedClass.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            var partialToken = SyntaxFactory.Token(SyntaxKind.PartialKeyword)
+                .WithTrailingTrivia(SyntaxFactory.Space);
+            updatedClass = updatedClass.WithModifiers(updatedClass.Modifiers.Add(partialToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+        }
+
+        var newUnit = unit.ReplaceNode(cls, updatedClass);
+
+        if (!HasUsing(newUnit, GameStatesNamespace))
+        {
+            var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(GameStatesNamespace))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            newUnit = newUnit.AddUsings(usingDirective);
+        }
+
+        return document.WithSyntaxRoot(newUnit);
+    }
+
+    private static bool HasAttribute(ClassDeclarationSyntax cls, string name)
+    {
+        foreach (var list in cls.AttributeLists)
+        {
+            foreach (var attr in list.Attributes)
+            {
+                var attrName = attr.Name switch
+                {
+                    IdentifierNameSyntax id => id.Identifier.ValueText,
+                    QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+                    _ => null,
+                };
+                if (attrName == name || attrName == name + "Attribute")
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasUsing(CompilationUnitSyntax unit, string ns)
+    {
+        foreach (var u in unit.Usings)
+        {
+            if (u.Name?.ToString() == ns)
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds `HonkNetworkedComponentStateFixer`, the code fix that pairs with the HONK0012 analyzer. One light-bulb action on a flagged class attaches `[AutoGenerateComponentState]`, marks the class `partial`, and inserts `using Robust.Shared.GameStates;` when it is missing.

Next item off the backlog in #587, stacked on #586.

## Why / Balance

Pure dev-tooling, no gameplay surface. The manual pass in #568 touched 22 components; a mechanical fixer collapses that kind of sweep into one keystroke per class the next time upstream churn re-introduces the pattern.

## Technical details

- Scope is deliberately narrow: the fixer only applies the *scaffolding* the analyzer checks for. Fields still need `[AutoNetworkedField]` (or a manual `GetComponentState` / `HandleComponentState` pair) to actually replicate, but that's a judgement-laden rewrite better handled in its own fixer than forced into this one.
- Uses `CompilationUnitSyntax.AddUsings` so the new `using` lands after existing ones without reordering.
- `HasAttribute` tolerates both `[AutoGenerateComponentState]` and fully-qualified `[Robust.Shared.GameStates.AutoGenerateComponentState]` so re-runs are idempotent.
- `FixAll` uses `BatchFixer`, same as the HONK0016 fixer.

Two fixer tests cover the happy path and the "using is missing" branch. Analyzer tests are unchanged.

## Media

Dev tooling, no in-game change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.