### PR TITLE
honksquad: refactor: lock down WoundComponent with [Access]

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRegenTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRegenTest.cs
@@ -1,5 +1,6 @@
 using Content.Server.RussStation.Wounds;
 using Content.Shared.RussStation.Wounds;
+using Content.Shared.RussStation.Wounds.Systems;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Wounds;
@@ -26,7 +27,7 @@ public sealed class WoundRegenTest
             var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
             var comp = entityManager.AddComponent<WoundComponent>(entity);
 
-            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 3) { NextDecayTime = TimeSpan.Zero });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 3) { NextDecayTime = TimeSpan.Zero });
 
             entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
 
@@ -53,7 +54,7 @@ public sealed class WoundRegenTest
             var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
             var comp = entityManager.AddComponent<WoundComponent>(entity);
 
-            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 3) { NextDecayTime = FarFuture });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 3) { NextDecayTime = FarFuture });
 
             entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
 
@@ -78,7 +79,7 @@ public sealed class WoundRegenTest
             var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
             var comp = entityManager.AddComponent<WoundComponent>(entity);
 
-            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
 
             entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
 
@@ -103,8 +104,8 @@ public sealed class WoundRegenTest
             var comp = entityManager.AddComponent<WoundComponent>(entity);
 
             // One tier-1 Burn due to expire (will be removed) + one tier-3 Burn that stays.
-            comp.ActiveWounds.Add(new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
-            comp.ActiveWounds.Add(new WoundEntry("ColdBurn", 3) { NextDecayTime = FarFuture });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("ColdBurn", 3) { NextDecayTime = FarFuture });
 
             entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
 

--- a/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRejuvenateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRejuvenateTest.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Rejuvenate;
 using Content.Shared.RussStation.Wounds;
