### PR TITLE
feat: auto-fit labels on fixed-size buttons

### DIFF
--- a/Content.Client/RussStation/UI/HonkKeyLabel.cs
+++ b/Content.Client/RussStation/UI/HonkKeyLabel.cs
@@ -1,0 +1,115 @@
+using Robust.Client.Input;
+using Robust.Shared.Input;
+
+namespace Content.Client.RussStation.UI;
+
+/// <summary>
+///     Fork-standard short keybind-label builder. Returns the same compact
+///     short-form the upstream <c>BoundKeyHelper.ShortKeyName</c> produces for
+///     unmodified keys (Del, Spc, Esc, Dwn…) and keeps that short form when
+///     the binding has modifiers, prefixing them (S+Del, C+Spc).
+/// </summary>
+/// <remarks>
+///     Upstream drops modifier bindings entirely because the original callers
+///     couldn't fit the extra text in a fixed tile; the fork autofits so we can
+///     and should show the real binding. Unknown keys fall back to the input
+///     manager's canonical string.
+/// </remarks>
+public static class HonkKeyLabel
+{
+    public static string For(BoundKeyFunction function)
+    {
+        var input = IoCManager.Resolve<IInputManager>();
+        if (!input.TryGetKeyBinding(function, out var binding))
+            return " ";
+
+        var baseLabel = ShortBase(binding.BaseKey) ?? input.GetKeyFunctionButtonString(function);
+        if (binding.Mod1 == Keyboard.Key.Unknown
+            && binding.Mod2 == Keyboard.Key.Unknown
+            && binding.Mod3 == Keyboard.Key.Unknown)
+        {
+            return baseLabel;
+        }
+
+        var parts = new List<string>(4);
+        if (binding.Mod1 != Keyboard.Key.Unknown) parts.Add(ModShort(binding.Mod1));
+        if (binding.Mod2 != Keyboard.Key.Unknown) parts.Add(ModShort(binding.Mod2));
+        if (binding.Mod3 != Keyboard.Key.Unknown) parts.Add(ModShort(binding.Mod3));
+        parts.Add(baseLabel);
+        return string.Join("+", parts);
+    }
+
+    private static string ModShort(Keyboard.Key key) => key switch
+    {
+        Keyboard.Key.Shift => "Shift",
+        Keyboard.Key.Control => "Ctrl",
+        Keyboard.Key.Alt => "Alt",
+        _ => ShortBase(key) ?? key.ToString(),
+    };
+
+    // Mirrors upstream BoundKeyHelper's short-form table but usable for any binding, modified or not.
+    private static string? ShortBase(Keyboard.Key key) => key switch
+    {
+        Keyboard.Key.Apostrophe => "'",
+        Keyboard.Key.Comma => ",",
+        Keyboard.Key.Delete => "Del",
+        Keyboard.Key.Down => "Dwn",
+        Keyboard.Key.Escape => "Esc",
+        Keyboard.Key.Equal => "=",
+        Keyboard.Key.Home => "Hom",
+        Keyboard.Key.Insert => "Ins",
+        Keyboard.Key.Left => "Lft",
+        Keyboard.Key.Menu => "Men",
+        Keyboard.Key.Minus => "-",
+        Keyboard.Key.Num0 => "0",
+        Keyboard.Key.Num1 => "1",
+        Keyboard.Key.Num2 => "2",
+        Keyboard.Key.Num3 => "3",
+        Keyboard.Key.Num4 => "4",
+        Keyboard.Key.Num5 => "5",
+        Keyboard.Key.Num6 => "6",
+        Keyboard.Key.Num7 => "7",
+        Keyboard.Key.Num8 => "8",
+        Keyboard.Key.Num9 => "9",
+        Keyboard.Key.Pause => "||",
+        Keyboard.Key.Period => ".",
+        Keyboard.Key.Return => "Ret",
+        Keyboard.Key.Right => "Rgt",
+        Keyboard.Key.Slash => "/",
+        Keyboard.Key.Space => "Spc",
+        Keyboard.Key.Tab => "Tab",
+        Keyboard.Key.Tilde => "~",
+        Keyboard.Key.BackSlash => "\\",
+        Keyboard.Key.BackSpace => "Bks",
+        Keyboard.Key.LBracket => "[",
+        Keyboard.Key.MouseButton4 => "M4",
+        Keyboard.Key.MouseButton5 => "M5",
+        Keyboard.Key.MouseButton6 => "M6",
+        Keyboard.Key.MouseButton7 => "M7",
+        Keyboard.Key.MouseButton8 => "M8",
+        Keyboard.Key.MouseButton9 => "M9",
+        Keyboard.Key.MouseLeft => "ML",
+        Keyboard.Key.MouseMiddle => "MM",
+        Keyboard.Key.MouseRight => "MR",
+        Keyboard.Key.NumpadDecimal => "N.",
+        Keyboard.Key.NumpadDivide => "N/",
+        Keyboard.Key.NumpadEnter => "Ent",
+        Keyboard.Key.NumpadMultiply => "*",
+        Keyboard.Key.NumpadNum0 => "N0",
+        Keyboard.Key.NumpadNum1 => "N1",
+        Keyboard.Key.NumpadNum2 => "N2",
+        Keyboard.Key.NumpadNum3 => "N3",
+        Keyboard.Key.NumpadNum4 => "N4",
+        Keyboard.Key.NumpadNum5 => "N5",
+        Keyboard.Key.NumpadNum6 => "N6",
+        Keyboard.Key.NumpadNum7 => "N7",
+        Keyboard.Key.NumpadNum8 => "N8",
+        Keyboard.Key.NumpadNum9 => "N9",
+        Keyboard.Key.NumpadSubtract => "N-",
+        Keyboard.Key.PageDown => "PgD",
+        Keyboard.Key.PageUp => "PgU",
+        Keyboard.Key.RBracket => "]",
+        Keyboard.Key.SemiColon => ";",
+        _ => null,
+    };
+}

