### PR TITLE
fix: stomach stops digesting into blood on corpses (#491)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Metabolism/DeadStomachTransferTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Metabolism/DeadStomachTransferTest.cs
@@ -1,0 +1,156 @@
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.RussStation.Metabolism;
+
+/// <summary>
+/// Regression tests for issue #491 (Bug 2): the stomach's Digestion-stage
+/// generic transfer branch used to drain reagents into the bloodstream on
+/// corpses, even for reagents flagged !WorksOnTheDead. The fork patch in
+/// <c>MetabolizerSystem.cs</c> resolves isDead against the organ's body
+/// (not the organ itself) and gates the generic branch on that.
+/// </summary>
+[TestFixture]
+public sealed class DeadStomachTransferTest : GameTest
+{
+    private static readonly ProtoId<DamageGroupPrototype> ToxinGroup = "Toxin";
+
+    private const string TestInertReagent = "TestDeadStomachInert";
+
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: reagent
+  id: TestDeadStomachInert
+  name: reagent-name-nothing
+  desc: reagent-desc-nothing
+  physicalDesc: reagent-physical-desc-nothing
+
+- type: entity
+  id: DeadStomachDummy
+  name: DeadStomachDummy
+  components:
+  - type: SolutionContainerManager
+  - type: Body
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 1
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: Damageable
+    damageContainer: Biological
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: OrganHumanStomach
+";
+
+    [Test]
+    public async Task LivingStomachStillTransfers()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entManager.System<SharedSolutionContainerSystem>();
+
+        EntityUid mob = default;
+        EntityUid stomach = default;
+
+        await server.WaitAssertion(() =>
+        {
+            mob = entManager.SpawnEntity("DeadStomachDummy", MapCoordinates.Nullspace);
+            stomach = FindStomach(entManager, mob);
+
+            Assert.That(containerSystem.TryGetSolution(stomach, "stomach", out var sHandle, out _),
+                "Stomach organ should have its 'stomach' solution from OrganBaseStomach.");
+
+            containerSystem.TryAddSolution(sHandle!.Value,
+                new Solution(TestInertReagent, FixedPoint2.New(20)));
+        });
+
+        await RunSeconds(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(containerSystem.GetTotalPrototypeQuantity(stomach, TestInertReagent),
+                Is.LessThan(FixedPoint2.New(20)),
+                "Alive mob: stomach should drain via generic transfer.");
+            Assert.That(containerSystem.GetTotalPrototypeQuantity(mob, TestInertReagent),
+                Is.GreaterThan(FixedPoint2.Zero),
+                "Alive mob: bloodstream should receive the transferred reagent.");
+        });
+    }
+
+    [Test]
+    public async Task DeadStomachFreezesGenericTransfer()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var containerSystem = entManager.System<SharedSolutionContainerSystem>();
+        var mobStateSystem = entManager.System<MobStateSystem>();
+        var damSystem = entManager.System<DamageableSystem>();
+
+        EntityUid mob = default;
+        EntityUid stomach = default;
+
+        await server.WaitAssertion(() =>
+        {
+            mob = entManager.SpawnEntity("DeadStomachDummy", MapCoordinates.Nullspace);
+            stomach = FindStomach(entManager, mob);
+
+            Assert.That(containerSystem.TryGetSolution(stomach, "stomach", out var sHandle, out _));
+
+            var damage = new DamageSpecifier(protoMan.Index(ToxinGroup), FixedPoint2.New(10000));
+            damSystem.TryChangeDamage(mob, damage, true);
+            Assert.That(mobStateSystem.IsDead(mob), Is.True, "Dummy should be dead after lethal damage.");
+
+            containerSystem.TryAddSolution(sHandle!.Value,
+                new Solution(TestInertReagent, FixedPoint2.New(20)));
+        });
+
+        await RunSeconds(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(containerSystem.GetTotalPrototypeQuantity(stomach, TestInertReagent),
+                Is.EqualTo(FixedPoint2.New(20)),
+                "Dead mob: stomach must not drain reagents without WorksOnTheDead.");
+            Assert.That(containerSystem.GetTotalPrototypeQuantity(mob, TestInertReagent),
+                Is.EqualTo(FixedPoint2.Zero),
+                "Dead mob: bloodstream must not receive reagents from the stomach.");
+        });
+    }
+
+    private static EntityUid FindStomach(IEntityManager entManager, EntityUid body)
+    {
+        var bodyComp = entManager.GetComponent<BodyComponent>(body);
+        Assert.That(bodyComp.Organs, Is.Not.Null, "Body container should be initialized.");
+        foreach (var organ in bodyComp.Organs!.ContainedEntities)
+        {
+            if (entManager.HasComponent<StomachComponent>(organ))
+                return organ;
+        }
+        Assert.Fail("Stomach organ missing from dummy body.");
+        return default;
+    }
+}

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -155,7 +155,13 @@ public sealed class MetabolizerSystem : EntitySystem
         var rand = SharedRandomExtensions.PredictedRandom(_gameTiming, GetNetEntity(ent), GetNetEntity(solutionOwner));
         rand.Shuffle(list);
 
