### PR TITLE
honksquad: feat: HONK0011 code fix, wrap unguarded Comp<T> in TryComp guard

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkMissingDirtyFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkMissingDirtyFixerTest.cs
@@ -1,0 +1,118 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkMissingDirtyAnalyzer, HonkMissingDirtyFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkMissingDirtyFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, Inherited = true)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class AutoNetworkedFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public abstract class Component : IComponent { }
+            public readonly struct EntityUid { }
+
+            public abstract class EntitySystem
+            {
+                protected void Dirty(EntityUid uid, IComponent comp) { }
+            }
+        }
+        namespace Fork.Stubs
+        {
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+
+            [NetworkedComponent]
+            public sealed class NetComp : Component
+            {
+                public int Value;
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/NetworkingStuff.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task InsertsDirtyCallAfterWrite()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Value = 5;
+                }
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(EntityUid uid, NetComp comp)
+                {
+                    comp.Value = 5;
+                    Dirty(uid, comp);
+                }
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0010", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 8, 9, 8, 23)
+                .WithArguments("Value", "NetComp"));
+    }
+
+    [Test]
+    public async Task BailsWhenNoEntityUidParameterInScope()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class MySys : EntitySystem
+            {
+                public void Poke(NetComp comp)
+                {
+                    comp.Value = 5;
+                }
+            }
+            """;
+
+        await Verify(before, before,
+            new DiagnosticResult("HONK0010", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 8, 9, 8, 23)
+                .WithArguments("Value", "NetComp"));
+    }
+}

--- a/Content.Analyzers.Honk.Tests/HonkUnguardedCompFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkUnguardedCompFixerTest.cs
@@ -1,0 +1,109 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkUnguardedCompAnalyzer, HonkUnguardedCompFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkUnguardedCompFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public interface IComponent { }
+            public readonly struct EntityUid { }
+
+            public abstract class EntitySystem
+            {
+                protected T Comp<T>(EntityUid uid) where T : IComponent => default!;
+                protected bool HasComp<T>(EntityUid uid) where T : IComponent => false;
+                protected bool TryComp<T>(EntityUid uid, out T? comp) where T : IComponent
+                { comp = default; return false; }
+            }
+        }
+        namespace Fork.Stubs
+        {
+            using Robust.Shared.GameObjects;
+            public sealed class TargetComp : IComponent { }
+            public sealed class SomeEvent
+            {
+                public EntityUid Target;
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/ForkSystem.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task WrapsLocalDeclInTryCompEarlyReturn()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var c = Comp<TargetComp>(args.Target);
+                }
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    if (!TryComp<TargetComp>(args.Target, out var c))
+                        return;
+                }
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 8, 17, 8, 46)
+                .WithArguments("TargetComp", "args.Target"));
+    }
+
+    [Test]
+    public async Task BailsOnNonVoidMethod()
+    {
+        const string before = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public int OnIt(SomeEvent args)
+                {
+                    var c = Comp<TargetComp>(args.Target);
+                    return 0;
+                }
+            }
+            """;
+
+        await Verify(before, before,
+            new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 8, 17, 8, 46)
+                .WithArguments("TargetComp", "args.Target"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkMissingDirtyFixer.cs
+++ b/Content.Analyzers.Honk/HonkMissingDirtyFixer.cs
@@ -1,0 +1,111 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0010: inserts <c>Dirty(uid, comp);</c> after a
+/// flagged networked-component write, where <c>uid</c> is the first
+/// <c>EntityUid</c> parameter of the enclosing method and <c>comp</c>
+/// is the receiver of the write's member-access. Bails out when there
+/// is no <c>EntityUid</c> parameter in scope, since guessing a name is
+/// worse than leaving the warning up for a human to resolve.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkMissingDirtyFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0010");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null || model is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var assignment = node.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+            if (assignment?.Left is not MemberAccessExpressionSyntax memberAccess)
+                continue;
+
+            var statement = assignment.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+            if (statement is null)
+                continue;
+
+            var method = assignment.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+            if (method is null)
+                continue;
+
+            if (!TryGetEntityUidParameter(method, model, context.CancellationToken, out var uidName))
+                continue;
+
+            var compExpression = memberAccess.Expression;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Insert Dirty({uidName}, {compExpression}) after write",
+                    createChangedDocument: c => InsertDirtyAsync(context.Document, statement, uidName, compExpression, c),
+                    equivalenceKey: "HonkInsertDirty"),
+                diagnostic);
+        }
+    }
+
+    private static bool TryGetEntityUidParameter(BaseMethodDeclarationSyntax method, SemanticModel model, CancellationToken ct, out string name)
+    {
+        name = string.Empty;
+        if (method.ParameterList is null)
+            return false;
+
+        foreach (var parameter in method.ParameterList.Parameters)
+        {
+            if (parameter.Type is null)
+                continue;
+            var type = model.GetTypeInfo(parameter.Type, ct).Type;
+            if (type?.Name == "EntityUid")
+            {
+                name = parameter.Identifier.ValueText;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static async Task<Document> InsertDirtyAsync(
+        Document document,
+        ExpressionStatementSyntax writeStatement,
+        string uidName,
+        ExpressionSyntax compExpression,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var dirtyCall = SyntaxFactory.ExpressionStatement(
+                SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.IdentifierName("Dirty"),
+                    SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+                    {
+                        SyntaxFactory.Argument(SyntaxFactory.IdentifierName(uidName)),
+                        SyntaxFactory.Argument(compExpression.WithoutTrivia()),
+                    }))))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newRoot = root.InsertNodesAfter(writeStatement, new[] { dirtyCall });
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/Content.Analyzers.Honk/HonkUnguardedCompFixer.cs
+++ b/Content.Analyzers.Honk/HonkUnguardedCompFixer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0011: converts <c>var comp = Comp&lt;T&gt;(args.X);</c>
+/// into an early-return TryComp guard in a void method:
+/// <c>if (!TryComp&lt;T&gt;(args.X, out var comp)) return;</c>. Only rewrites
+/// the local-declaration form inside a <c>void</c> method, so the existing
+/// control flow stays intact. Any other shape (expression statement,
+/// non-void method, nested use) is left for the human.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkUnguardedCompFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0011");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocation is null)
+                continue;
+
+            var genericName = GetCompGeneric(invocation);
+            if (genericName is null || invocation.ArgumentList.Arguments.Count < 1)
+                continue;
+
+            var uidArg = invocation.ArgumentList.Arguments[0].Expression;
+
+            // Pattern: `var name = Comp<T>(args.X);` as a sole declarator in a local decl statement
+            var localDecl = invocation.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+            if (localDecl is null)
+                continue;
+            if (localDecl.Declaration.Variables.Count != 1)
+                continue;
+            var declarator = localDecl.Declaration.Variables[0];
+            if (declarator.Initializer?.Value != invocation)
+                continue;
+
+            var method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+            if (method is null || !IsVoidReturn(method))
+                continue;
+
+            var compName = declarator.Identifier.ValueText;
+            var typeArg = genericName.TypeArgumentList.Arguments[0];
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Wrap in if (!TryComp<{typeArg}>(...)) return;",
+                    createChangedDocument: c => RewriteAsync(context.Document, localDecl, typeArg, uidArg, compName, c),
+                    equivalenceKey: "HonkWrapTryComp"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> RewriteAsync(
+        Document document,
+        LocalDeclarationStatementSyntax localDecl,
+        TypeSyntax typeArg,
+        ExpressionSyntax uidArg,
+        string compName,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var tryCompCall = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.GenericName(SyntaxFactory.Identifier("TryComp"))
+                .WithTypeArgumentList(SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(typeArg.WithoutTrivia()))),
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+            {
+                SyntaxFactory.Argument(uidArg.WithoutTrivia()),
+                SyntaxFactory.Argument(null,
+                    SyntaxFactory.Token(SyntaxKind.OutKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+                    SyntaxFactory.DeclarationExpression(
+                        SyntaxFactory.IdentifierName("var").WithTrailingTrivia(SyntaxFactory.Space),
+                        SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier(compName)))),
+            })));
+
+        var ifStatement = SyntaxFactory.IfStatement(
+                SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, tryCompCall),
+                SyntaxFactory.ReturnStatement())
+            .WithTriviaFrom(localDecl)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(localDecl, ifStatement));
+    }
+
+    private static GenericNameSyntax? GetCompGeneric(InvocationExpressionSyntax invocation)
+    {
+        var generic = invocation.Expression switch
+        {
+            GenericNameSyntax gn => gn,
+            MemberAccessExpressionSyntax m => m.Name as GenericNameSyntax,
+            _ => null,
+        };
+        if (generic?.Identifier.ValueText != "Comp")
+            return null;
+        if (generic.TypeArgumentList.Arguments.Count == 0)
+            return null;
+        return generic;
+    }
+
+    private static bool IsVoidReturn(MethodDeclarationSyntax method)
+    {
+        return method.ReturnType is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.VoidKeyword);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds `HonkUnguardedCompFixer`, the code fix that pairs with the HONK0011 analyzer. For the local-declaration shape inside a `void` method (`var comp = Comp<T>(args.X);`), the fixer replaces the statement with `if (!TryComp<T>(args.X, out var comp)) return;`. Every other shape stays flagged so a human picks the right control-flow rewrite.

Next item off the backlog in #587. Stacked on #593.

## Why / Balance

Pure dev-tooling, no gameplay surface. HONK0011 has a long tail because the guard rewrite is usually mechanical when the surrounding method returns `void`, but scope-widening in expression-bodied or value-returning methods would change semantics. Giving the fixer only the safe shape keeps the auto-apply path narrow and the remaining cases visible.

## Technical details

- Only rewrites when the `Comp<T>` invocation is the sole initializer of a single-declarator `LocalDeclarationStatement`, and the enclosing method's return type is the `void` keyword. Anything else (property bodies, non-void return, expression context, multi-declarator) bails out.
- The declarator name carries through, so `var foo = Comp<T>(uid);` becomes `if (!TryComp<T>(uid, out var foo)) return;` without renaming downstream references.
- Trivia from the original declaration transfers to the new `if`, and `Formatter.Annotation` lets Roslyn reindent the body.
- `FixAll` uses `BatchFixer`, matching the other fork fixers.

Two fixer tests: the happy path, and the bail when the enclosing method is non-void.

## Media

Dev tooling, no in-game change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.