--- a/Content.Client/RussStation/UI/HonkLabelFitter.cs
+++ b/Content.Client/RussStation/UI/HonkLabelFitter.cs
@@ -1,0 +1,266 @@
+using Content.Client.Resources;
+using Content.Client.Stylesheets;
+using Content.Client.Stylesheets.Fonts;
+using Content.Shared.CCVar;
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Configuration;
+
+namespace Content.Client.RussStation.UI;
+
+/// <summary>
+///     Fork-standard auto-fit helper for Labels that need to stay within a
+///     bounded tile without being clipped. Each call site declares the size
+///     the label would render at when the game's UI font is at its default
+///     (<see cref="GameDefaultUIFontSize"/>, 12pt), and the fitter scales that
+///     proportionally to the user's current UI font CVar. Width and optional
+///     height budgets shrink it further if the result would overflow the tile.
+///
+///     Fonts come from the fork <see cref="FontCustomizationManager"/>, so the
+///     user's custom font family and the caller's requested kind (Regular,
+///     Bold, Italic, BoldItalic) are both preserved.
+/// </summary>
+/// <remarks>
+///     Call whenever the text or the available space changes. A floor
+///     (<see cref="MinSize"/>) keeps text readable in narrow tiles.
+/// </remarks>
+public static class HonkLabelFitter
+{
+    public const int MinSize = 6;
+    public const int AbsoluteMaxSize = 32;
+    public const int GameDefaultUIFontSize = 12;
+
+    /// <summary>
+    ///     Pick a font size for <paramref name="text"/>, starting from
+    ///     <paramref name="baseSizeAtGameDefault"/> scaled by the user's UI
+    ///     font preference, then shrunk to fit the width (and optional height)
+    ///     budget. Apply it as the Label's FontOverride, using the user's
+    ///     current font family and the requested <paramref name="kind"/>.
+    /// </summary>
+    /// <param name="baseSizeAtGameDefault">
+    ///     Size this label would render at when the game's UI font is at its
+    ///     default (<see cref="GameDefaultUIFontSize"/>). Effective
+    ///     pre-measurement max is
+    ///     <c>baseSizeAtGameDefault * userUIFontSize / GameDefaultUIFontSize</c>.
+    /// </param>
+    /// <param name="kind">
+    ///     Font kind to match the label's existing style (pass Bold for
+    ///     bold style-class labels, etc.).
+    /// </param>
+    public static void Fit(
+        Label label,
+        string text,
+        float targetWidthPx,
+        int baseSizeAtGameDefault,
+        FontKind kind = FontKind.Regular,
+        float? targetHeightPx = null)
+    {
+        var size = PickSize(text, targetWidthPx, targetHeightPx, baseSizeAtGameDefault, kind);
+        label.FontOverride = GetFont(size, kind);
+    }
+
+    private static int PickSize(string text, float targetWidthPx, float? targetHeightPx, int baseSizeAtGameDefault, FontKind kind)
+    {
+        // Scale the caller's design-time size by the user's UI font preference.
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        var userSize = Math.Clamp(cfg.GetCVar(CCVars.UIFontSize), MinSize, AbsoluteMaxSize);
+        var scaled = (int) MathF.Round(baseSizeAtGameDefault * (float) userSize / GameDefaultUIFontSize);
+        var maxSize = Math.Clamp(scaled, MinSize, AbsoluteMaxSize);
+
+        if (string.IsNullOrEmpty(text))
+            return maxSize;
+
+        var size = maxSize;
+        if (targetWidthPx > 0f)
+        {
+            var measuredW = MeasureText(GetFont(maxSize, kind), text);
+            if (measuredW > targetWidthPx)
+            {
+                size = (int) MathF.Floor(maxSize * targetWidthPx / measuredW);
+                size = Math.Clamp(size, MinSize, maxSize);
+            }
+        }
+
+        if (targetHeightPx.HasValue && targetHeightPx.Value > 0f)
+        {
+            var lineHeight = GetFont(size, kind).GetLineHeight(1f);
+            if (lineHeight > targetHeightPx.Value)
+            {
+                var shrunk = (int) MathF.Floor(size * targetHeightPx.Value / lineHeight);
+                size = Math.Clamp(shrunk, MinSize, size);
+            }
+        }
+
+        return size;
+    }
+
+    private static Font GetFont(int size, FontKind kind)
+    {
+        // Route through the fork font manager so the user's custom family and
+        // requested kind (bold/italic) both carry through.
+        // During early startup (XAML-populated widgets constructed before the
+        // stylesheet manager finishes initializing) FontManager can be null,
+        // so fall back to the built-in NotoSans resource in that case.
+        if (IoCManager.Resolve<IStylesheetManager>() is StylesheetManager man
+            && man.FontManager is { } fonts)
+        {
+            return fonts.GetCurrentFont(size, kind);
+        }
+
+        var cache = IoCManager.Resolve<IResourceCache>();
+        var kindStr = kind.AsFileName();
+        return cache.GetFont($"/Fonts/NotoSans/NotoSans-{kindStr}.ttf", size);
+    }
+
+    private static float MeasureText(Font font, string text)
+    {
+        var width = 0f;
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (font.TryGetCharMetrics(rune, 1f, out var metrics))
+                width += metrics.Advance;
+        }
+        return width;
+    }
+
+    /// <summary>
+    ///     Fit <paramref name="text"/> into the panel, preferring shrink over wrap so
+    ///     the layout stays on one line whenever it still reads. Order of preference:
+    ///     <list type="number">
+    ///         <item>single line at the user-scaled size,</item>
+    ///         <item>single line at a shrunk size, down to a readable floor
+    ///             (half the scaled size or <see cref="MinSize"/>, whichever is larger),</item>
+    ///         <item>wrap — walk down from the scaled size and take the largest font
+    ///             whose wrap stays within <paramref name="maxWrapLines"/>,</item>
+    ///         <item>floor at <see cref="MinSize"/> and accept the wrap as-is.</item>
+    ///     </list>
+    /// </summary>
+    public static void FitOrWrap(
+        Label label,
+        string text,
+        float targetWidthPx,
+        int baseSizeAtGameDefault,
+        FontKind kind = FontKind.Regular,
+        int maxWrapLines = 2,
+        float? targetHeightPx = null)
+    {
+        if (string.IsNullOrEmpty(text) || targetWidthPx <= 0f)
+        {
+            label.Text = text;
+            label.FontOverride = GetFont(PickScaledSize(baseSizeAtGameDefault), kind);
+            return;
+        }
+
+        var scaledSize = PickScaledSize(baseSizeAtGameDefault);
+        var readableFloor = Math.Max(MinSize, scaledSize / 2);
+
+        // 1/2: Prefer single-line; shrink down to readableFloor looking for a fit that
+        // respects BOTH targetWidthPx and targetHeightPx. Width-only fit isn't enough
+        // when the panel caps vertical room (beaker/gun status panels).
+        for (var size = scaledSize; size >= readableFloor; size--)
+        {
+            var font = GetFont(size, kind);
+            if (MeasureText(font, text) > targetWidthPx)
+                continue;
+            if (targetHeightPx.HasValue && font.GetLineHeight(1f) > targetHeightPx.Value)
+                continue;
+            label.FontOverride = font;
+            label.Text = text;
+            return;
+        }
+
+        // 3: Can't fit single-line at a readable size — allow wrap. Pick the largest font
+        // whose wrap stays within both the line budget AND the vertical budget (if given).
+        // Line-to-line height is font.GetLineHeight, which includes the line gap Label uses.
+        for (var size = scaledSize; size >= MinSize; size--)
+        {
+            var font = GetFont(size, kind);
+            var wrapped = WordWrapAtSize(text, targetWidthPx, font);
+            var lines = CountLines(wrapped);
+            if (lines > maxWrapLines)
+                continue;
+            if (targetHeightPx.HasValue && lines * font.GetLineHeight(1f) > targetHeightPx.Value)
+                continue;
+
+            label.FontOverride = font;
+            label.Text = wrapped;
+            return;
+        }
+
+        // If wrap is disabled (maxWrapLines=1) and we fell through everything, pick the
+        // largest single-line size that fits width at least, so at worst we emit a small font
+        // rather than nothing at all.
+        if (maxWrapLines == 1)
+        {
+            for (var size = readableFloor - 1; size >= MinSize; size--)
+            {
+                var font = GetFont(size, kind);
+                if (MeasureText(font, text) > targetWidthPx)
+                    continue;
+                if (targetHeightPx.HasValue && font.GetLineHeight(1f) > targetHeightPx.Value)
+                    continue;
+                label.FontOverride = font;
+                label.Text = text;
+                return;
+            }
+        }
+
+        // 4: Floor fallback.
+        var floorFont = GetFont(MinSize, kind);
+        label.FontOverride = floorFont;
+        label.Text = WordWrapAtSize(text, targetWidthPx, floorFont);
+    }
+
+    private static int PickScaledSize(int baseSizeAtGameDefault)
+    {
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        var userSize = Math.Clamp(cfg.GetCVar(CCVars.UIFontSize), MinSize, AbsoluteMaxSize);
+        return Math.Clamp(
+            (int) MathF.Round(baseSizeAtGameDefault * (float) userSize / GameDefaultUIFontSize),
+            MinSize,
+            AbsoluteMaxSize);
+    }
+
+    private static int CountLines(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return 0;
+        var lines = 1;
+        foreach (var ch in text)
+        {
+            if (ch == '\n') lines++;
+        }
+        return lines;
+    }
+
+    private static string WordWrapAtSize(string text, float maxWidthPx, Font font)
+    {
+        var spaceWidth = MeasureText(font, " ");
+        var builder = new System.Text.StringBuilder(text.Length);
+        var lineWidth = 0f;
+        var firstOnLine = true;
+        foreach (var word in text.Split(' '))
+        {
+            var wordWidth = MeasureText(font, word);
+            if (!firstOnLine && lineWidth + spaceWidth + wordWidth > maxWidthPx)
+            {
+                builder.Append('\n');
+                lineWidth = 0f;
+                firstOnLine = true;
+            }
+
+            if (!firstOnLine)
+            {
+                builder.Append(' ');
+                lineWidth += spaceWidth;
+            }
+
+            builder.Append(word);
+            lineWidth += wordWidth;
+            firstOnLine = false;
+        }
+        return builder.ToString();
+    }
+
+}