+using Content.Shared.RussStation.Wounds.Systems;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.RussStation.Wounds;
@@ -20,9 +21,10 @@ public sealed class WoundRejuvenateTest
         {
             var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
             var comp = entityManager.AddComponent<WoundComponent>(entity);
+            var wounds = entityManager.System<SharedWoundSystem>();
 
-            comp.ActiveWounds.Add(new WoundEntry("BluntFracture", 2));
-            comp.BleedSourceDamageType = "Slash";
+            wounds.AddWound(comp, new WoundEntry("BluntFracture", 2));
+            wounds.SetBleedSource(comp, "Slash");
 
             entityManager.EventBus.RaiseLocalEvent(entity, new RejuvenateEvent());
 

--- a/Content.Server/RussStation/Wounds/WoundRegenSystem.cs
+++ b/Content.Server/RussStation/Wounds/WoundRegenSystem.cs
@@ -19,6 +19,7 @@ public sealed class WoundRegenSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedWoundSystem _wound = default!;
 
     private TimeSpan _nextTick;
 
@@ -70,7 +71,7 @@ public sealed class WoundRegenSystem : EntitySystem
 
             if (wound.Tier <= 1)
             {
-                comp.ActiveWounds.RemoveAt(i);
+                _wound.RemoveWoundAt(comp, i);
                 changed = true;
                 if (IsCategoryCleared(comp, wound))
                     clearedCategory = true;

--- a/Content.Shared/RussStation/Traits/FrailSystem.cs
+++ b/Content.Shared/RussStation/Traits/FrailSystem.cs
@@ -1,9 +1,12 @@
 using Content.Shared.RussStation.Wounds;
+using Content.Shared.RussStation.Wounds.Systems;
 
 namespace Content.Shared.RussStation.Traits;
 
 public sealed class FrailSystem : EntitySystem
 {
+    [Dependency] private readonly SharedWoundSystem _wound = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -13,18 +16,18 @@ public sealed class FrailSystem : EntitySystem
 
     private void OnInit(EntityUid uid, FrailComponent component, ComponentInit args)
     {
-        if (!TryComp<WoundComponent>(uid, out var wound))
+        if (!HasComp<WoundComponent>(uid))
             return;
 
-        wound.ThresholdMultiplier *= component.ThresholdMultiplier;
+        _wound.ScaleThresholdMultiplier(uid, component.ThresholdMultiplier);
     }
 
     private void OnRemove(EntityUid uid, FrailComponent component, ComponentRemove args)
     {
-        if (!TryComp<WoundComponent>(uid, out var wound))
+        if (!HasComp<WoundComponent>(uid))
             return;
 
         if (component.ThresholdMultiplier != 0f)
-            wound.ThresholdMultiplier /= component.ThresholdMultiplier;
+            _wound.ScaleThresholdMultiplier(uid, 1f / component.ThresholdMultiplier);
     }
 }

--- a/Content.Shared/RussStation/Traits/ToughSystem.cs
+++ b/Content.Shared/RussStation/Traits/ToughSystem.cs
@@ -1,9 +1,12 @@
 using Content.Shared.RussStation.Wounds;
+using Content.Shared.RussStation.Wounds.Systems;
 
 namespace Content.Shared.RussStation.Traits;
 
 public sealed class ToughSystem : EntitySystem
 {
+    [Dependency] private readonly SharedWoundSystem _wound = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -13,18 +16,18 @@ public sealed class ToughSystem : EntitySystem
 
     private void OnInit(EntityUid uid, ToughComponent component, ComponentInit args)
     {
-        if (!TryComp<WoundComponent>(uid, out var wound))
+        if (!HasComp<WoundComponent>(uid))
             return;
 
-        wound.ThresholdMultiplier *= component.ThresholdMultiplier;
+        _wound.ScaleThresholdMultiplier(uid, component.ThresholdMultiplier);
     }
 
     private void OnRemove(EntityUid uid, ToughComponent component, ComponentRemove args)
     {
-        if (!TryComp<WoundComponent>(uid, out var wound))
+        if (!HasComp<WoundComponent>(uid))
             return;
 
         if (component.ThresholdMultiplier != 0f)
-            wound.ThresholdMultiplier /= component.ThresholdMultiplier;
+            _wound.ScaleThresholdMultiplier(uid, 1f / component.ThresholdMultiplier);
     }
 }

--- a/Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs
+++ b/Content.Shared/RussStation/Wounds/Systems/SharedWoundSystem.cs
@@ -186,6 +186,47 @@ public abstract class SharedWoundSystem : EntitySystem
     }
 
     /// <summary>
+    /// Appends a wound entry directly. Bypasses the damage-spike pipeline in
+    /// <see cref="OnDamageChanged"/>, so it's the right entry point for tests
+    /// and for external systems that already decided a wound should exist.
+    /// </summary>
+    public void AddWound(WoundComponent comp, WoundEntry entry)
+    {
+        comp.ActiveWounds.Add(entry);
+    }
+
+    /// <summary>
+    /// Overwrites the bleed source damage type without the precedence logic in
+    /// <see cref="WoundDisplaySystem.UpdateBleedSource"/>. For tests and resets.
+    /// </summary>
+    public void SetBleedSource(WoundComponent comp, string? damageType)
+    {
+        comp.BleedSourceDamageType = damageType;
+    }
+
+    /// <summary>
+    /// Removes the wound entry at <paramref name="index"/>. Caller is responsible
+    /// for calling <see cref="SharedEntitySystem.Dirty"/> after a batch of changes.
+    /// </summary>
+    public void RemoveWoundAt(WoundComponent comp, int index)
+    {
+        comp.ActiveWounds.RemoveAt(index);
+    }
+
+    /// <summary>
+    /// Multiplies <see cref="WoundComponent.ThresholdMultiplier"/> by the given
+    /// factor. Funnel for trait systems that raise or lower a mob's wound
+    /// resistance (apply with the trait's factor, remove with its reciprocal).
+    /// </summary>
+    public void ScaleThresholdMultiplier(EntityUid uid, float factor, WoundComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return;
+
+        comp.ThresholdMultiplier *= factor;
+    }
+
+    /// <summary>
     /// Gets the highest tier among active wounds of a given category.
     /// Returns 0 if no wounds of that category exist.
     /// </summary>

--- a/Content.Shared/RussStation/Wounds/WoundComponent.cs
+++ b/Content.Shared/RussStation/Wounds/WoundComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Alert;
+using Content.Shared.RussStation.Wounds.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -11,6 +12,7 @@ namespace Content.Shared.RussStation.Wounds;
 /// Tracks active wounds (fractures and burns) and bleed source info for display.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedWoundSystem), typeof(WoundDisplaySystem))]
 public sealed partial class WoundComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## About the PR

Locks WoundComponent behind `[Access(typeof(SharedWoundSystem), typeof(WoundDisplaySystem))]` so external systems can't silently mutate its fields. Fork-side trait systems (Frail, Tough) and the server-side regen tick now go through setter methods on SharedWoundSystem instead of poking fields directly.

First take on #602, one candidate per PR.

## Why / Balance

No gameplay change. This is the fork-side counterpart to the upstream Access Analyzer pattern, so missed `Dirty()` calls and invariant violations fail at build time rather than drifting into production desync bugs.

## Technical details

- `WoundComponent`: added `[Access]` restricting to SharedWoundSystem and WoundDisplaySystem.
- `SharedWoundSystem`: new helpers `AddWound`, `SetBleedSource`, `RemoveWoundAt`, `ScaleThresholdMultiplier` so other systems have a documented write path.
- `FrailSystem` / `ToughSystem`: call `ScaleThresholdMultiplier` via `[Dependency]` on SharedWoundSystem instead of `wound.ThresholdMultiplier *= ...`.
- `WoundRegenSystem`: depends on SharedWoundSystem and uses `RemoveWoundAt` for the decay removal.
- Integration tests for regen and rejuvenate updated to seed state through the new setters.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. All touched fields stayed fork-side. The new setters are additive.