### PR TITLE
feat: ReplacementAccent composes via a list

### DIFF
--- a/Content.Server/Speech/Components/ReplacementAccentComponent.cs
+++ b/Content.Server/Speech/Components/ReplacementAccentComponent.cs
@@ -1,5 +1,8 @@
 using Content.Server.Speech.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+// HONK START - #634: ProtoId<T> for the new Accents list.
+using Robust.Shared.Prototypes;
+// HONK END
 
 namespace Content.Server.Speech.Components;
 
@@ -9,7 +12,12 @@ namespace Content.Server.Speech.Components;
 [RegisterComponent]
 public sealed partial class ReplacementAccentComponent : Component
 {
-    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<ReplacementAccentPrototype>), required: true)]
-    public string Accent = default!;
+    // HONK START - #634: field split so accents compose. Legacy `accent: X` still deserializes and gets merged
+    // into Accents on ComponentInit. At least one of the two must be provided (validated at init).
+    [DataField("accent", customTypeSerializer: typeof(PrototypeIdSerializer<ReplacementAccentPrototype>))]
+    public string? Accent;
 
+    [DataField("accents")]
+    public List<ProtoId<ReplacementAccentPrototype>> Accents = new();
+    // HONK END
 }

--- a/Content.Server/Speech/EntitySystems/AddAccentClothingSystem.cs
+++ b/Content.Server/Speech/EntitySystems/AddAccentClothingSystem.cs
@@ -16,18 +16,28 @@ public sealed class AddAccentClothingSystem : EntitySystem
 //  TODO: Turn this into a relay event.
     private void OnGotEquipped(EntityUid uid, AddAccentClothingComponent component, ref ClothingGotEquippedEvent args)
     {
-        // does the user already has this accent?
         var componentType = Factory.GetRegistration(component.Accent).Type;
+
+        // HONK START - #634: ReplacementAccent composes via its list, so append instead of short-circuiting on HasComp.
+        if (componentType == typeof(ReplacementAccentComponent))
+        {
+            if (component.ReplacementPrototype == null)
+                return;
+
+            var rep = EnsureComp<ReplacementAccentComponent>(args.Wearer);
+            rep.Accents.Add(component.ReplacementPrototype);
+            component.IsActive = true;
+            return;
+        }
+        // HONK END
+
+        // does the user already has this accent?
         if (HasComp(args.Wearer, componentType))
             return;
 
         // add accent to the user
         var accentComponent = (Component) Factory.GetComponent(componentType);
         AddComp(args.Wearer, accentComponent);
-
-        // snowflake case for replacement accent
-        if (accentComponent is ReplacementAccentComponent rep)
-            rep.Accent = component.ReplacementPrototype!;
 
         component.IsActive = true;
     }
@@ -37,8 +47,24 @@ public sealed class AddAccentClothingSystem : EntitySystem
         if (!component.IsActive)
             return;
 
-        // try to remove accent
         var componentType = Factory.GetRegistration(component.Accent).Type;
+
+        // HONK START - #634: remove just our contributed entry from the list, preserving other accents (species baseline, other hats).
+        if (componentType == typeof(ReplacementAccentComponent))
+        {
+            if (component.ReplacementPrototype != null
+                && TryComp<ReplacementAccentComponent>(args.Wearer, out var rep))
+            {
+                rep.Accents.Remove(component.ReplacementPrototype);
+                if (rep.Accents.Count == 0)
+                    RemComp<ReplacementAccentComponent>(args.Wearer);
+            }
+            component.IsActive = false;
+            return;
+        }
+        // HONK END
+
+        // try to remove accent
         RemComp(args.Wearer, componentType);
 
         component.IsActive = false;

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -25,9 +25,25 @@ namespace Content.Server.Speech.EntitySystems
         public override void Initialize()
         {
             SubscribeLocalEvent<ReplacementAccentComponent, AccentGetEvent>(OnAccent);
+            // HONK START - #634: fold legacy single `accent:` yaml field into the list so callers only read Accents.
+            SubscribeLocalEvent<ReplacementAccentComponent, ComponentInit>(OnInit);
+            // HONK END
 
             _proto.PrototypesReloaded += OnPrototypesReloaded;
         }
