### PR TITLE
refactor: surgery step presets and number extraction

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
@@ -169,8 +169,8 @@ public sealed class SurgerySystemTest : GameTest
         {
             Assert.That(protoManager.TryIndex<SurgeryProcedurePrototype>(TestProcedureId, out var proto), Is.True);
             Assert.That(proto!.Steps.Count, Is.EqualTo(2));
-            Assert.That(proto.Steps[0].Quality.Id, Is.EqualTo("Slicing"));
-            Assert.That(proto.Steps[1].Quality.Id, Is.EqualTo("Retracting"));
+            Assert.That(proto.Steps[0].GetQuality().Id, Is.EqualTo("Slicing"));
+            Assert.That(proto.Steps[1].GetQuality().Id, Is.EqualTo("Retracting"));
         });
     }
 
@@ -194,8 +194,9 @@ public sealed class SurgerySystemTest : GameTest
                 for (var i = 0; i < proto.Steps.Count; i++)
                 {
                     var step = proto.Steps[i];
-                    Assert.That(protoManager.HasIndex<ToolQualityPrototype>(step.Quality),
-                        $"Procedure '{proto.ID}' step {i} references unknown quality '{step.Quality}'.");
+                    var quality = step.GetQuality();
+                    Assert.That(protoManager.HasIndex<ToolQualityPrototype>(quality),
+                        $"Procedure '{proto.ID}' step {i} references unknown quality '{quality}'.");
 
                     var baseDuration = SharedSurgerySystem.GetBaseStepDuration(step);
                     Assert.That(baseDuration, Is.GreaterThan(0f),
@@ -549,4 +550,50 @@ public sealed class SurgerySystemTest : GameTest
                 Is.EqualTo(1.5f).Within(0.001f));
         });
     }
+
+    /// <summary>
+    /// For every shipped procedure, verifies that each step whose preset is non-None resolves to
+    /// the same tool quality and duration the preset table declares, unless the step explicitly
+    /// overrides them. Guards against a procedure picking a preset and then silently diverging.
+    /// </summary>
+    [Test]
+    public async Task ProcedurePresetsResolveConsistentlyTest()
+    {
+        var server = Server;
+        var protoManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            foreach (var proto in protoManager.EnumeratePrototypes<SurgeryProcedurePrototype>())
+            {
+                for (var i = 0; i < proto.Steps.Count; i++)
+                {
+                    var step = proto.Steps[i];
+                    if (step.Preset == SurgeryStepPreset.None)
+                        continue;
+
+                    var defaults = SurgeryStepPresets.Resolve(step.Preset);
+
+                    if (step.Quality == null)
+                    {
+                        Assert.That(step.GetQuality(), Is.EqualTo(defaults.Quality),
+                            $"Procedure '{proto.ID}' step {i} ({step.Preset}) inherits the wrong tool quality.");
+                    }
+
+                    if (!step.Duration.HasValue && defaults.Duration.HasValue)
+                    {
+                        Assert.That(step.GetDuration(), Is.EqualTo(defaults.Duration),
+                            $"Procedure '{proto.ID}' step {i} ({step.Preset}) inherits the wrong duration.");
+                    }
+
+                    if (!step.Repeatable && defaults.Repeatable)
+                    {
+                        Assert.That(step.GetRepeatable(), Is.True,
+                            $"Procedure '{proto.ID}' step {i} ({step.Preset}) should be repeatable via preset.");
+                    }
+                }
+            }
+        });
+    }
+
 }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
