### PR TITLE
feat: coalesce popup mirror within a 2s window (#578, PR 4/4)

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -12,7 +12,9 @@ using Robust.Shared.Utility;
 
 namespace Content.Client.Chat.UI
 {
-    public abstract class SpeechBubble : Control
+    // HONK START - partial so the fork can add RepeatWith for emote coalescing (issue #578)
+    public abstract partial class SpeechBubble : Control
+    // HONK END
     {
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IEyeManager _eyeManager = default!;
@@ -104,6 +106,9 @@ namespace Content.Client.Chat.UI
             ContentSize = bubble.DesiredSize;
             _verticalOffsetAchieved = -ContentSize.Y;
             _deathTime = _timing.RealTime + TotalTime;
+            // HONK START - stash ctor args for RepeatWith rebuilds (issue #578)
+            HonkStashCtorArgs(message, speechStyleClass, fontColor);
+            // HONK END
         }
 
         protected abstract Control BuildBubble(ChatMessage message, string speechStyleClass, Color? fontColor = null);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml
@@ -1,6 +1,12 @@
 ﻿<Control xmlns="https://spacestation14.io"
          xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
     <BoxContainer Orientation="Vertical">
+        <!-- HONK START - assign action-bar slot hotkeys toggle (#579) -->
+        <BoxContainer Orientation="Horizontal" Margin="8 8 8 0">
+            <CheckBox Name="AssignActionSlotHotkeyCheckBox" Access="Public"
+                      Text="{Loc 'honk-ui-options-controls-assign-slot-hotkey'}"/>
+        </BoxContainer>
+        <!-- HONK END -->
         <ScrollContainer VerticalExpand="True">
             <BoxContainer Name="KeybindsContainer" Orientation="Vertical" Margin="8 8 8 8">
 

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -111,6 +111,21 @@ namespace Content.Client.Options.UI.Tabs
                 });
             };
 
+            //HONK START - per-slot action-bar hotkey assignment toggle (#579).
+            // Backed by SlotHotkeyController; reflects and drives its AssignMode so
+            // ticking this reveals the action bar slots and lets clicking a slot
+            // arm it for the next hotbar keypress. No window needs to be open.
+            var slotHotkeys = IoCManager.Resolve<Robust.Client.UserInterface.IUserInterfaceManager>()
+                .GetUIController<Content.Client.RussStation.ActionBar.SlotHotkeyController>();
+            AssignActionSlotHotkeyCheckBox.Pressed = slotHotkeys.AssignMode;
+            AssignActionSlotHotkeyCheckBox.OnToggled += args => slotHotkeys.SetAssignMode(args.Pressed);
+            slotHotkeys.AssignStateChanged += () =>
+            {
+                if (AssignActionSlotHotkeyCheckBox.Pressed != slotHotkeys.AssignMode)
+                    AssignActionSlotHotkeyCheckBox.Pressed = slotHotkeys.AssignMode;
+            };
+            //HONK END
+
             var first = true;
 
             void AddHeader(string headerContents)

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -93,9 +93,18 @@ namespace Content.Client.Popups
             RaiseLocalEvent(new Content.Shared.RussStation.Popups.CategorizedPopupRaisedEvent(message, null, type, entity));
             //HONK END
 
-            var popupData = new WorldPopupData(message, type, coordinates, entity);
+            //HONK START - entity-attached popups key on the entity only, so the repeat counter
+            // survives the mob moving between ticks. Coordinate-only popups still key on position
+            // so unrelated popups at different spots don't collapse.
+            var keyCoordinates = entity != null ? default : coordinates;
+            var popupData = new WorldPopupData(message, type, keyCoordinates, entity);
+            //HONK END
             if (_aliveWorldLabels.TryGetValue(popupData, out var existingLabel))
             {
+                //HONK START - follow the entity: update the label's position to the latest coords
+                // so the stacked popup floats above where the mob actually is now.
+                existingLabel.InitialPos = coordinates;
+                //HONK END
                 WrapAndRepeatPopup(existingLabel, popupData.Message);
                 return;
             }

--- a/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Systems.Actions;
 using Content.Client.UserInterface.Systems.Actions.Controls;
@@ -39,7 +40,7 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
     // Read by the gameplay-screen resize handlers (HONK guards) to keep them from
     // calling MaxGridHeight/MaxGridWidth, which would flip the grid into size-limit
     // mode and silently overwrite the user's explicit row count on resize.
-    public const bool OverridesRowLayout = true;
+    public static readonly bool OverridesRowLayout = true;
 
     // Base 0.0-1.0 alpha applied to every action button's slot background. Read each
     // frame by ActionButton.UpdateBackground (HONK block). The empty-slot fade scales
@@ -49,6 +50,23 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
     // Flipped by ActionUIController drag hooks so empty drop targets are padded into the
     // container even when the persistent show-empty toggle is off.
     public static bool IsDragActive { get; private set; }
+
+    // Mirrored from SlotHotkeyController so the bar-side code (UpdateBackground, ApplyLabels)
+    // can reveal every slot and its keybind label while the player is assigning hotkeys.
+    public static bool AssignHotkeyMode { get; private set; }
+
+    // Emote proto id -> slot index, persisted via honk.action_bar.emote_slots so a player's
+    // curated emote layout survives disconnects and server restarts. Read by OnActionAdded
+    // through TryGetSavedEmoteSlot so the controller is guaranteed to be instantiated.
+    private readonly Dictionary<string, int> _emoteSlots = new();
+
+    public bool TryGetSavedEmoteSlot(string? emoteProtoId, out int slot)
+    {
+        if (!string.IsNullOrEmpty(emoteProtoId) && _emoteSlots.TryGetValue(emoteProtoId, out slot))
+            return true;
+        slot = default;
+        return false;
+    }
 
     public override void Initialize()
     {
@@ -72,6 +90,42 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         _cfg.OnValueChanged(CCVars.HonkActionBarLock, v => LockActions = v, true);
         _cfg.OnValueChanged(CCVars.HonkActionBarButtonBackgroundAlpha,
             v => ButtonBackgroundAlpha = Math.Clamp(v, 0f, 1f), true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarEmoteSlots, OnEmoteSlotsChanged, true);
+
+        // Mirror the assign-hotkey toggle so the bar auto-reveals while the player rebinds slots.
+        var slotHotkeys = UIManager.GetUIController<SlotHotkeyController>();
+        AssignHotkeyMode = slotHotkeys.AssignMode;
+        slotHotkeys.AssignStateChanged += OnAssignStateChanged;
+        // Rebuild the hotbar when any action-bar slot's binding changes so the labels track
+        // what Settings → Controls currently holds.
+        slotHotkeys.SlotBindingChanged += RefreshHotbar;
+    }
+
+    private void OnAssignStateChanged()
+    {
+        var slotHotkeys = UIManager.GetUIController<SlotHotkeyController>();
+        AssignHotkeyMode = slotHotkeys.AssignMode;
+        ApplyLayout();
+        ApplyLabels();
+        ApplyArmedHighlight();
+        RefreshHotbar();
+    }
+
+    // Highlight the currently-armed slot so the player has feedback between clicking a slot
+    // and pressing the hotbar key that will be assigned to it. Clears all highlights when
+    // assign mode is off or no slot is armed.
+    private void ApplyArmedHighlight()
+    {
+        if (GetContainer() is not { } container)
+            return;
+
+        var armed = UIManager.GetUIController<SlotHotkeyController>().ArmedSlot;
+        var i = 0;
+        foreach (var button in container.GetButtons())
+        {
+            button.HighlightRect.Visible = AssignHotkeyMode && armed == i;
+            i++;
+        }
     }
 
     private void OnRowsChanged(int value)
@@ -123,7 +177,11 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         container.Columns = _slotsPerRow;
         container.HSeparationOverride = _slotSpacing;
         container.VSeparationOverride = _slotSpacing;
-        container.HonkMinSlotCount = ShowEmptySlots || IsDragActive ? _rows * _slotsPerRow : 0;
+        // Reveal every slot (pad up to rows x slots_per_row) when either the user's persistent
+        // toggle is on, a drag is active, or the player is actively rebinding slot hotkeys.
+        container.HonkMinSlotCount = ShowEmptySlots || IsDragActive || AssignHotkeyMode
+            ? _rows * _slotsPerRow
+            : 0;
     }
 
     private void ApplyLabels()
@@ -131,12 +189,12 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         if (GetContainer() is not { } container)
             return;
 
-        // Only reveal labels on slots that actually hold an action; empty buttons
-        // shouldn't display a keybind that does nothing. Empty slots also show
-        // labels during a drag so the player can see which slot maps to which key.
+        // Normally labels only render on slots with an action and on drag targets. Assign-hotkey
+        // mode forces every slot's label visible so the player can see which key they're rebinding.
         foreach (var button in container.GetButtons())
         {
-            button.Label.Visible = _showKeybindLabel && (button.Action != null || IsDragActive);
+            button.Label.Visible = AssignHotkeyMode
+                || (_showKeybindLabel && (button.Action != null || IsDragActive));
         }
     }
 
@@ -147,6 +205,103 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         UIManager.GetUIController<ActionUIController>().HonkRefreshHotbar();
         // Padding may have added buttons; labels must be re-applied to the new ones.
         ApplyLabels();
