### PR TITLE
honksquad: feat: third parties can pry free a carried entity (#501)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryInterruptTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryInterruptTest.cs
@@ -1,0 +1,132 @@
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Systems;
+using Content.Shared.Stunnable;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Carrying;
+
+[TestFixture]
+[TestOf(typeof(SharedCarryingSystem))]
+public sealed class CarryInterruptTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CarryInterruptCarrier
+  components:
+  - type: Carrier
+  - type: Carriable
+  - type: Hands
+  - type: ComplexInteraction
+  - type: InputMover
+  - type: Physics
+    bodyType: KinematicController
+  - type: Puller
+  - type: StandingState
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: Damageable
+    damageContainer: Biological
+  - type: Body
+    prototype: Human
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.35
+
+- type: entity
+  id: CarryInterruptTarget
+  components:
+  - type: Carriable
+  - type: Physics
+    bodyType: KinematicController
+  - type: StandingState
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: Damageable
+    damageContainer: Biological
+  - type: Body
+    prototype: Human
+  - type: Pullable
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.35
+";
+
+    /// <summary>
+    /// Completion path: InterruptCarry ends the carry, stuns the carrier, and is safe
+    /// to call when no carry is in progress.
+    /// </summary>
+    [Test]
+    public async Task InterruptEndsCarryAndStunsCarrier()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var carrier = entityManager.SpawnEntity("CarryInterruptCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryInterruptTarget", mapData.GridCoords);
+            var bystander = entityManager.SpawnEntity("CarryInterruptCarrier", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+            carrying.Carry(carrier, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True);
+
+            carrying.InterruptCarry(bystander, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "Interrupt must tear down the carrier-side marker");
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False,
+                "Interrupt must tear down the target-side marker");
+            Assert.That(entityManager.HasComponent<StunnedComponent>(carrier), Is.True,
+                "Interrupt must stun the carrier");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// If the carry already ended before the DoAfter completes, the interrupt must
+    /// no-op rather than throw or create stray effects on the former carrier.
+    /// </summary>
+    [Test]
+    public async Task InterruptWithoutActiveCarryNoOps()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var target = entityManager.SpawnEntity("CarryInterruptTarget", mapData.GridCoords);
+            var bystander = entityManager.SpawnEntity("CarryInterruptCarrier", mapData.GridCoords);
+
+            Assert.DoesNotThrow(() => carrying.InterruptCarry(bystander, target),
+                "Interrupting a non-carried target must be safe");
+            Assert.That(entityManager.HasComponent<StunnedComponent>(bystander), Is.False,
+                "No-op path must not stun anyone");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/RussStation/Carrying/CarryingConstants.cs
+++ b/Content.Shared/RussStation/Carrying/CarryingConstants.cs
@@ -12,6 +12,10 @@ public static class CarryingConstants
 
     public static readonly TimeSpan CarryDoAfterDuration = TimeSpan.FromSeconds(3);
 
+    public static readonly TimeSpan DefaultInterruptDuration = TimeSpan.FromSeconds(3);
+
+    public static readonly TimeSpan DefaultInterruptStunDuration = TimeSpan.FromSeconds(1.5);
+
     /// <summary>
     /// Horizontal component of the carried-entity visual offset. The offset lives
     /// entirely on the Y axis; X stays at the carrier's origin.

--- a/Content.Shared/RussStation/Carrying/Components/CarriableComponent.cs
+++ b/Content.Shared/RussStation/Carrying/Components/CarriableComponent.cs
@@ -6,8 +6,33 @@ namespace Content.Shared.RussStation.Carrying.Components;
 /// <summary>
 /// Indicates this entity can be fireman carried (permission tag).
 /// The active relationship lives on <see cref="BeingCarriedComponent"/>;
-/// this component carries no per-carry state.
+/// this component carries no per-carry state, only tuning for third-party
+/// interventions against the carry.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedCarryingSystem))]
-public sealed partial class CarriableComponent : Component;
+public sealed partial class CarriableComponent : Component
+{
+    /// <summary>
+    /// Time a third party must stand next to the carrier to pry this entity
+    /// free from them.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan InterruptDuration = CarryingConstants.DefaultInterruptDuration;
+
+    /// <summary>
+    /// How long the carrier is stunned and knocked down after a successful
+    /// third-party intervention. Short by design — it buys the interrupter a
+    /// window to act, it isn't an arrest tool.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan InterruptStunDuration = CarryingConstants.DefaultInterruptStunDuration;
+
+    /// <summary>
+    /// If true, the interrupter needs at least one free hand to start the
+    /// intervention DoAfter. Matches the intuition that you can't pry someone
+    /// off a carrier with both hands full.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public bool InterruptRequiresFreeHand = true;
+}

--- a/Content.Shared/RussStation/Carrying/Events/CarryDoAfterEvent.cs
+++ b/Content.Shared/RussStation/Carrying/Events/CarryDoAfterEvent.cs
@@ -8,3 +8,10 @@ namespace Content.Shared.RussStation.Carrying.Events;
 /// </summary>
 [Serializable, NetSerializable]
 public sealed partial class CarryDoAfterEvent : SimpleDoAfterEvent;
+
+/// <summary>
+/// DoAfter event for a third party prying a carried entity free from its carrier.
+/// User is the interrupter, target is the carried entity.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class CarryInterruptDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -42,6 +42,7 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
@@ -55,12 +56,13 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
         base.Initialize();
 
         SubscribeLocalEvent<CarriableComponent, GetVerbsEvent<InteractionVerb>>(AddCarryVerb);
-        SubscribeLocalEvent<BeingCarriedComponent, GetVerbsEvent<InteractionVerb>>(AddDropVerb);
+        SubscribeLocalEvent<BeingCarriedComponent, GetVerbsEvent<InteractionVerb>>(AddCarriedVerbs);
 
         SubscribeLocalEvent<CarriableComponent, DragDropDraggedEvent>(OnDragDropDragged);
         SubscribeLocalEvent<CarriableComponent, CanDropDraggedEvent>(OnCanDropDragged);
         SubscribeLocalEvent<CarrierComponent, CanDropTargetEvent>(OnCanDropTarget);
         SubscribeLocalEvent<CarrierComponent, CarryDoAfterEvent>(OnCarryDoAfter);
+        SubscribeLocalEvent<BeingCarriedComponent, CarryInterruptDoAfterEvent>(OnCarryInterruptDoAfter);
         SubscribeLocalEvent<ActiveCarrierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
         SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnCarriedCanMove);
 
