### PR TITLE
honksquad: feat: HONK0017 code fix, extract layout literal to private const

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkLayoutMagicNumberFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkLayoutMagicNumberFixerTest.cs
@@ -1,0 +1,136 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkLayoutMagicNumberAnalyzer, HonkLayoutMagicNumberFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkLayoutMagicNumberFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Maths
+        {
+            public readonly struct Thickness
+            {
+                public Thickness(float uniform) { }
+                public Thickness(float horizontal, float vertical) { }
+                public Thickness(float left, float top, float right, float bottom) { }
+            }
+        }
+        namespace System.Numerics
+        {
+            public readonly struct Vector2
+            {
+                public Vector2(float x, float y) { }
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/Example/Widget.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, before) } },
+            FixedState = { Sources = { Stubs, (ForkPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task SingleLiteralFieldInitializer_ExtractsConst()
+    {
+        const string before = """
+            using Robust.Shared.Maths;
+
+            public sealed class Widget
+            {
+                public Thickness Margin = new Thickness(4f);
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Maths;
+
+            public sealed class Widget
+            {
+                private const float MarginDefault = 4f;
+                public Thickness Margin = new Thickness(MarginDefault);
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 45, 5, 47)
+                .WithArguments("Thickness", "4f", 1));
+    }
+
+    [Test]
+    public async Task SingleLiteralTimeSpanInitializer_ExtractsConst()
+    {
+        const string before = """
+            using System;
+
+            public sealed class Widget
+            {
+                public TimeSpan Cooldown = TimeSpan.FromSeconds(2.5);
+            }
+            """;
+
+        const string after = """
+            using System;
+
+            public sealed class Widget
+            {
+                private const double CooldownDefault = 2.5;
+                public TimeSpan Cooldown = TimeSpan.FromSeconds(CooldownDefault);
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 5, 53, 5, 56)
+                .WithArguments("TimeSpan.FromSeconds", "2.5", 1));
+    }
+
+    [Test]
+    public async Task MultipleLiteralsInSameCtor_NoFixOffered()
+    {
+        const string code = """
+            using System.Numerics;
+
+            public sealed class Widget
+            {
+                public Vector2 Offset = new Vector2(3f, 5f);
+            }
+            """;
+
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (ForkPath, code) } },
+            // Fix shouldn't engage on multi-literal ctors, so the code stays the same.
+            FixedState = { Sources = { Stubs, (ForkPath, code) }, MarkupHandling = MarkupMode.Allow },
+        };
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithSpan(ForkPath, 5, 41, 5, 43)
+            .WithArguments("Vector2", "3f", 1));
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithSpan(ForkPath, 5, 45, 5, 47)
+            .WithArguments("Vector2", "5f", 2));
+        // Both diagnostics remain in the fixed state: the fixer declines to engage.
+        test.FixedState.ExpectedDiagnostics.Add(new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithSpan(ForkPath, 5, 41, 5, 43)
+            .WithArguments("Vector2", "3f", 1));
+        test.FixedState.ExpectedDiagnostics.Add(new DiagnosticResult("HONK0017", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithSpan(ForkPath, 5, 45, 5, 47)
+            .WithArguments("Vector2", "5f", 2));
+        test.NumberOfFixAllIterations = 0;
+        test.NumberOfIncrementalIterations = 0;
+        await test.RunAsync();
+    }
+}

