### PR TITLE
honksquad: feat: audible chat highlights on radio (#609)

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -14,19 +14,24 @@
                 <ui:OptionSlider Name="SpeechBubbleTextOpacitySlider" Title="{Loc 'ui-options-speech-bubble-text-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleSpeakerOpacitySlider" Title="{Loc 'ui-options-speech-bubble-speaker-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleBackgroundOpacitySlider" Title="{Loc 'ui-options-speech-bubble-background-opacity'}" />
-                <!-- HONK - action bar button background opacity lives here next to the other UI opacity sliders -->
+                <!-- HONK START - action bar opacity, highlight section (issue #609), hover tooltip, font customization -->
                 <ui:OptionSlider Name="ActionBarButtonBackgroundAlphaSlider" Title="{Loc 'ui-options-action-bar-button-background-alpha'}" />
+                <Label Text="{Loc 'honk-options-header-highlights'}"
+                       StyleClasses="LabelKeyText"/>
                 <CheckBox Name="AutoFillHighlightsCheckBox" Text="{Loc 'ui-options-auto-fill-highlights'}" />
                 <ui:OptionColorSlider Name="HighlightsColorSlider"
                     Title="{Loc 'ui-options-highlights-color'}"
                     Example="{Loc 'ui-options-highlights-color-example'}"/>
-                <!-- HONK START - Hover tooltip options -->
+                <CheckBox Name="HonkHighlightSoundCheckBox" Text="{Loc 'honk-options-highlight-sound-enabled'}"
+                          ToolTip="{Loc 'honk-options-highlight-sound-enabled-tooltip'}"/>
+                <ui:OptionSlider Name="HonkHighlightSoundCooldownSlider"
+                                 Title="{Loc 'honk-options-highlight-sound-cooldown'}"/>
+                <ui:OptionSlider Name="HonkHighlightSoundVolumeSlider"
+                                 Title="{Loc 'honk-options-highlight-sound-volume'}"/>
                 <Label Text="{Loc 'ui-options-header-hover-tooltip'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="HoverTooltipEnabledCheckBox" Text="{Loc 'ui-options-hover-tooltip-enabled'}" />
                 <ui:OptionSlider Name="HoverTooltipDelaySlider" Title="{Loc 'ui-options-hover-tooltip-delay'}" />
-                <!-- HONK END -->
-                <!-- HONK START - Font customization -->
                 <Label Text="{Loc 'ui-options-header-font'}"
                        StyleClasses="LabelKeyText"/>
                 <ui:OptionDropDown Name="FontFamilyDropDown" Title="{Loc 'ui-options-font-family'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -28,7 +28,7 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleTextOpacity, SpeechBubbleTextOpacitySlider);
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleSpeakerOpacity, SpeechBubbleSpeakerOpacitySlider);
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleBackgroundOpacity, SpeechBubbleBackgroundOpacitySlider);
-        //HONK START - action bar button background opacity sits with the other UI opacity sliders
+        //HONK START - action bar opacity, highlight section (issue #609), hover tooltip, font customization
         Control.AddOption(new OptionSliderFloatCVar(
             Control,
             IoCManager.Resolve<IConfigurationManager>(),
@@ -36,11 +36,25 @@ public sealed partial class AccessibilityTab : Control
             ActionBarButtonBackgroundAlphaSlider,
             0f, 1f, 1f,
             (_, value) => $"{(int)(value * 100)}%"));
-        //HONK END
+
         Control.AddOptionCheckBox(CCVars.ChatAutoFillHighlights, AutoFillHighlightsCheckBox);
         Control.AddOptionColorSlider(CCVars.ChatHighlightsColor, HighlightsColorSlider);
+        Control.AddOptionCheckBox(CCVars.ChatHighlightSoundEnabled, HonkHighlightSoundCheckBox);
+        Control.AddOption(new OptionSliderFloatCVar(
+            Control,
+            IoCManager.Resolve<IConfigurationManager>(),
+            CCVars.ChatHighlightSoundCooldown,
+            HonkHighlightSoundCooldownSlider,
+            0f, 10f, 0.5f,
+            (_, value) => $"{value:F1}s"));
+        Control.AddOption(new OptionSliderFloatCVar(
+            Control,
+            IoCManager.Resolve<IConfigurationManager>(),
+            CCVars.ChatHighlightSoundVolume,
+            HonkHighlightSoundVolumeSlider,
+            -20f, 0f, 1f,
+            (_, value) => $"{value:F0} dB"));
 
