### PR TITLE
fix: hide CentComm/ERT IDs from PDA messenger contacts

### DIFF
--- a/Content.Server/RussStation/Messenger/MessengerServerSystem.cs
+++ b/Content.Server/RussStation/Messenger/MessengerServerSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.CartridgeLoader;
 using Content.Shared.GameTicking;
 using Content.Shared.PDA;
 using Content.Shared.RussStation.Messenger;
+using Content.Shared.StationRecords;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -203,19 +204,17 @@ public sealed class MessengerServerSystem : EntitySystem
             if (!TryComp<PdaComponent>(loaderUid, out var pda))
                 continue;
 
-            var isAntag = IsAntagAddress(cartComp.Address);
-            var hasId = pda.ContainedId != null;
+            // Station crew = not an antag, holds an ID, ID is registered in station records.
+            // Anyone else (antag, no ID, CentComm/ERT) only shows up when there's already a
+            // conversation, and is always read-only.
+            var isCrew = !IsAntagAddress(cartComp.Address)
+                         && pda.ContainedId is { } id
+                         && IsStationCrewId(id);
 
-            // Antag cartridges: only show if there's a conversation.
-            if (isAntag && !HasConversation(myCart, cartUid))
+            if (!isCrew && !HasConversation(myCart, cartUid))
                 continue;
 
-            // No ID: only show if there's an existing conversation.
-            if (!hasId && !HasConversation(myCart, cartUid))
-                continue;
-
-            var readOnly = isAntag || !hasId;
-            var contact = BuildContact(myCart, cartUid, pda, readOnly);
+            var contact = BuildContact(myCart, cartUid, pda, readOnly: !isCrew);
             contacts.Add(contact);
         }
 
@@ -267,21 +266,29 @@ public sealed class MessengerServerSystem : EntitySystem
     }
 
     /// <summary>
-    /// Check if a target cartridge is read-only (antag or no ID).
+    /// Check if a target cartridge is read-only. A cartridge is writable only when it belongs
+    /// to station crew: not an antag address, has an ID inserted, and that ID is on the station
+    /// records roster (so CentComm and ERT IDs are excluded).
     /// </summary>
-    public bool IsContactReadOnly(EntityUid targetCart)
+    public bool IsContactReadOnly(EntityUid targetCart) => !IsStationCrewCartridge(targetCart);
+
+    private bool IsStationCrewCartridge(EntityUid cartUid)
     {
-        if (!TryComp<MessengerCartridgeComponent>(targetCart, out var comp))
-            return true;
+        return TryComp<MessengerCartridgeComponent>(cartUid, out var comp)
+               && !IsAntagAddress(comp.Address)
+               && TryComp<PdaComponent>(Transform(cartUid).ParentUid, out var pda)
+               && pda.ContainedId is { } id
+               && IsStationCrewId(id);
+    }
 
-        if (IsAntagAddress(comp.Address))
-            return true;
-
-        var loaderUid = Transform(targetCart).ParentUid;
-        if (!TryComp<PdaComponent>(loaderUid, out var pda) || pda.ContainedId == null)
-            return true;
-
-        return false;
+    /// <summary>
+    /// True if the ID card was issued through station records (i.e. the holder is on the station crew roster).
+    /// CentComm/ERT IDs spawn directly from prototypes and lack a station record key.
+    /// </summary>
+    private bool IsStationCrewId(EntityUid idCard)
+    {
+        return TryComp<StationRecordKeyStorageComponent>(idCard, out var keyStorage)
+               && keyStorage.Key != null;
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR

CentComm, ERT, and other off-station PDAs showed up in the station crew messenger contacts list because the cartridge scan had no notion of who belongs to the station. This filters them out.

## Why / Balance

Station crew shouldn't be able to cold-message CentComm or a spawned-in ERT operative, and the messenger has no IC plumbing to justify it. Matches how the crew monitor and records console already scope their listings.

Off-station PDAs still appear in the contacts list if they messaged you first, but the entry is read-only. So an ERT operative can reach out and you can scroll back through the conversation, you just can't initiate one out of nowhere.

Closes #606.

## Technical details

The discriminator is the station record key. `StationRecordKeyStorageComponent.Key` is assigned when an ID goes through `CreateGeneralRecord` at station spawn. CentComm/ERT IDs come straight from prototypes and skip that step, so absence of the key is a reliable "not on the roster" signal without touching upstream.

`MessengerServerSystem` now has one shared concept of "station crew cartridge": not an antag address, has an ID inserted, ID is on the roster. `GetContacts` and `IsContactReadOnly` both read from it, which collapsed three near-duplicate skip branches in the scan loop down to one condition.

Side effect: ERT-to-ERT messaging is also blocked, since both ends lack station records. The messenger is effectively inert between off-station roles. That seems correct given the bug scope.

## Media

Tested in-game: CentComm PDAs no longer surface in the contacts list. Existing conversations with off-station IDs still appear, marked read-only. Crew stays fully messageable.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None.

**Changelog**

:cl:
- fix: CentComm, ERT, and other off-station IDs no longer appear in the PDA messenger contacts list. They can still reply in existing conversations, but station crew can't cold-message them.