### PR TITLE
honksquad: fix: vending UI stock greying stays fresh through virtualization (#573)

### DIFF
--- a/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
+++ b/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
@@ -24,6 +24,9 @@ namespace Content.Client.VendingMachines.UI
         private readonly Dictionary<EntProtoId, EntityUid> _dummies = [];
         private readonly Dictionary<EntProtoId, (ListContainerButton Button, VendingMachineItem Item)> _listItems = new();
         private readonly Dictionary<EntProtoId, uint> _amounts = new();
+        //HONK START - Track list data per proto so UpdateAmounts can refresh stale entries
+        private readonly Dictionary<EntProtoId, VendorItemsListData> _listDataByProto = new();
+        //HONK END
 
         //HONK START - Vending prices display
         private Dictionary<string, int>? _prices;
@@ -101,6 +104,9 @@ namespace Content.Client.VendingMachines.UI
             //HONK END
             _listItems.Clear();
             _amounts.Clear();
+            //HONK START
+            _listDataByProto.Clear();
+            //HONK END
 
             if (inventory.Count == 0 && VendingContents.Visible)
             {
@@ -154,10 +160,14 @@ namespace Content.Client.VendingMachines.UI
                 if (itemText.Length > longestEntry.Length)
                     longestEntry = itemText;
 
-                listData.Add(new VendorItemsListData(prototype.ID, i)
+                //HONK START - Track list data records so UpdateAmounts can refresh them
+                var entryData = new VendorItemsListData(prototype.ID, i)
                 {
                     ItemText = itemText,
-                });
+                };
+                listData.Add(entryData);
+                _listDataByProto[entry.ID] = entryData;
+                //HONK END
             }
 
             VendingContents.PopulateList(listData);
@@ -179,15 +189,23 @@ namespace Content.Client.VendingMachines.UI
 
             foreach (var proto in _dummies.Keys)
             {
-                if (!_listItems.TryGetValue(proto, out var button))
-                    continue;
-
                 var dummy = _dummies[proto];
                 if (!cachedInventory.TryFirstOrDefault(o => o.ID == proto, out var entry))
                     continue;
                 var amount = entry.Amount;
                 // Could be better? Problem is all inventory entries get squashed.
                 var text = GetItemText(dummy, amount, proto);
+
+                //HONK START - Keep _amounts and list data in sync so that ListContainer
+                // virtualizing a row out and back in rebuilds it with the correct
+                // disabled state and label instead of stale values from Populate.
+                _amounts[proto] = amount;
+                if (_listDataByProto.TryGetValue(proto, out var data))
+                    data.ItemText = text;
+                //HONK END
+
+                if (!_listItems.TryGetValue(proto, out var button))
+                    continue;
 
                 button.Item.SetText(text);
                 button.Button.Disabled = !enabled || amount == 0;


### PR DESCRIPTION
## About the PR

Closes #573.

Keeps the client-side vending-machine menu's `_amounts` dictionary and per-item `VendorItemsListData.ItemText` in sync whenever `UpdateAmounts` runs, so scrolling a row out of view and back in (or re-rendering after a state update) rebuilds the button with the current stock instead of the values captured during the initial `Populate`.

## Why / Balance

The seed vendor surfaces this most visibly because it's the only vendor with enough rows to exercise `ListContainer` virtualization. When `UpdateAmounts` ran, it only poked the currently-visible buttons; the next time a row re-entered the viewport, `GenerateButton` read the stale `_amounts[proto]` and pre-rendered `ItemText`, which is how in-stock items could come back disabled. Same underlying bug as upstream space-wizards/space-station-14#37099.

## Technical details

`Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs`:

- Added a `_listDataByProto` map so the menu can still reach each `VendorItemsListData` record after `PopulateList` hands off to `ListContainer`.
- `Populate` now registers each row into that map alongside the existing `_amounts` / `_dummies` bookkeeping.
- `UpdateAmounts` refreshes `_amounts[proto]` and `data.ItemText` before the `_listItems` lookup, so items that aren't currently virtualized still get up-to-date cached state; the visible-button path is unchanged.

All additions are block-wrapped in `//HONK START` / `//HONK END` markers (`cs_audit.py --pr-mode` confirms no new upstream drift).

## Media

Visual bug fix; no new assets.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches. (See `BRANCHING.md`.)
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix. (See `CONTRIBUTING.md`.)

**Changelog**

:cl: HellWatcher
- fix: In-stock vendor items no longer randomly display as greyed out after scrolling or a restock.