@@ -113,16 +115,37 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
         });
     }
 
-    private void AddDropVerb(EntityUid uid, BeingCarriedComponent component, GetVerbsEvent<InteractionVerb> args)
+    private void AddCarriedVerbs(EntityUid uid, BeingCarriedComponent component, GetVerbsEvent<InteractionVerb> args)
     {
-        if (component.Carrier != args.User)
+        if (args.User == component.Carrier)
+        {
+            args.Verbs.Add(new InteractionVerb
+            {
+                Text = Loc.GetString("carrying-verb-drop"),
+                Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
+                Act = () => Drop(args.User),
+            });
+            return;
+        }
+
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        // Carried is the target itself; only third parties get the interrupt.
+        if (args.User == uid)
+            return;
+
+        if (!TryComp<CarriableComponent>(uid, out var carriable))
+            return;
+
+        if (!CanInterruptCarry(args.User, carriable))
             return;
 
         args.Verbs.Add(new InteractionVerb
         {
-            Text = Loc.GetString("carrying-verb-drop"),
+            Text = Loc.GetString("carrying-verb-interrupt"),
             Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
-            Act = () => Drop(args.User),
+            Act = () => StartInterruptDoAfter(args.User, uid, carriable),
         });
     }
 
@@ -224,6 +247,73 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
 
         args.Handled = true;
         Carry(uid, args.Target.Value);
