### PR TITLE
honksquad: refactor: lock down PlayerBalanceComponent with [Access]

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/PayrollJobUpdateTest.cs
@@ -4,7 +4,6 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
-using Content.Shared.RussStation.Economy.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 
@@ -34,7 +33,7 @@ public sealed class PayrollJobUpdateTest : GameTest
             // Create mob with balance component, initial job is Passenger.
             var mob = entMan.SpawnEntity(null, new MapCoordinates());
             var balance = entMan.AddComponent<PlayerBalanceComponent>(mob);
-            balance.JobId = "Passenger";
+            entMan.System<PlayerBalanceSystem>().SetJobId(mob, "Passenger", balance);
             entMan.AddComponent<MindContainerComponent>(mob);
 
             // Create a mind and attach it to the mob.
@@ -68,7 +67,7 @@ public sealed class PayrollJobUpdateTest : GameTest
 
             var mob = entMan.SpawnEntity(null, new MapCoordinates());
             var balance = entMan.AddComponent<PlayerBalanceComponent>(mob);
-            balance.JobId = "StationEngineer";
+            entMan.System<PlayerBalanceSystem>().SetJobId(mob, "StationEngineer", balance);
             entMan.AddComponent<MindContainerComponent>(mob);
 
             var mindId = mindSystem.CreateMind(null).Owner;

--- a/Content.IntegrationTests/Tests/RussStation/Economy/VendingPaymentTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/VendingPaymentTest.cs
@@ -3,7 +3,6 @@ using Content.IntegrationTests.Tests.Interaction;
 using Content.Server.RussStation.Economy;
 using Content.Server.VendingMachines;
 using Content.Shared.Hands.EntitySystems;
-using Content.Shared.RussStation.Economy.Components;
 using Content.Shared.Stacks;
 using Content.Shared.VendingMachines;
 
@@ -82,7 +81,7 @@ public sealed class VendingPaymentTest : InteractionTest
         await Server.WaitPost(() =>
         {
             var comp = SEntMan.EnsureComponent<PlayerBalanceComponent>(SPlayer);
-            comp.Balance = 0;
+            SEntMan.System<PlayerBalanceSystem>().SetBalance(SPlayer, 0, comp);
         });
 
         // Power and open
@@ -116,7 +115,7 @@ public sealed class VendingPaymentTest : InteractionTest
         await Server.WaitPost(() =>
         {
             var comp = SEntMan.EnsureComponent<PlayerBalanceComponent>(SPlayer);
-            comp.Balance = 10000;
+            SEntMan.System<PlayerBalanceSystem>().SetBalance(SPlayer, 10000, comp);
         });
 
         // Power and open

--- a/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
@@ -108,8 +108,8 @@ public sealed class VendingInteractionTest : InteractionTest
         //HONK START - Give test mob funds so the payment system doesn't block the vend
         await Server.WaitPost(() =>
         {
-            var comp = SEntMan.EnsureComponent<Content.Shared.RussStation.Economy.Components.PlayerBalanceComponent>(SPlayer);
-            comp.Balance = 99999;
+            var comp = SEntMan.EnsureComponent<Content.Server.RussStation.Economy.PlayerBalanceComponent>(SPlayer);
+            SEntMan.System<Content.Server.RussStation.Economy.PlayerBalanceSystem>().SetBalance(SPlayer, 99999, comp);
         });
         //HONK END
 