--- a/Content.Client/UserInterface/Controls/MenuButton.cs
+++ b/Content.Client/UserInterface/Controls/MenuButton.cs
@@ -6,6 +6,12 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Graphics;
 using Robust.Shared.Input;
 using Robust.Shared.Utility;
+//HONK START - fork short-form label helper, autofit helper, font kind, UIFontSize CVars
+using Content.Client.RussStation.UI;
+using Content.Client.Stylesheets.Fonts;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+//HONK END
 
 namespace Content.Client.UserInterface.Controls;
 
@@ -36,9 +42,40 @@ public sealed class MenuButton : ContainerButton
         set
         {
             _function = value;
-            _buttonLabel!.Text = _function == null ? "" : BoundKeyHelper.ShortKeyName(_function.Value);
+            //HONK START - replaces the inline `_buttonLabel!.Text = ...` with fork short-form + autofit
+            HonkUpdateKeyLabel();
+            //HONK END
         }
     }
+
+    //HONK START - text uses the fork short-form helper (modifier bindings visible) AND
+    // autofits so it tracks the user's UIFontSize accessibility setting. The button itself
+    // is free to grow to fit whatever font size results. At the game's default UI font
+    // (12pt) topButtonLabel renders at 14pt bold; the fitter scales proportionally with
+    // the user's CVar. The width/height budget is intentionally generous — we want the
+    // button to grow, not for the text to shrink.
+    private const int HonkKeyLabelBaseSize = 14;
+    private const float HonkKeyLabelMaxWidthPx = 200f;
+    private const float HonkKeyLabelMaxHeightPx = 100f;
+
+    private void HonkUpdateKeyLabel()
+    {
+        if (_buttonLabel == null)
+            return;
+        var keyString = _function == null ? "" : HonkKeyLabel.For(_function.Value);
+        _buttonLabel.Text = keyString;
+        if (string.IsNullOrEmpty(keyString))
+            return;
+
+        HonkLabelFitter.Fit(
+            _buttonLabel,
+            keyString,
+            HonkKeyLabelMaxWidthPx,
+            baseSizeAtGameDefault: HonkKeyLabelBaseSize,
+            kind: FontKind.Bold,
+            targetHeightPx: HonkKeyLabelMaxHeightPx);
+    }
+    //HONK END
 
     public BoxContainer ButtonRoot => _root;
 
