### PR TITLE
honksquad: fix: drapes fall off and cancel surgery when patient stands

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.Interrupt.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Interrupt.cs
@@ -70,7 +70,7 @@ public sealed partial class SurgerySystem
         var cauteryStep = -1;
         for (var i = 0; i < proto.Steps.Count; i++)
         {
-            var quality = proto.Steps[i].Quality;
+            var quality = proto.Steps[i].GetQuality();
             if (incisionStep < 0 && quality == InterruptSlicingQuality)
                 incisionStep = i;
             else if (incisionStep >= 0 && clampStep < 0 && quality == InterruptClampingQuality)

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Interrupt.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Interrupt.cs
@@ -1,0 +1,94 @@
+using Content.Shared.Buckle.Components;
+using Content.Shared.RussStation.Surgery;
+using Content.Shared.RussStation.Surgery.Components;
+using Content.Shared.Standing;
+using Content.Shared.Tools;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Surgery;
+
+public sealed partial class SurgerySystem
+{
+    private static readonly ProtoId<ToolQualityPrototype> InterruptSlicingQuality = "Slicing";
+    private static readonly ProtoId<ToolQualityPrototype> InterruptClampingQuality = "Clamping";
+    private static readonly ProtoId<ToolQualityPrototype> InterruptCauterizingQuality = "Cauterizing";
+
+    private void InitializeInterrupt()
+    {
+        SubscribeLocalEvent<SurgeryDrapedComponent, StoodEvent>(OnDrapedStood);
+        SubscribeLocalEvent<SurgeryDrapedComponent, UnbuckledEvent>(OnDrapedUnbuckled);
+    }
+
+    private void OnDrapedStood(Entity<SurgeryDrapedComponent> ent, ref StoodEvent args)
+    {
+        CancelActiveSurgery(ent.Owner);
+    }
+
+    private void OnDrapedUnbuckled(Entity<SurgeryDrapedComponent> ent, ref UnbuckledEvent args)
+    {
+        // Only react when the patient was on a dedicated surgery surface; slipping off a chair
+        // back-rest or a random bed shouldn't void an ongoing procedure.
+        if (!HasComp<SurgerySurfaceComponent>(args.Strap.Owner))
+            return;
+
+        CancelActiveSurgery(ent.Owner);
+    }
+
+    // Tears down a draped patient's active procedure, applies the clamp-release consequence when
+    // applicable, and notifies surgeon + patient. The DoAfter itself is cancelled by BreakOnMove
+    // on the surgery DoAfterArgs, so we only need to clean up components and popups here.
+    private void CancelActiveSurgery(EntityUid patient)
+    {
+        EntityUid? surgeon = null;
+        if (_activeSurgeryQuery.TryComp(patient, out var active))
+        {
+            ApplyInterruptConsequences(patient, active);
+            surgeon = active.Surgeon;
+        }
+
+        RemComp<ActiveSurgeryComponent>(patient);
+        // OnDrapedShutdown drops the bedsheet, clears the alert, and deletes the drape visual.
+        // Removed last so the popups below still have a valid patient.
+        RemComp<SurgeryDrapedComponent>(patient);
+
+        _popup.PopupEntity(Loc.GetString("surgery-interrupt-patient"), patient, patient);
+        if (surgeon is { } surgeonUid && Exists(surgeonUid))
+            _popup.PopupEntity(Loc.GetString("surgery-interrupt-surgeon", ("target", patient)), patient, surgeonUid);
+    }
+
+    // Restores the bleed the hemostat had clamped off, when the procedure started with an incision,
+    // reached a clamping step, and hasn't cauterised yet. Any other phase leaves the accumulated
+    // step effects as they are: those effects are the consequence on their own.
+    private void ApplyInterruptConsequences(EntityUid patient, ActiveSurgeryComponent active)
+    {
+        if (active.ProcedureId is not { } procId ||
+            !ProtoManager.TryIndex<SurgeryProcedurePrototype>(procId, out var proto))
+            return;
+
+        var incisionStep = -1;
+        var clampStep = -1;
+        var cauteryStep = -1;
+        for (var i = 0; i < proto.Steps.Count; i++)
+        {
+            var quality = proto.Steps[i].Quality;
+            if (incisionStep < 0 && quality == InterruptSlicingQuality)
+                incisionStep = i;
+            else if (incisionStep >= 0 && clampStep < 0 && quality == InterruptClampingQuality)
+                clampStep = i;
+            else if (quality == InterruptCauterizingQuality)
+            {
+                cauteryStep = i;
+                break;
+            }
+        }
+
+        if (incisionStep < 0 || clampStep < 0)
+            return;
+        if (active.CurrentStep <= clampStep)
+            return;
+        if (cauteryStep >= 0 && active.CurrentStep > cauteryStep)
+            return;
+
+        _bloodstream.TryModifyBleedAmount((patient, null), SurgeryConstants.IncisionBleedAmount);
+    }
+}

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -65,6 +65,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
 
         InitializeOrgans();
+        InitializeInterrupt();
         CacheProcedureIds();
     }
 

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -57,7 +57,6 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         SubscribeLocalEvent<ActiveSurgeryComponent, SurgeryStepDoAfterEvent>(OnStepDoAfter);
         SubscribeLocalEvent<ActiveSurgeryComponent, SurgeryCauteryDoAfterEvent>(OnCauteryDoAfter);
         SubscribeLocalEvent<SurgeryDrapedComponent, ComponentStartup>(OnDrapedStartup);
