### PR TITLE
feat: count repeats for popups and emotes in chat + float (#578)

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -12,7 +12,9 @@ using Robust.Shared.Utility;
 
 namespace Content.Client.Chat.UI
 {
-    public abstract class SpeechBubble : Control
+    // HONK START - partial so the fork can add RepeatWith for emote coalescing (issue #578)
+    public abstract partial class SpeechBubble : Control
+    // HONK END
     {
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IEyeManager _eyeManager = default!;
@@ -104,6 +106,9 @@ namespace Content.Client.Chat.UI
             ContentSize = bubble.DesiredSize;
             _verticalOffsetAchieved = -ContentSize.Y;
             _deathTime = _timing.RealTime + TotalTime;
+            // HONK START - stash ctor args for RepeatWith rebuilds (issue #578)
+            HonkStashCtorArgs(message, speechStyleClass, fontColor);
+            // HONK END
         }
 
         protected abstract Control BuildBubble(ChatMessage message, string speechStyleClass, Color? fontColor = null);

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -93,9 +93,18 @@ namespace Content.Client.Popups
             RaiseLocalEvent(new Content.Shared.RussStation.Popups.CategorizedPopupRaisedEvent(message, null, type, entity));
             //HONK END
 
-            var popupData = new WorldPopupData(message, type, coordinates, entity);
+            //HONK START - entity-attached popups key on the entity only, so the repeat counter
+            // survives the mob moving between ticks. Coordinate-only popups still key on position
+            // so unrelated popups at different spots don't collapse.
+            var keyCoordinates = entity != null ? default : coordinates;
+            var popupData = new WorldPopupData(message, type, keyCoordinates, entity);
+            //HONK END
             if (_aliveWorldLabels.TryGetValue(popupData, out var existingLabel))
             {
+                //HONK START - follow the entity: update the label's position to the latest coords
+                // so the stacked popup floats above where the mob actually is now.
+                existingLabel.InitialPos = coordinates;
+                //HONK END
                 WrapAndRepeatPopup(existingLabel, popupData.Message);
                 return;
             }

--- a/Content.Client/RussStation/Chat/ChatUIController.Honk.cs
+++ b/Content.Client/RussStation/Chat/ChatUIController.Honk.cs
@@ -1,0 +1,111 @@
+using Content.Client.Chat.UI;
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.Chat;
+using Robust.Shared.Network;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+// HONK - Fork partial adding in-place coalescing for repeated popup mirror and emote chat lines,
+// plus repeat-in-place for floating emote speech bubbles. Mirrors upstream's PopupSystem
+// WrapAndRepeatPopup behavior: if an identical message from the same sender lands inside a short
+// window, mutate the existing rendered entry rather than appending a new line. Chat boxes get
+// notified via MessageUpdated and patch the rendered OutputPanel entry in place. After the window
+// lapses, the next identical message starts a new line at count 1.
+public sealed partial class ChatUIController
+{
+    private static readonly TimeSpan HonkCoalesceWindow = TimeSpan.FromSeconds(2);
+
+    // Channels whose repeats should collapse into a single rendered entry with an (xN) suffix.
+    // Other channels keep one-entry-per-message behavior so e.g. two identical Local lines from
+    // different speakers don't collapse visually.
+    private static readonly HashSet<ChatChannel> HonkCoalesceChannels = new()
+    {
+        ChatChannel.Popup,
+        ChatChannel.Emotes,
+    };
+
+    private readonly Dictionary<(ChatChannel Channel, NetEntity Sender, string Message), HonkChatCoalesceEntry> _honkCoalesce = new();
+
+    /// <summary>
+    /// Raised when an existing ChatMessage's WrappedMessage has been mutated in place because a
+    /// matching repeat landed within the coalesce window. Subscribers should re-render that message
+    /// without adding a new entry.
+    /// </summary>
+    public event Action<ChatMessage>? MessageUpdated;
+
+    /// <summary>
+    /// Returns true when <paramref name="msg"/> was folded into an existing rendered entry instead
+    /// of producing a new one. The caller should skip History.Add / MessageAdded when this returns true.
+    /// </summary>
+    private bool HonkTryCoalesceChatMessage(ChatMessage msg)
+    {
+        if (!HonkCoalesceChannels.Contains(msg.Channel))
+            return false;
+
+        if (string.IsNullOrEmpty(msg.Message))
+            return false;
+
+        var now = _timing.RealTime;
+        var key = (msg.Channel, msg.SenderEntity, msg.Message);
+
+        if (_honkCoalesce.TryGetValue(key, out var entry) && now - entry.LastSeen < HonkCoalesceWindow)
+        {
+            entry.Repeats += 1;
+            entry.LastSeen = now;
+            entry.Msg.WrappedMessage = Loc.GetString(
+                "popup-system-repeated-popup-stacking-wrap",
+                ("popup-message", entry.OriginalWrapped),
+                ("count", entry.Repeats));
+            MessageUpdated?.Invoke(entry.Msg);
+            return true;
+        }
+
+        _honkCoalesce[key] = new HonkChatCoalesceEntry
+        {
+            Msg = msg,
+            OriginalWrapped = msg.WrappedMessage,
+            Repeats = 1,
+            LastSeen = now,
+        };
+        HonkPruneCoalesce(now);
+        return false;
+    }
+
+    private void HonkPruneCoalesce(TimeSpan now)
+    {
+        if (_honkCoalesce.Count < 32)
+            return;
+
+        var stale = new List<(ChatChannel, NetEntity, string)>();
+        foreach (var (key, entry) in _honkCoalesce)
+        {
+            if (now - entry.LastSeen >= HonkCoalesceWindow)
+                stale.Add(key);
+        }
+        foreach (var key in stale)
+            _honkCoalesce.Remove(key);
+    }
+
+    /// <summary>
+    /// Returns true when an alive emote bubble for <paramref name="entity"/> already displays
+    /// <paramref name="msg"/>'s text and was updated in place. Caller should skip creating a new bubble.
+    /// </summary>
+    private bool HonkTryCoalesceEmoteBubble(EntityUid entity, ChatMessage msg, SpeechBubble.SpeechType speechType)
+    {
+        if (speechType != SpeechBubble.SpeechType.Emote)
+            return false;
+
+        if (!_activeSpeechBubbles.TryGetValue(entity, out var bubbles) || bubbles.Count == 0)
+            return false;
+
+        // Match the most recent alive bubble only. Coalescing into an older bubble that has a newer
+        // different bubble above it would visually reorder the stack.
+        var candidate = bubbles[^1];
+        if (candidate.OriginalMessageText != msg.Message)
+            return false;
+
+        candidate.RepeatWith(msg);
+        return true;
+    }
+
+}

--- a/Content.Client/RussStation/Chat/HonkChatCoalesceEntry.cs
+++ b/Content.Client/RussStation/Chat/HonkChatCoalesceEntry.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Chat;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+// Coalesce bookkeeping for a single (channel, sender, message) cluster. Lives in its own file so
+// the HONK analyzer does not require a non-Honk counterpart declaration.
+internal sealed class HonkChatCoalesceEntry
+{
+    public required ChatMessage Msg;
+    public required string OriginalWrapped;
+    public int Repeats;
+    public TimeSpan LastSeen;
+}

--- a/Content.Client/RussStation/Chat/SpeechBubble.Honk.cs
+++ b/Content.Client/RussStation/Chat/SpeechBubble.Honk.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Chat;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Chat.UI;
+
+// HONK - Fork partial adding repeat-in-place support for speech bubbles, mirroring the
+// PopupSystem.WrapAndRepeatPopup behavior. When an alive bubble gets another copy of the same
+// emote from the same entity inside the coalesce window, ChatUIController calls RepeatWith on
+// the existing bubble instead of spawning a stacked one. Only emote bubbles are coalesced today;
+// say/whisper/looc keep one-bubble-per-line since repeats there are rare and usually carry
+// meaningful turn-taking.
+public abstract partial class SpeechBubble
+{
+    // Snapshots taken at construction so a later mutation of the source ChatMessage (e.g. the
+    // chat coalescer rewriting WrappedMessage to "(xN)") can't leak into a rebuild and produce
+    // double-wrapped counts.
+    private string _honkOriginalRawMessage = string.Empty;
+    private string _honkOriginalWrapped = string.Empty;
+    private ChannelMetadata _honkMetadata;
+    private string _honkSpeechStyleClass = string.Empty;
+    private Color? _honkFontColor;
+
+    /// <summary>
+    /// Raw message text of the first bubble in the current repeat cluster. Used by ChatUIController
+    /// to match incoming emotes against alive bubbles.
+    /// </summary>
+    public string OriginalMessageText => _honkOriginalRawMessage;
+
+    /// <summary>
+    /// Number of repeats this bubble currently displays (1 for a fresh bubble).
+    /// </summary>
+    public int Repeats { get; private set; } = 1;
+
+    private void HonkStashCtorArgs(ChatMessage message, string speechStyleClass, Color? fontColor)
+    {
+        _honkOriginalRawMessage = message.Message;
+        _honkOriginalWrapped = message.WrappedMessage;
+        _honkMetadata = new ChannelMetadata(message.Channel, message.SenderEntity, message.SenderKey);
+        _honkSpeechStyleClass = speechStyleClass;
+        _honkFontColor = fontColor;
+    }
+
+    private readonly record struct ChannelMetadata(ChatChannel Channel, NetEntity Sender, int? SenderKey);
+
+    /// <summary>
+    /// Fold another identical emote into this bubble: bump the repeat count, rebuild the rendered
+    /// text with an (xN) suffix using the same loc key PopupSystem uses, and reset the death timer
+    /// so the bubble stays visible while repeats keep arriving.
+    /// </summary>
+    public void RepeatWith(ChatMessage newMessage)
+    {
+        Repeats += 1;
+
+        var display = new ChatMessage(
+            _honkMetadata.Channel,
+            _honkOriginalRawMessage,
+            Loc.GetString(
+                "popup-system-repeated-popup-stacking-wrap",
+                ("popup-message", _honkOriginalWrapped),
+                ("count", Repeats)),
+            _honkMetadata.Sender,
+            _honkMetadata.SenderKey);
+
+        RemoveAllChildren();
+        var rebuilt = BuildBubble(display, _honkSpeechStyleClass, _honkFontColor);
+        AddChild(rebuilt);
+        ForceRunStyleUpdate();
+        rebuilt.Measure(Vector2Helpers.Infinity);
+        ContentSize = rebuilt.DesiredSize;
+        _deathTime = _timing.RealTime + TotalTime;
+    }
+}

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,10 +1,12 @@
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
+using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Client.RussStation.Popups;
@@ -23,6 +25,13 @@ public sealed class PopupLogSystem : EntitySystem
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    // Window during which an identical popup (by message text) is treated as a duplicate
+    // and suppressed from the chat mirror. The floating display keeps its own upstream coalescing independently.
+    private static readonly TimeSpan CoalesceWindow = TimeSpan.FromSeconds(2);
+
+    private readonly Dictionary<string, TimeSpan> _recentMirror = new();
 
     private ChatUIController? _chat;
     private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
@@ -34,6 +43,12 @@ public sealed class PopupLogSystem : EntitySystem
         // PopupMessage / PopupCursorInternal (HONK blocks), so network-sent popups, client-predicted
         // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        _recentMirror.Clear();
     }
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
@@ -60,6 +75,12 @@ public sealed class PopupLogSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(message))
             return;
 