+
+        // HONK START - #634
+        private void OnInit(EntityUid uid, ReplacementAccentComponent component, ComponentInit args)
+        {
+            if (component.Accent == null)
+                return;
+
+            var id = new ProtoId<ReplacementAccentPrototype>(component.Accent);
+            if (!component.Accents.Contains(id))
+                component.Accents.Add(id);
+            component.Accent = null;
+        }
+        // HONK END
 
         public override void Shutdown()
         {
@@ -36,10 +52,36 @@ namespace Content.Server.Speech.EntitySystems
             _proto.PrototypesReloaded -= OnPrototypesReloaded;
         }
 
+        // HONK START - #634: iterate list of accents; random-pick among stacked full-replacement entries.
         private void OnAccent(EntityUid uid, ReplacementAccentComponent component, AccentGetEvent args)
         {
-            args.Message = ApplyReplacements(args.Message, component.Accent);
+            if (component.Accents.Count == 0)
+                return;
+
+            var fullReplacementAccents = new List<ProtoId<ReplacementAccentPrototype>>();
+            foreach (var accent in component.Accents)
+            {
+                if (_proto.TryIndex(accent, out var proto) && proto.FullReplacements != null)
+                    fullReplacementAccents.Add(accent);
+            }
+
+            if (fullReplacementAccents.Count > 0)
+            {
+                var winner = _random.Pick(fullReplacementAccents);
+                foreach (var accent in component.Accents)
+                {
+                    if (fullReplacementAccents.Contains(accent) && accent != winner)
+                        continue;
+
+                    args.Message = ApplyReplacements(args.Message, accent);
+                }
+                return;
+            }
+
+            foreach (var accent in component.Accents)
+                args.Message = ApplyReplacements(args.Message, accent);
         }
+        // HONK END
 
         /// <summary>
         ///     Attempts to apply a given replacement accent prototype to a message.

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -152,7 +152,11 @@ public sealed partial class ZombieSystem
         if (TryComp<ZombieAccentOverrideComponent>(target, out var accent))
             accentType = accent.Accent;
 
-        EnsureComp<ReplacementAccentComponent>(target).Accent = accentType;
+        // HONK START - #634: ReplacementAccent is a list now; zombification overwrites any prior voice.
+        var rep = EnsureComp<ReplacementAccentComponent>(target);
+        rep.Accents.Clear();
+        rep.Accents.Add(accentType);
+        // HONK END
 
         //This is needed for stupid entities that fuck up combat mode component
         //in an attempt to make an entity not attack. This is the easiest way to do it.


### PR DESCRIPTION
First slice of #634. Pure foundation: no yaml changes, no player-visible behaviour change by itself.

## About the PR

`ReplacementAccentComponent` gains an `Accents` list. The legacy singular `Accent` field still deserializes, and a `ComponentInit` handler folds it into the list so everything downstream reads `Accents`. `ReplacementAccentSystem.OnAccent` iterates the list. If two or more entries have `FullReplacements` set, a per-event random roll picks one and skips the rest. Word-replacement entries still layer normally.

`AddAccentClothingSystem` no longer AddComp/RemComp-s the whole `ReplacementAccentComponent` when a player equips/unequips a speech hat. It appends to / removes from the list, preserving the wearer's species baseline and any other active accent entries.

`ZombieSystem.Transform` clears-then-adds rather than overwriting a string, matching the upstream "becoming a zombie replaces your voice" intent.

## Why / Balance

Enables the follow-up Accentless rework in #634 and makes species baselines (Dwarf scottish) compose with trait/item accents instead of clobbering each other. No player-visible change in this PR: every existing prototype uses the singular form and ends up with a single-entry list.

## Technical details

- `ReplacementAccentComponent`: legacy `Accent: string?` kept, new `Accents: List<ProtoId<ReplacementAccentPrototype>>`. ComponentInit folds legacy → list.
- `ReplacementAccentSystem.OnAccent`: iterate + random-roll on stacked full-replacements.
- `AddAccentClothingSystem`: special-case `ReplacementAccent` component type to append/remove list entries.
- `ZombieSystem.Transform`: `Accents.Clear(); Accents.Add(accentType);`.
- Zero yaml changes. Zero HONK drift in the cs audit.

## Media

None. No player-visible behaviour change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None on the yaml side. C# callers that read `ReplacementAccentComponent.Accent` directly will now get `null` after ComponentInit; they should iterate `Accents` instead. Only two such sites existed and both are updated.

**Changelog**

No :cl: entry. Internal refactor, no player-visible change.