### PR TITLE
fix: extract RowIndent Thickness to satisfy HONK0017

### DIFF
--- a/Content.Client/RussStation/Light/LightReplacerRecyclerWindow.xaml.cs
+++ b/Content.Client/RussStation/Light/LightReplacerRecyclerWindow.xaml.cs
@@ -13,6 +13,8 @@ namespace Content.Client.RussStation.Light;
 [GenerateTypedNameReferences]
 public sealed partial class LightReplacerRecyclerWindow : DefaultWindow
 {
+    private static readonly Thickness RowIndent = new(16, 0, 0, 0);
+
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly IComponentFactory _compFactory = default!;
 
@@ -84,7 +86,7 @@ public sealed partial class LightReplacerRecyclerWindow : DefaultWindow
             Orientation = BoxContainer.LayoutOrientation.Horizontal,
             HorizontalExpand = true,
             SeparationOverride = 6,
-            Margin = new Thickness(16, 0, 0, 0),
+            Margin = RowIndent,
         };
 
         var name = _protoManager.TryIndex<EntityPrototype>(entry.ProtoId, out var proto)
@@ -158,7 +160,7 @@ public sealed partial class LightReplacerRecyclerWindow : DefaultWindow
             Orientation = BoxContainer.LayoutOrientation.Horizontal,
             HorizontalExpand = true,
             SeparationOverride = 6,
-            Margin = new Thickness(16, 0, 0, 0),
+            Margin = RowIndent,
         };
 
         var name = _protoManager.TryIndex<EntityPrototype>(protoId, out var proto)


### PR DESCRIPTION
## About the PR

Hoists the `new Thickness(16, 0, 0, 0)` call in `LightReplacerRecyclerWindow` into a single `static readonly RowIndent` field and references that field at both row-builder sites.

## Why / Balance

PR #285 merged with the raw `Thickness(...)` literals inline. HONK0017 (the layout-magic-number analyzer) flagged both call sites, the YAML Linter job went red, but that check wasn't required for merge, so release shipped with a failing full build. Every downstream PR that triggers a full build now inherits the failure, including the janitorial docs PR #445.

Separately, the release ruleset has been updated to require `YAML Linter` going forward, so this class of drift gets caught before merge.

## Technical details

The analyzer (`HonkLayoutMagicNumberAnalyzer.IsInsideNamedConstantDeclaration`) skips literals inside `const` or `static readonly` field initializers, so extracting the whole `Thickness` avoids having to pull each `0` argument into its own named constant.

## Media

n/a, no visual change.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

No player-facing change.