### PR TITLE
fix: debounce failed knockdown auto-stand retries

### DIFF
--- a/Content.Shared/Stunnable/KnockedDownComponent.cs
+++ b/Content.Shared/Stunnable/KnockedDownComponent.cs
@@ -43,4 +43,13 @@ public sealed partial class KnockedDownComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan GetUpDoAfter = TimeSpan.FromSeconds(1);
+
+    // HONK START - #492: debounce failed auto-stand retries so prediction divergence can't spawn per-tick DoAfter ghosts.
+    /// <summary>
+    /// Earliest game time at which a failed auto-stand attempt may retry. Separate from <see cref="NextUpdate"/>
+    /// so the knockdown expiry timer and knockdown alert cooldown aren't disturbed by retry throttling.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextStandAttempt;
+    // HONK END
 }

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -93,9 +93,22 @@ public abstract partial class SharedStunSystem
             if (!knockedDown.AutoStand || knockedDown.DoAfterId.HasValue || knockedDown.NextUpdate > GameTiming.CurTime)
                 continue;
 
-            TryStanding(uid);
+            // HONK START - #492: debounce failed retries so prediction divergence can't spawn per-tick DoAfter ghosts.
+            if (knockedDown.NextStandAttempt > GameTiming.CurTime)
+                continue;
+
+            if (!TryStanding(uid))
+            {
+                knockedDown.NextStandAttempt = GameTiming.CurTime + StandupRetryCooldown;
+                DirtyField(uid, knockedDown, nameof(KnockedDownComponent.NextStandAttempt));
+            }
+            // HONK END
         }
     }
+
+    // HONK START - #492: retry cooldown for failed auto-stand attempts (sleep/stun blocking stand-up).
+    private static readonly TimeSpan StandupRetryCooldown = TimeSpan.FromMilliseconds(250);
+    // HONK END
 
     private void OnRejuvenate(Entity<KnockedDownComponent> entity, ref RejuvenateEvent args)
     {


### PR DESCRIPTION
Closes #492.

## About the PR

Sleeping or stunned mobs showed a rapid red progress-bar flicker above their heads on the client only. This PR stops the flicker by rate-limiting failed auto-stand attempts.

## Why / Balance

No balance impact. The knockdown Update loop previously re-entered `TryStanding` every single tick while `AutoStand` was set. When sleep or stun blocked the stand-up server-side, any brief prediction divergence on the client (sleep state not yet replayed) let `TryStartDoAfter` succeed client-side, and `ActiveDoAfterComponent` is not networked so the ghost DoAfter persisted. With SSD sleep the status-effect re-apply amplified the churn to several ghosts per second.

## Technical details

Adds `NextStandAttempt` to `KnockedDownComponent` and gates the Update loop on it. On a failed `TryStanding`, bumps the field by 250ms.

Kept separate from the existing `NextUpdate` field because `NextUpdate` is the knockdown expiry clock and also anchors the knockdown alert cooldown via `Alerts.UpdateAlert`. Reusing it for retry throttling would extend knockdown duration and flicker the alert timer.

Retry cooldown is a `private static readonly` in `SharedStunSystem`, not a datafield — it's an internal debounce, not a design knob. 250ms is well under human reaction time so real auto-stand (stun baton wearing off, sleep ending) still feels immediate.

Upstream bug, upstream files. Edits are HONK-block wrapped per fork policy. Worth upstreaming separately after this lands.

## Media

N/A — fix removes a visual bug, no new art/UI.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed rapid progress-bar flicker above sleeping or stunned mobs.