### PR TITLE
feat: per-category popup mirror routing CVars + settings (#578, PR 3/4)

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -36,6 +36,17 @@
                     <Button Name="RescanFontsButton" Text="{Loc 'ui-options-rescan-fonts'}" />
                 </BoxContainer>
                 <!-- HONK END -->
+                <!-- HONK START - popup mirror routing (issue #578) -->
+                <Label Text="{Loc 'ui-options-header-popup-mirror'}"
+                       StyleClasses="LabelKeyText"/>
+                <ui:OptionDropDown Name="PopupMirrorDefaultDropDown" Title="{Loc 'ui-options-popup-mirror-default'}" />
+                <ui:OptionDropDown Name="PopupMirrorFlavorDropDown" Title="{Loc 'ui-options-popup-mirror-flavor'}" />
+                <ui:OptionDropDown Name="PopupMirrorCombatDropDown" Title="{Loc 'ui-options-popup-mirror-combat'}" />
+                <ui:OptionDropDown Name="PopupMirrorMedicalDropDown" Title="{Loc 'ui-options-popup-mirror-medical'}" />
+                <ui:OptionDropDown Name="PopupMirrorEnvironmentalDropDown" Title="{Loc 'ui-options-popup-mirror-environmental'}" />
+                <ui:OptionDropDown Name="PopupMirrorInteractionDropDown" Title="{Loc 'ui-options-popup-mirror-interaction'}" />
+                <ui:OptionDropDown Name="PopupMirrorSystemDropDown" Title="{Loc 'ui-options-popup-mirror-system'}" />
+                <!-- HONK END -->
                 <Label Text="{Loc 'ui-options-accessability-header-content'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="CensorNudityCheckBox" Text="{Loc 'ui-options-censor-nudity'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -81,6 +81,22 @@ public sealed partial class AccessibilityTab : Control
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 
+        // HONK START - popup mirror routing (issue #578)
+        var popupMirrorOptions = new[]
+        {
+            new OptionDropDownCVar<int>.ValueOption(0, Loc.GetString("ui-options-popup-mirror-disabled")),
+            new OptionDropDownCVar<int>.ValueOption(1, Loc.GetString("ui-options-popup-mirror-popup-tab")),
+            new OptionDropDownCVar<int>.ValueOption(2, Loc.GetString("ui-options-popup-mirror-main-chat")),
+        };
+        Control.AddOptionDropDown(CCVars.PopupMirrorDefault, PopupMirrorDefaultDropDown, popupMirrorOptions);
+        Control.AddOptionDropDown(CCVars.PopupMirrorFlavor, PopupMirrorFlavorDropDown, popupMirrorOptions);
+        Control.AddOptionDropDown(CCVars.PopupMirrorCombat, PopupMirrorCombatDropDown, popupMirrorOptions);
+        Control.AddOptionDropDown(CCVars.PopupMirrorMedical, PopupMirrorMedicalDropDown, popupMirrorOptions);
+        Control.AddOptionDropDown(CCVars.PopupMirrorEnvironmental, PopupMirrorEnvironmentalDropDown, popupMirrorOptions);
+        Control.AddOptionDropDown(CCVars.PopupMirrorInteraction, PopupMirrorInteractionDropDown, popupMirrorOptions);
+        Control.AddOptionDropDown(CCVars.PopupMirrorSystem, PopupMirrorSystemDropDown, popupMirrorOptions);
+        // HONK END
+
         Control.Initialize();
     }
 

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,17 +1,20 @@
 using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
 
 namespace Content.Client.RussStation.Popups;
 
 /// <summary>
-/// Mirrors every popup the local client sees into a dedicated chat channel so players can scroll back
-/// through text that otherwise disappears with the floating display.
+/// Mirrors every popup the local client sees into a chat channel so players can scroll back through
+/// text that otherwise vanishes with the floating display. Destination is governed by the
+/// <c>honk.popup.mirror.*</c> CVars, per-category or fallback.
 /// </summary>
 /// <remarks>
 /// Popups for entities the local player can't examine (out of range, occluded, wrong map) are dropped
@@ -21,6 +24,7 @@ namespace Content.Client.RussStation.Popups;
 public sealed class PopupLogSystem : EntitySystem
 {
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
 
@@ -60,18 +64,39 @@ public sealed class PopupLogSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(message))
             return;
 
+        var route = ResolveRoute(category);
+        if (route == PopupMirrorRoute.Disabled)
+            return;
+
+        var channel = route == PopupMirrorRoute.MainChat ? ChatChannel.Local : ChatChannel.Popup;
         var escaped = FormattedMessage.EscapeText(message);
         var wrapped = category is { } cat
             ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
             : escaped;
 
-        var mirror = new ChatMessage(
-            ChatChannel.Popup,
-            message,
-            wrapped,
-            source,
-            senderKey: null);
-
+        var mirror = new ChatMessage(channel, message, wrapped, source, senderKey: null);
         Chat.ProcessChatMessage(mirror, speechBubble: false);
+    }
+
+    private PopupMirrorRoute ResolveRoute(PopupCategory? category)
+    {
+        var cvar = category switch
+        {
+            PopupCategory.Flavor => CCVars.PopupMirrorFlavor,
+            PopupCategory.Combat => CCVars.PopupMirrorCombat,
+            PopupCategory.Medical => CCVars.PopupMirrorMedical,
+            PopupCategory.Environmental => CCVars.PopupMirrorEnvironmental,
+            PopupCategory.Interaction => CCVars.PopupMirrorInteraction,
+            PopupCategory.System => CCVars.PopupMirrorSystem,
+            _ => CCVars.PopupMirrorDefault,
+        };
+
+        var raw = _cfg.GetCVar(cvar);
+        return raw switch
+        {
+            (int) PopupMirrorRoute.PopupTab => PopupMirrorRoute.PopupTab,
+            (int) PopupMirrorRoute.MainChat => PopupMirrorRoute.MainChat,
+            _ => PopupMirrorRoute.Disabled,
+        };
     }
 }

