### PR TITLE
feat: right-click text boxes to clear, drop redundant clear buttons

### DIFF
--- a/Content.Client/Mapping/MappingPrototypeList.xaml
+++ b/Content.Client/Mapping/MappingPrototypeList.xaml
@@ -5,9 +5,8 @@
         <BoxContainer Orientation="Horizontal">
             <Button Name="CollapseAllButton" Access="Public" Text="-" SetSize="48 48"
                     StyleClasses="ButtonSquare" ToolTip="Collapse All" TooltipDelay="0" />
+            <!-- HONK - ClearSearchButton removed; right-click the search box to clear it -->
             <LineEdit Name="SearchBar" SetHeight="48" HorizontalExpand="True" Access="Public" />
-            <Button Name="ClearSearchButton" Access="Public" Text="X" SetSize="48 48"
-                    StyleClasses="ButtonSquare" />
         </BoxContainer>
         <ScrollContainer Name="ScrollContainer" Access="Public" VerticalExpand="True"
                          ReserveScrollbarSpace="True">

--- a/Content.Client/Mapping/MappingState.cs
+++ b/Content.Client/Mapping/MappingState.cs
@@ -106,7 +106,7 @@ public sealed class MappingState : GameplayStateBase
         Screen.DecalSystem = _decal;
         Screen.Prototypes.SearchBar.OnTextChanged += OnSearch;
         Screen.Prototypes.CollapseAllButton.OnPressed += OnCollapseAll;
-        Screen.Prototypes.ClearSearchButton.OnPressed += OnClearSearch;
+        //HONK - ClearSearchButton removed from XAML; right-click search box to clear
         Screen.Prototypes.GetPrototypeData += OnGetData;
         Screen.Prototypes.SelectionChanged += OnSelected;
         Screen.Prototypes.CollapseToggled += OnCollapseToggled;
@@ -165,7 +165,7 @@ public sealed class MappingState : GameplayStateBase
 
         Screen.Prototypes.SearchBar.OnTextChanged -= OnSearch;
         Screen.Prototypes.CollapseAllButton.OnPressed -= OnCollapseAll;
-        Screen.Prototypes.ClearSearchButton.OnPressed -= OnClearSearch;
+        //HONK - ClearSearchButton removed from XAML; right-click search box to clear
         Screen.Prototypes.GetPrototypeData -= OnGetData;
         Screen.Prototypes.SelectionChanged -= OnSelected;
         Screen.Prototypes.CollapseToggled -= OnCollapseToggled;
@@ -444,12 +444,6 @@ public sealed class MappingState : GameplayStateBase
         }
 
         Screen.Prototypes.ScrollContainer.SetScrollValue(new Vector2(0, 0));
-    }
-
-    private void OnClearSearch(ButtonEventArgs obj)
-    {
-        Screen.Prototypes.SearchBar.Text = string.Empty;
-        OnSearch(new LineEditEventArgs(Screen.Prototypes.SearchBar, string.Empty));
     }
 
     private void OnGetData(IPrototype prototype, List<Texture> textures)

--- a/Content.Client/RussStation/UI/RightClickClearTextBoxController.cs
+++ b/Content.Client/RussStation/UI/RightClickClearTextBoxController.cs
@@ -1,0 +1,39 @@
+using Robust.Client.Input;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Input;
+
+namespace Content.Client.RussStation.UI;
+
+// HONK Right-click anywhere inside a focused text box clears it. Mirrors the
+// "clear" affordance the upstream actions menu used to ship as a button, but
+// applies to every LineEdit / HistoryLineEdit in the client. We subscribe to
+// the input manager's UI-scope keybind event so we can inspect the function
+// (UIManager.OnKeyBindDown only surfaces the Control, not the function).
+public sealed class RightClickClearTextBoxController : UIController
+{
+    [Dependency] private readonly IInputManager _input = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _input.UIKeyBindStateChanged += OnUIKeyBind;
+    }
+
+    private bool OnUIKeyBind(BoundKeyEventArgs args)
+    {
+        if (args.State != BoundKeyState.Down || args.Function != EngineKeyFunctions.UIRightClick)
+            return false;
+
+        var hovered = UIManager.MouseGetControl(args.PointerLocation);
+        if (hovered is not LineEdit line || UIManager.KeyboardFocused != line || !line.Editable)
+            return false;
+
+        // Clear() sets Text directly and suppresses OnTextChanged, so callers that
+        // react to search input wouldn't see the clear. Use SetText with invokeEvent.
+        line.SetText(string.Empty, invokeEvent: true);
+        args.Handle();
+        return true;
+    }
+}

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -485,16 +485,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         _menuDragHelper.EndDrag();
     }
 
