### PR TITLE
feat: expose ramping scheduler baseline interval as datafields

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -31,6 +31,20 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     [DataField]
     public float TimeUntilNextEvent;
 
+    //HONK START - expose roller cadence as datafields so presets can tune it without a code patch
+    /// <summary>
+    /// Lower bound (seconds) of the baseline roll interval before chaos scaling.
+    /// </summary>
+    [DataField]
+    public float MinBaselineInterval = 240f;
+
+    /// <summary>
+    /// Upper bound (seconds) of the baseline roll interval before chaos scaling.
+    /// </summary>
+    [DataField]
+    public float MaxBaselineInterval = 720f;
+    //HONK END
+
     /// <summary>
     /// The gamerules that the scheduler can choose from
     /// </summary>

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -69,7 +69,9 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     {
         var mod = GetChaosModifier(uid, component);
 
-        // 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
-        component.TimeUntilNextEvent = _random.NextFloat(240f / mod, 720f / mod);
+        //HONK START - read baseline interval from datafields so presets can tune it
+        // Defaults to 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
+        component.TimeUntilNextEvent = _random.NextFloat(component.MinBaselineInterval / mod, component.MaxBaselineInterval / mod);
+        //HONK END
     }
 }


### PR DESCRIPTION
## About the PR

Exposes the ramping station event scheduler's baseline roll interval as datafields on the component, instead of hardcoded literals in the system.

## Why / Balance

Closes #500. Tuning how often the scheduler picks a new event used to require a code patch. The sibling BasicStationEventScheduler already parameterises its cadence on the component, so this brings the ramping one in line.

Defaults are unchanged (240s / 720s), so upstream behaviour is preserved.

## Technical details

- `RampingStationEventSchedulerComponent`: adds `MinBaselineInterval` (240f) and `MaxBaselineInterval` (720f) datafields, wrapped in a HONK block.
- `RampingStationEventSchedulerSystem.PickNextEventTime`: reads the two datafields instead of the literals.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. Default values match the previous hardcoded literals.

**Changelog**

:cl: HellWatcher
- tweak: Ramping event scheduler's baseline roll interval is now configurable via component datafields (defaults unchanged).