--- a/Content.Shared/RussStation/CCVar/CCVars.Popups.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Popups.cs
@@ -1,0 +1,35 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    // Popup mirror routing (issue #578). Each CVar holds a route enum:
+    //   0 = Disabled (float only, no mirror)
+    //   1 = PopupTab (mirror into the Popup chat tab)
+    //   2 = MainChat (mirror into the local chat tab as well)
+    //
+    // Server-originated popups carry no category and fall back to the Default CVar.
+    // Categorized popups use their category's CVar.
+
+    public static readonly CVarDef<int> PopupMirrorDefault =
+        CVarDef.Create("honk.popup.mirror.default", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> PopupMirrorFlavor =
+        CVarDef.Create("honk.popup.mirror.flavor", 0, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> PopupMirrorCombat =
+        CVarDef.Create("honk.popup.mirror.combat", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> PopupMirrorMedical =
+        CVarDef.Create("honk.popup.mirror.medical", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> PopupMirrorEnvironmental =
+        CVarDef.Create("honk.popup.mirror.environmental", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> PopupMirrorInteraction =
+        CVarDef.Create("honk.popup.mirror.interaction", 0, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> PopupMirrorSystem =
+        CVarDef.Create("honk.popup.mirror.system", 1, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/RussStation/Popups/PopupMirrorRoute.cs
+++ b/Content.Shared/RussStation/Popups/PopupMirrorRoute.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared.RussStation.Popups;
+
+/// <summary>
+/// Where a popup is mirrored in addition to the floating display.
+/// Stored as int in the per-category CVars so users can tweak via server config without an enum mapping layer.
+/// </summary>
+public enum PopupMirrorRoute
+{
+    Disabled = 0,
+    PopupTab = 1,
+    MainChat = 2,
+}

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -387,6 +387,19 @@ ui-options-rescan-fonts = Rescan Fonts
 
 ui-options-censor-nudity = Censor character nudity
 
+## Popup Mirror (issue #578)
+ui-options-header-popup-mirror = Popup Mirror
+ui-options-popup-mirror-default = Uncategorized popups
+ui-options-popup-mirror-flavor = Flavor popups
+ui-options-popup-mirror-combat = Combat popups
+ui-options-popup-mirror-medical = Medical popups
+ui-options-popup-mirror-environmental = Environmental popups
+ui-options-popup-mirror-interaction = Interaction popups
+ui-options-popup-mirror-system = System popups
+ui-options-popup-mirror-disabled = Float only
+ui-options-popup-mirror-popup-tab = Float + Popup tab
+ui-options-popup-mirror-main-chat = Float + Main chat
+
 ## Admin menu
 
 ui-options-admin-player-panel = Admin Menu Players List


### PR DESCRIPTION
## About the PR

Third PR in the issue #578 stack, stacked on #588. Lets a player route each popup category independently: keep it as a float only, mirror it into the Popup tab (PR 2 behavior), or mirror it into the main chat. Uncategorized popups fall back to a Default CVar.

## Why / Balance

Not every player wants the same popups logged. Combat players might want combat and medical mirrored into the main chat so they can't miss a crit notification, and silence Flavor entirely. A roleplayer might want Flavor mirrored into the Popup tab for reference, and route System into main chat to catch admin notices. This PR just gives them the knobs.

No new mirror behavior, the work is all plumbing and settings UI. Server behavior is untouched, everything is client-local.

## Technical details

- `Content.Shared/RussStation/CCVar/CCVars.Popups.cs` adds seven int CVars (`honk.popup.mirror.default` + one per category). All `CLIENTONLY | ARCHIVE`.
- `Content.Shared/RussStation/Popups/PopupMirrorRoute.cs` defines the enum values (`Disabled=0`, `PopupTab=1`, `MainChat=2`). Stored as int so server configs can tweak without an enum mapping layer.
- `PopupLogSystem.ResolveRoute` picks the CVar for the incoming category (or Default) and either skips, mirrors into `ChatChannel.Popup`, or mirrors into `ChatChannel.Local`.
- `AccessibilityTab.xaml` / `AccessibilityTab.xaml.cs` gain a HONK-wrapped "Popup Mirror" section with seven dropdowns using the existing `OptionDropDownCVar<int>` helper.
- `Resources/Locale/en-US/escape-menu/ui/options-menu.ftl` gets the new loc strings.

Defaults: Combat/Medical/Environmental/System/Default all mirror into the Popup tab. Flavor and Interaction stay float-only because they generate the most noise.

## Media

Needs in-game verification, draft for now.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None. New CVars, additive dropdowns, no upstream signature changes.

**Changelog**

:cl:
- add: You can now route each popup category (Combat, Medical, Environmental, Interaction, Flavor, System) to either the Popup chat tab, main chat, or keep as a float-only notification. Settings live under Accessibility.