### PR TITLE
fix: trolley bucket drink and alt-click/E binding swap

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -111,6 +111,12 @@ public sealed partial class IngestionSystem
         if (!ent.Comp.Slots.Any(slot => slot.Value.HasItem))
             return;
 
+        //HONK START - fork containers (janitorial trolley) opt out of this block via a marker
+        // component so the trolley's bucket drink still works while tools are stowed.
+        if (HasComp<Content.Shared.RussStation.Janitorial.IgnoreItemSlotsEdibleBlockComponent>(ent))
+            return;
+        //HONK END
+
         args.Cancelled = true;
 
         _popup.PopupClient(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);

--- a/Content.Shared/RussStation/ItemSlots/ItemSlotEjectMenuSystem.cs
+++ b/Content.Shared/RussStation/ItemSlots/ItemSlotEjectMenuSystem.cs
@@ -18,8 +18,36 @@ public sealed class ItemSlotEjectMenuSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ItemSlotEjectMenuComponent, InteractHandEvent>(OnInteractHand);
-        SubscribeLocalEvent<ItemSlotEjectMenuComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
+        SubscribeLocalEvent<ItemSlotEjectMenuComponent, ActivateInWorldEvent>(OnActivate);
         SubscribeLocalEvent<ItemSlotEjectMenuComponent, ItemSlotEjectMenuEjectMessage>(OnEjectMessage);
+    }
+
+    /// <summary>
+    ///     Activate-in-world (E): open the radial eject menu if any slot is occupied.
+    /// </summary>
+    private void OnActivate(EntityUid uid, ItemSlotEjectMenuComponent comp, ActivateInWorldEvent args)
+    {
+        if (args.Handled || !args.Complex)
+            return;
+
+        if (!TryComp<ItemSlotsComponent>(uid, out var itemSlots))
+            return;
+
+        var hasOccupied = false;
+        foreach (var slot in itemSlots.Slots.Values)
+        {
+            if (slot.Item != null)
+            {
+                hasOccupied = true;
+                break;
+            }
+        }
+
+        if (!hasOccupied)
+            return;
+
+        _ui.TryToggleUi(uid, ItemSlotEjectMenuUiKey.Key, args.User);
+        args.Handled = true;
     }
 
     /// <summary>
@@ -45,54 +73,6 @@ public sealed class ItemSlotEjectMenuSystem : EntitySystem
                 return;
             }
         }
-    }
-
-    /// <summary>
-    ///     Alt-click: add a verb that opens the radial eject menu.
-    /// </summary>
-    private void OnGetAltVerbs(EntityUid uid, ItemSlotEjectMenuComponent comp, GetVerbsEvent<AlternativeVerb> args)
-    {
-        if (args.Hands == null || !args.CanAccess || !args.CanInteract)
-            return;
-
-        if (!TryComp<ItemSlotsComponent>(uid, out var itemSlots))
-            return;
-
-        // If the user is holding an item that fits any slot, let the upstream insert verbs win.
-        if (args.Using != null)
-        {
-            foreach (var slot in itemSlots.Slots.Values)
-            {
-                if (slot.InsertOnInteract)
-                    continue;
-
-                if (_itemSlots.CanInsert(uid, args.Using.Value, args.User, slot))
-                    return;
-            }
-        }
-
-        // Only show the radial menu verb if there's at least one occupied slot to eject.
-        var hasOccupied = false;
-        foreach (var slot in itemSlots.Slots.Values)
-        {
-            if (slot.Item != null)
-            {
-                hasOccupied = true;
-                break;
-            }
-        }
-
-        if (!hasOccupied)
-            return;
-
-        var user = args.User;
-        args.Verbs.Add(new AlternativeVerb
-        {
-            Text = Loc.GetString("item-slot-eject-menu-verb"),
-            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/eject.svg.192dpi.png")),
-            Act = () => _ui.TryToggleUi(uid, ItemSlotEjectMenuUiKey.Key, user),
-            Priority = ItemSlotsConstants.EjectVerbPriority
-        });
     }
 
     /// <summary>