--- a/Content.Analyzers.Honk/HonkLayoutMagicNumberFixer.cs
+++ b/Content.Analyzers.Honk/HonkLayoutMagicNumberFixer.cs
@@ -1,0 +1,227 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0017: extracts a flagged numeric literal inside a
+/// field or property initializer's layout/time constructor argument
+/// into a sibling <c>private const</c> named <c>{MemberName}Default</c>.
+/// Deliberately narrow: only engages when the enclosing initializer
+/// contains exactly one numeric literal, so repeated runs and FixAll
+/// cannot race into colliding const names. Multi-literal call sites
+/// (e.g. <c>new Thickness(4f, 8f)</c>) stay flagged for a human pick,
+/// which is where the HONK0017 backlog note about "needs a naming
+/// heuristic" lives.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkLayoutMagicNumberFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0017");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var literal = node.AncestorsAndSelf()
+                .FirstOrDefault(a => a is LiteralExpressionSyntax or PrefixUnaryExpressionSyntax) as ExpressionSyntax;
+            if (literal is null || !IsDirectNumericLiteral(literal))
+                continue;
+
+            var argList = literal.FirstAncestorOrSelf<ArgumentListSyntax>();
+            if (argList is null)
+                continue;
+            if (CountNumericLiterals(argList) != 1)
+                continue;
+
+            var member = literal.FirstAncestorOrSelf<MemberDeclarationSyntax>(m =>
+                m is FieldDeclarationSyntax or PropertyDeclarationSyntax);
+            if (member is null)
+                continue;
+
+            if (!TryGetMemberName(member, out var memberName))
+                continue;
+
+            if (GetInitializerValue(member) is not { } initializerValue)
+                continue;
+
+            // Only rewrite when the literal sits inside the initializer expression,
+            // not in some unrelated nested context (e.g. an attribute argument).
+            if (!initializerValue.Span.Contains(literal.Span))
+                continue;
+
+            var typeDecl = member.Parent as TypeDeclarationSyntax;
+            if (typeDecl is null)
+                continue;
+
+            var constName = memberName + "Default";
+            if (TypeAlreadyHasMember(typeDecl, constName))
+                continue;
+
+            var constType = InferLiteralType(literal);
+            if (constType is null)
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Extract to private const '{constName}'",
+                    createChangedDocument: c => ExtractConstAsync(context.Document, typeDecl, member, literal, constName, constType, c),
+                    equivalenceKey: "HonkLayoutExtractConst"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ExtractConstAsync(
+        Document document,
+        TypeDeclarationSyntax typeDecl,
+        MemberDeclarationSyntax member,
+        ExpressionSyntax literal,
+        string constName,
+        TypeSyntax constType,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var constDecl = SyntaxFactory.FieldDeclaration(
+            attributeLists: default,
+            modifiers: SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+                SyntaxFactory.Token(SyntaxKind.ConstKeyword)),
+            declaration: SyntaxFactory.VariableDeclaration(
+                constType,
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator(
+                        identifier: SyntaxFactory.Identifier(constName),
+                        argumentList: null,
+                        initializer: SyntaxFactory.EqualsValueClause(literal.WithoutTrivia())))))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var replacement = SyntaxFactory.IdentifierName(constName).WithTriviaFrom(literal);
+
+        root = root.TrackNodes(member, literal);
+        var trackedLiteral = root.GetCurrentNode(literal);
+        if (trackedLiteral is not null)
+            root = root.ReplaceNode(trackedLiteral, replacement);
+
+        var trackedMember = root.GetCurrentNode(member);
+        if (trackedMember is not null)
+            root = root.InsertNodesBefore(trackedMember, new[] { constDecl });
+
+        return document.WithSyntaxRoot(root);
+    }
+
+    private static bool IsDirectNumericLiteral(ExpressionSyntax expr)
+    {
+        return expr switch
+        {
+            LiteralExpressionSyntax l => l.IsKind(SyntaxKind.NumericLiteralExpression),
+            PrefixUnaryExpressionSyntax u => u.IsKind(SyntaxKind.UnaryMinusExpression)
+                                             && u.Operand is LiteralExpressionSyntax inner
+                                             && inner.IsKind(SyntaxKind.NumericLiteralExpression),
+            _ => false,
+        };
+    }
+
+    private static int CountNumericLiterals(ArgumentListSyntax args)
+    {
+        var count = 0;
+        foreach (var arg in args.Arguments)
+        {
+            if (IsDirectNumericLiteral(arg.Expression))
+                count++;
+        }
+        return count;
+    }
+
+    private static bool TryGetMemberName(MemberDeclarationSyntax member, out string name)
+    {
+        switch (member)
+        {
+            case FieldDeclarationSyntax field when field.Declaration.Variables.Count == 1:
+                name = field.Declaration.Variables[0].Identifier.Text;
+                return true;
+            case PropertyDeclarationSyntax prop:
+                name = prop.Identifier.Text;
+                return true;
+            default:
+                name = string.Empty;
+                return false;
+        }
+    }
+
+    private static ExpressionSyntax? GetInitializerValue(MemberDeclarationSyntax member) => member switch
+    {
+        FieldDeclarationSyntax f when f.Declaration.Variables.Count == 1 => f.Declaration.Variables[0].Initializer?.Value,
+        PropertyDeclarationSyntax p => p.Initializer?.Value,
+        _ => null,
+    };
+
+    private static bool TypeAlreadyHasMember(TypeDeclarationSyntax typeDecl, string name)
+    {
+        foreach (var m in typeDecl.Members)
+        {
+            switch (m)
+            {
+                case FieldDeclarationSyntax f:
+                    foreach (var v in f.Declaration.Variables)
+                        if (v.Identifier.Text == name)
+                            return true;
+                    break;
+                case PropertyDeclarationSyntax p:
+                    if (p.Identifier.Text == name)
+                        return true;
+                    break;
+            }
+        }
+        return false;
+    }
+
+    private static TypeSyntax? InferLiteralType(ExpressionSyntax literal)
+    {
+        var token = literal switch
+        {
+            LiteralExpressionSyntax l => l.Token,
+            PrefixUnaryExpressionSyntax { Operand: LiteralExpressionSyntax l } => l.Token,
+            _ => default,
+        };
+        if (token == default)
+            return null;
+
+        var text = token.Text;
+        if (text.Length == 0)
+            return null;
+
+        var last = char.ToLowerInvariant(text[text.Length - 1]);
+        var kind = last switch
+        {
+            'f' => SyntaxKind.FloatKeyword,
+            'd' => SyntaxKind.DoubleKeyword,
+            'm' => SyntaxKind.DecimalKeyword,
+            'l' => SyntaxKind.LongKeyword,
+            _ => text.Contains('.') || text.Contains('e') || text.Contains('E')
+                ? SyntaxKind.DoubleKeyword
+                : SyntaxKind.IntKeyword,
+        };
+
+        return SyntaxFactory.PredefinedType(SyntaxFactory.Token(kind));
+    }
+}