+        var now = _timing.RealTime;
+        if (_recentMirror.TryGetValue(message, out var lastSeen) && now - lastSeen < CoalesceWindow)
+            return;
+        _recentMirror[message] = now;
+        PruneStaleCoalesceEntries(now);
+
         var escaped = FormattedMessage.EscapeText(message);
         var wrapped = category is { } cat
             ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
@@ -73,5 +94,20 @@ public sealed class PopupLogSystem : EntitySystem
             senderKey: null);
 
         Chat.ProcessChatMessage(mirror, speechBubble: false);
+    }
+
+    private void PruneStaleCoalesceEntries(TimeSpan now)
+    {
+        if (_recentMirror.Count < 32)
+            return;
+
+        var stale = new List<string>();
+        foreach (var (key, seenAt) in _recentMirror)
+        {
+            if (now - seenAt >= CoalesceWindow)
+                stale.Add(key);
+        }
+        foreach (var key in stale)
+            _recentMirror.Remove(key);
     }
 }

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,12 +1,10 @@
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
-using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Client.RussStation.Popups;
@@ -19,19 +17,14 @@ namespace Content.Client.RussStation.Popups;
 /// Popups for entities the local player can't examine (out of range, occluded, wrong map) are dropped
 /// so the log doesn't leak information the player shouldn't have. Cursor / coordinate-only popups with
 /// no source entity always log since those are typically addressed directly to the local player.
