### PR TITLE
honksquad: fix: drop redundant drape popup at surgery start

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -237,8 +237,6 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         _xform.SetLocalPosition(overlay, System.Numerics.Vector2.Zero);
         draped.OverlayEntity = overlay;
 
-        _popup.PopupEntity(Loc.GetString("surgery-drape-patient", ("target", target.Value)), target.Value);
-
         var active = EnsureComp<ActiveSurgeryComponent>(target.Value);
         active.ProcedureId = ev.ProcedureId;
         active.CurrentStep = SurgeryConstants.InitialProcedureStepIndex;

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -1,7 +1,6 @@
 # Surgery System
 
 ## Draping
-surgery-drape-patient = You drape {THE($target)} for surgery.
 surgery-patient-not-down = The patient must be lying down for surgery.
 
 ## Procedure Selection


### PR DESCRIPTION
## About the PR

When starting a surgery, two popups fired at the same instant on the patient: the drape popup and the procedure-name popup. This drops the drape popup so only one shows.

## Why / Balance

Closes #621. The procedure-started popup already implies draping has happened, and stacking two popups in the same frame just clutters the screen.

## Technical details

- `Content.Server/RussStation/Surgery/SurgerySystem.cs`: removed the `surgery-drape-patient` PopupEntity call in `OnProcedureSelected`, leaving only `surgery-procedure-started`.
- `Resources/Locale/en-US/@RussStation/surgery/surgery.ftl`: removed the now-unused `surgery-drape-patient` loc key.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl: HellWatcher
- fix: Surgery no longer spams two stacked popups when you begin a procedure.