### PR TITLE
honksquad: refactor: lock down HealthAnalyzerReagentScannerComponent with [Access]

### DIFF
--- a/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
+++ b/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
@@ -42,7 +42,7 @@ namespace Content.Server.RussStation.MedicalScanner;
 /// on <see cref="HealthAnalyzerDoAfterEvent"/> to push reagent state (bloodstream /
 /// metabolites / stomachs / lungs) alongside the Health tab.
 /// </summary>
-public sealed class HealthAnalyzerReagentSystem : EntitySystem
+public sealed class HealthAnalyzerReagentSystem : SharedHealthAnalyzerReagentSystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;

--- a/Content.Shared/RussStation/MedicalScanner/HealthAnalyzerReagentScannerComponent.cs
+++ b/Content.Shared/RussStation/MedicalScanner/HealthAnalyzerReagentScannerComponent.cs
@@ -9,6 +9,7 @@ namespace Content.Shared.RussStation.MedicalScanner;
 /// off this component to avoid colliding with upstream's (component, event) subscription slot.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(SharedHealthAnalyzerReagentSystem))]
 public sealed partial class HealthAnalyzerReagentScannerComponent : Component
 {
     /// <summary>

--- a/Content.Shared/RussStation/MedicalScanner/SharedHealthAnalyzerReagentSystem.cs
+++ b/Content.Shared/RussStation/MedicalScanner/SharedHealthAnalyzerReagentSystem.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.RussStation.MedicalScanner;
+
+/// <summary>
+/// Base type for the reagent-scanner extension to the health analyzer. Exists so
+/// <see cref="HealthAnalyzerReagentScannerComponent"/>'s <c>[Access]</c> attribute
+/// can reference a shared type while the actual logic lives server-side.
+/// </summary>
+public abstract class SharedHealthAnalyzerReagentSystem : EntitySystem
+{
+}


### PR DESCRIPTION
## About the PR

Adds `[Access(typeof(SharedHealthAnalyzerReagentSystem))]` to HealthAnalyzerReagentScannerComponent via the usual Shared abstract base pattern, so fields can't be mutated from outside the reagent-scanner system.

Part of #602.

## Why / Balance

No gameplay change. Preventative lockdown on a networked component whose state is already owned by a single system.

## Technical details

- New `Content.Shared/RussStation/MedicalScanner/SharedHealthAnalyzerReagentSystem.cs` (empty abstract `EntitySystem`).
- `HealthAnalyzerReagentSystem` now inherits it.
- `[Access(typeof(SharedHealthAnalyzerReagentSystem))]` added to the component.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.