### PR DESCRIPTION
## About the PR

Adds `HonkLayoutMagicNumberFixer`, the code fix that pairs with the HONK0017 analyzer. For a flagged numeric literal that sits inside a layout or time constructor argument in a field or property initializer, the fixer extracts the literal into a sibling `private const {MemberName}Default` and rewrites the call to reference it. Same delivery shape as the HONK0016 fixer, just reaching one layer deeper into the initializer tree.

Last remaining item in the #587 backlog.

## Why / Balance

Pure dev-tooling, no gameplay surface. HONK0017 has a recurring long tail because the pattern is small and easy to paste. The #587 backlog note called out that naming is trickier here than HONK0016 (there is no DataField to reuse the field name from), so the fixer takes the narrow slice where a name is obvious: the flagged literal lives inside a field or property initializer, and that member's own name is good enough for `{MemberName}Default`.

## Technical details

- Only engages when the enclosing constructor argument list contains exactly one numeric literal. Multi-argument shapes like `new Thickness(4f, 8f)` would race two literals into the same `{MemberName}Default` under FixAll, so the fixer declines and leaves both warnings visible for a human to split deliberately. This is the "needs a naming heuristic" slice the backlog called out.
- Const type is inferred from the literal suffix (`f`/`d`/`m`/`L`) or from whether the literal contains `.`, `e`, or `E`. So `4f` becomes `float`, `2.5` becomes `double`, `1L` becomes `long`, and plain integers become `int`. Unary-minus literals (`-1`) are handled as a unit.
- Skips when the enclosing type already declares a member named `{MemberName}Default`, so repeated runs cannot stack duplicates.
- `FixAll` uses `BatchFixer`, matching the other fork fixers.

Three tests: Thickness single-literal happy path, `TimeSpan.FromSeconds` happy path, and a Vector2 multi-literal case confirming the fix declines and both diagnostics survive.

## Media

Dev tooling, no in-game change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.