+    }
+
+    private void OnEmoteSlotsChanged(string raw)
+    {
+        _emoteSlots.Clear();
+        if (string.IsNullOrWhiteSpace(raw))
+            return;
+        var protoMan = IoCManager.Resolve<Robust.Shared.Prototypes.IPrototypeManager>();
+        var dropped = false;
+        foreach (var entry in raw.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = entry.IndexOf('=');
+            if (eq <= 0 || eq == entry.Length - 1)
+                continue;
+            var id = entry[..eq];
+            if (!int.TryParse(entry.AsSpan(eq + 1), out var slot) || slot < 0)
+                continue;
+
+            // Drop entries whose proto id doesn't match a real EmotePrototype (hand-edited CVar,
+            // stale entry from a removed emote, etc.). The server still gates allowlist + per-mob
+            // AllowedToUseEmote on grant, so an invalid entry here just means dead weight.
+            if (!protoMan.HasIndex<Content.Shared.Chat.Prototypes.EmotePrototype>(id))
+            {
+                dropped = true;
+                continue;
+            }
+
+            _emoteSlots[id] = slot;
+        }
+
+        // Rewrite the CVar if we filtered anything so the pruned list is what lands on disk.
+        if (dropped)
+        {
+            _cfg.SetCVar(CCVars.HonkActionBarEmoteSlots, SerializeEmoteSlots());
+            _cfg.SaveToFile();
+        }
+    }
+
+    private string SerializeEmoteSlots()
+    {
+        var sb = new System.Text.StringBuilder();
+        var first = true;
+        foreach (var (id, slot) in _emoteSlots.OrderBy(kv => kv.Value))
+        {
+            if (!first)
+                sb.Append(';');
+            sb.Append(id).Append('=').Append(slot);
+            first = false;
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Persist a saved slot for an emote prototype. Pass null to forget the slot.</summary>
+    public void HonkRememberEmoteSlot(string? emoteProtoId, int? slot)
+    {
+        if (string.IsNullOrEmpty(emoteProtoId))
+            return;
+
+        // Only persist real emote prototypes. Stops a bad caller (or a stale entity with
+        // garbage in the component) from poisoning the saved layout with unknown ids.
+        // The server gates actual dispatch through AllowedToUseEmote, so even if something
+        // slipped through here it wouldn't fire for a disallowed species.
+        if (slot != null
+            && !IoCManager.Resolve<Robust.Shared.Prototypes.IPrototypeManager>()
+                .HasIndex<Content.Shared.Chat.Prototypes.EmotePrototype>(emoteProtoId))
+        {
+            return;
+        }
+
+        var changed = false;
+        if (slot is { } index)
+        {
+            // If some other emote used to live in this slot, bump it out so two entries
+            // don't race each other back onto the bar on reconnect.
+            foreach (var existing in _emoteSlots.Where(kv => kv.Value == index && kv.Key != emoteProtoId)
+                         .Select(kv => kv.Key).ToList())
+            {
+                _emoteSlots.Remove(existing);
+                changed = true;
+            }
+
+            if (!_emoteSlots.TryGetValue(emoteProtoId, out var prior) || prior != index)
+            {
+                _emoteSlots[emoteProtoId] = index;
+                changed = true;
+            }
+        }
+        else if (_emoteSlots.Remove(emoteProtoId))
+        {
+            changed = true;
+        }
+
+        if (changed)
+        {
+            _cfg.SetCVar(CCVars.HonkActionBarEmoteSlots, SerializeEmoteSlots());
+            _cfg.SaveToFile();
+        }
     }
 
     // Wires the lock + auto-add toggle checkboxes on the actions window, called from

--- a/Content.Client/RussStation/ActionBar/SlotHotkeyController.cs
+++ b/Content.Client/RussStation/ActionBar/SlotHotkeyController.cs
@@ -1,0 +1,142 @@
+using System.Linq;
+using Content.Shared.Input;
+using JetBrains.Annotations;
+using Robust.Client.Input;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Shared.Input;
+
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Per-slot hotkey assignment for the fork's resizable action bar (#579).
+// Each slot uses the BoundKeyFunction at the same index in ContentKeyFunctions.
+// GetHotbarBoundKeys (Hotbar1-0 for slots 0-9, HotbarShift1-0 for slots 10-19
+// by default). Assign mode rebinds the physical key for that function via
+// IInputManager, so Settings → Controls is the single source of truth and the
+// action bar labels refresh when the user changes the binding from either side.
+[UsedImplicitly]
+public sealed class SlotHotkeyController : UIController
+{
+    [Dependency] private readonly IInputManager _input = default!;
+
+    private bool _assignMode;
+    private int? _armedSlot;
+
+    public bool AssignMode => _assignMode;
+
+    /// <summary>Raised whenever the assign-mode flag or armed slot changes, so
+    /// views can refresh any visual indicator they own.</summary>
+    public event Action? AssignStateChanged;
+
+    /// <summary>Raised whenever a keybinding relevant to the action bar changes,
+    /// so the bar can refresh its labels without each button polling.</summary>
+    public event Action? SlotBindingChanged;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        // FirstChanceOnKeyEvent sees raw key presses before normal dispatch, matching the
+        // engine's key-rebind menu. While a slot is armed we consume the event and use it
+        // to rebind the slot's function directly through IInputManager.
+        _input.FirstChanceOnKeyEvent += OnFirstChanceKey;
+        _input.OnKeyBindingAdded += OnBindingChanged;
+        _input.OnKeyBindingRemoved += OnBindingChanged;
+    }
+
+    /// <summary>Stable slot → function mapping. Fixed for the lifetime of the bar.</summary>
+    public static BoundKeyFunction? FunctionForSlot(int slot)
+    {
+        if (slot < 0)
+            return null;
+        var hotbar = ContentKeyFunctions.GetHotbarBoundKeys();
+        return slot < hotbar.Length ? (BoundKeyFunction?) hotbar[slot] : null;
+    }
+
+    private void OnBindingChanged(IKeyBinding _) => SlotBindingChanged?.Invoke();
+
+    private void OnFirstChanceKey(KeyEventArgs keyEvent, KeyEventType type)
+    {
+        if (!_assignMode || _armedSlot is not { } slot)
+            return;
+
+        // Consume on down so gameplay (firing actions, typing into chat, etc.) never sees it.
+        // Commit on up so release doesn't immediately trigger the just-bound function.
+        keyEvent.Handle();
+        if (type != KeyEventType.Up)
+            return;
+
+        var key = keyEvent.Key;
+        if (IsIgnoredKey(key))
+            return;
+
+        if (FunctionForSlot(slot) is not { } function)
+            return;
+
+        RebindFunction(function, keyEvent);
+        _armedSlot = null;
+        AssignStateChanged?.Invoke();
+    }
+
+    private static bool IsIgnoredKey(Keyboard.Key key)
+    {
+        return key == Keyboard.Key.Control || key == Keyboard.Key.Shift || key == Keyboard.Key.Alt
+               || key == Keyboard.Key.LSystem || key == Keyboard.Key.RSystem
+               || key == Keyboard.Key.MouseLeft || key == Keyboard.Key.MouseRight
+               || key == Keyboard.Key.MouseMiddle
+               || key == Keyboard.Key.Unknown;
+    }
+
+    // Replace every existing binding for this function with a single new binding at the
+    // captured key+modifiers, matching what the engine's key-rebind menu does. Saving to
+    // user data persists the change so Settings → Controls reflects it immediately.
+    private void RebindFunction(BoundKeyFunction function, KeyEventArgs keyEvent)
+    {
+        foreach (var existing in _input.GetKeyBindings(function).ToArray())
+            _input.RemoveBinding(existing);
+
+        var mods = new Keyboard.Key[3];
+        var i = 0;
+        if (keyEvent.Control && keyEvent.Key != Keyboard.Key.Control)
+            mods[i++] = Keyboard.Key.Control;
+        if (keyEvent.Shift && keyEvent.Key != Keyboard.Key.Shift)
+            mods[i++] = Keyboard.Key.Shift;
+        if (keyEvent.Alt && keyEvent.Key != Keyboard.Key.Alt && i < 3)
+            mods[i++] = Keyboard.Key.Alt;
+
+        _input.RegisterBinding(new KeyBindingRegistration
+        {
+            Function = function,
+            BaseKey = keyEvent.Key,
+            Mod1 = mods[0],
+            Mod2 = mods[1],
+            Mod3 = mods[2],
+            Type = KeyBindingType.State,
+            CanFocus = false,
+            CanRepeat = false,
+            AllowSubCombs = true,
+        });
+        _input.SaveToUserData();
+    }
+
+    /// <summary>Returns the key function that fires the given slot, or null if the
+    /// slot index is outside the supported range.</summary>
+    public BoundKeyFunction? GetHotkeyForSlot(int slot) => FunctionForSlot(slot);
+
+    public void SetAssignMode(bool value)
+    {
+        if (_assignMode == value)
+            return;
+        _assignMode = value;
+        _armedSlot = null;
+        AssignStateChanged?.Invoke();
+    }
+
+    public void ArmSlot(int slot)
+    {
+        if (!_assignMode)
+            return;
+        _armedSlot = slot;
+        AssignStateChanged?.Invoke();
+    }
+
+    public int? ArmedSlot => _armedSlot;
+}

--- a/Content.Client/RussStation/Chat/ChatUIController.Honk.cs
+++ b/Content.Client/RussStation/Chat/ChatUIController.Honk.cs
@@ -1,0 +1,111 @@
+using Content.Client.Chat.UI;
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.Chat;
+using Robust.Shared.Network;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+// HONK - Fork partial adding in-place coalescing for repeated popup mirror and emote chat lines,
+// plus repeat-in-place for floating emote speech bubbles. Mirrors upstream's PopupSystem
+// WrapAndRepeatPopup behavior: if an identical message from the same sender lands inside a short
+// window, mutate the existing rendered entry rather than appending a new line. Chat boxes get
+// notified via MessageUpdated and patch the rendered OutputPanel entry in place. After the window
+// lapses, the next identical message starts a new line at count 1.
+public sealed partial class ChatUIController
+{
+    private static readonly TimeSpan HonkCoalesceWindow = TimeSpan.FromSeconds(2);
+
+    // Channels whose repeats should collapse into a single rendered entry with an (xN) suffix.
+    // Other channels keep one-entry-per-message behavior so e.g. two identical Local lines from
+    // different speakers don't collapse visually.
+    private static readonly HashSet<ChatChannel> HonkCoalesceChannels = new()
+    {
+        ChatChannel.Popup,
+        ChatChannel.Emotes,
+    };
+
+    private readonly Dictionary<(ChatChannel Channel, NetEntity Sender, string Message), HonkChatCoalesceEntry> _honkCoalesce = new();
+
+    /// <summary>
+    /// Raised when an existing ChatMessage's WrappedMessage has been mutated in place because a
+    /// matching repeat landed within the coalesce window. Subscribers should re-render that message
+    /// without adding a new entry.
+    /// </summary>
+    public event Action<ChatMessage>? MessageUpdated;
+
+    /// <summary>
+    /// Returns true when <paramref name="msg"/> was folded into an existing rendered entry instead
+    /// of producing a new one. The caller should skip History.Add / MessageAdded when this returns true.
+    /// </summary>
+    private bool HonkTryCoalesceChatMessage(ChatMessage msg)
+    {
+        if (!HonkCoalesceChannels.Contains(msg.Channel))
+            return false;
+
+        if (string.IsNullOrEmpty(msg.Message))
+            return false;
+
+        var now = _timing.RealTime;
+        var key = (msg.Channel, msg.SenderEntity, msg.Message);
+
+        if (_honkCoalesce.TryGetValue(key, out var entry) && now - entry.LastSeen < HonkCoalesceWindow)
+        {
+            entry.Repeats += 1;
+            entry.LastSeen = now;
+            entry.Msg.WrappedMessage = Loc.GetString(
+                "popup-system-repeated-popup-stacking-wrap",
+                ("popup-message", entry.OriginalWrapped),
+                ("count", entry.Repeats));
+            MessageUpdated?.Invoke(entry.Msg);
+            return true;
+        }
+
+        _honkCoalesce[key] = new HonkChatCoalesceEntry
+        {
+            Msg = msg,
+            OriginalWrapped = msg.WrappedMessage,
+            Repeats = 1,
+            LastSeen = now,
+        };
+        HonkPruneCoalesce(now);
+        return false;
+    }
+
+    private void HonkPruneCoalesce(TimeSpan now)
+    {
+        if (_honkCoalesce.Count < 32)
+            return;
+
+        var stale = new List<(ChatChannel, NetEntity, string)>();
+        foreach (var (key, entry) in _honkCoalesce)
+        {
+            if (now - entry.LastSeen >= HonkCoalesceWindow)
+                stale.Add(key);
+        }
+        foreach (var key in stale)
+            _honkCoalesce.Remove(key);
+    }
+
+    /// <summary>
+    /// Returns true when an alive emote bubble for <paramref name="entity"/> already displays
+    /// <paramref name="msg"/>'s text and was updated in place. Caller should skip creating a new bubble.
+    /// </summary>
+    private bool HonkTryCoalesceEmoteBubble(EntityUid entity, ChatMessage msg, SpeechBubble.SpeechType speechType)
+    {
+        if (speechType != SpeechBubble.SpeechType.Emote)
+            return false;
+
+        if (!_activeSpeechBubbles.TryGetValue(entity, out var bubbles) || bubbles.Count == 0)
+            return false;
+
+        // Match the most recent alive bubble only. Coalescing into an older bubble that has a newer
+        // different bubble above it would visually reorder the stack.
+        var candidate = bubbles[^1];
+        if (candidate.OriginalMessageText != msg.Message)
+            return false;
+
+        candidate.RepeatWith(msg);
+        return true;
+    }
+
+}

--- a/Content.Client/RussStation/Chat/HonkChatCoalesceEntry.cs
+++ b/Content.Client/RussStation/Chat/HonkChatCoalesceEntry.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Chat;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+// Coalesce bookkeeping for a single (channel, sender, message) cluster. Lives in its own file so
+// the HONK analyzer does not require a non-Honk counterpart declaration.
+internal sealed class HonkChatCoalesceEntry
+{
+    public required ChatMessage Msg;
+    public required string OriginalWrapped;
+    public int Repeats;
+    public TimeSpan LastSeen;
+}

--- a/Content.Client/RussStation/Chat/SpeechBubble.Honk.cs
+++ b/Content.Client/RussStation/Chat/SpeechBubble.Honk.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Chat;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Chat.UI;
+
+// HONK - Fork partial adding repeat-in-place support for speech bubbles, mirroring the
+// PopupSystem.WrapAndRepeatPopup behavior. When an alive bubble gets another copy of the same
+// emote from the same entity inside the coalesce window, ChatUIController calls RepeatWith on
+// the existing bubble instead of spawning a stacked one. Only emote bubbles are coalesced today;
+// say/whisper/looc keep one-bubble-per-line since repeats there are rare and usually carry
+// meaningful turn-taking.
+public abstract partial class SpeechBubble
+{
+    // Snapshots taken at construction so a later mutation of the source ChatMessage (e.g. the
+    // chat coalescer rewriting WrappedMessage to "(xN)") can't leak into a rebuild and produce
+    // double-wrapped counts.
+    private string _honkOriginalRawMessage = string.Empty;
+    private string _honkOriginalWrapped = string.Empty;
+    private ChannelMetadata _honkMetadata;
+    private string _honkSpeechStyleClass = string.Empty;
+    private Color? _honkFontColor;
+
+    /// <summary>
+    /// Raw message text of the first bubble in the current repeat cluster. Used by ChatUIController
+    /// to match incoming emotes against alive bubbles.
+    /// </summary>
+    public string OriginalMessageText => _honkOriginalRawMessage;
+
+    /// <summary>
+    /// Number of repeats this bubble currently displays (1 for a fresh bubble).
+    /// </summary>
+    public int Repeats { get; private set; } = 1;
+
+    private void HonkStashCtorArgs(ChatMessage message, string speechStyleClass, Color? fontColor)
+    {
+        _honkOriginalRawMessage = message.Message;
+        _honkOriginalWrapped = message.WrappedMessage;
+        _honkMetadata = new ChannelMetadata(message.Channel, message.SenderEntity, message.SenderKey);
+        _honkSpeechStyleClass = speechStyleClass;
+        _honkFontColor = fontColor;
+    }
+
+    private readonly record struct ChannelMetadata(ChatChannel Channel, NetEntity Sender, int? SenderKey);
+
+    /// <summary>
+    /// Fold another identical emote into this bubble: bump the repeat count, rebuild the rendered
+    /// text with an (xN) suffix using the same loc key PopupSystem uses, and reset the death timer
+    /// so the bubble stays visible while repeats keep arriving.
+    /// </summary>
+    public void RepeatWith(ChatMessage newMessage)
+    {
+        Repeats += 1;
+
+        var display = new ChatMessage(
+            _honkMetadata.Channel,
+            _honkOriginalRawMessage,
+            Loc.GetString(
+                "popup-system-repeated-popup-stacking-wrap",
+                ("popup-message", _honkOriginalWrapped),
+                ("count", Repeats)),
+            _honkMetadata.Sender,
+            _honkMetadata.SenderKey);
+
+        RemoveAllChildren();
+        var rebuilt = BuildBubble(display, _honkSpeechStyleClass, _honkFontColor);
+        AddChild(rebuilt);
+        ForceRunStyleUpdate();
+        rebuilt.Measure(Vector2Helpers.Infinity);
+        ContentSize = rebuilt.DesiredSize;
+        _deathTime = _timing.RealTime + TotalTime;
+    }
+}

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,10 +1,12 @@
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
+using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Client.RussStation.Popups;
@@ -23,6 +25,13 @@ public sealed class PopupLogSystem : EntitySystem
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    // Window during which an identical popup (by message text) is treated as a duplicate
+    // and suppressed from the chat mirror. The floating display keeps its own upstream coalescing independently.
+    private static readonly TimeSpan CoalesceWindow = TimeSpan.FromSeconds(2);
+
+    private readonly Dictionary<string, TimeSpan> _recentMirror = new();
 
     private ChatUIController? _chat;
     private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
@@ -34,6 +43,12 @@ public sealed class PopupLogSystem : EntitySystem
         // PopupMessage / PopupCursorInternal (HONK blocks), so network-sent popups, client-predicted
         // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        _recentMirror.Clear();
     }
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
@@ -60,6 +75,12 @@ public sealed class PopupLogSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(message))
             return;
 