--- a/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
+++ b/Content.Server/RussStation/Economy/BalanceCartridgeSystem.cs
@@ -12,6 +12,7 @@ namespace Content.Server.RussStation.Economy;
 public sealed class BalanceCartridgeSystem : EntitySystem
 {
     [Dependency] private readonly CartridgeLoaderSystem? _cartridgeLoader = default!;
+    [Dependency] private readonly PlayerBalanceSystem _balance = default!;
 
     public override void Initialize()
     {
@@ -54,7 +55,7 @@ public sealed class BalanceCartridgeSystem : EntitySystem
         if (!TryComp<PlayerBalanceComponent>(holder, out var balance))
             return;
 
-        balance.PaycheckMuted = !balance.PaycheckMuted;
+        _balance.SetPaycheckMuted(holder, !balance.PaycheckMuted, balance);
         UpdateUiState(uid, loaderUid);
     }
 

--- a/Content.Server/RussStation/Economy/PlayerBalanceComponent.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceComponent.cs
@@ -1,12 +1,13 @@
-using Robust.Shared.GameObjects;
+using Content.Shared.RussStation.Economy;
 
-namespace Content.Shared.RussStation.Economy.Components;
+namespace Content.Server.RussStation.Economy;
 
 /// <summary>
 /// Tracks a player's speso balance for the current round.
 /// Added to the player mob on spawn.
 /// </summary>
 [RegisterComponent]
+[Access(typeof(PlayerBalanceSystem), typeof(PayrollSystem))]
 public sealed partial class PlayerBalanceComponent : Component
 {
     [DataField]

--- a/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
+++ b/Content.Server/RussStation/Economy/PlayerBalanceSystem.cs
@@ -166,6 +166,42 @@ public sealed class PlayerBalanceSystem : EntitySystem
     }
 
     /// <summary>
+    /// Directly overwrites the balance. Use <see cref="AddBalance"/> or
+    /// <see cref="TryDeduct"/> for normal gameplay paths; this is for tests
+    /// and admin tooling that need to seed state.
+    /// </summary>
+    public void SetBalance(EntityUid uid, int amount, PlayerBalanceComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return;
+
+        comp.Balance = amount;
+    }
+
+    /// <summary>
+    /// Assigns the player's job id used for wage tier lookup.
+    /// </summary>
+    public void SetJobId(EntityUid uid, string? jobId, PlayerBalanceComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return;
+
+        comp.JobId = jobId;
+    }
+
+    /// <summary>
+    /// Toggles or sets whether paycheck notifications are muted for this entity.
+    /// Exposed so the wallet cartridge UI can flip the flag without poking the component directly.
+    /// </summary>
+    public void SetPaycheckMuted(EntityUid uid, bool muted, PlayerBalanceComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return;
+
+        comp.PaycheckMuted = muted;
+    }
+
+    /// <summary>
     /// Create a new bank account for an entity, invalidating any previous account.
     /// Intentionally resets balance to startingBalance (default 0) -- creating a new account
     /// means the old one and its funds are gone. This is the intended penalty for account replacement.


### PR DESCRIPTION
## About the PR

Moves PlayerBalanceComponent from Content.Shared to Content.Server (no client or shared consumers, component is not networked) and adds `[Access(typeof(PlayerBalanceSystem), typeof(PayrollSystem))]` so external mutation requires a setter call.

Part of #602.

## Why / Balance

No gameplay change. Balance mutation already had `TryDeduct`/`AddBalance` funnels for in-game paths; this closes the remaining direct-field gaps (cartridge mute toggle, test seeding) and makes silent money desync impossible to ship.

## Technical details

- `PlayerBalanceComponent` moved to `Content.Server/RussStation/Economy/`; namespace changed accordingly.
- New setters on `PlayerBalanceSystem`: `SetBalance`, `SetJobId`, `SetPaycheckMuted`. Used by the wallet cartridge and integration tests; gameplay still goes through `TryDeduct`/`AddBalance`/`CreateAccount`.
- `BalanceCartridgeSystem` depends on `PlayerBalanceSystem` and calls `SetPaycheckMuted` instead of writing the field.
- Integration tests updated to route seeding through the setters.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

Namespace change for `PlayerBalanceComponent`: any consumer using `Content.Shared.RussStation.Economy.Components.PlayerBalanceComponent` will need to switch to `Content.Server.RussStation.Economy.PlayerBalanceComponent`. Fork-only type, no upstream impact.