@@ -80,6 +117,11 @@ public sealed class MenuButton : ContainerButton
         _inputManager.OnKeyBindingAdded += OnKeyBindingChanged;
         _inputManager.OnKeyBindingRemoved += OnKeyBindingChanged;
         _inputManager.OnInputModeChanged += OnKeyBindingChanged;
+        //HONK START - refit when the user changes UI font size or family
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        cfg.OnValueChanged(CCVars.UIFontSize, HonkOnFontSizeChanged);
+        cfg.OnValueChanged(CCVars.UIFontFamily, HonkOnFontFamilyChanged);
+        //HONK END
     }
 
     protected override void ExitedTree()
@@ -87,17 +129,31 @@ public sealed class MenuButton : ContainerButton
         _inputManager.OnKeyBindingAdded -= OnKeyBindingChanged;
         _inputManager.OnKeyBindingRemoved -= OnKeyBindingChanged;
         _inputManager.OnInputModeChanged -= OnKeyBindingChanged;
+        //HONK START - unsubscribe UI font CVar handlers
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        cfg.UnsubValueChanged(CCVars.UIFontSize, HonkOnFontSizeChanged);
+        cfg.UnsubValueChanged(CCVars.UIFontFamily, HonkOnFontFamilyChanged);
+        //HONK END
     }
