### PR TITLE
honksquad: fix: wound repair surgeries reject patients with no matching wounds

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
@@ -5,6 +5,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.RussStation.Surgery.Effects;
+using Content.Shared.RussStation.Wounds;
 
 namespace Content.Server.RussStation.Surgery;
 
@@ -127,35 +128,48 @@ public sealed partial class SurgerySystem
     }
 
     /// <summary>
-    /// True if any healing step in the procedure has at least one target damage type
-    /// the patient currently carries above a small epsilon. Procedures whose only
-    /// useful effect is healing (tend-wounds) fail this check on an uninjured patient.
-    /// Procedures with no healing steps (e.g. organ manipulation) always pass.
+    /// True if the procedure has at least one useful step whose target condition
+    /// is present on the patient: a healing step matching current damage above a
+    /// small epsilon, or a wound-clearing step matching an active wound category.
+    /// Procedures with no healing or wound-clearing steps (e.g. organ manipulation)
+    /// always pass.
     /// </summary>
     private bool ProcedureHasAnythingToTend(EntityUid patient, SurgeryProcedurePrototype proto)
     {
-        if (!TryComp<DamageableComponent>(patient, out var damageable))
-            return true;
+        var hasUsefulStep = false;
+        DamageSpecifier? currentDamage = null;
+        if (TryComp<DamageableComponent>(patient, out var damageable))
+            currentDamage = _damageable.GetPositiveDamage((patient, damageable));
 
-        var hasHealingStep = false;
-        var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
+        TryComp<WoundComponent>(patient, out var wounds);
 
         foreach (var step in proto.Steps)
         {
             var healing = step.GetHealing();
-            if (healing == null)
-                continue;
-
-            hasHealingStep = true;
-
-            foreach (var type in healing.DamageDict.Keys)
+            if (healing != null)
             {
-                if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > FixedPoint2.New(SurgeryConstants.HealingDamageEpsilon))
+                hasUsefulStep = true;
+
+                if (currentDamage != null)
+                {
+                    foreach (var type in healing.DamageDict.Keys)
+                    {
+                        if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > FixedPoint2.New(SurgeryConstants.HealingDamageEpsilon))
+                            return true;
+                    }
+                }
+            }
+
+            if (step.GetEffect() is ClearWoundCategoryEffect clear)
+            {
+                hasUsefulStep = true;
+
+                if (wounds != null && _wounds.GetWorstTier(wounds, clear.Category) > 0)
                     return true;
             }
         }
 
-        return !hasHealingStep;
+        return !hasUsefulStep;
     }
 
     private bool StepCanStillHeal(EntityUid patient, SurgeryStep step)


### PR DESCRIPTION
## About the PR

Wound-repair procedures (`WoundRepairBurn`, `WoundRepairFracture`) now refuse to drape when the patient has no wounds in the category the procedure targets. Matches the existing tend-wounds reject behaviour.

Closes #615.

## Why / Balance

Before this, a surgeon could drape and run a wound-repair procedure on a patient with no burns or no fractures. The procedure ate time and step damage (including incision bleed on a healthy patient) for zero effect. Tend-wound procedures already reject this case; wound-repair procedures slipped through because the existing check only looked at damage types.

## Technical details

`ProcedureHasAnythingToTend` in `Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs` previously only counted healing steps as "useful". It now also counts steps whose terminal effect is `ClearWoundCategoryEffect`: the step is only useful if the patient currently has at least one active wound in that category (checked via `SharedWoundSystem.GetWorstTier`). A procedure passes if any useful step has work to do; a procedure with no useful steps at all (organ manipulation, etc.) still passes unconditionally. The existing `surgery-nothing-to-tend` popup is reused, since the reject path is the same.

## Media

N/A, behaviour change only, surfaces via the existing reject popup.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Wound-repair surgeries now refuse to start on patients who have no wounds in the matching category.