### PR TITLE
tweak: lowpop runs on ramping scheduler with doubled baseline cadence

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -31,6 +31,20 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     [DataField]
     public float TimeUntilNextEvent;
 
+    //HONK START - expose roller cadence as datafields so presets can tune it without a code patch
+    /// <summary>
+    /// Lower bound (seconds) of the baseline roll interval before chaos scaling.
+    /// </summary>
+    [DataField]
+    public float MinBaselineInterval = 240f;
+
+    /// <summary>
+    /// Upper bound (seconds) of the baseline roll interval before chaos scaling.
+    /// </summary>
+    [DataField]
+    public float MaxBaselineInterval = 720f;
+    //HONK END
+
     /// <summary>
     /// The gamerules that the scheduler can choose from
     /// </summary>

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -69,7 +69,9 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     {
         var mod = GetChaosModifier(uid, component);
 
-        // 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
-        component.TimeUntilNextEvent = _random.NextFloat(240f / mod, 720f / mod);
+        //HONK START - read baseline interval from datafields so presets can tune it
+        // Defaults to 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
+        component.TimeUntilNextEvent = _random.NextFloat(component.MinBaselineInterval / mod, component.MaxBaselineInterval / mod);
+        //HONK END
     }
 }

--- a/Resources/Prototypes/@RussStation/GameRules/lowpop_events.yml
+++ b/Resources/Prototypes/@RussStation/GameRules/lowpop_events.yml
@@ -373,9 +373,13 @@
 # === Lowpop scheduler ===
 
 - type: entity
-  id: LowpopBasicStationEventScheduler
+  id: LowpopRampingStationEventScheduler
   parent: BaseGameRule
   components:
-    - type: BasicStationEventScheduler
+    - type: RampingStationEventScheduler
+      # Lowpop runs calmer: 8-24 min baseline (double the 4-12 min upstream default)
+      # before the chaos modifier compresses intervals later in the round.
+      minBaselineInterval: 480
+      maxBaselineInterval: 1440
       scheduledGameRules: !type:NestedSelector
         tableId: LowpopGameRulesTable

--- a/Resources/Prototypes/@RussStation/GameRules/lowpop_presets.yml
+++ b/Resources/Prototypes/@RussStation/GameRules/lowpop_presets.yml
@@ -12,7 +12,7 @@
     - DummyNonAntagChance
     - LowpopTraitor
     - SubGamemodesRuleNoWizard
-    - LowpopBasicStationEventScheduler
+    - LowpopRampingStationEventScheduler
     - MeteorSwarmMildScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
@@ -28,7 +28,7 @@
     - DummyNonAntagChance
     - LowpopRevolutionary
     - SubGamemodesRuleNoWizard
-    - LowpopBasicStationEventScheduler
+    - LowpopRampingStationEventScheduler
     - MeteorSwarmMildScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
@@ -44,7 +44,7 @@
     - DummyNonAntagChance
     - LowpopChangeling
     - SubGamemodesRuleNoWizard
-    - LowpopBasicStationEventScheduler
+    - LowpopRampingStationEventScheduler
     - MeteorSwarmMildScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
@@ -58,7 +58,7 @@
   showInVote: false
   rules:
     - LowpopZombie
-    - LowpopBasicStationEventScheduler
+    - LowpopRampingStationEventScheduler
     - MeteorSwarmMildScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation


### PR DESCRIPTION
## About the PR

Switches the lowpop preset family from the basic event scheduler to a new `LowpopRampingStationEventScheduler` entity that uses `RampingStationEventScheduler`, with the baseline roll interval doubled compared to upstream defaults.

Stacked on #626 (which adds the `MinBaselineInterval` / `MaxBaselineInterval` datafields this relies on).

## Why / Balance

Lowpop has fewer hands to react to events, so a slower roller cadence keeps rounds from spiralling. Doubling upstream's 4-12 minute baseline to 8-24 minutes still lets the chaos modifier compress intervals as the round drags on, just from a calmer starting point.

The old `LowpopBasicStationEventScheduler` entity is removed since nothing else referenced it.

## Technical details

- `lowpop_events.yml`: replaces `LowpopBasicStationEventScheduler` (Basic) with `LowpopRampingStationEventScheduler` (Ramping) carrying `minBaselineInterval: 480` and `maxBaselineInterval: 1440`.
- `lowpop_presets.yml`: swaps the four lowpop presets to reference the new scheduler entity.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None for upstream. The fork-only `LowpopBasicStationEventScheduler` entity ID is removed; nothing referenced it outside the lowpop presets that are already swapped in this PR.

**Changelog**

:cl: HellWatcher
- tweak: Lowpop rounds now use a ramping event scheduler with longer 8-24 minute baseline intervals, so events ease in instead of arriving as often as on full pop.