+
+    //HONK START - CVar change handlers for live UIFontSize / UIFontFamily refit.
+    private void HonkOnFontSizeChanged(int _) => HonkUpdateKeyLabel();
+    private void HonkOnFontFamilyChanged(string _) => HonkUpdateKeyLabel();
+    //HONK END
 
 
     private void OnKeyBindingChanged(IKeyBinding obj)
     {
-        _buttonLabel!.Text = _function == null ? "" : BoundKeyHelper.ShortKeyName(_function.Value);
+        //HONK START - fork short-form label with modifier support + autofit
+        HonkUpdateKeyLabel();
+        //HONK END
     }
 
     private void OnKeyBindingChanged()
     {
-        _buttonLabel!.Text = _function == null ? "" : BoundKeyHelper.ShortKeyName(_function.Value);
+        //HONK START
+        HonkUpdateKeyLabel();
+        //HONK END
     }
 
     protected override void StylePropertiesChanged()

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -2,7 +2,6 @@ using System.Numerics;
 using Content.Client.Actions;
 using Content.Client.Actions.UI;
 using Content.Client.Cooldown;
-using Content.Client.Stylesheets;
 using Content.Shared.Actions.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Examine;
@@ -11,6 +10,12 @@ using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+//HONK START - fork autofit helpers + input events + CVar subscriptions for label refresh
+using Content.Client.RussStation.UI;
+using Content.Shared.CCVar;
+using Robust.Client.Input;
+using Robust.Shared.Configuration;
+//HONK END
 using Robust.Shared.Input;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -37,12 +42,58 @@ public sealed class ActionButton : Control, IEntityControl
         set
         {
             _keybind = value;
-            if (_keybind != null)
-            {
-                Label.Text = BoundKeyHelper.ShortKeyName(_keybind.Value);
-            }
+            //HONK START - fork autofit + short-form label with modifier support
+            HonkRefreshKeybindLabel();
+            //HONK END
         }
     }
+
+    //HONK START - autofit + live re-fit when the user rebinds the hotbar key.
+    // Corner tag on a 64px tile was small by design; at the game's default UI font (12pt)
+    // it reads at ~10pt so the icon isn't crowded. The fitter scales this up when the
+    // user picks a larger UI font.
+    // Budget derives from the button's actual size. Width is capped so long combos can't
+    // spill into the next slot; the height cap is the full tile so the font is free to
+    // scale with UIFontSize without being clamped by a tight corner allowance.
+    private const float HonkKeyLabelFallbackWidthPx = 50f;
+    private const float HonkKeyLabelFallbackHeightPx = 64f;
+    // Label sits top-left with a 5px left margin; leave a few more px gutter before the next slot.
+    private const float HonkKeyLabelWidthGutterPx = 4f;
+    private const int HonkKeyLabelBaseSize = 10;
+
+    protected override void Resized()
+    {
+        base.Resized();
+        HonkRefreshKeybindLabel();
+    }
+
+    private void HonkRefreshKeybindLabel()
+    {
+        if (_keybind == null)
+            return;
+        // Short form for unmodified keys (Del, Spc, etc.), short form + modifier prefix
+        // for bound combos (Shift+Del, Ctrl+1). Autofit shrinks whatever we produce.
+        var keyString = HonkKeyLabel.For(_keybind.Value);
+        Label.Text = keyString;
+
+        var widthBudget = Size.X > 0f
+            ? Size.X - Label.Margin.Left - HonkKeyLabelWidthGutterPx
+            : HonkKeyLabelFallbackWidthPx;
+        var heightBudget = Size.Y > 0f ? Size.Y : HonkKeyLabelFallbackHeightPx;
+
+        HonkLabelFitter.Fit(
+            Label,
+            keyString,
+            widthBudget,
+            baseSizeAtGameDefault: HonkKeyLabelBaseSize,
+            targetHeightPx: heightBudget);
+    }
+
+    private void HonkOnKeyBindingChanged(IKeyBinding _) => HonkRefreshKeybindLabel();
+    private void HonkOnInputModeChanged() => HonkRefreshKeybindLabel();
+    private void HonkOnFontSizeChanged(int _) => HonkRefreshKeybindLabel();
+    private void HonkOnFontFamilyChanged(string _) => HonkRefreshKeybindLabel();
+    //HONK END
 
     private BoundKeyFunction? _keybind;
 
@@ -170,6 +221,34 @@ public sealed class ActionButton : Control, IEntityControl
         _buttonBackgroundTexture = Theme.ResolveTexture("SlotBackground");
         Label.FontColorOverride = Theme.ResolveColorOrSpecified("whiteText");
     }
