### PR TITLE
honksquad: feat: tint chat input border with active channel color (#581)

### DIFF
--- a/Content.Client/RussStation/Chat/ChatInputChannelTint.cs
+++ b/Content.Client/RussStation/Chat/ChatInputChannelTint.cs
@@ -1,0 +1,71 @@
+// HONK - Tint the chat input's border with the active channel color so the
+// player has a peripheral cue for which channel Enter will send to. Covers
+// both the anchored chat panel and the floating input from #577. Issue #581.
+
+using Content.Client.UserInterface.Systems.Chat.Controls;
+using Content.Shared.Chat;
+using Content.Shared.Radio;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.RussStation.Chat;
+
+public static class ChatInputChannelTint
+{
+    private const int BorderPx = 2;
+    private const float BorderAlpha = 0.85f;
+
+    /// <summary>
+    /// Applies a channel-colored border to the <see cref="ChatInputBox"/> that
+    /// owns <paramref name="button"/>. No-op when the button isn't parented to
+    /// a ChatInputBox yet.
+    /// </summary>
+    public static void Apply(ChannelSelectorButton button, ChatSelectChannel channel, RadioChannelPrototype? radio)
+    {
+        var inputBox = FindChatInputBox(button);
+        if (inputBox == null)
+            return;
+
+        var color = (radio?.Color ?? button.ChannelSelectColor(channel)).WithAlpha(BorderAlpha);
+
+        var style = EnsureStyleBox(inputBox);
+        style.BorderColor = color;
+        style.BorderThickness = new Thickness(BorderPx);
+    }
+
+    private static StyleBoxFlat EnsureStyleBox(ChatInputBox inputBox)
+    {
+        if (inputBox.PanelOverride is StyleBoxFlat existing)
+            return existing;
+
+        // Clone the resolved sheet panel so the override keeps the themed
+        // background; only the border is our change. Fall back to transparent
+        // when the sheet doesn't supply a StyleBoxFlat (e.g. texture-based
+        // panel in a future theme).
+        StyleBoxFlat clone;
+        if (inputBox.TryGetStyleProperty<StyleBox>(PanelContainer.StylePropertyPanel, out var sheetBox)
+            && sheetBox is StyleBoxFlat sheetFlat)
+        {
+            clone = new StyleBoxFlat(sheetFlat);
+        }
+        else
+        {
+            clone = new StyleBoxFlat(Color.Transparent);
+        }
+
+        inputBox.PanelOverride = clone;
+        return clone;
+    }
+
+    private static ChatInputBox? FindChatInputBox(Control? control)
+    {
+        while (control != null)
+        {
+            if (control is ChatInputBox input)
+                return input;
+            control = control.Parent;
+        }
+        return null;
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
@@ -72,5 +72,8 @@ public sealed class ChannelSelectorButton : ChatPopupButton<ChannelSelectorPopup
     {
         Text = radio != null ? Loc.GetString(radio.Name) : ChannelSelectorName(channel);
         Modulate = radio?.Color ?? ChannelSelectColor(channel);
+        // HONK START - Tint parent ChatInputBox border to match active channel. Issue #581.
+        Content.Client.RussStation.Chat.ChatInputChannelTint.Apply(this, channel, radio);
+        // HONK END
     }
 }


### PR DESCRIPTION
Closes #581.

## About the PR

Colors the chat input panel's border with the active channel's color while typing. Local stays neutral; OOC, LOOC, Dead, Admin, and Radio (including specific radio channels like :s, :e) each get their own tint. Updates live as the player types a prefix.

Applies to the anchored chat box and the floating chat input from #577.

## Why / Balance

Players often hit Enter on the wrong channel because only the selector button label updates when a prefix is typed, and that button is tiny and peripheral. A colored border around the input gives an unmissable cue in peripheral vision without taking up screen space.

No gameplay impact, purely a visual nudge.

## Technical details

- New helper `Content.Client/RussStation/Chat/ChatInputChannelTint.cs` walks up from the channel selector button to find the parent `ChatInputBox` and mutates (or installs) a `StyleBoxFlat` PanelOverride, setting only `BorderColor` and `BorderThickness`. When the box already has a PanelOverride (floating input), the background is preserved so its opacity CVar still works.
- One HONK-marked call inside `ChannelSelectorButton.UpdateChannelSelectButton` wires it in. Every existing code path that updates the channel label (anchored text change, floating text change, dropdown selection) already funnels through that method, so no separate subscriptions are needed.
- When the sheet panel isn't a `StyleBoxFlat`, falls back to a transparent install so the border still shows.

## Media

Tested locally, adding in-game media before marking ready.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [ ] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

:cl:
- add: Chat input border now tints to match the active channel (radio, OOC, dead, admin, etc.) so it's easier to tell at a glance which channel Enter will send to.