+/// Repeated popups within a short window are coalesced in-place by ChatUIController (shared path with
+/// emote coalescing), so this system does not need its own dedup dictionary.
 /// </remarks>
 public sealed class PopupLogSystem : EntitySystem
 {
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-
-    // Window during which an identical popup (by message text) is treated as a duplicate
-    // and suppressed from the chat mirror. The floating display keeps its own upstream coalescing independently.
-    private static readonly TimeSpan CoalesceWindow = TimeSpan.FromSeconds(2);
-
-    private readonly Dictionary<string, TimeSpan> _recentMirror = new();
 
     private ChatUIController? _chat;
     private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
@@ -43,12 +36,6 @@ public sealed class PopupLogSystem : EntitySystem
         // PopupMessage / PopupCursorInternal (HONK blocks), so network-sent popups, client-predicted
         // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
-        SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundRestart);
-    }
-
-    private void OnRoundRestart(RoundRestartCleanupEvent ev)
-    {
-        _recentMirror.Clear();
     }
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
@@ -75,12 +62,6 @@ public sealed class PopupLogSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(message))
             return;
 
-        var now = _timing.RealTime;
-        if (_recentMirror.TryGetValue(message, out var lastSeen) && now - lastSeen < CoalesceWindow)
-            return;
-        _recentMirror[message] = now;
-        PruneStaleCoalesceEntries(now);
-
         var escaped = FormattedMessage.EscapeText(message);
         var wrapped = category is { } cat
             ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