-        //HONK START
         Control.AddOptionCheckBox(CCVars.HoverTooltipEnabled, HoverTooltipEnabledCheckBox);
         Control.AddOption(new OptionSliderFloatCVar(
             Control,

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.HonkHighlightSound.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.HonkHighlightSound.cs
@@ -1,0 +1,95 @@
+// HONK - issue #609. Audible highlight pings on radio. Owns its own plain-text
+// regex list so the upstream visual matcher (which targets WrappedMessage with
+// sanitized brackets and `says, "..."` lookbehinds) stays untouched.
+using System.Text.RegularExpressions;
+using Content.Shared.CCVar;
+using Content.Shared.Chat;
+using Robust.Client.Audio;
+using Robust.Client.Replays.Playback;
+using Robust.Client.UserInterface;
+using Robust.Shared.Audio;
+using Robust.Shared.Player;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+public sealed partial class ChatUIController
+{
+    [Dependency] private readonly IReplayPlaybackManager _replayPlayback = default!;
+    [UISystemDependency] private readonly AudioSystem _honkAudio = default!;
+
+    private readonly List<Regex> _honkHighlightsPlain = new();
+
+    private bool _honkHighlightSoundEnabled;
+    private string _honkHighlightSoundPath = string.Empty;
+    private float _honkHighlightSoundVolume;
+    private float _honkHighlightSoundCooldown;
+    private TimeSpan _honkHighlightSoundNextAllowed;
+
+    private void HonkInitializeHighlightSound()
+    {
+        _config.OnValueChanged(CCVars.ChatHighlightSoundEnabled, v => _honkHighlightSoundEnabled = v, true);
+        _config.OnValueChanged(CCVars.ChatHighlightSoundPath, v => _honkHighlightSoundPath = v, true);
+        _config.OnValueChanged(CCVars.ChatHighlightSoundVolume, v => _honkHighlightSoundVolume = v, true);
+        _config.OnValueChanged(CCVars.ChatHighlightSoundCooldown, v => _honkHighlightSoundCooldown = v, true);
+
+        _config.OnValueChanged(CCVars.ChatHighlights, HonkRebuildPlainHighlights, true);
+    }
+
+    private void HonkRebuildPlainHighlights(string raw)
+    {
+        _honkHighlightsPlain.Clear();
+        if (string.IsNullOrEmpty(raw))
+            return;
+
+        foreach (var entry in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            // Drop the leading "@" used by the visual matcher to anchor a name to a
+            // speech context: in raw msg.Message there's no "says," wrapper, so a
+            // bare substring match is what we want.
+            var word = entry.StartsWith('@') ? entry[1..] : entry;
+            // Quoted entries become whole-word in the visual matcher; mirror that
+            // intent here cheaply by collapsing surrounding quotes into \b.
+            var quoted = word.Length >= 2 && word[0] == '"' && word[^1] == '"';
+            if (quoted)
+                word = word[1..^1];
+            if (string.IsNullOrEmpty(word))
+                continue;
+
+            var pattern = Regex.Escape(word);
+            if (quoted)
+                pattern = $@"\b{pattern}\b";
+            _honkHighlightsPlain.Add(new Regex(pattern, RegexOptions.IgnoreCase));
+        }
+    }
+
+    private void HonkTryPlayHighlightSound(ChatMessage msg)
+    {
+        if (!_honkHighlightSoundEnabled)
+            return;
+        if (_honkHighlightsPlain.Count == 0)
+            return;
+        if ((msg.Channel & ChatChannel.Radio) == 0)
+            return;
+        if (_replayPlayback.Replay != null)
+            return;
+        if (_timing.RealTime < _honkHighlightSoundNextAllowed)
+            return;
+        // Don't ping on your own transmissions.
+        var localUid = _player.LocalEntity;
+        if (localUid != null && _ent.GetEntity(msg.SenderEntity) == localUid.Value)
+            return;
+
+        foreach (var pattern in _honkHighlightsPlain)
+        {
+            if (!pattern.IsMatch(msg.Message))
+                continue;
+            _honkAudio.PlayGlobal(
+                _honkHighlightSoundPath,
+                Filter.Local(),
+                false,
+                AudioParams.Default.WithVolume(_honkHighlightSoundVolume));
+            _honkHighlightSoundNextAllowed = _timing.RealTime + TimeSpan.FromSeconds(_honkHighlightSoundCooldown);
+            return;
+        }
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -241,6 +241,9 @@ public sealed partial class ChatUIController : UIController
         _config.OnValueChanged(CCVars.ChatWindowOpacity, OnChatWindowOpacityChanged);
 
         InitializeHighlights();
+        // HONK START - issue #609 audible radio highlights
+        HonkInitializeHighlightSound();
+        // HONK END
     }
 
     public void OnScreenLoad()
@@ -857,6 +860,10 @@ public sealed partial class ChatUIController : UIController
         {
             msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, highlight, "color", _highlightsColor);
         }
+
+        // HONK START - issue #609 audible radio highlights
+        HonkTryPlayHighlightSound(msg);
+        // HONK END
 
         // Color any codewords for minds that have roles that use them
         if (_player.LocalUser != null && _mindSystem != null && _roleCodewordSystem != null)

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -46,13 +46,13 @@ public sealed partial class CCVars
     /// Resource path of the sound played by <see cref="ChatHighlightSoundEnabled"/>.
     /// </summary>
     public static readonly CVarDef<string> ChatHighlightSoundPath =
-        CVarDef.Create("honk.chat.highlight_sound_path", "/Audio/Effects/Cargo/ping.ogg", CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("honk.chat.highlight_sound_path", "/Audio/Effects/newplayerping.ogg", CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
     /// Extra gain in dB applied on top of the highlight sound clip.
     /// </summary>
     public static readonly CVarDef<float> ChatHighlightSoundVolume =
-        CVarDef.Create("honk.chat.highlight_sound_volume", 0f, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("honk.chat.highlight_sound_volume", -10f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
     /// Minimum seconds between highlight pings, regardless of how many radio messages match.

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -34,4 +34,29 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> FloatingChatInputLastRadioChannel =
         CVarDef.Create("honk.chat.floating_input_last_radio_channel", string.Empty, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// When true, plays a sound client-side whenever a chat highlight word arrives over radio.
+    /// Off by default, set via console (no in-game checkbox in this pass).
+    /// </summary>
+    public static readonly CVarDef<bool> ChatHighlightSoundEnabled =
+        CVarDef.Create("honk.chat.highlight_sound_enabled", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Resource path of the sound played by <see cref="ChatHighlightSoundEnabled"/>.
+    /// </summary>
+    public static readonly CVarDef<string> ChatHighlightSoundPath =
+        CVarDef.Create("honk.chat.highlight_sound_path", "/Audio/Effects/Cargo/ping.ogg", CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Extra gain in dB applied on top of the highlight sound clip.
+    /// </summary>
+    public static readonly CVarDef<float> ChatHighlightSoundVolume =
+        CVarDef.Create("honk.chat.highlight_sound_volume", 0f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Minimum seconds between highlight pings, regardless of how many radio messages match.
+    /// </summary>
+    public static readonly CVarDef<float> ChatHighlightSoundCooldown =
+        CVarDef.Create("honk.chat.highlight_sound_cooldown", 2f, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
@@ -1,0 +1,5 @@
+honk-options-header-highlights = Highlights
+honk-options-highlight-sound-enabled = Play sound on radio match
+honk-options-highlight-sound-enabled-tooltip = Plays a short ping when one of your highlight words arrives over radio. Path is honk.chat.highlight_sound_path.
+honk-options-highlight-sound-cooldown = Highlight sound cooldown
+honk-options-highlight-sound-volume = Highlight sound volume


### PR DESCRIPTION
## About the PR

Adds an opt-in client-side ping that fires when one of your chat highlight words arrives over radio. Visual highlights only help if your eyes are on the chat box, so a short bleep makes you look up when your name (or any keyword) comes through comms.

Closes #609.

## Why / Balance

Pure quality-of-life, no balance impact. Off by default; opt-in via the new Highlights section in the Accessibility tab.

## Technical details

- 4 new client CVars in `Content.Shared/RussStation/CCVar/CCVars.Chat.cs`:
  - `honk.chat.highlight_sound_enabled` (bool, default `false`)
  - `honk.chat.highlight_sound_path` (string, default `/Audio/Effects/newplayerping.ogg`)
  - `honk.chat.highlight_sound_volume` (float dB, default `-10`)
  - `honk.chat.highlight_sound_cooldown` (float seconds, default `2`)
- New partial `ChatUIController.HonkHighlightSound.cs`. Owns its own plain-text regex list rebuilt from the existing `chat.highlights` CVar so the upstream visual matcher (which targets `WrappedMessage` with sanitized brackets and `says, "..."` lookbehinds) is left alone. The trigger gates on:
  - feature enabled and at least one highlight present
  - `ChatChannel.Radio` in the message channel mask
  - active replay playback (skipped)
  - global cooldown window
  - sender is the local entity (skipped)
- Two HONK-blocked one-liners in `ChatUIController.cs`: init call in `Initialize()` and the trigger call in `ProcessChatMessage` after the visual-highlight loop.
- Settings UI: added a new "Highlights" section in the Accessibility tab grouping auto-fill, color, sound on/off, cooldown, and volume sliders. Adjacent fork sections (action-bar opacity, hover tooltip, font customization) merged into one contiguous HONK block.

## Media

N/A — audio cue, no in-game visual.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches. (See \`BRANCHING.md\`.)
- [X] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix. (See \`CONTRIBUTING.md\`.)

## Breaking changes

None.

**Changelog**

:cl:
- add: Highlighted chat words can now play a sound when they come through radio. Off by default; toggle in Options - Accessibility - Highlights.