### PR TITLE
honksquad: feat: HONK0014 code fix, convert ProtoId<T> field to const string

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkTestPrototypeRefStyleFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkTestPrototypeRefStyleFixerTest.cs
@@ -1,0 +1,116 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkTestPrototypeRefStyleAnalyzer, HonkTestPrototypeRefStyleFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkTestPrototypeRefStyleFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Prototypes
+        {
+            public readonly struct ProtoId<T> where T : class, IPrototype
+            {
+                public readonly string Id;
+                public ProtoId(string id) { Id = id; }
+                public static implicit operator ProtoId<T>(string id) => new(id);
+            }
+            public interface IPrototype { }
+            public sealed class TagPrototype : IPrototype { }
+        }
+        namespace Robust.UnitTesting
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field)]
+            public sealed class TestPrototypesAttribute : System.Attribute { }
+        }
+        """;
+
+    private const string ForkPath = "/0/RussStation/FooTest.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.SolutionTransforms.Add((solution, projectId) =>
+            solution.WithProjectAssemblyName(projectId, "Content.IntegrationTests"));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task PublicProtoIdField_RewrittenToConstString()
+    {
+        const string before = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: DirectDummy";
+
+                public ProtoId<TagPrototype> MyRef = "DirectDummy";
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: DirectDummy";
+
+                public const string MyRef = "DirectDummy";
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0014", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 9, 42, 9, 55)
+                .WithArguments("DirectDummy"));
+    }
+
+    [Test]
+    public async Task ReadOnlyModifier_StrippedInFavorOfConst()
+    {
+        const string before = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: DirectDummy";
+
+                private readonly ProtoId<TagPrototype> _myRef = "DirectDummy";
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Prototypes;
+            using Robust.UnitTesting;
+
+            public sealed class Foo
+            {
+                [TestPrototypes]
+                private const string Prototypes = "- type: Tag\n  id: DirectDummy";
+
+                private const string _myRef = "DirectDummy";
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0014", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 9, 53, 9, 66)
+                .WithArguments("DirectDummy"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkTestPrototypeRefStyleAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkTestPrototypeRefStyleAnalyzer.cs
@@ -1,8 +1,9 @@
-using System.Collections.Concurrent;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -28,8 +29,7 @@ public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
         category: "Honk.TestPrototypes",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "The YAML linter does not load [TestPrototypes] YAML blocks, so ProtoId<T> fields pointing at those ids fail CI with 'Unknown prototype'. Use a private const string threaded through IPrototypeManager.Index<T>() to dodge both the linter and upstream's [ForbidLiteral] RA0033.",
-        customTags: WellKnownDiagnosticTags.CompilationEnd);
+        description: "The YAML linter does not load [TestPrototypes] YAML blocks, so ProtoId<T> fields pointing at those ids fail CI with 'Unknown prototype'. Use a private const string threaded through IPrototypeManager.Index<T>() to dodge both the linter and upstream's [ForbidLiteral] RA0033.");
 
     private static readonly Regex IdRegex = new(@"id:\s*(?:\{(?<name>\w+)\}|(?<lit>\w+))", RegexOptions.Compiled);
 
@@ -43,118 +43,123 @@ public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(OnCompilationStart);
     }
 
-    private sealed class State
-    {
-        public readonly ConcurrentDictionary<string, string> ConstValues = new();
-        public readonly ConcurrentBag<string> TestPrototypeYaml = new();
-        public readonly ConcurrentBag<(string Value, Location Location)> ProtoIdLiterals = new();
-    }
-
     private static void OnCompilationStart(CompilationStartAnalysisContext context)
     {
         var assembly = context.Compilation.AssemblyName ?? string.Empty;
-        if (!assembly.StartsWith("Content.IntegrationTests", System.StringComparison.Ordinal))
+        if (!assembly.StartsWith("Content.IntegrationTests", StringComparison.Ordinal))
             return;
 
-        var state = new State();
+        // TestIds are a cross-tree lookup, but we compute them lazily the first
+        // time a tree's field/property analysis actually needs them. Each tree
+        // still reports locally, so code fixes can engage.
+        var testIds = new Lazy<HashSet<string>>(
+            () => ComputeTestIds(context.Compilation, context.CancellationToken),
+            LazyThreadSafetyMode.ExecutionAndPublication);
 
-        context.RegisterSemanticModelAction(ctx => Collect(ctx, state));
-        context.RegisterCompilationEndAction(ctx => Report(ctx, state));
+        context.RegisterSyntaxNodeAction(ctx => AnalyzeField(ctx, testIds), SyntaxKind.FieldDeclaration);
+        context.RegisterSyntaxNodeAction(ctx => AnalyzeProperty(ctx, testIds), SyntaxKind.PropertyDeclaration);
     }
 
-    private static void Collect(SemanticModelAnalysisContext context, State state)
+    private static void AnalyzeField(SyntaxNodeAnalysisContext context, Lazy<HashSet<string>> testIds)
     {
-        var root = context.SemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
-        var model = context.SemanticModel;
+        var field = (FieldDeclarationSyntax)context.Node;
+        if (!IsProtoIdType(field.Declaration.Type, context.SemanticModel, context.CancellationToken))
+            return;
 
-        foreach (var field in root.DescendantNodes().OfType<FieldDeclarationSyntax>())
+        foreach (var declarator in field.Declaration.Variables)
         {
-            var hasTestProto = HasTestPrototypesAttribute(field, model, context.CancellationToken);
+            if (declarator.Initializer?.Value is not LiteralExpressionSyntax lit
+                || !lit.IsKind(SyntaxKind.StringLiteralExpression))
+                continue;
 
-            if (IsConstString(field))
+            ReportIfMatch(context, lit, testIds);
+        }
+    }
+
+    private static void AnalyzeProperty(SyntaxNodeAnalysisContext context, Lazy<HashSet<string>> testIds)
+    {
+        var prop = (PropertyDeclarationSyntax)context.Node;
+        if (!IsProtoIdType(prop.Type, context.SemanticModel, context.CancellationToken))
+            return;
+
+        if (prop.Initializer?.Value is not LiteralExpressionSyntax lit
+            || !lit.IsKind(SyntaxKind.StringLiteralExpression))
+            return;
+
+        ReportIfMatch(context, lit, testIds);
+    }
+
+    private static void ReportIfMatch(
+        SyntaxNodeAnalysisContext context,
+        LiteralExpressionSyntax literal,
+        Lazy<HashSet<string>> testIds)
+    {
+        var location = literal.GetLocation();
+        if (!IsForkFile(location.SourceTree?.FilePath))
+            return;
+
+        var value = literal.Token.ValueText;
+        if (!testIds.Value.Contains(value))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, value));
+    }
+
+    private static HashSet<string> ComputeTestIds(Compilation compilation, CancellationToken ct)
+    {
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        var constValues = new Dictionary<string, string>(StringComparer.Ordinal);
+        var rawYaml = new List<string>();
+
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            ct.ThrowIfCancellationRequested();
+            var root = tree.GetRoot(ct);
+
+            foreach (var field in root.DescendantNodes().OfType<FieldDeclarationSyntax>())
             {
-                foreach (var declarator in field.Declaration.Variables)
+                if (IsConstString(field))
                 {
-                    if (declarator.Initializer?.Value is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
+                    foreach (var declarator in field.Declaration.Variables)
                     {
-                        state.ConstValues[declarator.Identifier.ValueText] = lit.Token.ValueText;
+                        if (declarator.Initializer?.Value is LiteralExpressionSyntax lit
+                            && lit.IsKind(SyntaxKind.StringLiteralExpression))
+                        {
+                            constValues[declarator.Identifier.ValueText] = lit.Token.ValueText;
+                        }
                     }
                 }
-            }
 
-            if (hasTestProto)
-            {
+                if (!HasTestPrototypesAttributeSyntax(field))
+                    continue;
+
                 foreach (var declarator in field.Declaration.Variables)
                 {
                     var raw = ExtractRawText(declarator.Initializer?.Value);
                     if (raw is not null)
-                        state.TestPrototypeYaml.Add(raw);
+                        rawYaml.Add(raw);
                 }
             }
-
-            CollectProtoIdFromField(field, model, state, context.CancellationToken);
         }
 
-        foreach (var prop in root.DescendantNodes().OfType<PropertyDeclarationSyntax>())
-        {
-            CollectProtoIdFromProperty(prop, model, state, context.CancellationToken);
-        }
-    }
-
-    private static void CollectProtoIdFromField(FieldDeclarationSyntax field, SemanticModel model, State state, System.Threading.CancellationToken ct)
-    {
-        if (!IsProtoIdType(field.Declaration.Type, model, ct))
-            return;
-        foreach (var declarator in field.Declaration.Variables)
-        {
-            if (declarator.Initializer?.Value is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
-            {
-                state.ProtoIdLiterals.Add((lit.Token.ValueText, lit.GetLocation()));
-            }
-        }
-    }
-
-    private static void CollectProtoIdFromProperty(PropertyDeclarationSyntax prop, SemanticModel model, State state, System.Threading.CancellationToken ct)
-    {
-        if (!IsProtoIdType(prop.Type, model, ct))
-            return;
-        if (prop.Initializer?.Value is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
-        {
-            state.ProtoIdLiterals.Add((lit.Token.ValueText, lit.GetLocation()));
-        }
-    }
-
-    private static void Report(CompilationAnalysisContext context, State state)
-    {
-        var testIds = new HashSet<string>(System.StringComparer.Ordinal);
-        foreach (var raw in state.TestPrototypeYaml)
+        foreach (var raw in rawYaml)
         {
             foreach (Match match in IdRegex.Matches(raw))
             {
                 var name = match.Groups["name"].Value;
                 if (!string.IsNullOrEmpty(name))
                 {
-                    if (state.ConstValues.TryGetValue(name, out var value))
-                        testIds.Add(value);
+                    if (constValues.TryGetValue(name, out var value))
+                        ids.Add(value);
                 }
                 else
                 {
-                    testIds.Add(match.Groups["lit"].Value);
+                    ids.Add(match.Groups["lit"].Value);
                 }
             }
         }
 
-        if (testIds.Count == 0)
-            return;
-
-        foreach (var (value, location) in state.ProtoIdLiterals)
-        {
-            if (!testIds.Contains(value))
-                continue;
-            if (!IsForkFile(location.SourceTree?.FilePath))
-                continue;
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, value));
-        }
+        return ids;
     }
 
     private static bool IsForkFile(string? path)
@@ -162,7 +167,7 @@ public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
         if (string.IsNullOrEmpty(path))
             return false;
         var norm = path!.Replace('\\', '/');
-        return norm.Contains("/RussStation/") || norm.EndsWith(".Honk.cs", System.StringComparison.Ordinal);
+        return norm.Contains("/RussStation/") || norm.EndsWith(".Honk.cs", StringComparison.Ordinal);
     }
 
     private static bool IsConstString(FieldDeclarationSyntax field)
@@ -179,14 +184,19 @@ public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
         return field.Declaration.Type is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.StringKeyword);
     }
 
-    private static bool HasTestPrototypesAttribute(FieldDeclarationSyntax field, SemanticModel model, System.Threading.CancellationToken ct)
+    private static bool HasTestPrototypesAttributeSyntax(FieldDeclarationSyntax field)
     {
         foreach (var list in field.AttributeLists)
         {
             foreach (var attr in list.Attributes)
             {
-                var type = model.GetTypeInfo(attr, ct).Type;
-                if (type?.Name == "TestPrototypesAttribute" || type?.Name == "TestPrototypes")
+                var name = attr.Name switch
+                {
+                    QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+                    SimpleNameSyntax s => s.Identifier.ValueText,
+                    _ => attr.Name.ToString(),
+                };
+                if (name == "TestPrototypes" || name == "TestPrototypesAttribute")
                     return true;
             }
         }
@@ -203,7 +213,7 @@ public sealed class HonkTestPrototypeRefStyleAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    private static bool IsProtoIdType(TypeSyntax? typeSyntax, SemanticModel model, System.Threading.CancellationToken ct)
+    private static bool IsProtoIdType(TypeSyntax? typeSyntax, SemanticModel model, CancellationToken ct)
     {
         if (typeSyntax is null)
             return false;

--- a/Content.Analyzers.Honk/HonkTestPrototypeRefStyleFixer.cs
+++ b/Content.Analyzers.Honk/HonkTestPrototypeRefStyleFixer.cs
@@ -1,0 +1,107 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0014: rewrites a flagged
+/// <c>ProtoId&lt;T&gt; Name = "literal";</c> field into
+/// <c>const string Name = "literal";</c>. ProtoId&lt;T&gt; has an implicit
+/// conversion from string, so assignment sites keep compiling; direct
+/// <c>.Id</c> access is rare and left as a follow-up when it breaks.
+/// Properties are out of scope since a property cannot be <c>const</c>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkTestPrototypeRefStyleFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0014");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var field = node.FirstAncestorOrSelf<FieldDeclarationSyntax>();
+            if (field is null)
+                continue;
+            if (field.Declaration.Variables.Count != 1)
+                continue;
+
+            var declarator = field.Declaration.Variables[0];
+            if (declarator.Initializer?.Value is not LiteralExpressionSyntax lit
+                || !lit.IsKind(SyntaxKind.StringLiteralExpression))
+                continue;
+
+            if (field.Modifiers.Any(m => m.IsKind(SyntaxKind.ConstKeyword)))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Convert to 'const string'",
+                    createChangedDocument: c => RewriteAsync(context.Document, field, c),
+                    equivalenceKey: "HonkTestProtoConstString"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> RewriteAsync(
+        Document document,
+        FieldDeclarationSyntax field,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var keptModifiers = field.Modifiers
+            .Where(m => !m.IsKind(SyntaxKind.ReadOnlyKeyword)
+                        && !m.IsKind(SyntaxKind.StaticKeyword)
+                        && !m.IsKind(SyntaxKind.VolatileKeyword))
+            .ToList();
+
+        var constToken = SyntaxFactory.Token(SyntaxKind.ConstKeyword);
+        var insertIndex = keptModifiers.FindIndex(m => !IsVisibilityModifier(m));
+        if (insertIndex < 0)
+            insertIndex = keptModifiers.Count;
+        keptModifiers.Insert(insertIndex, constToken);
+
+        var newModifiers = SyntaxFactory.TokenList(keptModifiers);
+        if (newModifiers.Count > 0)
+            newModifiers = newModifiers.Replace(newModifiers[0], newModifiers[0].WithLeadingTrivia(field.Modifiers.Count > 0 ? field.Modifiers[0].LeadingTrivia : field.GetLeadingTrivia()));
+
+        var stringType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword))
+            .WithTriviaFrom(field.Declaration.Type);
+
+        var newDeclaration = field.Declaration.WithType(stringType);
+        var newField = field
+            .WithModifiers(newModifiers)
+            .WithDeclaration(newDeclaration)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(field, newField));
+    }
+
+    private static bool IsVisibilityModifier(SyntaxToken token)
+    {
+        return token.IsKind(SyntaxKind.PublicKeyword)
+               || token.IsKind(SyntaxKind.PrivateKeyword)
+               || token.IsKind(SyntaxKind.ProtectedKeyword)
+               || token.IsKind(SyntaxKind.InternalKeyword);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds `HonkTestPrototypeRefStyleFixer`, the code fix that pairs with the HONK0014 analyzer. For the flagged shape (a single-declarator `ProtoId<T> Name = "literal"` field that collides with a `[TestPrototypes]` YAML id), the fixer rewrites the declaration to `const string Name = "literal"`. ProtoId<T> has an implicit conversion from string, so call sites keep compiling; direct `.Id` access on such a field is rare enough to leave as a manual follow-up when it actually breaks.

This PR also contains a small refactor of the analyzer itself. Roslyn's code-fix tooling refuses diagnostics reported from a `CompilationEndAction` (they are "non-local"), so the reporting path had to move to `RegisterSyntaxNodeAction`. The cross-tree set of `[TestPrototypes]` ids now sits behind a `Lazy<>` that the first field or property analysis triggers. The cross-tree scan is syntax-only so the analyzer avoids RS1030 (no `Compilation.GetSemanticModel()` from inside an analyzer). The existing five analyzer tests pass unchanged.

Next item off the backlog in #587.

## Why / Balance

Pure dev-tooling, no gameplay surface. HONK0014 has a recurring long tail because the shape is small and easy to paste, and writing a mechanical fixer means the warning auto-clears as the analyzer spots more. The narrow scope (fields only, single declarator) keeps the rewrite purely local; everything else stays flagged so a human picks the right transformation.

## Technical details

- Fixer only engages with `FieldDeclarationSyntax` whose single declarator has a string-literal initializer. Property cases stay warned because a property cannot be `const`.
- Modifier handling: keeps visibility (`public`/`private`/`protected`/`internal`), drops `readonly`/`static`/`volatile`, inserts `const` after the visibility slot.
- Type rewrite: replaces the `ProtoId<T>` node with the `string` keyword, preserving the original trivia so attribute lists and blank lines around the field stay intact.
- `FixAll` uses `BatchFixer`, matching the other fork fixers.

Two fixer tests: the public happy path and the `readonly` strip.

## Media

Dev tooling, no in-game change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.