@@ -94,20 +75,5 @@ public sealed class PopupLogSystem : EntitySystem
             senderKey: null);
 
         Chat.ProcessChatMessage(mirror, speechBubble: false);
-    }
-
-    private void PruneStaleCoalesceEntries(TimeSpan now)
-    {
-        if (_recentMirror.Count < 32)
-            return;
-
-        var stale = new List<string>();
-        foreach (var (key, seenAt) in _recentMirror)
-        {
-            if (now - seenAt >= CoalesceWindow)
-                stale.Add(key);
-        }
-        foreach (var key in stale)
-            _recentMirror.Remove(key);
     }
 }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -449,11 +449,23 @@ public sealed partial class ChatUIController : UIController
             return;
         }
 
+        // HONK START - coalesce at enqueue time so rapid repeats bump the counter immediately
+        // instead of waiting for the speech-bubble delay queue to dequeue each duplicate. Falls
+        // through to the existing enqueue path when there's no alive match yet. (issue #578)
+        if (HonkTryCoalesceEmoteBubble(ent, msg, speechType))
+            return;
+        // HONK END
+
         EnqueueSpeechBubble(ent, msg, speechType);
     }
 
     private void CreateSpeechBubble(EntityUid entity, SpeechBubbleData speechData)
     {
+        // HONK START - coalesce repeated emote bubbles in place instead of stacking a new bubble (issue #578)
+        if (HonkTryCoalesceEmoteBubble(entity, speechData.Message, speechData.Type))
+            return;
+        // HONK END
+
         var bubble =
             SpeechBubble.CreateSpeechBubble(speechData.Type, speechData.Message, entity);
 
@@ -878,8 +890,17 @@ public sealed partial class ChatUIController : UIController
         }
         //HONK END
 
+        // HONK START - coalesce repeated popup-mirror / emote entries in place (issue #578).
+        // When a match is found, the existing History entry's WrappedMessage is mutated and the
+        // chat boxes re-render that entry via the MessageUpdated event. We still fall through to
+        // the speech-bubble path so emote bubbles can coalesce the same way.
+        var honkCoalesced = !msg.HideChat && HonkTryCoalesceChatMessage(msg);
+        // HONK END
+
         // Log all incoming chat to repopulate when filter is un-toggled