--- a/Content.Shared/RussStation/Janitorial/IgnoreItemSlotsEdibleBlockComponent.cs
+++ b/Content.Shared/RussStation/Janitorial/IgnoreItemSlotsEdibleBlockComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared.RussStation.Janitorial;
+
+/// <summary>
+/// Marker: skip upstream's "has stored items, can't drink" cancellation in
+/// <c>IngestionSystem.OnItemSlotsEdible</c> for this entity. Used by the janitorial trolley so
+/// drinking from its bucket works even when a mop or plunger is stowed in the other slots.
+/// </summary>
+[RegisterComponent]
+public sealed partial class IgnoreItemSlotsEdibleBlockComponent : Component
+{
+}

--- a/Content.Shared/RussStation/Janitorial/JanitorialTrolleySystem.cs
+++ b/Content.Shared/RussStation/Janitorial/JanitorialTrolleySystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Interaction;
-using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Verbs;
@@ -9,12 +8,12 @@ using Content.Shared.Whitelist;
 namespace Content.Shared.RussStation.Janitorial;
 
 /// <summary>
-///     Trolley-specific interactions: trash bag pass-through on left-click, and
-///     routes the drink interaction to ActivateInWorld (E) instead of the alt-verb.
+///     Trolley-specific interactions: trash bag pass-through on left-click, and alt-verb filtering
+///     so alt-click surfaces Drink / Insert without the per-slot Eject verbs. Ejecting lives on
+///     left-click (priority pop) and E (radial menu) instead.
 /// </summary>
 public sealed class JanitorialTrolleySystem : EntitySystem
 {
-    [Dependency] private readonly IngestionSystem _ingestion = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
@@ -24,10 +23,17 @@ public sealed class JanitorialTrolleySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<JanitorialTrolleyComponent, InteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<JanitorialTrolleyComponent, ActivateInWorldEvent>(OnActivate);
         SubscribeLocalEvent<JanitorialTrolleyComponent, GetVerbsEvent<AlternativeVerb>>(
             OnGetAltVerbs,
-            after: [typeof(IngestionSystem)]);
+            after: [typeof(ItemSlotsSystem)]);
+    }
+
+    // Remove the per-slot Eject alt-verbs upstream's ItemSlotsSystem adds. The trolley uses E
+    // (radial menu) and empty-hand left-click (priority pop) for ejection; alt-click should only
+    // offer Drink and Insert.
+    private void OnGetAltVerbs(EntityUid uid, JanitorialTrolleyComponent comp, GetVerbsEvent<AlternativeVerb> args)
+    {
+        args.Verbs.RemoveWhere(v => v.Category == VerbCategory.Eject);
     }
 
     private void OnInteractUsing(EntityUid uid, JanitorialTrolleyComponent comp, InteractUsingEvent args)
@@ -61,20 +67,4 @@ public sealed class JanitorialTrolleySystem : EntitySystem
             args.Handled = true;
     }
 
-    private void OnActivate(EntityUid uid, JanitorialTrolleyComponent comp, ActivateInWorldEvent args)
-    {
-        if (args.Handled || !args.Complex)
-            return;
-
-        if (_ingestion.TryIngest(args.User, uid))
-            args.Handled = true;
-    }
-
-    // Remove the drink alt-verb so alt-click stays reserved for the eject menu.
-    // Drinking is handled by ActivateInWorld (E) above.
-    private void OnGetAltVerbs(EntityUid uid, JanitorialTrolleyComponent comp, GetVerbsEvent<AlternativeVerb> args)
-    {
-        var drinkText = Loc.GetString("ingestion-verb-drink");
-        args.Verbs.RemoveWhere(v => v.Text == drinkText);
-    }
 }

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -402,6 +402,9 @@
   # HONK START - Left-click inserts into trash bag if item doesn't fit a trolley slot
   - type: JanitorialTrolley
   # HONK END
+  # HONK START - Skip upstream's "slots are full, can't drink" popup on the trolley bucket
+  - type: IgnoreItemSlotsEdibleBlock
+  # HONK END
   - type: GuideHelp
     guides:
     - Janitorial