+
+    //HONK START - live-refresh the keybind label on rebind AND when the user's UI font settings change
+    protected override void EnteredTree()
+    {
+        base.EnteredTree();
+        var input = IoCManager.Resolve<IInputManager>();
+        input.OnKeyBindingAdded += HonkOnKeyBindingChanged;
+        input.OnKeyBindingRemoved += HonkOnKeyBindingChanged;
+        input.OnInputModeChanged += HonkOnInputModeChanged;
+        // Subscribe directly to CVars — FontManager.FontsChanged isn't reliable here
+        // because StylesheetManager may not be initialized when early widgets enter the tree.
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        cfg.OnValueChanged(CCVars.UIFontSize, HonkOnFontSizeChanged);
+        cfg.OnValueChanged(CCVars.UIFontFamily, HonkOnFontFamilyChanged);
+    }
+
+    protected override void ExitedTree()
+    {
+        base.ExitedTree();
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        cfg.UnsubValueChanged(CCVars.UIFontSize, HonkOnFontSizeChanged);
+        cfg.UnsubValueChanged(CCVars.UIFontFamily, HonkOnFontFamilyChanged);
+        var input = IoCManager.Resolve<IInputManager>();
+        input.OnKeyBindingAdded -= HonkOnKeyBindingChanged;
+        input.OnKeyBindingRemoved -= HonkOnKeyBindingChanged;
+        input.OnInputModeChanged -= HonkOnInputModeChanged;
+    }
+    //HONK END
 
     private void OnPressed(GUIBoundKeyEventArgs args)
     {

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Content.Client.Actions;
 using Content.Shared.Input;
-using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
@@ -12,7 +11,6 @@ namespace Content.Client.UserInterface.Systems.Actions.Controls;
 public class ActionButtonContainer : GridContainer
 {
     [Dependency] private readonly IEntityManager _entity = default!;
-    [Dependency] private readonly IInputManager _input = default!;
 
     public event Action<GUIBoundKeyEventArgs, ActionButton>? ActionPressed;
     public event Action<GUIBoundKeyEventArgs, ActionButton>? ActionUnpressed;
@@ -57,11 +55,9 @@ public class ActionButtonContainer : GridContainer
             if (!keys.TryGetValue(index, out var boundKey))
                 return button;
 
+            //HONK START - KeyBind setter now resolves the short label and autofits it; no extra work here
             button.KeyBind = boundKey;
-            if (_input.TryGetKeyBinding(boundKey, out var binding))
-            {
-                button.Label.Text = binding.GetKeyString();
-            }
+            //HONK END
 
             return button;
         }

--- a/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml
+++ b/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml
@@ -19,7 +19,7 @@
             </graphics:StyleBoxTexture>
         </PanelContainer.PanelOverride>
     </PanelContainer>
-    <BoxContainer Name="Contents" Orientation="Vertical" Margin="0 6 0 4" RectClipContent="True">
+    <BoxContainer Name="Contents" Access="Public" Orientation="Vertical" Margin="0 6 0 4" RectClipContent="True">
         <BoxContainer Name="StatusContents" Orientation="Vertical" VerticalExpand="True" VerticalAlignment="Bottom" />
         <Control>
             <Label Name="NoItemLabel" ClipText="True" StyleClasses="ItemStatusNotHeld" Align="Left" Text="{Loc 'item-status-not-held'}" />

--- a/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
@@ -8,6 +8,12 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+//HONK START - fork autofit helper, font kind, UIFontSize CVars
+using Content.Client.RussStation.UI;
+using Content.Client.Stylesheets.Fonts;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+//HONK END
 
 namespace Content.Client.UserInterface.Systems.Inventory.Controls;
 
@@ -26,7 +32,112 @@ public sealed partial class ItemStatusPanel : Control
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
+        //HONK START - intentionally no refit here. Size is 0 before first layout so we'd
+        // pick a bad fallback-based font that then visibly retargets. Wait for Resized.
+        //HONK END
     }