-        if (!msg.HideChat)
+        // HONK START - skip History.Add when the fork coalescer folded this into an existing entry (issue #578)
+        if (!msg.HideChat && !honkCoalesced)
+        // HONK END
         {
             History.Add((_timing.CurTick, msg));
             MessageAdded?.Invoke(msg);

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -25,6 +25,12 @@ public partial class ChatBox : UIWidget
     private readonly ISawmill _sawmill;
     private readonly ChatUIController _controller;
 
+    // HONK START - tracks which OutputPanel entry index each rendered ChatMessage lives at, so in-place
+    // coalesce updates (see ChatUIController.HonkTryCoalesceChatMessage) can patch that one entry
+    // instead of repopulating the whole box. Cleared whenever Contents is Cleared.
+    private readonly Dictionary<ChatMessage, int> _honkRenderedAt = new();
+    // HONK END
+
     public bool Main { get; set; }
 
     public ChatSelectChannel SelectedChannel => ChatInput.ChannelSelector.SelectedChannel;
@@ -44,6 +50,9 @@ public partial class ChatBox : UIWidget
         ChatInput.FilterButton.Popup.OnNewHighlights += OnNewHighlights;
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
+        // HONK START - in-place rerender for coalesced repeats (issue #578)
+        _controller.MessageUpdated += OnMessageUpdated;
+        // HONK END
         _controller.HighlightsUpdated += OnHighlightsUpdated;
         _controller.RegisterChat(this);
     }
@@ -69,7 +78,28 @@ public partial class ChatBox : UIWidget
         var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
 
         AddLine(msg.WrappedMessage, color);
+        // HONK START - remember this message's rendered position so coalesce updates can patch it (issue #578)
+        _honkRenderedAt[msg] = Contents.EntryCount - 1;
+        // HONK END
     }
