### PR TITLE
honksquad: docs: guidebook entries for action bar customization, Escape cancel, wound healing

### DIFF
--- a/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
@@ -78,11 +78,11 @@ Treats burn damage (heat, shock, cold, caustic).
 
 ### Wound Repair (Fracture)
 Clears fractures left by heavy blunt damage.
-- [color=#a4885c]Bonesetter[/color] - set the bone
+- [color=#a4885c]Bonesetter[/color] - set broken bones
 
 ### Wound Repair (Burn)
 Clears burn wounds left by severe heat or shock damage.
-- [color=#a4885c]Cautery[/color] - cauterize the wound
+- [color=#a4885c]Cautery[/color] - dress and cauterize burns
 
 ### Organ Manipulation
 Open the body cavity to remove or insert organs.

--- a/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
@@ -77,11 +77,11 @@ Treats burn damage (heat, shock, cold, caustic).
 - [color=#a4885c]Cautery[/color] - close incision
 
 ### Wound Repair (Fracture)
-Clears fractures, the lasting bone wounds applied by heavy blunt damage.
+Clears fractures left by heavy blunt damage.
 - [color=#a4885c]Bonesetter[/color] - set the bone
 
 ### Wound Repair (Burn)
-Clears burn wounds, the lasting tissue wounds left by severe heat or shock damage (separate from the raw burn damage on the health bar).
+Clears burn wounds left by severe heat or shock damage. Burn wounds are separate from the raw burn damage on the health bar.
 - [color=#a4885c]Cautery[/color] - cauterize the wound
 
 ### Organ Manipulation

--- a/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
@@ -94,7 +94,7 @@ Open the body cavity to remove or insert organs.
 - [color=#a4885c]Cautery[/color] - close incision
 
 ## Natural Healing
-Untreated wounds slowly heal on their own over a few minutes. A tier-3 wound drops to tier-2 after about 2 minutes, all the way cleared in roughly 10 minutes total. Surgery is still the fast path. Dead bodies don't regenerate.
+Untreated wounds slowly fade. A serious wound takes about 10 minutes to clear entirely, roughly 2 minutes per severity tier. Surgery is faster. Dead bodies don't regenerate.
 
 ## Cancelling Surgery
 The patient can click the [color=#a4885c]drape alert[/color] on their HUD to remove the drape and cancel the procedure at any time.

--- a/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
@@ -76,6 +76,14 @@ Treats burn damage (heat, shock, cold, caustic).
 - [color=#a4885c]Hemostat[/color] - treat burns (repeats automatically until healed)
 - [color=#a4885c]Cautery[/color] - close incision
 
+### Wound Repair (Fracture)
+Clears fractures, the lasting bone wounds applied by heavy blunt damage.
+- [color=#a4885c]Bonesetter[/color] - set the bone
+
+### Wound Repair (Burn)
+Clears burn wounds, the lasting tissue wounds left by severe heat or shock damage (separate from the raw burn damage on the health bar).
+- [color=#a4885c]Cautery[/color] - cauterize the wound
+
 ### Organ Manipulation
 Open the body cavity to remove or insert organs.
 - [color=#a4885c]Scalpel[/color] - make incision
@@ -84,6 +92,9 @@ Open the body cavity to remove or insert organs.
 - [color=#a4885c]Bone saw[/color] - saw through bone
 - [color=#a4885c]Hemostat[/color] - select organ to remove (opens organ picker), or use an organ in your hand on the patient to insert it
 - [color=#a4885c]Cautery[/color] - close incision
+
+## Natural Healing
+Untreated wounds slowly heal on their own over a few minutes. A tier-3 wound drops to tier-2 after about 2 minutes, all the way cleared in roughly 10 minutes total. Surgery is still the fast path. Dead bodies don't regenerate.
 
 ## Cancelling Surgery
 The patient can click the [color=#a4885c]drape alert[/color] on their HUD to remove the drape and cancel the procedure at any time.

--- a/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Surgery.xml
@@ -81,7 +81,7 @@ Clears fractures left by heavy blunt damage.
 - [color=#a4885c]Bonesetter[/color] - set the bone
 
 ### Wound Repair (Burn)
-Clears burn wounds left by severe heat or shock damage. Burn wounds are separate from the raw burn damage on the health bar.
+Clears burn wounds left by severe heat or shock damage.
 - [color=#a4885c]Cautery[/color] - cauterize the wound
 
 ### Organ Manipulation

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -16,6 +16,11 @@
   It's also a [bold]hotbar[/bold] — perform those actions by pressing their corresponding [color=yellow][bold]number keys[/bold][/color] on your keyboard.
   Rearrange them by [bold]dragging[/bold] one icon over another, or remove icons temporarily by dragging them away.
 
+  <!-- HONK START - Action bar customization (#584) -->
+  You can customize the action bar in [bold]Settings → Misc → Action Bar[/bold] (rows, slots per row, slot spacing, keybind labels, empty slot visibility) and in [bold]Settings → Accessibility[/bold] (button background opacity).
+  The actions window header also has [bold]Lock[/bold] (freezes the bar against right-click clear and drag rearrange, click-to-fire still works) and [bold]Auto-add[/bold] (when off, server-granted actions stay in the menu instead of jumping onto the bar).
+  <!-- HONK END -->
+
   ### Status bar
   Below the chat window on the right, there's the [bold]status bar[/bold] showing your character's statuses.
   As with the action bar, hover over those icons to see what they mean.
@@ -138,6 +143,14 @@
   Don't worry about having to memorize them — they're usually intuitive and consistent across entity categories, and you'll find that most entities only use one or two interactions.
 
   [bold]Items stored in containers are still interactable.[/bold]
+
+  <!-- HONK START - Escape cancels DoAfters (#571) -->
+  ## Cancelling progress bars
+  Press [color=yellow][bold][keybind="EscapeContext"][/bold][/color] to [color=cyan]cancel[/color] any active progress-bar action you started (eating, drinking, channeled actions, etc.).
+  This works as long as no menu or text field is in the way (Escape still closes open windows and opens the game menu in the usual order).
+
+  Forced actions you didn't start (being grabbed, stripped, or operated on) aren't cancellable this way.
+  <!-- HONK END -->
 
   ## Context menus
   Click [color=yellow][bold][keybind="UIRightClick"/][/bold][/color] on any interactive entity to open the [color=cyan]context menu[/color], which shows you additional interaction you can currently perform.


### PR DESCRIPTION
## About the PR

Adds guidebook coverage for three recently-merged player-facing features that weren't reflected in the existing pages.

- **#584 action bar customization** — `Controls.xml` Action bar section gains a paragraph pointing players at `Settings → Misc → Action Bar`, the Accessibility opacity slider, and the Lock / Auto-add checkboxes on the actions window header.
- **#571 Escape cancels DoAfters** — new `## Cancelling progress bars` section in `Controls.xml` describing the Escape behavior, the menu/text-field precedence rule, and the carve-out for forced actions you didn't start.
- **#572 wound healing via surgery + slow natural regen** — `Surgery.xml` gains two procedure entries (Wound Repair Fracture, Wound Repair Burn) and a `## Natural Healing` section with the rough decay timings.

## Why / Balance

Pure documentation, no gameplay impact. These features all shipped without guidebook entries, so a new player opening the in-game guide has no way to discover them.

## Technical details

`Controls.xml` is upstream, so both additions are wrapped in `<!-- HONK START -->` / `<!-- HONK END -->` markers and named for the originating PR. `Surgery.xml` is fork-owned (no upstream history), so no markers there.

The Escape keybind reference uses `EscapeContext` (the actual function name in `keybinds.yml`), not `EscapeMenu`.

## Media

N/A, text-only.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Guidebook now documents action bar customization, the Escape-to-cancel-progress-bars shortcut, and the surgical wound repair procedures plus natural wound regen.