### PR TITLE
honksquad: feat: HONK0005 code fix, wrap fork Access attribute in HONK markers

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkAccessForkFriendFixerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkAccessForkFriendFixerTest.cs
@@ -1,0 +1,136 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpCodeFixTest<HonkAccessForkFriendAnalyzer, HonkAccessForkFriendFixer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkAccessForkFriendFixerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+            public sealed class AccessAttribute : System.Attribute
+            {
+                public AccessAttribute() { }
+                public AccessAttribute(System.Type type) { }
+                public AccessAttribute(System.Type a, System.Type b) { }
+            }
+        }
+        namespace Content.Shared.RussStation.Traits
+        {
+            public sealed class BloodDeficiencySystem { }
+        }
+        namespace Content.Shared.Body.Systems
+        {
+            public sealed class SharedBloodstreamSystem { }
+        }
+        """;
+
+    private const string UpstreamPath = "Content.Shared/Body/Components/BloodstreamComponent.cs";
+
+    private static Task Verify(string before, string after, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (UpstreamPath, before) } },
+            FixedState = { Sources = { Stubs, (UpstreamPath, after) } },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task TopLevelAttribute_WrapsWithMarkers()
+    {
+        const string before = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            [Access(typeof(BloodDeficiencySystem))]
+            public sealed class BloodstreamComponent { }
+            """;
+
+        const string after = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            // HONK START
+            [Access(typeof(BloodDeficiencySystem))]
+            // HONK END
+            public sealed class BloodstreamComponent { }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0005", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(UpstreamPath, 4, 2, 4, 39)
+                .WithArguments("BloodDeficiencySystem"));
+    }
+
+    [Test]
+    public async Task IndentedAttribute_PreservesIndent()
+    {
+        const string before = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            public static class Outer
+            {
+                [Access(typeof(BloodDeficiencySystem))]
+                public sealed class BloodstreamComponent { }
+            }
+            """;
+
+        const string after = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+
+            public static class Outer
+            {
+                // HONK START
+                [Access(typeof(BloodDeficiencySystem))]
+                // HONK END
+                public sealed class BloodstreamComponent { }
+            }
+            """;
+
+        await Verify(before, after,
+            new DiagnosticResult("HONK0005", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .WithSpan(UpstreamPath, 6, 6, 6, 43)
+                .WithArguments("BloodDeficiencySystem"));
+    }
+
+    [Test]
+    public async Task CombinedAttributeList_NoFixOffered()
+    {
+        // [A, B] is a single list with two attributes; wrapping the whole list
+        // would also wrap the unrelated upstream attribute, so the fixer bails.
+        const string code = """
+            using Robust.Shared.Analyzers;
+            using Content.Shared.RussStation.Traits;
+            using Content.Shared.Body.Systems;
+
+            [Access(typeof(SharedBloodstreamSystem)), Access(typeof(BloodDeficiencySystem))]
+            public sealed class BloodstreamComponent { }
+            """;
+
+        var test = new VerifyCS
+        {
+            TestState = { Sources = { Stubs, (UpstreamPath, code) } },
+            FixedState = { Sources = { Stubs, (UpstreamPath, code) }, MarkupHandling = MarkupMode.Allow },
+        };
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("HONK0005", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .WithSpan(UpstreamPath, 5, 43, 5, 80)
+            .WithArguments("BloodDeficiencySystem"));
+        test.FixedState.ExpectedDiagnostics.Add(new DiagnosticResult("HONK0005", Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .WithSpan(UpstreamPath, 5, 43, 5, 80)
+            .WithArguments("BloodDeficiencySystem"));
+        test.NumberOfFixAllIterations = 0;
+        test.NumberOfIncrementalIterations = 0;
+        await test.RunAsync();
+    }
+}

--- a/Content.Analyzers.Honk/HonkAccessForkFriendFixer.cs
+++ b/Content.Analyzers.Honk/HonkAccessForkFriendFixer.cs
@@ -1,0 +1,114 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// Code fix for HONK0005: wraps the flagged
+/// <c>[Access(typeof(ForkSystem))]</c> in <c>// HONK START</c> /
+/// <c>// HONK END</c> marker comments so rebase can see the fork-specific
+/// friend. Only engages when the attribute is alone in its list; lists
+/// with multiple attributes need a human to decide whether to split them.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class HonkAccessForkFriendFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("HONK0005");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var attribute = node.FirstAncestorOrSelf<AttributeSyntax>();
+            if (attribute?.Parent is not AttributeListSyntax list)
+                continue;
+
+            // Multi-attribute lists like `[A, B]` need a human to decide whether
+            // to split them; skip the fix rather than guess.
+            if (list.Attributes.Count != 1)
+                continue;
+
+            // If the attribute list is already inside a HONK block, leave it alone.
+            var text = list.SyntaxTree.GetText(context.CancellationToken);
+            var blocks = HonkMarkerBlocks.Find(text);
+            if (HonkMarkerBlocks.Contains(blocks, list.Span))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Wrap in // HONK START / // HONK END",
+                    createChangedDocument: c => WrapAsync(context.Document, list, c),
+                    equivalenceKey: "HonkAccessForkFriendWrap"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> WrapAsync(Document document, AttributeListSyntax list, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var indent = ExtractIndent(list.GetLeadingTrivia());
+
+        var newLeading = list.GetLeadingTrivia()
+            .Add(SyntaxFactory.Comment("// HONK START"))
+            .Add(SyntaxFactory.EndOfLine("\n"));
+        if (indent.Length > 0)
+            newLeading = newLeading.Add(SyntaxFactory.Whitespace(indent));
+
+        var newTrailing = SyntaxFactory.TriviaList(
+            SyntaxFactory.EndOfLine("\n"));
+        if (indent.Length > 0)
+            newTrailing = newTrailing.Add(SyntaxFactory.Whitespace(indent));
+        newTrailing = newTrailing
+            .Add(SyntaxFactory.Comment("// HONK END"))
+            .AddRange(list.GetTrailingTrivia());
+
+        var replacement = list
+            .WithLeadingTrivia(newLeading)
+            .WithTrailingTrivia(newTrailing);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(list, replacement));
+    }
+
+    private static string ExtractIndent(SyntaxTriviaList leading)
+    {
+        // The indent is the whitespace between the last newline in the leading
+        // trivia (or the start of the trivia) and the attribute's `[`.
+        var lastWhitespace = string.Empty;
+        foreach (var trivia in leading)
+        {
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                lastWhitespace = string.Empty;
+                continue;
+            }
+            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                lastWhitespace = trivia.ToString();
+            }
+            else
+            {
+                lastWhitespace = string.Empty;
+            }
+        }
+        return lastWhitespace;
+    }
+}