+
+    //HONK START - scale hand-status item-name label with the user's UI font size, fit into
+    // the fixed 60px panel. When there are status widgets above the label (beaker reagents,
+    // gun ammo, etc.) we just give the label half the Contents height instead of trying to
+    // measure the widgets — their sizes populate asynchronously and measuring here
+    // produced flicker or wrong fits. Simple and flicker-free.
+    private const int HonkItemStatusBaseSize = 10;
+    private const float HonkItemStatusFallbackWidthPx = 120f;
+    private const float HonkItemStatusFallbackHeightPx = 40f;
+    private const float HonkItemStatusSafetyPaddingPx = 2f;
+    private const float HonkItemStatusMinHeightBudgetPx = 10f;
+    private const float HonkItemStatusExtraLeftPaddingPx = 4f;
+    private const float HonkItemStatusLabelShareWithStatus = 0.5f;
+
+    // Cache the inputs the last successful fit was made with so we can skip redundant refit
+    // calls every frame (UpdateItemName fires from FrameUpdate). Redoing the fit on every
+    // frame causes visible text flicker as the font bounces between candidate sizes.
+    private string? _honkLastItemText;
+    private string? _honkLastNoItemText;
+    private float _honkLastWidthBudget;
+    private float _honkLastHeightBudget;
+
+    private void HonkRefitLabels()
+    {
+        var widthBudget = Contents.Size.X > 0f
+            ? Contents.Size.X - HonkItemStatusSafetyPaddingPx
+            : HonkItemStatusFallbackWidthPx;
+
+        // Status widgets populate their text asynchronously (e.g. SolutionStatusControl
+        // polls on FrameUpdate), so measuring them during BuildNewEntityStatus returns
+        // stale 0s. Instead: reserve a fixed fraction of the Contents height whenever
+        // any status widget exists. Not perfect but stable and flicker-free.
+        var fullHeight = Contents.Size.Y > 0f
+            ? Contents.Size.Y - HonkItemStatusSafetyPaddingPx
+            : HonkItemStatusFallbackHeightPx;
+        var heightBudget = StatusContents.ChildCount > 0
+            ? fullHeight * HonkItemStatusLabelShareWithStatus
+            : fullHeight;
+        heightBudget = MathF.Max(HonkItemStatusMinHeightBudgetPx, heightBudget);
+
+        // Skip redundant refits — only re-apply FontOverride when an input actually changed.
+        if (ItemNameLabel.Text == _honkLastItemText
+            && NoItemLabel.Text == _honkLastNoItemText
+            && MathF.Abs(widthBudget - _honkLastWidthBudget) < 0.5f
+            && MathF.Abs(heightBudget - _honkLastHeightBudget) < 0.5f)
+            return;
+
+        _honkLastItemText = ItemNameLabel.Text;
+        _honkLastNoItemText = NoItemLabel.Text;
+        _honkLastWidthBudget = widthBudget;
+        _honkLastHeightBudget = heightBudget;
+
+        HonkLabelFitter.FitOrWrap(
+            ItemNameLabel,
+            ItemNameLabel.Text ?? string.Empty,
+            widthBudget,
+            baseSizeAtGameDefault: HonkItemStatusBaseSize,
+            maxWrapLines: 1,
+            targetHeightPx: heightBudget);
+        HonkLabelFitter.FitOrWrap(
+            NoItemLabel,
+            NoItemLabel.Text ?? string.Empty,
+            widthBudget,
+            baseSizeAtGameDefault: HonkItemStatusBaseSize,
+            kind: FontKind.Italic,
+            maxWrapLines: 1,
+            targetHeightPx: heightBudget);
+    }
+
+    // Invalidating via _honkLastItemText=null forces the next HonkRefitLabels call to
+    // re-apply the FontOverride even if text and budgets look unchanged.
+    private void HonkOnFontSizeChanged(int _) => HonkForceRefit();
+    private void HonkOnFontFamilyChanged(string _) => HonkForceRefit();
+
+    private void HonkForceRefit()
+    {
+        _honkLastItemText = null;
+        HonkRefitLabels();
+    }
+
+    protected override void EnteredTree()
+    {
+        base.EnteredTree();
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        cfg.OnValueChanged(CCVars.UIFontSize, HonkOnFontSizeChanged);
+        cfg.OnValueChanged(CCVars.UIFontFamily, HonkOnFontFamilyChanged);
+    }
+
+    protected override void ExitedTree()
+    {
+        base.ExitedTree();
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+        cfg.UnsubValueChanged(CCVars.UIFontSize, HonkOnFontSizeChanged);
+        cfg.UnsubValueChanged(CCVars.UIFontFamily, HonkOnFontFamilyChanged);
+    }
+
+    protected override void Resized()
+    {
+        base.Resized();
+        HonkRefitLabels();
+    }
+    //HONK END
 
     public void SetSide(HandLocation location)
     {
@@ -61,7 +172,13 @@ public sealed partial class ItemStatusPanel : Control
                 throw new ArgumentOutOfRangeException(nameof(location), location, null);
         }
 
-        Contents.Margin = contentMargin;
+        //HONK START - small extra left padding so text isn't flush with the panel's cut-out border
+        Contents.Margin = new Thickness(
+            contentMargin.Left + HonkItemStatusExtraLeftPaddingPx,
+            contentMargin.Top,
+            contentMargin.Right,
+            contentMargin.Bottom);
+        //HONK END
 
         //Important to note for patchMargin!
         //Because of hand ui flipping, left and right instead correspond to outside and inside respectively.
@@ -131,6 +248,9 @@ public sealed partial class ItemStatusPanel : Control
                 ItemNameLabel.Text = "";
             }
 
+            //HONK START - refit after empty-hand text assignment
+            HonkRefitLabels();
+            //HONK END
             return;
         }
 
@@ -169,6 +289,9 @@ public sealed partial class ItemStatusPanel : Control
         {
             ItemNameLabel.Text = Identity.Name(_entity.Value, _entityManager);
         }
+        //HONK START - refit after item name changes
+        HonkRefitLabels();
+        //HONK END
     }
 
     private void ClearOldStatus()
@@ -189,5 +312,9 @@ public sealed partial class ItemStatusPanel : Control
         {
             StatusContents.AddChild(control);
         }
+
+        //HONK START - status widget list changed, force a refit to pick the share-based budget
+        HonkForceRefit();
+        //HONK END
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
@@ -149,9 +149,9 @@ public sealed partial class GunSystem
 
         public void Update(int count, int max)
         {
-            _ammoCount.Visible = true;
-
-            _ammoCount.Text = $"x{count:00}";
+            //HONK START - hide the raw round count label; bullet render already conveys quantity
+            _ammoCount.Visible = false;
+            //HONK END
 
             _bullets.Capacity = max;
             _bullets.Count = count;
@@ -233,7 +233,9 @@ public sealed partial class GunSystem
 
             _bulletRender.Visible = true;
             _noMagazineLabel.Visible = false;
-            _ammoCount.Visible = true;
+            //HONK START - hide the raw round count label; bullet render already conveys quantity
+            _ammoCount.Visible = false;
+            //HONK END
 
             _bulletRender.Count = count;
             _bulletRender.Capacity = capacity;
@@ -244,8 +246,6 @@ public sealed partial class GunSystem
                 > 15 => BulletRender.BulletType.Normal,
                 _ => BulletRender.BulletType.Large
             };
