### PR TITLE
honksquad: refactor: lock down LightReplacerRecyclerComponent with [Access]

### DIFF
--- a/Content.Server/RussStation/Light/LightReplacerRecyclerSystem.cs
+++ b/Content.Server/RussStation/Light/LightReplacerRecyclerSystem.cs
@@ -15,7 +15,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.RussStation.Light;
 
-public sealed class LightReplacerRecyclerSystem : EntitySystem
+public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSystem
 {
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;

--- a/Content.Shared/RussStation/Light/LightReplacerRecyclerComponent.cs
+++ b/Content.Shared/RussStation/Light/LightReplacerRecyclerComponent.cs
@@ -11,6 +11,7 @@ namespace Content.Shared.RussStation.Light;
 ///     Players can spend points to print new bulbs via a radial menu.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedLightReplacerRecyclerSystem))]
 public sealed partial class LightReplacerRecyclerComponent : Component
 {
     /// <summary>

--- a/Content.Shared/RussStation/Light/SharedLightReplacerRecyclerSystem.cs
+++ b/Content.Shared/RussStation/Light/SharedLightReplacerRecyclerSystem.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.RussStation.Light;
+
+/// <summary>
+/// Base type for the light replacer recycler system. Exists so
+/// <see cref="LightReplacerRecyclerComponent"/>'s <c>[Access]</c> attribute
+/// can reference a shared type while the actual logic lives server-side.
+/// </summary>
+public abstract class SharedLightReplacerRecyclerSystem : EntitySystem
+{
+}


### PR DESCRIPTION
## About the PR

Adds `[Access(typeof(SharedLightReplacerRecyclerSystem))]` to LightReplacerRecyclerComponent. The shared abstract base exists purely so the access attribute can reference a type visible from Content.Shared; actual logic stays in the server `LightReplacerRecyclerSystem`, which now inherits the base.

Part of #602.

## Why / Balance

No gameplay change. Nothing outside the recycler system mutated its fields, so this lockdown is preventative: future code that tries to bypass the recycler's point math will fail at build time.

## Technical details

- New `Content.Shared/RussStation/Light/SharedLightReplacerRecyclerSystem.cs` (empty abstract `EntitySystem`).
- `LightReplacerRecyclerSystem` now inherits `SharedLightReplacerRecyclerSystem`.
- `[Access(typeof(SharedLightReplacerRecyclerSystem))]` added to the component.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.