+    }
+
+    private bool CanInterruptCarry(EntityUid user, CarriableComponent carriable)
+    {
+        if (_standing.IsDown(user) || _mobState.IsIncapacitated(user))
+            return false;
+
+        if (TryComp<BuckleComponent>(user, out var buckle) && buckle.Buckled)
+            return false;
+
+        if (carriable.InterruptRequiresFreeHand && _hands.CountFreeHands(user) < 1)
+            return false;
+
+        return true;
+    }
+
+    private void StartInterruptDoAfter(EntityUid user, EntityUid target, CarriableComponent carriable)
+    {
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, carriable.InterruptDuration, new CarryInterruptDoAfterEvent(), target, target: target)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = carriable.InterruptRequiresFreeHand,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnCarryInterruptDoAfter(EntityUid uid, BeingCarriedComponent component, CarryInterruptDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.User == uid || args.User == component.Carrier)
+            return;
+
+        args.Handled = true;
+        InterruptCarry(args.User, uid);
+    }
+
+    /// <summary>
+    /// Third-party interrupt completion path: ends the carry on
+    /// <paramref name="target"/>, stuns the carrier, and plays popups.
+    /// No-ops silently if the carry ended (or swapped carriers) between
+    /// DoAfter start and completion. Public so tests can exercise the
+    /// completion outcome without running the full DoAfter.
+    /// </summary>
+    public void InterruptCarry(EntityUid user, EntityUid target)
+    {
+        if (!TryComp<BeingCarriedComponent>(target, out var being))
+            return;
+
+        var carrier = being.Carrier;
+        if (!HasComp<ActiveCarrierComponent>(carrier))
+            return;
+
+        if (TryComp<CarriableComponent>(target, out var carriable))
+            _stun.TryUpdateStunDuration(carrier, carriable.InterruptStunDuration);
+
+        Drop(carrier);
+
+        _popup.PopupPredicted(
+            Loc.GetString("carrying-interrupt-user", ("target", target), ("carrier", carrier)),
+            Loc.GetString("carrying-interrupt-carrier", ("user", user), ("target", target)),
+            user,
+            user);
+        _popup.PopupEntity(
+            Loc.GetString("carrying-interrupt-carried", ("user", user), ("carrier", carrier)),
+            target,
+            target);
     }
 
     /// <summary>

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -63,6 +63,7 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
         SubscribeLocalEvent<CarrierComponent, CanDropTargetEvent>(OnCanDropTarget);
         SubscribeLocalEvent<CarrierComponent, CarryDoAfterEvent>(OnCarryDoAfter);
         SubscribeLocalEvent<BeingCarriedComponent, CarryInterruptDoAfterEvent>(OnCarryInterruptDoAfter);
+        SubscribeLocalEvent<BeingCarriedComponent, Content.Shared.Pulling.Events.BeingPulledAttemptEvent>(OnCarriedPullAttempt);
         SubscribeLocalEvent<ActiveCarrierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
         SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnCarriedCanMove);
 
@@ -282,6 +283,19 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
 
         args.Handled = true;
         InterruptCarry(args.User, uid);
