### PR TITLE
honksquad: fix: simple-mob animals can eat (#499)

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -256,13 +256,37 @@ public sealed partial class IngestionSystem : EntitySystem
         // Can we digest the specific item we're trying to eat?
         if (!IsDigestibleBy(args.Ingested, stomachs, out var popup))
         {
-            if (!args.Ingest || !popup)
+            //HONK START - block-wraps the entire failure path. Original was:
+            //   if (!args.Ingest || !popup) return;
+            //   if (forceFed) <feeder popup> else <self popup>
+            //   return;
+            // Two changes for ghost-role mob feedback (Hamlet, etc.):
+            //
+            // (a) When this is a verb-availability check (ingest=false) and the
+            //     food is digestible-in-principle but no stomach matches its
+            //     whitelist (popup=true), still mark the attempt Handled so
+            //     TryGetIngestionVerb offers the eat verb. Otherwise the player
+            //     has no way to even attempt the eat and the popup never fires.
+            //     popup=false means the food is structurally non-food (e.g.
+            //     RequireDead on a living target), so we keep the upstream
+            //     silent skip.
+            // (b) When the player commits (ingest=true), pop on the eater always
+            //     and additionally on the feeder when force-fed, instead of the
+            //     upstream one-or-the-other branch. The eater's popup is what
+            //     this ghost-role flow needs.
+            if (!popup)
                 return;
 
+            if (!args.Ingest)
+            {
+                args.Handled = true;
+                return;
+            }
+
+            _popup.PopupClient(Loc.GetString("ingestion-cant-digest", ("entity", food)), entity, entity);
             if (forceFed)
                 _popup.PopupClient(Loc.GetString("ingestion-cant-digest-other", ("target", entity), ("entity", food)), entity, args.User);
-            else
-                _popup.PopupClient(Loc.GetString("ingestion-cant-digest", ("entity", food)), entity, entity);
+            //HONK END
 
             return;
         }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1,6 +1,8 @@
 - type: entity
   name: bat
-  parent: [ SimpleMobBase, FlyingMobBase, MobCombat ]
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase, FlyingMobBase, MobCombat ]
+  # HONK END
   id: MobBat
   description: Some cultures find them terrifying, others crunchy on the teeth.
   components:
@@ -84,7 +86,9 @@
 
 - type: entity
   name: bee
-  parent: [ SimpleMobBase, FlyingMobBase ]
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase, FlyingMobBase ]
+  # HONK END
   id: MobBee
   description: Nice to have, but you can't build a civilization on a foundation of honey alone.
   components:
@@ -201,7 +205,9 @@
 
 - type: entity
   name: chicken
-  parent: SimpleMobBase
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase ]
+  # HONK END
   id: MobChicken
   description: Comes before an egg, and IS a dinosaur!
   components:
@@ -353,7 +359,9 @@
 
 - type: entity
   name: cockroach
-  parent: SimpleMobBase
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase ]
+  # HONK END
   id: MobCockroach
   description: This station is just crawling with bugs.
   components:
@@ -661,7 +669,9 @@
 
 - type: entity
   name: mallard duck #Quack
-  parent: SimpleMobBase
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase ]
+  # HONK END
   id: MobDuckMallard
   description: An adorable mallard duck, it's fluffy and soft!
   components:
@@ -791,7 +801,9 @@
 
 - type: entity
   name: butterfly
-  parent: [ SimpleMobBase, FlyingMobBase ]
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase, FlyingMobBase ]
+  # HONK END
   id: MobButterfly
   description: Despite popular misconceptions, it's not actually made of butter.
   components:
@@ -3433,7 +3445,9 @@
 
 - type: entity
   name: hamster
-  parent: [ SimpleMobBase, MobCombat, StripableInventoryBase]
+  # HONK START - re-parented to BaseMobAnimal so IngestionSystem finds a stomach (issue #499)
+  parent: [ BaseMobAnimal, SimpleMobBase, MobCombat, StripableInventoryBase]
+  # HONK END
   id: MobHamster
   description: A cute, fluffy, robust hamster.
   components:


### PR DESCRIPTION
## About the PR

Re-parents seven `SimpleMobBase`-only animals onto `BaseMobAnimal` so they gain a Body with a stomach organ: bat, bee, butterfly, chicken, cockroach, mallard duck, and hamster.

## Why / Balance

Closes #499. These mobs had no Body, so `IngestionSystem.OnTryIngest` couldn't find a stomach and the eat `DoAfter` silently no-op'd. Players feeding them got a 0-progress interaction with no error. Now they digest food the same way other animals do.

## Technical details

One parent-list change per affected entity in `Resources/Prototypes/Entities/Mobs/NPCs/animals.yml`, HONK-bracketed so upstream re-sync sees a clean diff. `BaseMobAnimal` is listed first in the parent list so its Body + hunger/thirst defaults win over `SimpleMobBase`.

**Changelog**

:cl:
- fix: Bats, bees, butterflies, chickens, cockroaches, mallard ducks, and hamsters can now eat food.