+        var now = _timing.RealTime;
+        if (_recentMirror.TryGetValue(message, out var lastSeen) && now - lastSeen < CoalesceWindow)
+            return;
+        _recentMirror[message] = now;
+        PruneStaleCoalesceEntries(now);
+
         var escaped = FormattedMessage.EscapeText(message);
         var wrapped = category is { } cat
             ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
@@ -73,5 +94,20 @@ public sealed class PopupLogSystem : EntitySystem
             senderKey: null);
 
         Chat.ProcessChatMessage(mirror, speechBubble: false);
+    }
+
+    private void PruneStaleCoalesceEntries(TimeSpan now)
+    {
+        if (_recentMirror.Count < 32)
+            return;
+
+        var stale = new List<string>();
+        foreach (var (key, seenAt) in _recentMirror)
+        {
+            if (now - seenAt >= CoalesceWindow)
+                stale.Add(key);
+        }
+        foreach (var key in stale)
+            _recentMirror.Remove(key);
     }
 }

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,12 +1,10 @@
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
-using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Client.RussStation.Popups;
@@ -19,19 +17,14 @@ namespace Content.Client.RussStation.Popups;
 /// Popups for entities the local player can't examine (out of range, occluded, wrong map) are dropped
 /// so the log doesn't leak information the player shouldn't have. Cursor / coordinate-only popups with
 /// no source entity always log since those are typically addressed directly to the local player.