+
+    // HONK START - issue #578
+    private void OnMessageUpdated(ChatMessage msg)
+    {
+        if (!_honkRenderedAt.TryGetValue(msg, out var index))
+            return;
+
+        if (index < 0 || index >= Contents.EntryCount)
+            return;
+
+        var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
+        var formatted = new FormattedMessage(3);
+        formatted.PushColor(color);
+        formatted.AddMarkupOrThrow(msg.WrappedMessage);
+        formatted.Pop();
+        Contents.SetMessage(index, formatted, tagsAllowed: null);
+    }
+    // HONK END
 
     private void OnHighlightsUpdated(string highlights)
     {
@@ -84,6 +114,9 @@ public partial class ChatBox : UIWidget
     public void Repopulate()
     {
         Contents.Clear();
+        // HONK START - stale contents indices after Clear (issue #578)
+        _honkRenderedAt.Clear();
+        // HONK END
 
         foreach (var message in _controller.History)
         {
@@ -94,6 +127,9 @@ public partial class ChatBox : UIWidget
     private void OnChannelFilter(ChatChannel channel, bool active)
     {
         Contents.Clear();
+        // HONK START - stale contents indices after Clear (issue #578)
+        _honkRenderedAt.Clear();
+        // HONK END
 
         foreach (var message in _controller.History)
         {
@@ -208,6 +244,9 @@ public partial class ChatBox : UIWidget
 
         if (!disposing) return;
         _controller.UnregisterChat(this);
+        // HONK START - unsubscribe from coalesce update event (issue #578)
+        _controller.MessageUpdated -= OnMessageUpdated;
+        // HONK END
         ChatInput.Input.OnTextEntered -= OnTextEntered;
         ChatInput.Input.OnKeyBindDown -= OnInputKeyBindDown;
         ChatInput.Input.OnTextChanged -= OnTextChanged;

--- a/Content.Server/Mobs/DeathgaspSystem.cs
+++ b/Content.Server/Mobs/DeathgaspSystem.cs
@@ -1,5 +1,8 @@
 ﻿using Content.Server.Chat.Systems;
 using Content.Server.Speech.Muting;
+// HONK START - ChatTransmitRange for deathgasp FOV filter
+using Content.Shared.Chat;
+// HONK END
 using Content.Shared.Mobs;
 using Content.Shared.Speech.Muting;
 using Robust.Shared.Prototypes;
@@ -38,7 +41,10 @@ public sealed class DeathgaspSystem: EntitySystem
         if (HasComp<MutedComponent>(uid))
             return false;
 
-        _chat.TryEmoteWithChat(uid, component.Prototype, ignoreActionBlocker: true);
+        // HONK START - match involuntary gasps: send with HideChat so the client-side FOV filter
+        // re-enables the emote only for observers who can actually see the dying entity.
+        _chat.TryEmoteWithChat(uid, component.Prototype, range: ChatTransmitRange.HideChat, ignoreActionBlocker: true);
+        // HONK END
 
         return true;
     }


### PR DESCRIPTION
## About the PR

Rolls up repeats of the same popup or emote into a single chat line with an (xN) counter, matching the upstream floating popup counter. After a 2 second gap the next copy starts a new line at 1. The floating speech bubble for emotes got the same treatment, reusing the upstream popup loc key so the visual is consistent.

Two nearby bugs got fixed on the way:

- The upstream popup counter reset any time the mob moved one tile, because `WorldPopupData` keys on coordinates. Entity-attached popups now drop coordinates from the key and the existing label is moved to the latest position so the stack follows the mob.
- Deathgasp was visible through walls. It went out with `ChatTransmitRange.Normal`, bypassing the fork-side FOV filter that gates involuntary gasps. Switched it to `ChatTransmitRange.HideChat` so the same filter gets a chance to run.

## Why / Balance

Bleed ticks, gasps, and similar repeat text flood the Popup tab and clutter chat with essentially the same line over and over. A counter is the pattern players already know from the float, so matching it in chat keeps scrollback readable without dropping any information.

Picking 2s for the window: combat ticks fire about once per second, so 2s catches the ones that are clearly "the same event happening again" and still lets a genuinely-separate repeat 3 seconds later start on its own line.

The deathgasp fix is also a small stealth buff to stealth. Being able to time your silent deadman through a wall because you could read "X seizes up and falls limp!" in chat was dumb.

## Technical details

- `ChatUIController` owns coalescing for the `Popup` and `Emotes` channels. A dict keyed on (channel, sender, raw message) tracks the active cluster; on a hit inside the window, the existing `ChatMessage.WrappedMessage` is rewritten with the upstream `popup-system-repeated-popup-stacking-wrap` loc key and a new `MessageUpdated` event fires. `ChatBox` listens and patches the corresponding `OutputPanel` entry via `SetMessage`, so there's no Repopulate flicker.
- The fork-side dedup dict in `PopupLogSystem` is gone. All coalescing goes through the one path now.
- `SpeechBubble` grew a `RepeatWith(ChatMessage)` via a `.Honk.cs` partial. The original wrapped text is snapshotted at construction so a later in-place mutation of the source `ChatMessage` (done by the chat coalescer) can't leak back into a bubble rebuild and produce "(x2) x2" double counts.
- Emote bubble coalesce happens at `AddSpeechBubble` time, not `CreateSpeechBubble`. Otherwise rapid emote spam pile up behind the speech-bubble delay queue and the counter only ticks at `BubbleDelayBase` intervals.
- `PopupSystem.PopupMessage`: entity-attached popups now use `default` coordinates in the key and the existing label's `InitialPos` is refreshed on each match.
- `DeathgaspSystem`: adds `range: ChatTransmitRange.HideChat` to the `TryEmoteWithChat` call. That lets the client-side emote FOV filter re-enable the message only for observers who can actually examine the corpse.

## Media

Manually tested:

- Bleed tick spam: chat counter increments in place, resets after 2s gap.
- Walking while bleeding: counter keeps climbing instead of restarting every step.
- Repeated `*salute`: chat line and speech bubble both coalesce with (xN), counter keeps up with the input rate.
- Deathgasp behind a wall: not visible to observers who can't examine the corpse.
- Involuntary gasps behind a wall: still hidden, unchanged baseline.
- Two different players doing the same emote side by side: do not coalesce together.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Popup and emote repeats in chat now collapse into a single line with a count, matching the floating popup counter. The count resets when there's a 2 second gap.
- tweak: Emote speech bubbles above characters count repeats in place instead of stacking.
- fix: The floating popup counter no longer resets when the mob moves.
- fix: Deathgasp no longer shows in chat to observers who can't actually see the corpse.

---

Re-raised from #592, which merged into the closed `feat/issue-578-popup-routing` stub instead of release. Same commits, now targeting release directly.