### PR TITLE
honksquad: fix: HONK-wrap unmarked YAML drift (#485)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -4,8 +4,9 @@
     sprite: Objects/Specific/Janitorial/spray_bottle.rsi
     state: cleaner
   product: CrateServiceJanitorialSupplies
-  # HONK - raised from 560 to clear NoCargoOrderArbitrage (crate sells for ~714)
+  # HONK START - raised from 560 to clear NoCargoOrderArbitrage (crate sells for ~714)
   cost: 750
+  # HONK END
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -307,7 +307,9 @@
     whitelist:
       tags:
         - TrashBag
+        # HONK START - BoxTrashbag accepts fork TrashBagBlue variant
         - TrashBagBlue
+        # HONK END
   - type: Sprite
     layers:
       - state: box

--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -135,11 +135,15 @@
       - WetFloorSign
       - HolosignProjector
       - Plunger
+      # HONK START - blue trashbag variant
       - TrashBagBlue
+      # HONK END
       - GoldenPlunger
       - WireBrush
       - LightReplacer
+      # HONK START - cleaner grenade belt slot
       - CleanerGrenade
+      # HONK END
   - type: ItemMapper
     sprite: *BeltOverlay
     mapLayers:
@@ -151,6 +155,7 @@
         whitelist:
           tags:
           - Spray
+      # HONK START - per-tool sprite map layers for fork janitor belt contents
       light_replacer:
         whitelist:
           tags:
@@ -191,6 +196,7 @@
         whitelist:
           tags:
           - CleanerGrenade
+      # HONK END
   - type: Appearance
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -34,7 +34,9 @@
   - type: Clothing
     slots: [belt]
     sprite: Objects/Specific/Janitorial/trashbag.rsi
+    # HONK START - explicit equipped sprite state
     equippedState: equipped-BELT
+    # HONK END
   - type: Item
     size: Normal
 
@@ -51,6 +53,7 @@
     heldPrefix: blue
   - type: StorageFillVisualizer
     fillBaseName: blue-icon
+  # HONK START - blue variant gets its own clothing sprite + tag
   - type: Clothing
     slots: [belt]
     sprite: Objects/Specific/Janitorial/trashbag.rsi
@@ -58,6 +61,7 @@
   - type: Tag
     tags:
     - TrashBagBlue
+  # HONK END
 
 - type: entity
   name: spell of all-consuming cleanliness

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -22,9 +22,11 @@
   - type: ContainerContainer
     containers:
       light_replacer_storage: !type:Container
+  # HONK START - Tag for janitor belt whitelist
   - type: Tag
     tags:
     - LightReplacer
+  # HONK END
   # HONK START - Light replacer recycler
   - type: LightReplacerRecycler
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
@@ -41,9 +41,11 @@
       reagents:
       - ReagentId: SpaceCleaner
         Quantity: 30
+  # HONK START - tag for janitor belt storage whitelist
   - type: Tag
     tags:
     - CleanerGrenade
+  # HONK END
 
 - type: entity
   parent: SmokeGrenade

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -318,8 +318,10 @@
 - type: Tag
   id: Cleaver # Storage whitelist: ClothingBeltChef. ItemMapper: ClothingBeltChef
 
+# HONK START
 - type: Tag
   id: CleanerGrenade # Storage whitelist: ClothingBeltJanitor. ItemMapper: ClothingBeltJanitor
+# HONK END
 
 - type: Tag
   id: ClothMade # SpecialDigestible: OrganMothStomach. Storage whitelist: FoodBoxCloth
@@ -866,8 +868,10 @@
 - type: Tag
   id: LightBulb # Storage whitelist: BoxLightbulb. ConstructionGraph: HelmetJustice
 
+# HONK START
 - type: Tag
   id: LightReplacer # Storage whitelist: ClothingBeltJanitor. ItemMapper: ClothingBeltJanitor
+# HONK END
 
 - type: Tag
   id: Lime # CargoBounty: BountyLime
@@ -1452,8 +1456,10 @@
 - type: Tag
   id: TrashBag # Storage whitelist: BoxTrashbag, ClothingBeltJanitor, JanitorialTrolley. ItemMapper: JanitorialTrolley
 
+# HONK START
 - type: Tag
   id: TrashBagBlue # Storage whitelist: BoxTrashbag, ClothingBeltJanitor, JanitorialTrolley. ItemMapper: JanitorialTrolley
+# HONK END
 
 - type: Tag
   id: Truncheon # Storage whitelist: ClothingBeltSecurity


### PR DESCRIPTION
Contributes to #485 — clears the INLINE-HONK and CONTENT-NO-HONK buckets from the weekly YAML drift scan.

## About the PR

Seven upstream YAML files get HONK block markers wrapped around fork-added content that was drifting invisibly:

- `Resources/Prototypes/Catalog/Cargo/cargo_service.yml` — inline `# HONK -` tail comment promoted to block form.
- `Resources/Prototypes/Catalog/Fills/Boxes/general.yml`, `Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml`, `Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml`, `Resources/Prototypes/tags.yml` — fork janitor tools (TrashBagBlue, CleanerGrenade, LightReplacer tags, blue trashbag clothing variant) now wrapped.
- `Resources/Prototypes/Entities/Clothing/Belt/job.yml` — janitor belt now-sprite-mapped tool entries and extra tag items wrapped.
- `Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml` — the `- type: Tag` addition wrapped.

## Why / Balance

Every unmarked drift line is a blind spot during rebase: the scanner strips HONK blocks before diffing, so anything outside is indistinguishable from legitimate upstream content. Wrapping the fork-specific YAML turns these files into HONK-visible drift even when the audit can't move them out of MIXED.

### Weekly audit delta

| Bucket | Before | After |
|---|---|---|
| INLINE-HONK | 1 | 0 |
| CONTENT-NO-HONK | 4 | 0 |
| MIXED | 14 | 15 |

The +1 to MIXED is `cargo_service.yml` rolling over from INLINE-HONK once its comment became a block — expected. The 15 remaining MIXED files all replace upstream values (e.g. `cost: 560 → cost: 750`) or restructure upstream sequences; because `strip_honk_blocks` leaves a gap where the fork block used to be, a strict equality check still catches a hole. Those need either fork-value reverts or prototype overrides in `@RussStation/` and ship as follow-ups.

## Technical details

- YAML edits routed through Python-through-Bash (per project practice) to avoid the Prettier PostToolUse hook re-flowing upstream indentation.
- YAML linter runs clean (`No errors found`).

## Media

N/A — prototype markup cleanup, no in-game change.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.