+/// Repeated popups within a short window are coalesced in-place by ChatUIController (shared path with
+/// emote coalescing), so this system does not need its own dedup dictionary.
 /// </remarks>
 public sealed class PopupLogSystem : EntitySystem
 {
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-
-    // Window during which an identical popup (by message text) is treated as a duplicate
-    // and suppressed from the chat mirror. The floating display keeps its own upstream coalescing independently.
-    private static readonly TimeSpan CoalesceWindow = TimeSpan.FromSeconds(2);
-
-    private readonly Dictionary<string, TimeSpan> _recentMirror = new();
 
     private ChatUIController? _chat;
     private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
@@ -43,12 +36,6 @@ public sealed class PopupLogSystem : EntitySystem
         // PopupMessage / PopupCursorInternal (HONK blocks), so network-sent popups, client-predicted
         // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
-        SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundRestart);
-    }
-
-    private void OnRoundRestart(RoundRestartCleanupEvent ev)
-    {
-        _recentMirror.Clear();
     }
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
@@ -75,12 +62,6 @@ public sealed class PopupLogSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(message))
             return;
 
-        var now = _timing.RealTime;
-        if (_recentMirror.TryGetValue(message, out var lastSeen) && now - lastSeen < CoalesceWindow)
-            return;
-        _recentMirror[message] = now;
-        PruneStaleCoalesceEntries(now);
-
         var escaped = FormattedMessage.EscapeText(message);
         var wrapped = category is { } cat
             ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
@@ -94,20 +75,5 @@ public sealed class PopupLogSystem : EntitySystem
             senderKey: null);
 
         Chat.ProcessChatMessage(mirror, speechBubble: false);
-    }
-
-    private void PruneStaleCoalesceEntries(TimeSpan now)
-    {
-        if (_recentMirror.Count < 32)
-            return;
-
-        var stale = new List<string>();
-        foreach (var (key, seenAt) in _recentMirror)
-        {
-            if (now - seenAt >= CoalesceWindow)
-                stale.Add(key);
-        }
-        foreach (var key in stale)
-            _recentMirror.Remove(key);
     }
 }

--- a/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
@@ -32,6 +32,12 @@ public sealed partial class DefaultGameScreen : InGameScreen
 
     private void ResizeActionContainer()
     {
+        //HONK START - fork action-bar layout controls Columns directly, and setting MaxGridHeight
+        // flips the grid into height-based row mode which silently overwrites the chosen column
+        // count. Skip the resize and let ActionBarCustomizationController own the layout.
+        if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.OverridesRowLayout)
+            return;
+        //HONK END
         float indent = Inventory.Size.Y + TopBar.Size.Y + 40;
         Actions.ActionsContainer.MaxGridHeight = MainViewport.Size.Y - indent;
     }

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
@@ -36,6 +36,12 @@ public sealed partial class SeparatedChatGameScreen : InGameScreen
 
     private void ResizeActionContainer()
     {
+        //HONK START - fork action-bar layout controls Columns directly, and setting MaxGridWidth
+        // flips the grid into width-based column mode which silently overwrites the chosen column
+        // count. Skip the resize and let ActionBarCustomizationController own the layout.
+        if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.OverridesRowLayout)
+            return;
+        //HONK END
         float indent = 20;
         Actions.ActionsContainer.MaxGridWidth = ViewportContainer.Size.X - indent;
     }

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -107,6 +107,32 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _actionsSystem.OnActionAdded += OnActionAdded;
             _actionsSystem.OnActionRemoved += OnActionRemoved;
             _actionsSystem.ActionsUpdated += OnActionsUpdated;
+
+            //HONK START - catch emote actions whose OnActionAdded fired before the subscription
+            // above (initial ActionsComponent state is applied while we're still in LobbyState).
+            // Non-emote actions come back through LoadDefaultActions on link; emote actions have
+            // autoPopulate: false and would otherwise miss their saved slot restoration.
+            var custom = UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>();
+            foreach (var existing in _actionsSystem.GetClientActions())
+            {
+                if (!EntityManager.TryGetComponent<Content.Shared.RussStation.VerbBindings.HonkEmoteActionComponent>(existing.Owner, out var emoteTag))
+                    continue;
+                if (_actions.Contains(existing))
+                    continue;
+                if (!custom.TryGetSavedEmoteSlot(emoteTag.Emote, out var savedSlot))
+                    continue;
+                if (savedSlot < 0 || savedSlot >= ContentKeyFunctions.GetHotbarBoundKeys().Length)
+                    continue;
+                while (_actions.Count <= savedSlot)
+                    _actions.Add(null);
+                if (_actions[savedSlot] == null)
+                    _actions[savedSlot] = existing.Owner;
+            }
+            // Push the updated _actions into the bar; without this the placement is in our
+            // list but never reaches the visible container.
+            if (_container != null)
+                _container.SetActionData(_actionsSystem, _actions.ToArray());
+            //HONK END
         }
 
         UpdateFilterLabel();
@@ -265,12 +291,36 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actions.Contains(action))
             return;
 
-        //HONK START - fork auto-add toggle + provider-slot memory. Hand/pocket swaps of an item that
-        // already had a slot always restore to that slot regardless of auto-add (the player accepted
-        // the action onto the bar previously, so a move shouldn't silently drop it). The trailing-null
-        // trim in OnActionRemoved means the remembered slot can be past _actions.Count by the time
-        // we re-add, so pad up to it (capped at the bound hotbar key count). Truly new providers
-        // fall through to the auto-add check.
+        //HONK START - fork add-to-bar gating.
+        // * Emote actions never auto-add regardless of the global toggle; they stay in the
+        //   actions menu until the player drags one onto a slot.
+        // * Hand/pocket swaps of an item that already had a slot always restore to that slot
+        //   (player accepted the action onto the bar previously, so a move shouldn't silently
+        //   drop it). The trailing-null trim in OnActionRemoved means the remembered slot can
+        //   be past _actions.Count by the time we re-add, so pad up to it (capped at the bound
+        //   hotbar key count).
+        // * Truly new providers fall through to the auto-add CVar.
+        if (EntityManager.TryGetComponent<Content.Shared.RussStation.VerbBindings.HonkEmoteActionComponent>(actionId, out var emoteTag))
+        {
+            // Emotes normally stay in the menu, but a player's saved placement from a prior
+            // session wins: if the emote's proto id has a remembered slot we're free to fill,
+            // drop it there. Go through the controller directly so its Initialize (and CVar
+            // parse) is guaranteed to have run before we read the map.
+            var custom = UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>();
+            if (custom.TryGetSavedEmoteSlot(emoteTag.Emote, out var savedSlot)
+                && savedSlot >= 0
+                && savedSlot < ContentKeyFunctions.GetHotbarBoundKeys().Length)
+            {
+                while (_actions.Count <= savedSlot)
+                    _actions.Add(null);
+                if (_actions[savedSlot] == null)
+                {
+                    _actions[savedSlot] = action;
+                    return;
+                }
+            }
+            return;
+        }
         if (action.Comp.Container is {} provider
             && _honkLastSlotByProvider.TryGetValue(provider, out var lastSlot)
             && lastSlot >= 0
@@ -322,8 +372,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     }
 
     //HONK START - public entry so the fork controller can force a hotbar rebuild when empty-slot /
-    // slots-per-row / rows CVars change and the padding needs to grow or shrink.
+    // slots-per-row / rows CVars change and the padding needs to grow or shrink; and a slot-trigger
+    // entry point so SlotHotkeyController can dispatch after resolving a key→slot mapping that
+    // differs from the upstream fixed index.
     public void HonkRefreshHotbar() => OnActionsUpdated();