-        var isDead = _mobStateSystem.IsDead(solutionOwner.Value);
+        // HONK START - resolve isDead against the body when the metabolizer is on an organ (#491).
+        // Upstream queries isDead on solutionOwner, which for per-organ solutions (e.g. the stomach's
+        // Digestion stage) is the organ itself and lacks MobState, so the check always returned false
+        // on a corpse. Falling back to OrganComponent.Body makes the dead guard actually fire.
+        var deadCheckTarget = ent.Comp2?.Body ?? solutionOwner.Value;
+        var isDead = _mobStateSystem.IsDead(deadCheckTarget);
+        // HONK END
 
         int reagents = 0;
         foreach (var (reagent, quantity) in list)
@@ -169,6 +175,11 @@ public sealed class MetabolizerSystem : EntitySystem
 
             if (proto.Metabolisms is null || !proto.Metabolisms.Metabolisms.TryGetValue(stage, out var entry))
             {
+                // HONK START - freeze generic stomach transfer on corpses so revival chems don't drain (#491)
+                if (isDead && !proto.WorksOnTheDead)
+                    continue;
+                // HONK END
+
                 var mostToTransfer = FixedPoint2.Clamp(solutionData.TransferRate, 0, quantity);
 
                 if (transferSolution is not null)


### PR DESCRIPTION
## About the PR

Closes part of #491 (Bug 2 only; the oral-OD balance change lands in a follow-up).

Stops the stomach's Digestion-stage generic transfer from pushing reagents into the bloodstream on dead mobs.

## Why / Balance

Today, a corpse's stomach keeps draining into the chemstream. The symptom is that queuing revival chems on a body doesn't work as a buffer: a pre-mortem dose of, say, 40u bicaridine ends up fully migrated into blood by the time the body is revived, instead of trickling out of the stomach across the revival window. Food reagents on corpses also leak out instead of staying digestible. This matches SS13's behavior, where a dead mob's stomach does nothing until revived.

Bug 1 from the issue (oral meds can't overdose because stomach throughput is below bloodstream clearance) is intentionally not addressed here. That's a deliberate balance divergence from upstream and will go out as a separate follow-up so the conversation stays focused.

## Technical details

`MetabolizerSystem.TryMetabolizeStage` queried `isDead` against `solutionOwner`. For per-organ solutions (the stomach's `Digestion` stage has `SolutionOnBody: false`), `solutionOwner` is the organ itself, and organs have no `MobState`, so `IsDead` always returned false on a corpse. The existing dead-check at line 203 was therefore only effective for Bloodstream-stage metabolizers (heart) where the owner happens to be the body.

- Resolve `isDead` against `OrganComponent.Body` when available, falling back to `solutionOwner` for body-side metabolizers.
- Apply the same `isDead && !proto.WorksOnTheDead` guard to the generic transfer branch, so reagents without a Digestion entry freeze in a dead stomach unless the reagent opts in via `WorksOnTheDead`.
- HONK blocks keep the upstream diff contained.

Regression coverage in `Content.IntegrationTests/Tests/RussStation/Metabolism/DeadStomachTransferTest.cs`: a minimal body-with-stomach dummy, one test confirming the living case still transfers via the generic branch, one confirming a corpse's stomach holds its contents and the bloodstream stays empty.

## Media

N/A, backend behavior only.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [X] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Dead bodies no longer have their stomach contents drain into the bloodstream, so revival chems placed on a corpse stick around until revival.