-
-            _ammoCount.Text = $"x{count:00}";
         }
 
         public void PlayAlarmAnimation(Animation animation)


### PR DESCRIPTION
## About the PR

Keybind labels and hand-status item names now scale with the accessibility UI font size and shrink to fit their tiles instead of clipping. Adds two small fork helpers and applies them to the hotbar, top-bar menu, and hand item-status panels.

## Why / Balance

Two gripes that kept coming up in testing:

1. Long keybinds like `Shift+1` or `Ctrl+0` either clipped past the tile edge or were silently dropped, because `BoundKeyHelper.ShortKeyName` bails out on any binding with a modifier. That bail made sense when labels couldn't be resized, but we can resize them now.
2. The accessibility "UI font size" CVar resizes most of the client, but hand-status item names were stuck at a fixed 10pt. Bumping the setting didn't help people with vision issues read what they were holding.

## Technical details

Two new helpers under `Content.Client/RussStation/UI/`:

`HonkLabelFitter` has one public entry: `Fit(label, text, targetWidthPx, baseSizeAtGameDefault, kind, targetHeightPx?)`, with a `FitOrWrap` variant for the cases that can wrap. The caller declares the size the label would render at when the UI font is default (12pt), and the fitter scales that proportionally to the user's current CVar. If the result would overflow the width or height budget, it shrinks further. Fonts go through `FontCustomizationManager.GetCurrentFont` so the user's custom family and the requested `FontKind` (Regular, Bold, Italic) both carry through. Fallback to NotoSans if `StylesheetManager` isn't initialized yet (which happens for early XAML-populated widgets during startup).

`HonkKeyLabel.For(BoundKeyFunction)` returns the short form for unmodified keys (`Del`, `Spc`, `Dwn`, etc.) and prefixes modifiers as `Shift+Del`, `Ctrl+1`, `Alt+Spc` when present. Number-row `Num1..Num9` maps to `1..9` and numpad distinguishes as `N1..N9`. Drops the upstream "any modifier, return null" bail.

Three insertion points, each a contained HONK region plus one call at an existing setter:

`ActionButton.KeyBind` setter and a new `Resized` override. Width budget is `Size.X - Label.Margin.Left` minus a small gutter so long combos don't bleed into the next slot. Height budget is the full tile. Base 10pt at game default. Subscribes to `OnKeyBindingAdded/Removed/InputModeChanged` and `CCVars.UIFontSize/UIFontFamily` on `EnteredTree`, so the label refits on rebind and on accessibility font changes.

`MenuButton.BoundKey` setter. Base 14pt bold (matches the `topButtonLabel` style class). Budget is intentionally generous (200x100) so the button itself grows to fit the text rather than the text shrinking. Same rebind and CVar subscriptions.

`ItemStatusPanel` (item-name and not-held labels). Base 10pt. `Resized` override plus CVar subscriptions. Half the panel's interior height is reserved for status widgets whenever any exist (beakers, guns, etc.), because measuring them doesn't work. `SolutionStatusControl` and friends fill their text on `FrameUpdate`, so at the moment they're added their `DesiredSize` is zero, and any feedback-loop measurement path flickers. A small cache on `(text, widthBudget, heightBudget)` skips redundant refits that otherwise re-fire every frame from `UpdateItemName`'s FrameUpdate hook.

Two related fork tweaks the autofit either depends on or was competing against:

- `GunSystem.AmmoCounter.BoxesStatusControl` and `ChamberMagazineStatusControl` hide the `x{count:00}` text label. The bullet or battery render already conveys quantity and the extra label crowded the panel, eating the fit budget.
- `ItemStatusPanel.SetSide` adds 4px to the theme-calculated left margin so text isn't flush with the panel's cut-out border.

## Media

At the default UI font size there's nothing visible to show; the fix kicks in when the user bumps the accessibility font size or when a long modifier keybind that used to be hidden now renders.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

Modifier keybinds now appear on hotbar and top-bar buttons (they were silently dropped before). The gun status panel no longer shows the numeric round count; the bullet row stays. Hand-status item-name labels shrink when needed to fit under reagent or ammo widgets.

**Changelog**

:cl:

- fix: Hotbar and top-bar keybind labels scale with the accessibility UI font size setting and shrink to fit the button instead of clipping.
- fix: Modifier keybinds like Shift+1 and Ctrl+0 now show on hotbar and top-bar buttons.
- fix: Item-name labels on the hand status panels scale with the UI font size and shrink when a status widget (ammo counter, beaker reagents) leaves less room.
- tweak: Guns no longer print a numeric round count on top of the bullet row.