+
+    public void HonkTriggerSlot(int slot) => TriggerAction(slot);
     //HONK END
 
     private void ActionButtonPressed(ButtonEventArgs args)
@@ -372,6 +426,9 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             Filters.Innate => comp.Container == null || comp.Container == _playerManager.LocalEntity,
             Filters.Instant => EntityManager.HasComponent<InstantActionComponent>(uid),
             Filters.Targeted => EntityManager.HasComponent<TargetActionComponent>(uid),
+            //HONK START - emote-as-action filter (#579)
+            Filters.Emote => EntityManager.HasComponent<Content.Shared.RussStation.VerbBindings.HonkEmoteActionComponent>(uid),
+            //HONK END
             _ => throw new ArgumentOutOfRangeException(nameof(filter), filter, null)
         };
     }
@@ -483,9 +540,21 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             button.ClearData();
             if (_container?.TryGetButtonIndex(button, out position) ?? false)
             {
-                //HONK START - keep _actions sparse so a cleared middle slot doesn't shift later actions left
+                //HONK START - keep _actions sparse so a cleared middle slot doesn't shift later actions
+                // left, and forget any emote-slot memory for whatever was in this slot so it doesn't
+                // come back on reconnect.
                 if (position >= 0 && position < _actions.Count)
                 {
+                    if (_actions[position] is { } clearedAction
+                        && EntityManager.TryGetComponent<Content.Shared.RussStation.VerbBindings.HonkEmoteActionComponent>(clearedAction, out var clearedEmote))
+                    {
+                        // Only forget the saved slot if the emote hasn't already been moved to a
+                        // different slot in this same drag (DragAction does place-then-clear, so the
+                        // new slot is already in the map by the time we reach the clear).
+                        var custom = UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>();
+                        if (custom.TryGetSavedEmoteSlot(clearedEmote.Emote, out var savedPos) && savedPos == position)
+                            custom.HonkRememberEmoteSlot(clearedEmote.Emote, null);
+                    }
                     _actions[position] = null;
                     while (_actions.Count > 0 && _actions[^1] == null)
                         _actions.RemoveAt(_actions.Count - 1);
@@ -498,14 +567,19 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _container.TryGetButtonIndex(button, out position))
         {
             //HONK START - pad with nulls so an action dropped on slot N lands at slot N, not at Count,
-            // and update provider->slot memory so re-acquiring the item later restores to the new slot
-            // rather than the original auto-populated one.
+            // update provider->slot memory so re-acquiring the item later restores to the new slot,
+            // and persist emote placements so disconnect+reconnect restores the same layout.
             while (_actions.Count < position)
                 _actions.Add(null);
             if (_actionsSystem.GetAction(actionId.Value) is {} placedAction
                 && placedAction.Comp.Container is {} placedProvider)
             {
                 _honkLastSlotByProvider[placedProvider] = position;
+            }
+            if (EntityManager.TryGetComponent<Content.Shared.RussStation.VerbBindings.HonkEmoteActionComponent>(actionId.Value, out var placedEmote))
+            {
+                UIManager.GetUIController<Content.Client.RussStation.ActionBar.ActionBarCustomizationController>()
+                    .HonkRememberEmoteSlot(placedEmote.Emote, position);
             }
             //HONK END
             if (position >= _actions.Count)
@@ -606,6 +680,20 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     private void HandleActionPressed(GUIBoundKeyEventArgs args, ActionButton button)
     {
         args.Handle();
+
+        //HONK START - assign-hotkey mode: left-click arms the clicked slot so the
+        // next hotbar keypress becomes that slot's hotkey. Short-circuit the drag
+        // and trigger paths entirely while assign mode is on.
+        var slotHotkeys = UIManager.GetUIController<Content.Client.RussStation.ActionBar.SlotHotkeyController>();
+        if (slotHotkeys.AssignMode
+            && _container != null
+            && _container.TryGetButtonIndex(button, out var armSlot))
+        {
+            slotHotkeys.ArmSlot(armSlot);
+            return;
+        }
+        //HONK END
+
         if (button.Action != null)
         {
             //HONK START - lock blocks drag-rearrange on the bar; clicking an action to fire it still works
@@ -633,6 +721,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             return;
 
         args.Handle();
+
+        //HONK START - assign-hotkey mode: swallow release so the action doesn't trigger on a
+        // slot the player was arming for rebind. Arming already happened in HandleActionPressed.
+        if (UIManager.GetUIController<Content.Client.RussStation.ActionBar.SlotHotkeyController>().AssignMode)
+            return;
+        //HONK END
 
         if (_menuDragHelper.IsDragging)
         {

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -398,6 +398,7 @@ public sealed class ActionButton : Control, IEntityControl
         // texture draws in that case so the preview has something to render.
         var honkShowEmpty = Action == null
             && (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ShowEmptySlots
+                || Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AssignHotkeyMode
                 || _controller.IsDragging);
         var honkAlpha = Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ButtonBackgroundAlpha;
         const float honkEmptyFadeRatio = 0.4f;

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -36,7 +36,8 @@ public class ActionButtonContainer : GridContainer
         var uniqueCount = Math.Min(system.GetClientActions().Count(), actionTypes.Length + 1);
         var keys = ContentKeyFunctions.GetHotbarBoundKeys();
         //HONK START - honour the caller's sparse layout (drag-to-slot places actions at specific indices)
-        // and pad empties up to the fork-requested minimum, capped at bound hotbar key count.
+        // and pad empties up to the fork-requested minimum, capped at the bound hotbar key count.
+        // GetHotbarBoundKeys includes HotbarShift1-0, so slots 10-19 default to Shift+Num1..0.
         uniqueCount = Math.Max(uniqueCount, actionTypes.Length);
         if (HonkMinSlotCount > 0)
             uniqueCount = Math.Max(uniqueCount, Math.Min(HonkMinSlotCount, keys.Length));
@@ -63,11 +64,17 @@ public class ActionButtonContainer : GridContainer
         {
             var button = new ActionButton(_entity);
 
-            if (!keys.TryGetValue(index, out var boundKey))
-                return button;
-
-            //HONK START - KeyBind setter now resolves the short label and autofits it; no extra work here
-            button.KeyBind = boundKey;
+            //HONK START - per-slot hotkey lookup via SlotHotkeyController: user
+            // overrides and slots past the default hotbar range land on the right
+            // label. Falls back to the upstream fixed-index key when the UI
+            // subsystem isn't wired yet (tests, early init).
+            var resolved = UserInterfaceManager
+                .GetUIController<Content.Client.RussStation.ActionBar.SlotHotkeyController>()
+                .GetHotkeyForSlot(index);
+            if (resolved is { } slotKey)
+                button.KeyBind = slotKey;
+            else if (keys.TryGetValue(index, out var boundKey))
+                button.KeyBind = boundKey;
             //HONK END
 
             return button;

--- a/Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml.cs
@@ -42,6 +42,9 @@ public sealed partial class ActionsWindow : DefaultWindow
         Item,
         Innate,
         Instant,
-        Targeted
+        Targeted,
+        //HONK START - emote-as-action filter (#579)
+        Emote,
+        //HONK END
     }
 }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -449,11 +449,23 @@ public sealed partial class ChatUIController : UIController
             return;
         }
 
+        // HONK START - coalesce at enqueue time so rapid repeats bump the counter immediately
+        // instead of waiting for the speech-bubble delay queue to dequeue each duplicate. Falls
+        // through to the existing enqueue path when there's no alive match yet. (issue #578)
+        if (HonkTryCoalesceEmoteBubble(ent, msg, speechType))
+            return;
+        // HONK END
+
         EnqueueSpeechBubble(ent, msg, speechType);
     }
 
     private void CreateSpeechBubble(EntityUid entity, SpeechBubbleData speechData)
     {
+        // HONK START - coalesce repeated emote bubbles in place instead of stacking a new bubble (issue #578)
+        if (HonkTryCoalesceEmoteBubble(entity, speechData.Message, speechData.Type))
+            return;
+        // HONK END
+
         var bubble =
             SpeechBubble.CreateSpeechBubble(speechData.Type, speechData.Message, entity);
 
@@ -878,8 +890,17 @@ public sealed partial class ChatUIController : UIController
         }
         //HONK END
 
+        // HONK START - coalesce repeated popup-mirror / emote entries in place (issue #578).
+        // When a match is found, the existing History entry's WrappedMessage is mutated and the
+        // chat boxes re-render that entry via the MessageUpdated event. We still fall through to
+        // the speech-bubble path so emote bubbles can coalesce the same way.
+        var honkCoalesced = !msg.HideChat && HonkTryCoalesceChatMessage(msg);
+        // HONK END
+
         // Log all incoming chat to repopulate when filter is un-toggled
-        if (!msg.HideChat)
+        // HONK START - skip History.Add when the fork coalescer folded this into an existing entry (issue #578)
+        if (!msg.HideChat && !honkCoalesced)
+        // HONK END
         {
             History.Add((_timing.CurTick, msg));
             MessageAdded?.Invoke(msg);

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -25,6 +25,12 @@ public partial class ChatBox : UIWidget
     private readonly ISawmill _sawmill;
     private readonly ChatUIController _controller;
 
+    // HONK START - tracks which OutputPanel entry index each rendered ChatMessage lives at, so in-place
+    // coalesce updates (see ChatUIController.HonkTryCoalesceChatMessage) can patch that one entry
+    // instead of repopulating the whole box. Cleared whenever Contents is Cleared.
+    private readonly Dictionary<ChatMessage, int> _honkRenderedAt = new();
+    // HONK END
+
     public bool Main { get; set; }
 
     public ChatSelectChannel SelectedChannel => ChatInput.ChannelSelector.SelectedChannel;
@@ -44,6 +50,9 @@ public partial class ChatBox : UIWidget
         ChatInput.FilterButton.Popup.OnNewHighlights += OnNewHighlights;
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
+        // HONK START - in-place rerender for coalesced repeats (issue #578)
+        _controller.MessageUpdated += OnMessageUpdated;
+        // HONK END
         _controller.HighlightsUpdated += OnHighlightsUpdated;
         _controller.RegisterChat(this);
     }
@@ -69,7 +78,28 @@ public partial class ChatBox : UIWidget
         var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
 
         AddLine(msg.WrappedMessage, color);
+        // HONK START - remember this message's rendered position so coalesce updates can patch it (issue #578)
+        _honkRenderedAt[msg] = Contents.EntryCount - 1;
+        // HONK END
     }
+
+    // HONK START - issue #578
+    private void OnMessageUpdated(ChatMessage msg)
+    {
+        if (!_honkRenderedAt.TryGetValue(msg, out var index))
+            return;
+
+        if (index < 0 || index >= Contents.EntryCount)
+            return;
+
+        var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
+        var formatted = new FormattedMessage(3);
+        formatted.PushColor(color);
+        formatted.AddMarkupOrThrow(msg.WrappedMessage);
+        formatted.Pop();
+        Contents.SetMessage(index, formatted, tagsAllowed: null);
+    }
+    // HONK END
 
     private void OnHighlightsUpdated(string highlights)
     {
@@ -84,6 +114,9 @@ public partial class ChatBox : UIWidget
     public void Repopulate()
     {
         Contents.Clear();
+        // HONK START - stale contents indices after Clear (issue #578)
+        _honkRenderedAt.Clear();
+        // HONK END
 
         foreach (var message in _controller.History)
         {
@@ -94,6 +127,9 @@ public partial class ChatBox : UIWidget
     private void OnChannelFilter(ChatChannel channel, bool active)
     {
         Contents.Clear();
+        // HONK START - stale contents indices after Clear (issue #578)
+        _honkRenderedAt.Clear();
+        // HONK END
 
         foreach (var message in _controller.History)
         {
@@ -208,6 +244,9 @@ public partial class ChatBox : UIWidget
 
         if (!disposing) return;
         _controller.UnregisterChat(this);
+        // HONK START - unsubscribe from coalesce update event (issue #578)
+        _controller.MessageUpdated -= OnMessageUpdated;
+        // HONK END
         ChatInput.Input.OnTextEntered -= OnTextEntered;
         ChatInput.Input.OnKeyBindDown -= OnInputKeyBindDown;
         ChatInput.Input.OnTextChanged -= OnTextChanged;

--- a/Content.IntegrationTests/Tests/RussStation/VerbBindings/HonkEmoteActionTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/VerbBindings/HonkEmoteActionTest.cs
@@ -1,0 +1,92 @@
+#nullable enable
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.RussStation.VerbBindings;
+using Robust.Server.Player;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.RussStation.VerbBindings;
+
+/// <summary>
+/// Verifies the fork's emote-as-action grants run on player attach, land the allowlist's emotes
+/// as HonkEmoteAction entities on the player's ActionsComponent, and replicate the emote proto
+/// id to the client.
+/// </summary>
+[TestFixture]
+public sealed class HonkEmoteActionTest : GameTest
+{
+    public override PoolSettings PoolSettings => new PoolSettings { Connected = true, DummyTicker = false };
+
+    [Test]
+    public async Task EmoteActionsGrantedOnAttach()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var client = pair.Client;
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var cEntMan = client.ResolveDependency<IEntityManager>();
+        var sProto = server.ResolveDependency<IPrototypeManager>();
+        var sActions = server.System<SharedActionsSystem>();
+        var cActions = client.System<SharedActionsSystem>();
+        var serverSession = server.ResolveDependency<IPlayerManager>().Sessions.Single();
+
+        Assert.That(serverSession.AttachedEntity, Is.Not.Null);
+        var serverEnt = serverSession.AttachedEntity!.Value;
+        var clientEnt = client.Session!.AttachedEntity!.Value;
+
+        var sEmoteActions = sActions.GetActions(serverEnt)
+            .Where(ent => sEntMan.HasComponent<HonkEmoteActionComponent>(ent))
+            .ToArray();
+        var cEmoteActions = cActions.GetActions(clientEnt)
+            .Where(ent => cEntMan.HasComponent<HonkEmoteActionComponent>(ent))
+            .ToArray();
+
+        // The default allowlist has entries; at least one should pass AllowedToUseEmote on
+        // the default test mob. Exact count depends on species / whitelist checks.
+        Assert.That(sEmoteActions.Length, Is.GreaterThan(0));
+        // Actions should replicate one-for-one to the client.
+        Assert.That(cEmoteActions.Length, Is.EqualTo(sEmoteActions.Length));
+
+        // Every granted emote must have a non-empty proto id that resolves to a real
+        // EmotePrototype, on both sides. This catches regressions in the networked state
+        // generation (AutoGenerateComponentState + AutoNetworkedField).
+        foreach (var ent in sEmoteActions)
+        {
+            var comp = sEntMan.GetComponent<HonkEmoteActionComponent>(ent);
+            Assert.That(string.IsNullOrEmpty(comp.Emote), Is.False,
+                "Server-side HonkEmoteActionComponent.Emote must be set before the action is granted.");
+            Assert.That(sProto.HasIndex<Content.Shared.Chat.Prototypes.EmotePrototype>(comp.Emote), Is.True,
+                $"'{comp.Emote}' is not a valid EmotePrototype id.");
+        }
+        foreach (var ent in cEmoteActions)
+        {
+            var comp = cEntMan.GetComponent<HonkEmoteActionComponent>(ent);
+            Assert.That(string.IsNullOrEmpty(comp.Emote), Is.False,
+                "Client-side HonkEmoteActionComponent.Emote must be set after state replication.");
+        }
+    }
+
+    [Test]
+    public async Task EmoteActionsDoNotAutoPopulate()
+    {
+        // Emote action entities should have AutoPopulate=false so LoadDefaultActions leaves
+        // them in the menu. Regressing this would flood a new connection's bar with every
+        // emote the allowlist grants.
+        var pair = Pair;
+        var sEntMan = pair.Server.ResolveDependency<IEntityManager>();
+        var sActions = pair.Server.System<SharedActionsSystem>();
+        var serverSession = pair.Server.ResolveDependency<IPlayerManager>().Sessions.Single();
+        var serverEnt = serverSession.AttachedEntity!.Value;
+
+        foreach (var ent in sActions.GetActions(serverEnt)
+                     .Where(e => sEntMan.HasComponent<HonkEmoteActionComponent>(e)))
+        {
+            var action = sEntMan.GetComponent<ActionComponent>(ent);
+            Assert.That(action.AutoPopulate, Is.False,
+                "Emote action must have AutoPopulate=false so it doesn't land on the bar automatically.");
+        }
+    }
+}

--- a/Content.Server/Mobs/DeathgaspSystem.cs
+++ b/Content.Server/Mobs/DeathgaspSystem.cs
@@ -1,5 +1,8 @@
 ﻿using Content.Server.Chat.Systems;
 using Content.Server.Speech.Muting;
+// HONK START - ChatTransmitRange for deathgasp FOV filter
+using Content.Shared.Chat;
+// HONK END
 using Content.Shared.Mobs;
 using Content.Shared.Speech.Muting;
 using Robust.Shared.Prototypes;
@@ -38,7 +41,10 @@ public sealed class DeathgaspSystem: EntitySystem
         if (HasComp<MutedComponent>(uid))
             return false;
 
-        _chat.TryEmoteWithChat(uid, component.Prototype, ignoreActionBlocker: true);
+        // HONK START - match involuntary gasps: send with HideChat so the client-side FOV filter
+        // re-enables the emote only for observers who can actually see the dying entity.
+        _chat.TryEmoteWithChat(uid, component.Prototype, range: ChatTransmitRange.HideChat, ignoreActionBlocker: true);
+        // HONK END
 
         return true;
     }

--- a/Content.Server/RussStation/VerbBindings/HonkEmoteActionSystem.cs
+++ b/Content.Server/RussStation/VerbBindings/HonkEmoteActionSystem.cs
@@ -1,0 +1,114 @@
+using Content.Server.Chat.Systems;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.Ghost;
+using Content.Shared.RussStation.VerbBindings;
+using Content.Shared.Speech;
+using Content.Shared.Speech.Muting;
+using Content.Shared.Whitelist;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.VerbBindings;
+
+/// <summary>
+/// HONK Grants one <c>HonkActionEmote</c> action entity per emote the player-controlled mob can
+/// normally perform, and handles the action trigger by firing the emote through
+/// <c>ChatSystem.TryEmoteWithChat</c>. The set comes from every <c>EmotePrototype</c> that passes
+/// <c>SharedChatSystem.AllowedToUseEmote</c> for the performer, so species whitelists,
+/// <c>SpeechComponent.AllowedEmotes</c>, and per-emote whitelist / blacklist all apply exactly as
+/// they do when the player types the emote command. Emotes show up as regular action buttons in
+/// the action menu and drag onto hotbar slots like any other action.
+/// </summary>
+public sealed class HonkEmoteActionSystem : EntitySystem
+{
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
+    [Dependency] private readonly MetaDataSystem _meta = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    // Action entity prototype spawned once per allowed emote.
+    private const string EmoteActionProtoId = "HonkActionEmote";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<HonkEmoteActionComponent, HonkEmoteActionEvent>(OnActionFired);
+    }
+
+    private void OnPlayerAttached(PlayerAttachedEvent args)
+    {
+        var performer = args.Entity;
+
+        // Ghosts, lobby observers, and anything else without a SpeechComponent can't emote, so
+        // granting them emote actions just floods the menu. A living mob with speech is the
+        // thing we actually want these buttons on.
+        if (HasComp<GhostComponent>(performer) || !HasComp<SpeechComponent>(performer))
+            return;
+
+        // Reconnect or re-attach to the same body: skip if this mob already carries any emote
+        // action so we don't duplicate the full emote set in its menu every time.
+        if (TryComp<Content.Shared.Actions.Components.ActionsComponent>(performer, out var actions))
+        {
+            foreach (var existing in actions.Actions)
+            {
+                if (HasComp<HonkEmoteActionComponent>(existing))
+                    return;
+            }
+        }
+
+        foreach (var emote in _proto.EnumeratePrototypes<EmotePrototype>())
+        {
+            // Mirror the radial emote menu's filter exactly (EmotesUIController.ConvertToButtons):
+            // invalid category, no chat triggers (reflexive / death emotes), whitelist fail,
+            // blacklist match, or Available=false + not in SpeechComponent.AllowedEmotes.
+            if (emote.Category == EmoteCategory.Invalid)
+                continue;
+            if (emote.ChatTriggers.Count == 0)
+                continue;
+            if (!_whitelist.IsWhitelistPassOrNull(emote.Whitelist, performer))
+                continue;
+            if (_whitelist.IsWhitelistPass(emote.Blacklist, performer))
+                continue;
+            if (!emote.Available
+                && TryComp<SpeechComponent>(performer, out var speech)
+                && !speech.AllowedEmotes.Contains(emote.ID))
+                continue;
+
+            // Spawn, configure, then grant. Doing it in that order means the first network
+            // state the client sees for the new action entity already has Emote populated;
+            // otherwise the client's OnActionAdded fires before the delta from Dirty reaches
+            // it and the placement-persistence lookup misses.
+            EntityUid? actionId = null;
+            if (!_actionContainer.EnsureAction(performer, ref actionId, out _, EmoteActionProtoId))
+                continue;
+            var actionUid = actionId.Value;
+
+            if (TryComp<HonkEmoteActionComponent>(actionUid, out var tag))
+            {
+                tag.Emote = emote.ID;
+                Dirty(actionUid, tag);
+            }
+
+            _actions.SetIcon(actionUid, emote.Icon);
+            _meta.SetEntityName(actionUid, Loc.GetString(emote.Name));
+
+            _actions.AddActionDirect(performer, actionUid);
+        }
+    }
+
+    private void OnActionFired(Entity<HonkEmoteActionComponent> ent, ref HonkEmoteActionEvent args)
+    {
+        if (args.Handled)
+            return;
+        if (HasComp<MutedComponent>(args.Performer))
+            return;
+
+        _chat.TryEmoteWithChat(args.Performer, ent.Comp.Emote);
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.ActionBar.cs
@@ -66,4 +66,13 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> HonkActionBarButtonBackgroundAlpha =
         CVarDef.Create("honk.action_bar.button_background_alpha", 150f / 255f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Serialized emote-to-slot placements persisted across sessions: <c>emoteId=slotIndex</c>
+    /// pairs separated by semicolons, e.g. <c>Wave=3;Scream=5</c>. When the server grants an
+    /// emote action whose proto id is in this map, the client drops it onto the saved slot
+    /// instead of leaving it in the actions menu.
+    /// </summary>
+    public static readonly CVarDef<string> HonkActionBarEmoteSlots =
+        CVarDef.Create("honk.action_bar.emote_slots", string.Empty, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/RussStation/VerbBindings/HonkEmoteActionComponent.cs
+++ b/Content.Shared/RussStation/VerbBindings/HonkEmoteActionComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.VerbBindings;
+
+/// <summary>
+/// HONK Marks an action entity whose trigger plays a specific emote as the performer.
+/// Paired with <see cref="HonkEmoteActionEvent"/> on the action's <c>InstantActionComponent</c>
+/// so the server emote system picks it up and dispatches through <c>ChatSystem.TryEmoteWithChat</c>.
+/// Stored as a plain string (rather than ProtoId&lt;EmotePrototype&gt;) so the
+/// auto-networking generator round-trips the value cleanly on every client.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class HonkEmoteActionComponent : Component
+{
+    /// <summary>The emote proto id this action plays when fired. Overwritten by the server at
+    /// spawn to the allowlisted emote this action was granted for.</summary>
+    [DataField, AutoNetworkedField]
+    public string Emote = string.Empty;
+}

--- a/Content.Shared/RussStation/VerbBindings/HonkEmoteActionEvent.cs
+++ b/Content.Shared/RussStation/VerbBindings/HonkEmoteActionEvent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared.RussStation.VerbBindings;
+
+/// <summary>
+/// HONK Fires when the player triggers a <see cref="HonkEmoteActionComponent"/>-tagged action.
+/// The server system reads the action entity's <c>HonkEmoteActionComponent.Emote</c> and plays it.
+/// </summary>
+public sealed partial class HonkEmoteActionEvent : InstantActionEvent
+{
+}

--- a/Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/action-bar/action-bar-options.ftl
@@ -7,3 +7,5 @@ ui-options-action-bar-show-empty-slots = Show empty slots (faint)
 ui-options-action-bar-button-background-alpha = Action bar button background alpha
 ui-actionmenu-lock-button = Lock bar
 ui-actionmenu-auto-add-button = Auto-add new actions
+honk-ui-options-controls-assign-slot-hotkey = Assign action bar slot hotkeys (click a slot, then press a hotbar key)
+ui-actionmenu-emote = Emote

--- a/Resources/Locale/en-US/@RussStation/guidebook/action-bar.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/action-bar.ftl
@@ -1,0 +1,1 @@
+guide-entry-action-bar = Action bar

--- a/Resources/Prototypes/@RussStation/Guidebook/actionbar.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/actionbar.yml
@@ -1,0 +1,6 @@
+# HONK Action bar guidebook entry (#579). Surfaces the customization + rebind + emote-button
+# features so players find them without digging through Settings.
+- type: guideEntry
+  id: ActionBar
+  name: guide-entry-action-bar
+  text: "/ServerInfo/Guidebook/NewPlayer/Controls/ActionBar.xml"

--- a/Resources/Prototypes/@RussStation/VerbBindings/emote-action.yml
+++ b/Resources/Prototypes/@RussStation/VerbBindings/emote-action.yml
@@ -1,0 +1,20 @@
+# HONK Emote-as-action base entity (#579). The server HonkEmoteActionSystem spawns one per
+# allowlisted emote on player-attach, sets the Emote field and the action's icon/name from
+# the matching EmotePrototype, and adds it to the player's ActionsContainer.
+- type: entity
+  abstract: false
+  parent: BaseAction
+  id: HonkActionEmote
+  name: Emote
+  description: Play an emote.
+  components:
+  - type: Action
+    # Fire the HonkEmoteActionEvent on the action entity itself so HonkEmoteActionSystem's
+    # per-component handler can pull the emote id out of HonkEmoteAction and play it.
+    raiseOnAction: true
+    # Emotes stay in the actions menu until the player drags one onto a slot; don't let
+    # LoadDefaultActions pull them onto the bar on first connection either.
+    autoPopulate: false
+  - type: InstantAction
+    event: !type:HonkEmoteActionEvent
+  - type: HonkEmoteAction

--- a/Resources/Prototypes/Guidebook/newplayer.yml
+++ b/Resources/Prototypes/Guidebook/newplayer.yml
@@ -16,6 +16,9 @@
   text: "/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml"
   children:
   - Radio
+  # HONK START - action bar customization, rebind, emote buttons (#579)
+  - ActionBar
+  # HONK END
 
 - type: guideEntry
   id: Radio

--- a/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
@@ -76,6 +76,14 @@ Treats burn damage (heat, shock, cold, caustic).
 - [color=#a4885c]Hemostat[/color] - treat burns (repeats automatically until healed)
 - [color=#a4885c]Cautery[/color] - close incision
 
+### Wound Repair (Fracture)
+Clears fractures left by heavy blunt damage.
+- [color=#a4885c]Bonesetter[/color] - set broken bones
+
+### Wound Repair (Burn)
+Clears burn wounds left by severe heat or shock damage.
+- [color=#a4885c]Cautery[/color] - dress and cauterize burns
+
 ### Organ Manipulation
 Open the body cavity to remove or insert organs.
 - [color=#a4885c]Scalpel[/color] - make incision
@@ -84,6 +92,9 @@ Open the body cavity to remove or insert organs.
 - [color=#a4885c]Bone saw[/color] - saw through bone
 - [color=#a4885c]Hemostat[/color] - select organ to remove (opens organ picker), or use an organ in your hand on the patient to insert it
 - [color=#a4885c]Cautery[/color] - close incision
+
+## Natural Healing
+Untreated wounds slowly fade. A serious wound takes about 10 minutes to clear entirely, roughly 2 minutes per severity tier. Surgery is faster. Dead bodies don't regenerate.
 
 ## Cancelling Surgery
 The patient can click the [color=#a4885c]drape alert[/color] on their HUD to remove the drape and cancel the procedure at any time.

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/ActionBar.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/ActionBar.xml
@@ -1,0 +1,40 @@
+<Document>
+# Action bar
+
+The slot row at the top of the screen. Each slot holds one action: a species ability, an item you're holding, combat mode, an emote, whatever's available. Click a slot or press its key to fire.
+
+## Shape and look
+
+[color=yellow]Settings > Misc > Action Bar[/color] controls the layout.
+
+- [color=#a4885c]Rows[/color] and [color=#a4885c]Slots per row[/color] decide how many buttons are visible and how they wrap. Default is one row of ten.
+- [color=#a4885c]Slot spacing[/color] is the gap between buttons.
+- [color=#a4885c]Show keybind label[/color] toggles the small key letter in the corner of each slot.
+- [color=#a4885c]Show empty slots (faint)[/color] draws the outline of unused slots so the shape is always visible.
+
+Background opacity lives in [color=yellow]Settings > Accessibility[/color] with the other UI opacity sliders.
+
+## Hotkeys
+
+Defaults are [color=yellow][bold]1-0[/bold][/color] for the first row and [color=yellow][bold]Shift+1-0[/bold][/color] for the second. All 20 can be rebound two ways, and both write the same keybind:
+
+1. [color=yellow]Settings > Controls[/color] has an [color=#a4885c]Assign action bar slot hotkeys[/color] checkbox at the top. Tick it, click any slot on the bar, press the key you want. The matching [color=#a4885c]Hotbar 1[/color], [color=#a4885c]Hotbar Shift 1[/color], etc. row updates.
+2. Or scroll down that same options panel and click the key field next to the [color=#a4885c]Hotbar[/color] entry directly.
+
+The slot's label updates immediately.
+
+## Locking and auto-add
+
+The actions window (open with [color=yellow][bold][keybind="OpenActionsMenu"][/bold][/color]) has two checkboxes worth knowing about.
+
+- [color=#a4885c]Lock bar[/color] blocks right-click-clear and drag-to-rearrange. Clicking a slot to fire still works; the layout just can't be nudged by a misclick.
+- [color=#a4885c]Auto-add new actions[/color]. When off, picking up an item or getting a new ability leaves the bar alone. The action still appears in the actions menu, it just doesn't push your curated slots around.
+
+## Emotes
+
+Every emote you'd see in the radial emote menu also appears as a draggable button in the actions menu. The filter dropdown there has an [color=#a4885c]Emote[/color] checkbox if you want to look at just those.
+
+Drag one onto a hotbar slot. Rebind the slot's key if you want. Pressing that key plays the emote, same as typing the command.
+
+Emote slot placement is saved.
+</Document>

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -16,6 +16,11 @@
   It's also a [bold]hotbar[/bold] — perform those actions by pressing their corresponding [color=yellow][bold]number keys[/bold][/color] on your keyboard.
   Rearrange them by [bold]dragging[/bold] one icon over another, or remove icons temporarily by dragging them away.
 
+  <!-- HONK START - Action bar customization (#584) -->
+  You can customize the action bar in [bold]Settings → Misc → Action Bar[/bold] (rows, slots per row, slot spacing, keybind labels, empty slot visibility) and in [bold]Settings → Accessibility[/bold] (button background opacity).
+  The actions window header also has [bold]Lock[/bold] (freezes the bar against right-click clear and drag rearrange, click-to-fire still works) and [bold]Auto-add[/bold] (when off, server-granted actions stay in the menu instead of jumping onto the bar).
+  <!-- HONK END -->
+
   ### Status bar
   Below the chat window on the right, there's the [bold]status bar[/bold] showing your character's statuses.
   As with the action bar, hover over those icons to see what they mean.
@@ -138,6 +143,14 @@
   Don't worry about having to memorize them — they're usually intuitive and consistent across entity categories, and you'll find that most entities only use one or two interactions.
 
   [bold]Items stored in containers are still interactable.[/bold]
+
+  <!-- HONK START - Escape cancels DoAfters (#571) -->
+  ## Cancelling progress bars
+  Press [color=yellow][bold][keybind="EscapeContext"][/bold][/color] to [color=cyan]cancel[/color] any active progress-bar action you started (eating, drinking, channeled actions, etc.).
+  This works as long as no menu or text field is in the way (Escape still closes open windows and opens the game menu in the usual order).
+
+  Forced actions you didn't start (being grabbed, stripped, or operated on) aren't cancellable this way.
+  <!-- HONK END -->
 
   ## Context menus
   Click [color=yellow][bold][keybind="UIRightClick"/][/bold][/color] on any interactive entity to open the [color=cyan]context menu[/color], which shows you additional interaction you can currently perform.


### PR DESCRIPTION
## About the PR

Rolls up repeats of the same popup or emote into a single chat line with an (xN) counter, matching the upstream floating popup counter. After a 2 second gap the next copy starts a new line at 1. The floating speech bubble for emotes got the same treatment, reusing the upstream popup loc key so the visual is consistent.

Two nearby bugs got fixed on the way:

- The upstream popup counter reset any time the mob moved one tile, because `WorldPopupData` keys on coordinates. Entity-attached popups now drop coordinates from the key and the existing label is moved to the latest position so the stack follows the mob.
- Deathgasp was visible through walls. It went out with `ChatTransmitRange.Normal`, bypassing the fork-side FOV filter that gates involuntary gasps. Switched it to `ChatTransmitRange.HideChat` so the same filter gets a chance to run.

## Why / Balance

Bleed ticks, gasps, and similar repeat text flood the Popup tab and clutter chat with essentially the same line over and over. A counter is the pattern players already know from the float, so matching it in chat keeps scrollback readable without dropping any information.

Picking 2s for the window: combat ticks fire about once per second, so 2s catches the ones that are clearly "the same event happening again" and still lets a genuinely-separate repeat 3 seconds later start on its own line.

The deathgasp fix is also a small stealth buff to stealth. Being able to time your silent deadman through a wall because you could read "X seizes up and falls limp!" in chat was dumb.

## Technical details

- `ChatUIController` owns coalescing for the `Popup` and `Emotes` channels. A dict keyed on (channel, sender, raw message) tracks the active cluster; on a hit inside the window, the existing `ChatMessage.WrappedMessage` is rewritten with the upstream `popup-system-repeated-popup-stacking-wrap` loc key and a new `MessageUpdated` event fires. `ChatBox` listens and patches the corresponding `OutputPanel` entry via `SetMessage`, so there's no Repopulate flicker.
- The fork-side dedup dict in `PopupLogSystem` is gone. All coalescing goes through the one path now.
- `SpeechBubble` grew a `RepeatWith(ChatMessage)` via a `.Honk.cs` partial. The original wrapped text is snapshotted at construction so a later in-place mutation of the source `ChatMessage` (done by the chat coalescer) can't leak back into a bubble rebuild and produce "(x2) x2" double counts.
- Emote bubble coalesce happens at `AddSpeechBubble` time, not `CreateSpeechBubble`. Otherwise rapid emote spam pile up behind the speech-bubble delay queue and the counter only ticks at `BubbleDelayBase` intervals.
- `PopupSystem.PopupMessage`: entity-attached popups now use `default` coordinates in the key and the existing label's `InitialPos` is refreshed on each match.
- `DeathgaspSystem`: adds `range: ChatTransmitRange.HideChat` to the `TryEmoteWithChat` call. That lets the client-side emote FOV filter re-enable the message only for observers who can actually examine the corpse.

## Media

Manually tested:

- Bleed tick spam: chat counter increments in place, resets after 2s gap.
- Walking while bleeding: counter keeps climbing instead of restarting every step.
- Repeated `*salute`: chat line and speech bubble both coalesce with (xN), counter keeps up with the input rate.
- Deathgasp behind a wall: not visible to observers who can't examine the corpse.
- Involuntary gasps behind a wall: still hidden, unchanged baseline.
- Two different players doing the same emote side by side: do not coalesce together.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Popup and emote repeats in chat now collapse into a single line with a count, matching the floating popup counter. The count resets when there's a 2 second gap.
- tweak: Emote speech bubbles above characters count repeats in place instead of stacking.
- fix: The floating popup counter no longer resets when the mob moves.
- fix: Deathgasp no longer shows in chat to observers who can't actually see the corpse.