+    }
+
+    /// <summary>
+    /// Block third-party pull attempts on a carried entity. Pull-while-carried races
+    /// with the carry's reparent and drop hooks (the puller's virtual item handles
+    /// don't get fixed up cleanly), so the prying interrupt verb is the supported way
+    /// to intervene. The carrier's own pull-then-carry handoff is already cleared
+    /// during Carry() before BeingCarriedComponent gets attached, so this only blocks
+    /// new pulls that start after the carry is in progress.
+    /// </summary>
+    private void OnCarriedPullAttempt(EntityUid uid, BeingCarriedComponent component, Content.Shared.Pulling.Events.BeingPulledAttemptEvent args)
+    {
+        args.Cancel();
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/@RussStation/carrying/carrying.ftl
+++ b/Resources/Locale/en-US/@RussStation/carrying/carrying.ftl
@@ -1,6 +1,10 @@
 carrying-verb-carry = Fireman carry
 carrying-verb-drop = Drop
+carrying-verb-interrupt = Pry free
 carrying-start-carrier = You hoist {$target} over your shoulder.
 carrying-start-carried = {$carrier} hoists you over their shoulder!
 carrying-drop-carrier = You drop {$target}.
 carrying-drop-carried = {$carrier} drops you!
+carrying-interrupt-user = You pry {$target} free from {$carrier}.
+carrying-interrupt-carrier = {$user} pries {$target} out of your grip!
+carrying-interrupt-carried = {$user} pries you free from {$carrier}.

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -89,6 +89,8 @@
   - Carrying takes [bold]both hands[/bold] and slows you down.
   - To drop them, use [color=yellow][bold][keybind="Drop"][/bold][/color] or right-click and select [bold]Drop[/bold].
   - You drop them automatically if you get stunned, downed, or go critical. They also get dropped if they recover.
+  - Once they're on your shoulder, nobody else can [color=cyan]pull[/color] them off you.
+  - Bystanders who want them free have to right-click the carried mob and pick [bold]Pry free[/bold]. It takes a moment, stuns you, and drops them.
   <!-- HONK END -->
 
   ## Interactions


### PR DESCRIPTION
Closes #501.

## About the PR

Adds a **Pry free** verb on any carried entity, available to third parties (anyone who is not the carrier and not the carried). Selecting it starts a 3s DoAfter on the interrupter; on completion the carry ends and the carrier is stunned + knocked down for 1.5s.

The existing **Drop** verb still goes to the carrier. The interrupt verb is a separate path with its own gates.

## Why / Balance

Today only the carrier can end a carry. If someone is hauling a body off to space or dragging a victim into maint, bystanders can do nothing to the carry itself, only to the carrier. That leaves a gap in PvP agency around kidnap scenarios.

The 3s windup with `BreakOnMove` and `BreakOnDamage` means the carrier can fight the interrupter off, and the 1.5s stun is short enough that the carrier can re-grab if nothing else intervenes. It's a disruption tool, not an arrest.

## Technical details

- New `CarryInterruptDoAfterEvent` in `Events/CarryDoAfterEvent.cs`.
- `CarriableComponent` grows three fields: `InterruptDuration`, `InterruptStunDuration`, `InterruptRequiresFreeHand`, defaulted from `CarryingConstants`. Flipped to `AutoGenerateComponentState` so prototypes can override per mob.
- `SharedCarryingSystem` merges the old `AddDropVerb` and the new interrupt verb into a single `AddCarriedVerbs` handler. Engine rejects two subscriptions on the same component+event pair, so they live together.
- Completion path extracted as `public InterruptCarry(user, target)` so tests can exercise the outcome without running the full DoAfter machinery. Re-reads `BeingCarriedComponent.Carrier` at completion, so a mid-DoAfter carrier swap or drop no-ops cleanly.
- Stun + knockdown via `SharedStunSystem.TryUpdateStunDuration`; the existing `OnCarrierStunned` auto-drop is belt-and-braces with the explicit `Drop(carrier)` call.
- Two new integration tests under `Content.IntegrationTests/Tests/RussStation/Carrying/CarryInterruptTest.cs`: completion-ends-carry-and-stuns, and no-op-without-active-carry.
- Fork-only change, no upstream files touched.

## Media

Tested locally via integration tests. Adding in-game footage before marking ready.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [ ] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

:cl:
- add: You can now pry someone free from a fireman carry if you're not the one carrying them. Takes a few seconds of standing still, and drops the carrier onto their back when it finishes.