### PR DESCRIPTION
## About the PR

Adds `HonkAccessForkFriendFixer`, the code fix that pairs with the HONK0005 analyzer. When `[Access(typeof(ForkSystem))]` is flagged on an upstream class, the fixer wraps the attribute list in `// HONK START` / `// HONK END` marker comments so the rebase auditor can see the fork-specific friend.

Next item off the backlog in #587.

## Why / Balance

Dev-tooling, no gameplay surface. HONK0005 is an error-severity analyzer and the fix shape is identical every time: bracket the attribute in HONK markers. A fixer lands that in one click.

## Technical details

- Operates on the `AttributeListSyntax` surrounding the flagged attribute. Inserts `// HONK START` into the leading trivia and `// HONK END` into the trailing trivia, preserving the attribute's indent.
- Bails out when the list contains more than one attribute (`[A, B]`). Wrapping would also bracket the unrelated upstream attribute, so those stay flagged for a human to split by hand.
- Bails out when the attribute list already sits inside a HONK block (via `HonkMarkerBlocks.Contains`), so re-running the fix is a no-op.
- `FixAll` uses `BatchFixer`, same as the other fork fixers.

Three fixer tests cover the top-level happy path, an indented nested-class variant, and the multi-attribute bail.

## Media

Dev tooling, no in-game change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.