--- a/Resources/ServerInfo/Guidebook/Service/Janitorial.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Janitorial.xml
@@ -82,11 +82,11 @@ Small, slippery, useful twice over. Cleans tiles and floors anyone running acros
 Your [color=#88ccff]janitorial trolley[/color] is the closest thing to a mobile office you'll ever get. It has dedicated slots for your mop, trash bag, bucket, plunger, light replacer, spray bottle, and up to four wet floor signs, plus enough room in the trash bag for whatever disasters you find on the way. A few tricks the tutorial doesn't mention:
 
 - With a janitorial tool in hand, press [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] on the trolley to drop it into the matching slot. No fumbling, no misclicks.
-- With anything else (or an empty hand), [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] opens a [italic]radial menu[/italic]. Perfect for when you need your plunger and your mop is in the way.
+- With anything else (or an empty hand), [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color] opens a [italic]radial menu[/italic]. Perfect for when you need your plunger and your mop is in the way.
 - An empty-hand [color=yellow][bold][keybind="Use"][/bold][/color] yanks out the highest-priority item, which is usually your mop. Quick-draw.
 - [bold]Found trash on the floor?[/bold] Scoop it up, click the trolley, and it drops straight into the bag. No need to dig the bag out first.
 - Dragging a [color=#88ccff]sink[/color] or [color=#88ccff]floor drain[/color] onto the trolley tops up the bucket in place. Beats parking next to the sink every five minutes.
-- And if you really must, [color=yellow][bold][keybind="ActivateItemInWorld"][/bold][/color] lets you [italic]drink[/italic] from the bucket. The chaplain says it builds character.
+- And if you really must, [color=yellow][bold][keybind="AltActivateItemInWorld"][/bold][/color] lets you [italic]drink[/italic] from the bucket. The chaplain says it builds character.
 
 ## Extra Duties
 A good janitor is always on the lookout for a bit more to do. Keep an eye out for broken lights, help the chef take care of mice in the kitchen, and if you're feeling -really- generous, try to restock the vending machines and emergency closets around the station. Cargo will also take scrap off your hands; a full trash bag now and then adds up over a shift.


### PR DESCRIPTION
## About the PR

Two fixes on the janitorial trolley, one lead cause and one that surfaced while testing.

First, drinking from the bucket failed any time another slot was occupied. Upstream's ingestion blocker cancels drink attempts on ItemSlots entities whenever any slot has something in it, and pops a \"has stored items\" message. The trolley's bucket solution lives outside those slots, so the block was incorrect here. A small fork marker component opts the trolley out of that specific cancellation.

Second, while poking at it I had the alt-click/E bindings swapped relative to the SS14 convention. This PR flips them: alt-click is the verb menu (drink / insert), E opens the eject radial. Empty-hand left-click still yanks the highest-priority slot.

Closes #611.

## Why / Balance

Pure UX fix. No gameplay impact.

The trolley's bucket was advertised in the guidebook as drinkable, and this made that claim work reliably instead of only when the cart was empty. The binding swap lines the trolley up with how every other edible container in SS14 behaves, so the muscle memory players already have just works.

## Technical details

- \`IgnoreItemSlotsEdibleBlockComponent\` is a marker on the trolley prototype. A HONK-wrapped check in \`IngestionSystem.OnItemSlotsEdible\` skips the cancellation when the target has this component.
- \`ItemSlotEjectMenuSystem\` grows an \`ActivateInWorldEvent\` subscriber that toggles the radial eject UI when any slot is occupied, and drops its now-redundant alt-verb.
- \`JanitorialTrolleySystem\` removes its drink-on-E handler and drink-verb strip. Adds a \`GetVerbsEvent<AlternativeVerb>\` subscriber that strips the per-slot Eject alt-verbs (\`VerbCategory.Eject\`) so alt-click only shows Drink / Insert.
- Trolley prototype gets the marker via HONK block.
- Guidebook keybind swap: the radial menu bullet now references \`ActivateItemInWorld\`, the drink bullet now references \`AltActivateItemInWorld\`. Everything else in \"Your Cart\" is unchanged.

## Media

_n/a_

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches. (See \`BRANCHING.md\`.)
- [X] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix. (See \`CONTRIBUTING.md\`.)

## Breaking changes

None. The alt-click/E swap is a UX change, not a removed capability.

**Changelog**

:cl:
- fix: You can drink from the janitorial trolley's bucket even when tools are stowed in the other slots.
- tweak: Alt-click on the trolley now opens the standard verb menu (drink, insert). Pressing [ActivateItemInWorld] opens the radial eject menu. Empty-hand left-click still yanks the top-priority slot.