-        SubscribeLocalEvent<SurgeryDrapedComponent, RemoveSurgeryDrapeAlertEvent>(OnRemoveDrapeAlert);
 
         SubscribeNetworkEvent<SelectSurgeryProcedureEvent>(OnProcedureSelected);
         SubscribeNetworkEvent<SelectOrganEvent>(OnOrganSelected);
@@ -146,16 +145,6 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     private void OnDrapedStartup(Entity<SurgeryDrapedComponent> ent, ref ComponentStartup args)
     {
         _alerts.ShowAlert(ent.Owner, SurgeryDrapedAlert);
-    }
-
-    private void OnRemoveDrapeAlert(Entity<SurgeryDrapedComponent> ent, ref RemoveSurgeryDrapeAlertEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        args.Handled = true;
-        RemComp<ActiveSurgeryComponent>(ent);
-        RemComp<SurgeryDrapedComponent>(ent); // Triggers OnDrapedShutdown -> drops bedsheet, clears alert
     }
 
     private void OpenProcedureMenu(EntityUid surgeon, EntityUid patient, EntityUid bedsheet)

--- a/Content.Shared/RussStation/Surgery/Components/RemoveSurgeryDrapeAlertEvent.cs
+++ b/Content.Shared/RussStation/Surgery/Components/RemoveSurgeryDrapeAlertEvent.cs
@@ -1,6 +1,0 @@
-using Content.Shared.Alert;
-
-namespace Content.Shared.RussStation.Surgery.Components;
-
-[Serializable]
-public sealed partial class RemoveSurgeryDrapeAlertEvent : BaseAlertEvent;

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -23,7 +23,7 @@ surgery-step-treat-burn-wounds = {CAPITALIZE(THE($user))} cauterizes and dresses
 
 ## Alerts
 alerts-surgery-draped-name = Surgical Drapes
-alerts-surgery-draped-desc = You are draped for surgery. Click to remove the drapes.
+alerts-surgery-draped-desc = You are draped for surgery. They will fall off if you stand.
 
 ## Examine
 surgery-examine-active = [color=cyan]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} undergoing {$procedure}.[/color]

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -78,3 +78,7 @@ surgery-category-tend-wounds = Tend Wounds
 surgery-category-organ-manipulation = Organ Manipulation
 surgery-category-implants = Implants
 surgery-category-advanced = Advanced
+
+## Interrupt
+surgery-interrupt-patient = Your surgery is cut short as you move!
+surgery-interrupt-surgeon = {CAPITALIZE(THE($target))} moves! The procedure is ruined.

--- a/Resources/Prototypes/@RussStation/Surgery/alerts.yml
+++ b/Resources/Prototypes/@RussStation/Surgery/alerts.yml
@@ -1,6 +1,5 @@
 - type: alert
   id: SurgeryDraped
   icons: [/Textures/@RussStation/Interface/Alerts/Surgery/draped.png]
-  clickEvent: !type:RemoveSurgeryDrapeAlertEvent
   name: alerts-surgery-draped-name
   description: alerts-surgery-draped-desc


### PR DESCRIPTION
## About the PR

Closes #614.

A draped patient standing up (or being unbuckled from a surgery surface) now tears the drape off, cancels the active procedure, and pops a message to patient and surgeon. If the procedure had cleared the hemostat clamp step but not reached cautery, the clamp releases and the incision bleeds again.

The voluntary alert-click path that used to remove the drape is gone. Standing up is the one way out now, and the alert description tells the patient as much.

## Why / Balance

Right now a patient can stand up mid-surgery and keep the drape on while the DoAfter keeps ticking as if nothing happened. That's a free escape and makes the hemostat step meaningless. Tying the interrupt to standing gives the patient one clear consequence for bailing (a re-opened incision bleed if they were past the clamp), and folds the voluntary cancel into the same motion so there's no no-cost click-to-abort.

## Technical details

- `SurgerySystem.Interrupt.cs` (new): subscribes `StoodEvent` and `UnbuckledEvent` on `SurgeryDrapedComponent`. Unbuckle only reacts when the strap has `SurgerySurfaceComponent` so sliding off a chair doesn't void a procedure.
- `CancelActiveSurgery` removes `ActiveSurgeryComponent` and `SurgeryDrapedComponent` (the existing shutdown handler drops the bedsheet and clears the alert/overlay), then pops to patient and surgeon.
- `ApplyInterruptConsequences` walks the procedure's step list for Slashing -> Clamping -> Cauterizing. If clamp was cleared and cautery wasn't, it adds `SurgeryConstants.IncisionBleedAmount` back to the bloodstream. Any other phase leaves accumulated step effects alone.
- `RemoveSurgeryDrapeAlertEvent` deleted. `clickEvent` stripped from the `SurgeryDraped` alert prototype. Alert description reworded.
- DoAfter itself cancels via `BreakOnMove` on the surgery DoAfter args, so no explicit `DoAfterSystem.Cancel` call is needed.

## Media

N/A, behavioural fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

`RemoveSurgeryDrapeAlertEvent` is gone. Nothing else in the codebase referenced it.

**Changelog**

:cl:
- tweak: Surgical drapes fall off when the patient stands or leaves the surgery surface, and the active procedure is cancelled. If the incision was past the hemostat clamp, the clamp releases and bleeding resumes.
- remove: The drape alert can no longer be clicked to remove drapes. Stand up instead.