@@ -12,19 +12,23 @@ public sealed partial class SurgerySystem
 {
     private void ApplyStepEffects(EntityUid patient, SurgeryStep step)
     {
-        if (step.Damage != null)
-            _damageable.TryChangeDamage(patient, step.Damage);
+        var damage = step.GetDamage();
+        if (damage != null)
+            _damageable.TryChangeDamage(patient, damage);
 
-        if (step.Healing != null)
+        var healing = step.GetHealing();
+        if (healing != null)
         {
-            if ((step.HealingFlat > 0 || step.HealingMultiplier > 0) &&
+            var healingFlat = step.GetHealingFlat();
+            var healingMultiplier = step.GetHealingMultiplier();
+            if ((healingFlat > 0 || healingMultiplier > 0) &&
                 TryComp<DamageableComponent>(patient, out var damageable))
             {
                 // Calculate healing budget: flat + (total_eligible_damage * multiplier)
                 var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
                 var totalDamage = FixedPoint2.Zero;
 
-                foreach (var type in step.Healing.DamageDict.Keys)
+                foreach (var type in healing.DamageDict.Keys)
                 {
                     if (currentDamage.DamageDict.TryGetValue(type, out var current))
                         totalDamage += current;
@@ -32,11 +36,11 @@ public sealed partial class SurgerySystem
 
                 if (totalDamage > 0)
                 {
-                    var budget = FixedPoint2.New(step.HealingFlat + (float) totalDamage * step.HealingMultiplier);
+                    var budget = FixedPoint2.New(healingFlat + (float) totalDamage * healingMultiplier);
 
                     // Distribute proportionally across eligible damage types
                     var healSpec = new DamageSpecifier();
-                    foreach (var type in step.Healing.DamageDict.Keys)
+                    foreach (var type in healing.DamageDict.Keys)
                     {
                         if (currentDamage.DamageDict.TryGetValue(type, out var current) && current > 0)
                         {
@@ -51,7 +55,7 @@ public sealed partial class SurgerySystem
             else
             {
                 // No formula: heal each type independently by listed amount
-                var negated = new DamageSpecifier(step.Healing);
+                var negated = new DamageSpecifier(healing);
                 foreach (var key in negated.DamageDict.Keys.ToList())
                 {
                     negated.DamageDict[key] = -negated.DamageDict[key];
@@ -61,8 +65,15 @@ public sealed partial class SurgerySystem
             }
         }
 
-        if (step.BleedModifier != 0)
-            _bloodstream.TryModifyBleedAmount((patient, null), step.BleedModifier);
+        var bleed = step.GetBleedPreset() switch
+        {
+            SurgeryBleedPreset.Incision => SurgeryConstants.IncisionBleedAmount,
+            SurgeryBleedPreset.ClampFull => -SurgeryConstants.IncisionBleedAmount,
+            _ => step.GetBleedModifier(),
+        };
+
+        if (bleed != 0f)
+            _bloodstream.TryModifyBleedAmount((patient, null), bleed);
     }
 
     private void ApplyCauteryClose(EntityUid patient, EntityUid? surgeon)
@@ -131,12 +142,13 @@ public sealed partial class SurgerySystem
 
         foreach (var step in proto.Steps)
         {
-            if (step.Healing == null)
+            var healing = step.GetHealing();
+            if (healing == null)
                 continue;
 
             hasHealingStep = true;
 
-            foreach (var type in step.Healing.DamageDict.Keys)
+            foreach (var type in healing.DamageDict.Keys)
             {
                 if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > FixedPoint2.New(SurgeryConstants.HealingDamageEpsilon))
                     return true;
@@ -148,7 +160,8 @@ public sealed partial class SurgerySystem
 
     private bool StepCanStillHeal(EntityUid patient, SurgeryStep step)
     {
-        if (step.Healing == null || (step.HealingFlat <= 0 && step.HealingMultiplier <= 0))
+        var healing = step.GetHealing();
+        if (healing == null || (step.GetHealingFlat() <= 0 && step.GetHealingMultiplier() <= 0))
             return false;
 
         if (!TryComp<DamageableComponent>(patient, out var damageable))
@@ -156,7 +169,7 @@ public sealed partial class SurgerySystem
 
         var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
 
-        foreach (var type in step.Healing.DamageDict.Keys)
+        foreach (var type in healing.DamageDict.Keys)
         {
             if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > 0)
                 return true;

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -26,6 +26,13 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     private static readonly ProtoId<TagPrototype> TierAdvancedTag = "TierAdvanced";
     private static readonly ProtoId<TagPrototype> TierExperimentalTag = "TierExperimental";
 
+    private static readonly Dictionary<ProtoId<TagPrototype>, float> ToolTierModifiers = new()
+    {
+        { TierExperimentalTag, SurgeryConstants.ToolTierExperimentalModifier },
+        { TierAdvancedTag, SurgeryConstants.ToolTierAdvancedModifier },
+        { TierStandardTag, SurgeryConstants.ToolTierStandardModifier },
+    };
+
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
@@ -137,7 +144,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
     private void OnDrapedStartup(Entity<SurgeryDrapedComponent> ent, ref ComponentStartup args)
     {
-        _alerts.ShowAlert(ent.Owner, "SurgeryDraped");
+        _alerts.ShowAlert(ent.Owner, SurgeryDrapedAlert);
     }
 
     private void OnRemoveDrapeAlert(Entity<SurgeryDrapedComponent> ent, ref RemoveSurgeryDrapeAlertEvent args)
@@ -223,7 +230,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
         Dirty(target.Value, draped);
 
-        var drapeContainer = _container.EnsureContainer<Container>(target.Value, "surgery_drape");
+        var drapeContainer = _container.EnsureContainer<Container>(target.Value, SurgeryConstants.SurgeryDrapeContainerId);
         if (!_container.Insert(bedsheet.Value, drapeContainer))
         {
             Log.Warning($"Failed to insert bedsheet {ToPrettyString(bedsheet.Value)} into surgery drape container on {ToPrettyString(target.Value)}");
@@ -278,7 +285,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
 
         // Advance past repeatable step if tool matches next step
-        if (currentStep.Repeatable && active.CurrentStep + 1 < proto.Steps.Count)
+        if (currentStep.GetRepeatable() && active.CurrentStep + 1 < proto.Steps.Count)
         {
             var nextStep = proto.Steps[active.CurrentStep + 1];
             if (ToolMatchesStep(tool, nextStep))
@@ -296,7 +303,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     private void StartStepDoAfter(EntityUid surgeon, EntityUid patient, EntityUid tool, SurgeryStep step, SurgeryDifficulty difficulty)
     {
         var duration = TimeSpan.FromSeconds(
-            (float) GetStepDuration(step, patient, difficulty).TotalSeconds
+            (float) GetStepDuration(step, patient, difficulty, surgeon).TotalSeconds
             * GetToolTierModifier(tool));
 
         var doAfterArgs = new DoAfterArgs(
@@ -373,16 +380,19 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         ApplyStepEffects(patient, step);
 
         var suppressStepPopup = false;
+        var repeatable = step.GetRepeatable();
+        var effect = step.GetEffect();
+        var popup = step.GetPopup();
 
         // Advance step (unless repeatable).
         // Repeatable steps with effects (like organ manipulation) need manual re-use,
         // so only effect-less repeatable steps auto-repeat below.
-        if (!step.Repeatable)
+        if (!repeatable)
         {
             active.CurrentStep++;
             Dirty(patient, active);
         }
-        else if (step.Effect == null)
+        else if (effect == null)
         {
             var damageAfter = _damageable.GetTotalDamage((patient, null));
             var healedSomething = damageAfter < damageBefore;
@@ -399,12 +409,12 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
 
         // Step popup (skipped on the terminal iteration of a repeatable step).
-        if (!suppressStepPopup && !string.IsNullOrEmpty(step.Popup) && args.User is { } user)
-            _popup.PopupEntity(Loc.GetString(step.Popup, ("user", user), ("target", patient)), patient);
+        if (!suppressStepPopup && !string.IsNullOrEmpty(popup) && args.User is { } user)
+            _popup.PopupEntity(Loc.GetString(popup, ("user", user), ("target", patient)), patient);
 
         // Trigger effect if this step has one
-        if (step.Effect != null)
-            HandleEffect(args.User, patient, step.Effect);
+        if (effect != null)
+            HandleEffect(args.User, patient, effect);
 
         // Procedure steps exhausted, wait for cautery to close
         if (active.CurrentStep >= proto.Steps.Count)
@@ -426,15 +436,12 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     /// </summary>
     public float GetToolTierModifier(EntityUid tool)
     {
-        if (_tags.HasTag(tool, TierExperimentalTag))
-            return SurgeryConstants.ToolTierExperimentalModifier;
+        foreach (var (tag, modifier) in ToolTierModifiers)
+        {
+            if (_tags.HasTag(tool, tag))
+                return modifier;
+        }
 
-        if (_tags.HasTag(tool, TierAdvancedTag))
-            return SurgeryConstants.ToolTierAdvancedModifier;
-
-        if (_tags.HasTag(tool, TierStandardTag))
-            return SurgeryConstants.ToolTierStandardModifier;
-
-        return SurgeryConstants.ToolTierImprovisedModifier; // no tier tag = improvised
+        return SurgeryConstants.ToolTierImprovisedModifier;
     }
 }

--- a/Content.Shared/RussStation/Surgery/SurgeryBleedPreset.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryBleedPreset.cs
@@ -1,0 +1,17 @@
+namespace Content.Shared.RussStation.Surgery;
+
+/// <summary>
+/// Named bleed-delta presets that resolve to constants in <see cref="SurgeryConstants"/> at step
+/// application time, so procedure YAMLs don't have to duplicate the same float everywhere.
+/// </summary>
+public enum SurgeryBleedPreset : byte
+{
+    /// <summary>Use the step's explicit <c>bleedModifier</c> field. Default.</summary>
+    Manual = 0,
+
+    /// <summary>Full-depth incision bleed. Adds <see cref="SurgeryConstants.IncisionBleedAmount"/>.</summary>
+    Incision,
+
+    /// <summary>Full hemostat clamp. Subtracts <see cref="SurgeryConstants.IncisionBleedAmount"/>.</summary>
+    ClampFull,
+}

--- a/Content.Shared/RussStation/Surgery/SurgeryConstants.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryConstants.cs
@@ -58,4 +58,64 @@ public static class SurgeryConstants
     /// deciding whether a healing step has anything to do.
     /// </summary>
     public const float HealingDamageEpsilon = 0.01f;
+
+    // --- Step preset defaults ---
+
+    /// <summary>Slash damage applied by a standard incision.</summary>
+    public const float IncisionSlashDamage = 15f;
+
+    /// <summary>Blunt damage applied by a standard retract step.</summary>
+    public const float RetractBluntDamage = 6f;
+
+    /// <summary>Slash damage applied by a saw step opening a deeper cavity.</summary>
+    public const float SawSlashDamage = 9f;
+
+    /// <summary>Flat healing budget baseline for tend-wound steps.</summary>
+    public const float TendHealingFlat = 5f;
+
+    /// <summary>Fraction of current eligible damage added to the tend healing budget.</summary>
+    public const float TendHealingMultiplier = 0.07f;
+
+    /// <summary>Mild bleed reduction a tend step applies on each repeat.</summary>
+    public const float TendBleedReduction = -1f;
+
+    /// <summary>Base duration (seconds) of an incision step before modifiers.</summary>
+    public const float IncisionDuration = DefaultSlicingDuration;
+
+    /// <summary>Base duration (seconds) of a retract step before modifiers.</summary>
+    public const float RetractDuration = DefaultRetractingDuration;
+
+    /// <summary>Base duration (seconds) of a clamp step before modifiers.</summary>
+    public const float ClampDuration = DefaultClampingDuration;
+
+    /// <summary>Base duration (seconds) of a saw step before modifiers.</summary>
+    public const float SawDuration = DefaultSawingDuration;
+
+    /// <summary>Base duration (seconds) of an organ-removal clamp before modifiers.</summary>
+    public const float RemoveOrganDuration = DefaultClampingDuration;
+
+    /// <summary>Duration of one tend-wound repeat in seconds.</summary>
+    public const float TendStepDuration = 2.5f;
+
+    /// <summary>Fallback duration used when a custom step declares no preset, no explicit duration,
+    /// and no matching quality default. Picked low so a mis-authored step is still playable.</summary>
+    public const float FallbackStepDuration = 2.0f;
+
+    /// <summary>Container ID on the patient that holds the drape entity during surgery.</summary>
+    public const string SurgeryDrapeContainerId = "surgery_drape";
+
+    /// <summary>Duration of a burn-wound cautery / fracture bone-setting step in seconds.</summary>
+    public const float WoundRepairDuration = 6f;
+
+    /// <summary>
+    /// Baseline bleed rate used as the unit when computing surgery-related bleed deltas. Natural
+    /// bleed decay is 0.33 every 3 seconds (~0.11/s), so a value of 1.5 clots in roughly 14 seconds.
+    /// </summary>
+    public const float InterruptBleedBaseRate = 1.5f;
+
+    /// <summary>
+    /// Bleed amount added by an incision step and restored by an interrupt that unclamps a half-open
+    /// patient. Three times the base so an un-clamped incision is a real time pressure (~40s to clot).
+    /// </summary>
+    public const float IncisionBleedAmount = InterruptBleedBaseRate * 3f;
 }

--- a/Content.Shared/RussStation/Surgery/SurgeryProcedurePrototype.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryProcedurePrototype.cs
@@ -14,10 +14,19 @@ namespace Content.Shared.RussStation.Surgery;
 public sealed partial class SurgeryStep
 {
     /// <summary>
-    /// Tool quality the held tool must have to perform this step.
+    /// Named step template that fills in quality, damage, bleed, healing, duration, popup, effect,
+    /// and the repeatable flag from <see cref="SurgeryConstants"/>. Explicit fields on the step
+    /// still win when set. Use <see cref="SurgeryStepPreset.None"/> when authoring a fully custom
+    /// step that provides every field itself.
     /// </summary>
-    [DataField(required: true)]
-    public ProtoId<ToolQualityPrototype> Quality;
+    [DataField]
+    public SurgeryStepPreset Preset = SurgeryStepPreset.None;
+
+    /// <summary>
+    /// Tool quality the held tool must have to perform this step. Optional when a preset supplies one.
+    /// </summary>
+    [DataField]
+    public ProtoId<ToolQualityPrototype>? Quality;
 
     /// <summary>
     /// How long the DoAfter takes in seconds (before speed modifiers).
@@ -63,9 +72,18 @@ public sealed partial class SurgeryStep
 
     /// <summary>
     /// Modifier to the patient's bleed amount. Positive adds bleeding, negative reduces it.
+    /// Ignored when <see cref="BleedPreset"/> is set to anything other than
+    /// <see cref="SurgeryBleedPreset.Manual"/>.
     /// </summary>
     [DataField]
     public float BleedModifier;
+
+    /// <summary>
+    /// Named bleed delta that overrides <see cref="BleedModifier"/> with a constant from
+    /// <see cref="SurgeryConstants"/> at application time.
+    /// </summary>
+    [DataField]
+    public SurgeryBleedPreset BleedPreset = SurgeryBleedPreset.Manual;
 
     /// <summary>
     /// If true, this step can be repeated multiple times before advancing.

--- a/Content.Shared/RussStation/Surgery/SurgeryStepDurationModifierEvent.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryStepDurationModifierEvent.cs
@@ -1,0 +1,25 @@
+namespace Content.Shared.RussStation.Surgery;
+
+/// <summary>
+/// Raised on both the patient and the surgeon when a surgery step's duration is being computed.
+/// Subscribers can multiply <see cref="Multiplier"/> by their own factor to speed a step up or slow
+/// it down. Inspect <see cref="Step"/> if the subscriber only cares about specific presets or tool
+/// qualities. The standard surface / drape / difficulty / tool-tier multipliers are applied
+/// alongside this event, so anything added here stacks on top.
+/// </summary>
+[ByRefEvent]
+public struct SurgeryStepDurationModifierEvent
+{
+    public SurgeryStep Step;
+    public EntityUid Patient;
+    public EntityUid? Surgeon;
+    public float Multiplier;
+
+    public SurgeryStepDurationModifierEvent(SurgeryStep step, EntityUid patient, EntityUid? surgeon)
+    {
+        Step = step;
+        Patient = patient;
+        Surgeon = surgeon;
+        Multiplier = 1f;
+    }
+}

--- a/Content.Shared/RussStation/Surgery/SurgeryStepExtensions.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryStepExtensions.cs
@@ -1,0 +1,81 @@
+using Content.Shared.Damage;
+using Content.Shared.RussStation.Surgery.Effects;
+using Content.Shared.Tools;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Surgery;
+
+/// <summary>
+/// Helpers that read a surgery step's effective field values, honouring the preset defaults when
+/// the step doesn't override them. Avoids scattering preset-resolution logic across the system
+/// code paths that touch steps.
+/// </summary>
+public static class SurgeryStepExtensions
+{
+    public static ProtoId<ToolQualityPrototype> GetQuality(this SurgeryStep step)
+    {
+        if (step.Quality is { } explicitQuality)
+            return explicitQuality;
+        return SurgeryStepPresets.Resolve(step.Preset).Quality;
+    }
+
+    public static float? GetDuration(this SurgeryStep step)
+    {
+        if (step.Duration is { } explicitDuration)
+            return explicitDuration;
+        return SurgeryStepPresets.Resolve(step.Preset).Duration;
+    }
+
+    public static string GetPopup(this SurgeryStep step)
+    {
+        if (!string.IsNullOrEmpty(step.Popup))
+            return step.Popup;
+        return SurgeryStepPresets.Resolve(step.Preset).Popup ?? string.Empty;
+    }
+
+    public static DamageSpecifier? GetDamage(this SurgeryStep step)
+    {
+        return step.Damage ?? SurgeryStepPresets.Resolve(step.Preset).Damage;
+    }
+
+    public static DamageSpecifier? GetHealing(this SurgeryStep step)
+    {
+        return step.Healing ?? SurgeryStepPresets.Resolve(step.Preset).Healing;
+    }
+
+    public static float GetHealingFlat(this SurgeryStep step)
+    {
+        return step.HealingFlat != 0 ? step.HealingFlat : SurgeryStepPresets.Resolve(step.Preset).HealingFlat;
+    }
+
+    public static float GetHealingMultiplier(this SurgeryStep step)
+    {
+        return step.HealingMultiplier != 0 ? step.HealingMultiplier : SurgeryStepPresets.Resolve(step.Preset).HealingMultiplier;
+    }
+
+    public static SurgeryBleedPreset GetBleedPreset(this SurgeryStep step)
+    {
+        if (step.BleedPreset != SurgeryBleedPreset.Manual)
+            return step.BleedPreset;
+        return SurgeryStepPresets.Resolve(step.Preset).BleedPreset;
+    }
+
+    public static float GetBleedModifier(this SurgeryStep step)
+    {
+        if (step.BleedModifier != 0)
+            return step.BleedModifier;
+        return SurgeryStepPresets.Resolve(step.Preset).BleedModifier;
+    }
+
+    public static bool GetRepeatable(this SurgeryStep step)
+    {
+        if (step.Repeatable)
+            return true;
+        return SurgeryStepPresets.Resolve(step.Preset).Repeatable;
+    }
+
+    public static ISurgeryEffect? GetEffect(this SurgeryStep step)
+    {
+        return step.Effect ?? SurgeryStepPresets.Resolve(step.Preset).Effect;
+    }
+}

--- a/Content.Shared/RussStation/Surgery/SurgeryStepPreset.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryStepPreset.cs
@@ -1,0 +1,236 @@
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Surgery.Effects;
+using Content.Shared.Tools;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Surgery;
+
+/// <summary>
+/// Named templates that fill in a <see cref="SurgeryStep"/>'s tool quality, damage, bleed delta,
+/// healing, duration, popup, and repeatable flag from values defined in <see cref="SurgeryConstants"/>
+/// rather than duplicating them in every procedure YAML. Fields explicitly set on the step still
+/// win over the preset.
+/// </summary>
+public enum SurgeryStepPreset : byte
+{
+    /// <summary>Fallback: use the step's own fields.</summary>
+    None = 0,
+
+    /// <summary>Opens the patient. Slicing tool, slash damage, full incision bleed.</summary>
+    Incision,
+
+    /// <summary>Holds the incision open for the surgeon. Retracting tool, blunt damage.</summary>
+    Retract,
+
+    /// <summary>Clamps the incision closed. Clamping tool, reverses the full incision bleed.</summary>
+    Clamp,
+
+    /// <summary>Cuts through bone or cavity wall. Sawing tool, slash damage.</summary>
+    Saw,
+
+    /// <summary>Tend-wounds treat step for brute damage. Clamping tool with healing budget.</summary>
+    TendBrute,
+
+    /// <summary>Tend-wounds treat step for burn damage. Clamping tool with healing budget.</summary>
+    TendBurn,
+
+    /// <summary>Remove-organ terminal step. Clamping tool, triggers the organ removal effect.</summary>
+    RemoveOrgan,
+
+    /// <summary>Cauterize burn wounds terminal step.</summary>
+    CauterizeBurnWounds,
+
+    /// <summary>Manually set a fractured bone.</summary>
+    SetBones,
+}
+
+/// <summary>
+/// Static resolver that maps <see cref="SurgeryStepPreset"/> values onto the fields a
+/// <see cref="SurgeryStep"/> would otherwise set by hand. A preset carries a tool quality, a
+/// default duration (null falls back to the quality's default), and any damage / healing / bleed
+/// preset / popup / effect the step applies.
+/// </summary>
+public static class SurgeryStepPresets
+{
+    public readonly record struct PresetDefaults(
+        ProtoId<ToolQualityPrototype> Quality,
+        float? Duration,
+        string? Popup,
+        DamageSpecifier? Damage,
+        DamageSpecifier? Healing,
+        float HealingFlat,
+        float HealingMultiplier,
+        SurgeryBleedPreset BleedPreset,
+        float BleedModifier,
+        bool Repeatable,
+        ISurgeryEffect? Effect);
+
+    public static PresetDefaults Resolve(SurgeryStepPreset preset)
+    {
+        switch (preset)
+        {
+            case SurgeryStepPreset.Incision:
+                return new PresetDefaults(
+                    Quality: "Slicing",
+                    Duration: SurgeryConstants.IncisionDuration,
+                    Popup: "surgery-step-incision",
+                    Damage: Slash(SurgeryConstants.IncisionSlashDamage),
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Incision,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: null);
+
+            case SurgeryStepPreset.Retract:
+                return new PresetDefaults(
+                    Quality: "Retracting",
+                    Duration: SurgeryConstants.RetractDuration,
+                    Popup: "surgery-step-retract",
+                    Damage: Blunt(SurgeryConstants.RetractBluntDamage),
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: null);
+
+            case SurgeryStepPreset.Clamp:
+                return new PresetDefaults(
+                    Quality: "Clamping",
+                    Duration: SurgeryConstants.ClampDuration,
+                    Popup: "surgery-step-clamp",
+                    Damage: null,
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.ClampFull,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: null);
+
+            case SurgeryStepPreset.Saw:
+                return new PresetDefaults(
+                    Quality: "Sawing",
+                    Duration: SurgeryConstants.SawDuration,
+                    Popup: "surgery-step-saw",
+                    Damage: Slash(SurgeryConstants.SawSlashDamage),
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: null);
+
+            case SurgeryStepPreset.TendBrute:
+                return new PresetDefaults(
+                    Quality: "Clamping",
+                    Duration: SurgeryConstants.TendStepDuration,
+                    Popup: "surgery-step-treat-brute",
+                    Damage: null,
+                    Healing: DamageTypes("Blunt", "Slash", "Piercing"),
+                    HealingFlat: SurgeryConstants.TendHealingFlat,
+                    HealingMultiplier: SurgeryConstants.TendHealingMultiplier,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: SurgeryConstants.TendBleedReduction,
+                    Repeatable: true,
+                    Effect: null);
+
+            case SurgeryStepPreset.TendBurn:
+                return new PresetDefaults(
+                    Quality: "Clamping",
+                    Duration: SurgeryConstants.TendStepDuration,
+                    Popup: "surgery-step-treat-burn",
+                    Damage: null,
+                    Healing: DamageTypes("Heat", "Shock", "Cold", "Caustic"),
+                    HealingFlat: SurgeryConstants.TendHealingFlat,
+                    HealingMultiplier: SurgeryConstants.TendHealingMultiplier,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: SurgeryConstants.TendBleedReduction,
+                    Repeatable: true,
+                    Effect: null);
+
+            case SurgeryStepPreset.RemoveOrgan:
+                return new PresetDefaults(
+                    Quality: "Clamping",
+                    Duration: SurgeryConstants.RemoveOrganDuration,
+                    Popup: "surgery-step-remove-organ",
+                    Damage: null,
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: 0,
+                    Repeatable: true,
+                    Effect: new RemoveOrganEffect());
+
+            case SurgeryStepPreset.CauterizeBurnWounds:
+                return new PresetDefaults(
+                    Quality: "Cauterizing",
+                    Duration: SurgeryConstants.WoundRepairDuration,
+                    Popup: "surgery-step-treat-burn-wounds",
+                    Damage: null,
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: new ClearWoundCategoryEffect { Category = Content.Shared.RussStation.Wounds.WoundCategory.Burn });
+
+            case SurgeryStepPreset.SetBones:
+                return new PresetDefaults(
+                    Quality: "BoneSetting",
+                    Duration: SurgeryConstants.WoundRepairDuration,
+                    Popup: "surgery-step-set-bones",
+                    Damage: null,
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: new ClearWoundCategoryEffect { Category = Content.Shared.RussStation.Wounds.WoundCategory.Fracture });
+
+            default:
+                return new PresetDefaults(
+                    Quality: default!,
+                    Duration: null,
+                    Popup: null,
+                    Damage: null,
+                    Healing: null,
+                    HealingFlat: 0,
+                    HealingMultiplier: 0,
+                    BleedPreset: SurgeryBleedPreset.Manual,
+                    BleedModifier: 0,
+                    Repeatable: false,
+                    Effect: null);
+        }
+    }
+
+    private static DamageSpecifier Slash(float amount)
+    {
+        var spec = new DamageSpecifier();
+        spec.DamageDict["Slash"] = FixedPoint2.New(amount);
+        return spec;
+    }
+
+    private static DamageSpecifier Blunt(float amount)
+    {
+        var spec = new DamageSpecifier();
+        spec.DamageDict["Blunt"] = FixedPoint2.New(amount);
+        return spec;
+    }
+
+    private static DamageSpecifier DamageTypes(params string[] types)
+    {
+        var spec = new DamageSpecifier();
+        foreach (var t in types)
+            spec.DamageDict[t] = FixedPoint2.New(1);
+        return spec;
+    }
+}

--- a/Content.Shared/RussStation/Surgery/Systems/SharedSurgerySystem.cs
+++ b/Content.Shared/RussStation/Surgery/Systems/SharedSurgerySystem.cs
@@ -10,23 +10,9 @@ namespace Content.Shared.RussStation.Surgery.Systems;
 
 public abstract partial class SharedSurgerySystem : EntitySystem
 {
+    protected static readonly ProtoId<AlertPrototype> SurgeryDrapedAlert = "SurgeryDraped";
+
     private static readonly ProtoId<ToolQualityPrototype> CauterizingQuality = "Cauterizing";
-
-    /// <summary>
-    /// Default step durations per tool quality, used when a step doesn't specify its own.
-    /// </summary>
-    private static readonly Dictionary<string, float> DefaultStepDurations = new()
-    {
-        { "Slicing", SurgeryConstants.DefaultSlicingDuration },
-        { "Retracting", SurgeryConstants.DefaultRetractingDuration },
-        { "Clamping", SurgeryConstants.DefaultClampingDuration },
-        { "Sawing", SurgeryConstants.DefaultSawingDuration },
-        { "Drilling", SurgeryConstants.DefaultDrillingDuration },
-        { "BoneSetting", SurgeryConstants.DefaultBoneSettingDuration },
-        { "Cauterizing", SurgeryConstants.DefaultCauterizingDuration },
-    };
-
-    private const float FallbackStepDuration = 2.0f;
 
     [Dependency] protected readonly AlertsSystem _alerts = default!;
     [Dependency] protected readonly SharedToolSystem _tool = default!;
@@ -59,7 +45,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
 
     private void OnDrapedShutdown(Entity<SurgeryDrapedComponent> ent, ref ComponentShutdown args)
     {
-        _alerts.ClearAlert(ent.Owner, "SurgeryDraped");
+        _alerts.ClearAlert(ent.Owner, SurgeryDrapedAlert);
 
         // Remove the visible drape overlay (spawned server-side on startup).
         if (ent.Comp.OverlayEntity is { } overlay && Exists(overlay))
@@ -78,30 +64,37 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     /// </summary>
     public bool ToolMatchesStep(EntityUid tool, SurgeryStep step)
     {
-        return _tool.HasQuality(tool, step.Quality);
+        return _tool.HasQuality(tool, step.GetQuality());
     }
 
     /// <summary>
-    /// Gets the base duration for a step: explicit override or centralized default.
+    /// Gets the base duration for a step: explicit override, preset default, or fallback. Every
+    /// in-use preset now carries a duration, so hitting the fallback means a procedure authored
+    /// with <see cref="SurgeryStepPreset.None"/> and no explicit duration.
     /// </summary>
     public static float GetBaseStepDuration(SurgeryStep step)
     {
-        if (step.Duration.HasValue)
-            return step.Duration.Value;
-
-        return DefaultStepDurations.GetValueOrDefault(step.Quality, FallbackStepDuration);
+        return step.GetDuration() ?? SurgeryConstants.FallbackStepDuration;
     }
 
     /// <summary>
-    /// Gets the effective DoAfter duration for a surgery step, incorporating
-    /// surface, drape, and difficulty modifiers (not tool tier, that's server-side).
+    /// Gets the effective DoAfter duration for a surgery step, incorporating surface, drape, and
+    /// difficulty modifiers (not tool tier, that's server-side). Also raises a
+    /// <see cref="SurgeryStepDurationModifierEvent"/> so subscribers can stack their own per-step
+    /// multipliers without touching this system.
     /// </summary>
-    public TimeSpan GetStepDuration(SurgeryStep step, EntityUid patient, SurgeryDifficulty difficulty)
+    public TimeSpan GetStepDuration(SurgeryStep step, EntityUid patient, SurgeryDifficulty difficulty, EntityUid? surgeon = null)
     {
+        var ev = new SurgeryStepDurationModifierEvent(step, patient, surgeon);
+        RaiseLocalEvent(patient, ref ev);
+        if (surgeon is { } surgeonUid)
+            RaiseLocalEvent(surgeonUid, ref ev);
+
         return TimeSpan.FromSeconds(GetBaseStepDuration(step)
             * GetSurfaceSpeedModifier(patient)
             * GetDrapeSpeedModifier(patient)
-            * GetDifficultyModifier(difficulty));
+            * GetDifficultyModifier(difficulty)
+            * ev.Multiplier);
     }
 
     /// <summary>

--- a/Content.Tests/RussStation/Surgery/SurgeryStepPresetsTest.cs
+++ b/Content.Tests/RussStation/Surgery/SurgeryStepPresetsTest.cs
@@ -1,0 +1,152 @@
+using Content.Shared.RussStation.Surgery;
+using NUnit.Framework;
+
+namespace Content.Tests.RussStation.Surgery;
+
+/// <summary>
+/// Pure unit tests for <see cref="SurgeryStepPresets.Resolve"/>. These guard the preset table from
+/// accidental changes: any edit that shifts the surgery numbers or swaps tool qualities breaks
+/// these deliberately so the author has to update both.
+/// </summary>
+[TestFixture]
+public sealed class SurgeryStepPresetsTest
+{
+    [Test]
+    public void IncisionPreset_UsesSlicingQualityAndIncisionBleed()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.Incision);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Slicing"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.IncisionDuration));
+            Assert.That(defaults.BleedPreset, Is.EqualTo(SurgeryBleedPreset.Incision));
+            Assert.That(defaults.Repeatable, Is.False);
+        });
+    }
+
+    [Test]
+    public void ClampPreset_UsesClampingQualityAndFullBleedReversal()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.Clamp);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Clamping"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.ClampDuration));
+            Assert.That(defaults.BleedPreset, Is.EqualTo(SurgeryBleedPreset.ClampFull));
+            Assert.That(defaults.Effect, Is.Null);
+        });
+    }
+
+    [Test]
+    public void RetractPreset_UsesRetractingQualityAndBluntDamage()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.Retract);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Retracting"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.RetractDuration));
+            Assert.That(defaults.Damage?.DamageDict.ContainsKey("Blunt"), Is.True);
+        });
+    }
+
+    [Test]
+    public void SawPreset_UsesSawingQualityAndSlashDamage()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.Saw);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Sawing"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.SawDuration));
+            Assert.That(defaults.Damage?.DamageDict.ContainsKey("Slash"), Is.True);
+        });
+    }
+
+    [Test]
+    public void TendBrutePreset_HasHealingBudgetAndRepeats()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.TendBrute);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Clamping"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.TendStepDuration));
+            Assert.That(defaults.Repeatable, Is.True);
+            Assert.That(defaults.HealingFlat, Is.EqualTo(SurgeryConstants.TendHealingFlat));
+            Assert.That(defaults.HealingMultiplier, Is.EqualTo(SurgeryConstants.TendHealingMultiplier));
+            Assert.That(defaults.Healing, Is.Not.Null);
+            Assert.That(defaults.Healing!.DamageDict.Keys, Does.Contain("Blunt"));
+        });
+    }
+
+    [Test]
+    public void TendBurnPreset_HealsBurnDamageTypes()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.TendBurn);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Healing, Is.Not.Null);
+            Assert.That(defaults.Healing!.DamageDict.Keys, Does.Contain("Heat"));
+            Assert.That(defaults.Healing.DamageDict.Keys, Does.Not.Contain("Blunt"));
+            Assert.That(defaults.Repeatable, Is.True);
+        });
+    }
+
+    [Test]
+    public void RemoveOrganPreset_CarriesOrganEffect()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.RemoveOrgan);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Clamping"));
+            Assert.That(defaults.Repeatable, Is.True);
+            Assert.That(defaults.Effect, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void CauterizeBurnWoundsPreset_UsesCauterizingAndClearsBurns()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.CauterizeBurnWounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("Cauterizing"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.WoundRepairDuration));
+            Assert.That(defaults.Effect, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void SetBonesPreset_UsesBoneSettingAndClearsFractures()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.SetBones);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Quality.Id, Is.EqualTo("BoneSetting"));
+            Assert.That(defaults.Duration, Is.EqualTo(SurgeryConstants.WoundRepairDuration));
+            Assert.That(defaults.Effect, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void NonePreset_ReturnsEmptyDefaults()
+    {
+        var defaults = SurgeryStepPresets.Resolve(SurgeryStepPreset.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(defaults.Duration, Is.Null);
+            Assert.That(defaults.Damage, Is.Null);
+            Assert.That(defaults.Healing, Is.Null);
+            Assert.That(defaults.Effect, Is.Null);
+            Assert.That(defaults.Repeatable, Is.False);
+        });
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -10,16 +10,16 @@ surgery-procedure-started = You begin {$procedure} on {THE($target)}.
 surgery-procedure-complete = The procedure is complete. Cauterize to close the wound.
 
 ## Step Popups
-surgery-step-incision = {CAPITALIZE(THE($user))} makes an incision in {THE($target)}.
-surgery-step-retract = {CAPITALIZE(THE($user))} retracts the incision on {THE($target)}.
-surgery-step-clamp = {CAPITALIZE(THE($user))} clamps the blood vessels on {THE($target)}.
-surgery-step-saw = {CAPITALIZE(THE($user))} saws through tissue on {THE($target)}.
-surgery-step-cauterize = {CAPITALIZE(THE($user))} cauterizes the wound on {THE($target)}.
-surgery-step-treat-brute = {CAPITALIZE(THE($user))} repairs physical damage on {THE($target)}.
-surgery-step-treat-burn = {CAPITALIZE(THE($user))} treats burn damage on {THE($target)}.
-surgery-step-remove-organ = {CAPITALIZE(THE($user))} carefully extracts an organ from {THE($target)}.
-surgery-step-set-bones = {CAPITALIZE(THE($user))} sets {POSS-ADJ($target)} broken bones.
-surgery-step-treat-burn-wounds = {CAPITALIZE(THE($user))} dresses and cauterizes {POSS-ADJ($target)} burns.
+surgery-step-incision = {CAPITALIZE(THE($user))} slices {THE($target)} open. Blood wells up around the cut.
+surgery-step-retract = {CAPITALIZE(THE($user))} pries the incision apart, exposing raw tissue.
+surgery-step-clamp = {CAPITALIZE(THE($user))} clamps the severed vessels shut on {THE($target)}, stemming the bleed.
+surgery-step-saw = {CAPITALIZE(THE($user))} saws through dense tissue on {THE($target)}.
+surgery-step-cauterize = {CAPITALIZE(THE($user))} sears the wound on {THE($target)} shut with a sizzle.
+surgery-step-treat-brute = {CAPITALIZE(THE($user))} stitches torn muscle on {THE($target)} back together.
+surgery-step-treat-burn = {CAPITALIZE(THE($user))} scrapes away charred flesh on {THE($target)} and dresses what's left.
+surgery-step-remove-organ = {CAPITALIZE(THE($user))} plunges a hand into {THE($target)} and pulls out an organ.
+surgery-step-set-bones = {CAPITALIZE(THE($user))} wrenches {POSS-ADJ($target)} shattered bones back into line.
+surgery-step-treat-burn-wounds = {CAPITALIZE(THE($user))} cauterizes and dresses {POSS-ADJ($target)} weeping burns.
 
 ## Alerts
 alerts-surgery-draped-name = Surgical Drapes

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/organ_manipulation.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/organ_manipulation.yml
@@ -8,26 +8,8 @@
   category: OrganManipulation
   difficulty: Major
   steps:
-    - quality: Slicing
-      popup: surgery-step-incision
-      damage:
-        types:
-          Slash: 5
-      bleedModifier: 3.0
-    - quality: Retracting
-      popup: surgery-step-retract
-      damage:
-        types:
-          Blunt: 2
-    - quality: Clamping
-      popup: surgery-step-clamp
-      bleedModifier: -3.0
-    - quality: Sawing
-      popup: surgery-step-saw
-      damage:
-        types:
-          Slash: 3
-    - quality: Clamping
-      popup: surgery-step-remove-organ
-      repeatable: true
-      effect: !type:RemoveOrganEffect {}
+    - preset: Incision
+    - preset: Retract
+    - preset: Clamp
+    - preset: Saw
+    - preset: RemoveOrgan

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_brute.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_brute.yml
@@ -8,26 +8,6 @@
   category: TendWounds
   difficulty: Minor
   steps:
-    - quality: Slicing
-      popup: surgery-step-incision
-      damage:
-        types:
-          Slash: 5
-      bleedModifier: 3.0
-    - quality: Retracting
-      popup: surgery-step-retract
-      damage:
-        types:
-          Blunt: 2
-    - quality: Clamping
-      duration: 2.5
-      popup: surgery-step-treat-brute
-      repeatable: true
-      healingFlat: 5
-      healingMultiplier: 0.07
-      healing:
-        types:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
-      bleedModifier: -1.0
+    - preset: Incision
+    - preset: Retract
+    - preset: TendBrute

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_burn.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/tend_wounds_burn.yml
@@ -8,27 +8,6 @@
   category: TendWounds
   difficulty: Minor
   steps:
-    - quality: Slicing
-      popup: surgery-step-incision
-      damage:
-        types:
-          Slash: 5
-      bleedModifier: 3.0
-    - quality: Retracting
-      popup: surgery-step-retract
-      damage:
-        types:
-          Blunt: 2
-    - quality: Clamping
-      duration: 2.5
-      popup: surgery-step-treat-burn
-      repeatable: true
-      healingFlat: 5
-      healingMultiplier: 0.07
-      healing:
-        types:
-          Heat: 1
-          Shock: 1
-          Cold: 1
-          Caustic: 1
-      bleedModifier: -1.0
+    - preset: Incision
+    - preset: Retract
+    - preset: TendBurn

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_burn.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_burn.yml
@@ -8,8 +8,4 @@
   category: WoundRepair
   difficulty: Minor
   steps:
-    - quality: Cauterizing
-      duration: 6
-      popup: surgery-step-treat-burn-wounds
-      effect: !type:ClearWoundCategoryEffect
-        category: Burn
+    - preset: CauterizeBurnWounds

--- a/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_fracture.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/procedures/wound_repair_fracture.yml
@@ -8,8 +8,4 @@
   category: WoundRepair
   difficulty: Minor
   steps:
-    - quality: BoneSetting
-      duration: 6
-      popup: surgery-step-set-bones
-      effect: !type:ClearWoundCategoryEffect
-        category: Fracture
+    - preset: SetBones


### PR DESCRIPTION
## About the PR

Every surgery procedure YAML used to carry the same numbers inline: incision step declares \`Slash: 5\` and \`bleedModifier: 3\`, the next procedure declares the same thing again, and so on. This pulls all those numbers into \`SurgeryConstants\` and introduces a \`SurgeryStepPreset\` enum that names each recurring step shape (Incision, Retract, Clamp, Saw, TendBrute, TendBurn, RemoveOrgan, CauterizeBurnWounds, SetBones). Procedure YAMLs become a list of preset names.

Along the way, the step damage numbers got tripled (incision 15 slash, retract 6 blunt, saw 9 slash) and the incision bleed bumped to roughly 40 seconds of natural clot time. Mid-surgery states are meant to feel dangerous now; interrupt consequences land in a follow-up PR that hooks into this structure.

## Why / Balance

Three things in one.

1. Surgery authoring got simpler. Adding a new organ-removal procedure used to mean copy-pasting five steps with their damage / bleed / healing tuning. Now it's a list of preset references.
2. Tuning lives in one place. Any future rebalance (\"tend wounds heals too slowly\", \"incisions bleed too much\") is one constant instead of five YAMLs.
3. Step impact is meaningful. A clean organ manipulation leaves a patient down ~30 HP plus bleed; enough that a rushed surgeon leaves a mark. Tune further if playtest says it's too cruel.

## Technical details

- \`SurgeryStepPreset\` enum plus \`SurgeryStepPresets.Resolve\` static table. Each preset maps to a \`PresetDefaults\` record carrying tool quality, base duration, popup loc, damage spec, healing spec + flat + multiplier, bleed preset, repeatable flag, and terminal effect.
- \`SurgeryBleedPreset\` (Manual / Incision / ClampFull) resolved in \`ApplyStepEffects\`. Incision / Clamp step bleed deltas reference \`IncisionBleedAmount\` (= 3 × \`InterruptBleedBaseRate\`) instead of hardcoded floats.
- \`SurgeryStepExtensions\` provides \`step.GetQuality()\`, \`GetDuration()\`, etc. Each returns the explicit step field when set, otherwise the preset default. Callsites in \`SurgerySystem\` / \`SharedSurgerySystem\` / existing integration tests migrated to these.
- New constants: \`IncisionSlashDamage = 15\`, \`RetractBluntDamage = 6\`, \`SawSlashDamage = 9\`, \`TendHealingFlat = 5\`, \`TendHealingMultiplier = 0.07\`, \`TendBleedReduction = -1\`, \`TendStepDuration = 2.5\`, \`WoundRepairDuration = 6\`, plus \`Incision/Retract/Clamp/Saw/RemoveOrganDuration\` mirroring the existing quality defaults.
- \`SurgeryStepDurationModifierEvent\` (\`[ByRefEvent]\`) is raised on patient and surgeon from \`GetStepDuration\`. External systems can stack per-step multipliers without touching this subsystem.
- Tool tier ladder in \`GetToolTierModifier\` collapsed to a \`Dictionary<ProtoId<TagPrototype>, float>\` iterated lookup since tools carry exactly one tier tag.
- Small cleanups: \`FallbackStepDuration\`, \`SurgeryDrapeContainerId\`, and the \`SurgeryDrapedAlert\` ProtoId moved into central spots. Procedure YAMLs shrink to preset names only.
- Step popup strings rewritten to match the tuned numbers without being gratuitous.
- \`SurgeryStepPresetsTest\` (Content.Tests) covers every preset. \`ProcedurePresetsResolveConsistentlyTest\` (Content.IntegrationTests) walks every shipped procedure and asserts preset-driven steps resolve to the preset's declared quality, duration, and repeatable.

## Media

_adding shortly_

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches. (See \`BRANCHING.md\`.)
- [X] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix. (See \`CONTRIBUTING.md\`.)

## Breaking changes

Procedure YAMLs no longer accept arbitrary step field combinations as cleanly; authors should pick a preset and override only the fields that genuinely differ. Everything the fork currently ships with has been migrated.

**Changelog**

:cl:
- tweak: Surgery step impact bumped. Incisions, retracts, and saw steps deal more damage and bleed longer. Cautery is the only clean way to close.