-    private void OnClearPressed(ButtonEventArgs args)
-    {
-        if (_window == null)
-            return;
-
-        _window.SearchBar.Clear();
-        _window.FilterButton.DeselectAll();
-        UpdateFilterLabel();
-        QueueWindowUpdate();
-    }
+    //HONK - OnClearPressed removed; right-click the search box clears search text via the global handler
 
     private void OnSearchChanged(LineEditEventArgs args)
     {
@@ -648,7 +639,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         {
             _window.OnOpen -= OnWindowOpened;
             _window.OnClose -= OnWindowClosed;
-            _window.ClearButton.OnPressed -= OnClearPressed;
+            //HONK - ClearButton removed; right-click the search box to clear it
             _window.SearchBar.OnTextChanged -= OnSearchChanged;
             _window.FilterButton.OnItemSelected -= OnFilterSelected;
 
@@ -665,7 +656,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         _window.OnOpen += OnWindowOpened;
         _window.OnClose += OnWindowClosed;
-        _window.ClearButton.OnPressed += OnClearPressed;
+        //HONK - ClearButton removed; right-click the search box to clear it
         _window.SearchBar.OnTextChanged += OnSearchChanged;
         _window.FilterButton.OnItemSelected += OnFilterSelected;
 

--- a/Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Actions/Windows/ActionsWindow.xaml
@@ -14,7 +14,7 @@
             <LineEdit Name="SearchBar" Access="Public" StyleClasses="actionSearchBox" HorizontalExpand="True"
                       PlaceHolder="{Loc ui-actionmenu-search-bar-placeholder-text}"/>
         </BoxContainer>
-        <Button Name="ClearButton" Access="Public" Text="{Loc ui-actionmenu-clear-button}"/>
+        <!-- HONK - ClearButton removed; right-click the search box to clear it -->
         <Label Name="FilterLabel" Access="Public"/>
         <ScrollContainer VerticalExpand="True" HorizontalExpand="True">
             <GridContainer Name="ResultsGrid" Access="Public" MaxGridWidth="300"/>


### PR DESCRIPTION
## About the PR

New fork UIController: right-click anywhere inside a focused, editable `LineEdit` clears its contents and fires `OnTextChanged` so search handlers see the update. Works everywhere in the client.

Two dedicated clear buttons become redundant with that behaviour and are removed:

- `ActionsWindow.ClearButton` (actions menu) — also deselected filters; filter checkboxes stay in the tray.
- `MappingPrototypeList.ClearSearchButton` (mapper prototype list) — this one did literally nothing but wipe the search bar.

## Why / Balance

Lots of windows ship a tiny \"X\" or dedicated clear button next to search fields because `LineEdit` has no built-in way to empty itself with the mouse. Centralising that on right-click frees up the UI from per-window buttons and gives the same gesture in every search-style field going forward.

## Technical details

- `Content.Client/RussStation/UI/RightClickClearTextBoxController.cs`: subscribes to `IInputManager.UIKeyBindStateChanged`, matches `UIRightClick`+`Down`, confirms the control under the pointer is the currently keyboard-focused editable `LineEdit`, calls `SetText(string.Empty, invokeEvent: true)` and handles the event.
- `SetText` with `invokeEvent: true` is the important bit. `LineEdit.Clear()` suppresses `OnTextChanged`, so any search logic wouldn't re-query results.
- Upstream removals (HONK-wrapped): `ActionsWindow.xaml` ClearButton node, `ActionUIController.LoadGui`/`UnloadGui` subscriptions + `OnClearPressed`, `MappingPrototypeList.xaml` ClearSearchButton node, `MappingState.cs` subscriptions + `OnClearSearch`.
- Audit of other \"Clear\" buttons in the client found only construction and cargo, both of which clear non-search state (ghost list, cart), unchanged.

## Media

Not attached; gesture has no visual except the LineEdit emptying.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

Dedicated clear buttons in the actions menu and mapper are gone. Right-click the search bar instead.

**Changelog**

:cl:
- add: Right-click any search box to clear its contents.
- remove: Redundant clear buttons next to the actions menu and mapper prototype search bars.