### PR TITLE
honksquad: fix: diff-aware HONK drift scanner recognises replacements

### DIFF
--- a/Tools/honk/common.py
+++ b/Tools/honk/common.py
@@ -193,14 +193,19 @@ def unmarked_hunks(
     # Lift HONK membership onto the normalized index space.
     fork_in_honk = [in_honk_raw[i] for i in fork_idx]
 
-    # Lines that are just punctuation or a single keyword are alignment noise
-    # to SequenceMatcher — it'll pair them asymmetrically between the fork's
-    # and upstream's many `}` / `{` / `;` occurrences. Skip hunks consisting
-    # entirely of such lines on both sides.
-    _NOISE = re.compile(r"^[\s{}();,\[\]]*$")
+    # Lines that are just punctuation, HONK markers, or whitespace are
+    # alignment noise to SequenceMatcher — it'll pair repetitive `}`/`{`/`;`
+    # lines asymmetrically across the two inputs and sometimes drag a HONK
+    # marker along for the ride. Skip hunks consisting entirely of such lines.
+    _PUNCT = re.compile(r"^[\s{}();,\[\]]*$")
+
+    def _is_noise(line: str) -> bool:
+        return bool(
+            _PUNCT.match(line) or HONK_START.search(line) or HONK_END.search(line)
+        )
 
     def _all_noise(lines: list[str], lo: int, hi: int) -> bool:
-        return all(_NOISE.match(lines[k]) for k in range(lo, hi))
+        return all(_is_noise(lines[k]) for k in range(lo, hi))
 
     bad: list[tuple[int, int, int, int]] = []
     matcher = difflib.SequenceMatcher(a=fork_norm, b=ref_norm, autojunk=False)

--- a/Tools/honk/common.py
+++ b/Tools/honk/common.py
@@ -129,6 +129,110 @@ def drift_lines(fork_text: str, reference_text: str) -> set[str]:
     return fork_set - reference_set
 
 
+def _fork_line_in_honk(fork_text: str) -> list[bool]:
+    """For each fork line (0-indexed), whether it sits inside a HONK block
+    (including the START/END marker lines themselves, which are treated as
+    part of their own block)."""
+    out: list[bool] = []
+    depth = 0
+    for line in fork_text.splitlines():
+        if HONK_START.search(line):
+            depth += 1
+            out.append(True)
+            continue
+        if HONK_END.search(line):
+            out.append(True)
+            depth -= 1
+            continue
+        out.append(depth > 0)
+    return out
+
+
+def unmarked_hunks(
+    fork_text: str, reference_text: str
+) -> list[tuple[int, int, int, int]]:
+    """Diff-aware drift detection.
+
+    Returns a list of `(fork_start, fork_end, ref_start, ref_end)` hunks
+    (half-open intervals, 0-indexed into the whitespace-normalized line
+    lists) where fork and reference differ AND the difference is not covered
+    by a HONK block on the fork side.
+
+    A hunk is considered "marked" (and therefore OK) when:
+      * It has fork lines AND every fork line in the hunk is inside a HONK
+        block, OR
+      * It has no fork lines (pure upstream removal) AND the fork position
+        is adjacent to a HONK block (i.e. the line before or after the
+        insertion point is a HONK START/END marker or sits inside a block).
+
+    Empty / whitespace-only lines are ignored so indentation-style reflow
+    doesn't register as drift.
+    """
+    import difflib
+
+    fork_lines = fork_text.splitlines()
+    ref_lines = reference_text.splitlines()
+
+    in_honk_raw = _fork_line_in_honk(fork_text)
+
+    # Build whitespace-normalized sequences with index maps back to the raw
+    # line numbers so we can look up HONK membership.
+    def _build(lines: list[str]) -> tuple[list[str], list[int]]:
+        norm_out: list[str] = []
+        idx_out: list[int] = []
+        for i, line in enumerate(lines):
+            collapsed = re.sub(r"\s+", " ", line).strip()
+            if collapsed:
+                norm_out.append(collapsed)
+                idx_out.append(i)
+        return norm_out, idx_out
+
+    fork_norm, fork_idx = _build(fork_lines)
+    ref_norm = _build(ref_lines)[0]
+
+    # Lift HONK membership onto the normalized index space.
+    fork_in_honk = [in_honk_raw[i] for i in fork_idx]
+
+    # Lines that are just punctuation or a single keyword are alignment noise
+    # to SequenceMatcher — it'll pair them asymmetrically between the fork's
+    # and upstream's many `}` / `{` / `;` occurrences. Skip hunks consisting
+    # entirely of such lines on both sides.
+    _NOISE = re.compile(r"^[\s{}();,\[\]]*$")
+
+    def _all_noise(lines: list[str], lo: int, hi: int) -> bool:
+        return all(_NOISE.match(lines[k]) for k in range(lo, hi))
+
+    bad: list[tuple[int, int, int, int]] = []
+    matcher = difflib.SequenceMatcher(a=fork_norm, b=ref_norm, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+
+        if _all_noise(fork_norm, i1, i2) and _all_noise(ref_norm, j1, j2):
+            continue
+
+        fork_span = range(i1, i2)
+        if fork_span:
+            if all(fork_in_honk[i] for i in fork_span):
+                continue
+            bad.append((i1, i2, j1, j2))
+            continue
+
+        # Pure upstream-only hunk (fork removed lines). Accept if an adjacent
+        # fork position sits inside or at the boundary of a HONK block, which
+        # documents that the removal is intentional.
+        adjacent = False
+        for probe in (i1 - 1, i1):
+            if 0 <= probe < len(fork_in_honk) and fork_in_honk[probe]:
+                adjacent = True
+                break
+        if adjacent:
+            continue
+        bad.append((i1, i2, j1, j2))
+
+    return bad
+
+
 def pr_new_inline(path: str, base_ref: str, fork_ref: str) -> set[str]:
     """Inline HONK lines present in fork_ref but not in base_ref.
 

--- a/Tools/honk/cs_audit.py
+++ b/Tools/honk/cs_audit.py
@@ -25,14 +25,13 @@ from common import (
     DRIFT_CATEGORIES,
     HONK_START,
     balanced_honk,
-    drift_lines,
     git_show,
     inline_honk_lines,
     is_fork_owned,
     pr_new_drift,
     pr_new_inline,
     sh,
-    strip_honk_blocks,
+    unmarked_hunks,
 )
 
 DEFAULT_FORK_REF = "origin/release"
@@ -110,17 +109,16 @@ def classify(path: str, fork_ref: str, upstream_ref: str) -> Result:
         return Result(path, "IDENTICAL")
 
     has_honk = bool(HONK_START.search(release))
+    bad = unmarked_hunks(release, upstream)
 
-    stripped_release = strip_honk_blocks(release)
-
-    if not drift_lines(stripped_release, upstream):
+    if not bad:
         if has_honk:
             return Result(path, "HONK-ONLY")
         return Result(path, "REFORMAT-ONLY")
 
     if has_honk:
-        return Result(path, "MIXED", "drift outside HONK")
-    return Result(path, "CONTENT-NO-HONK", "unmarked content changes")
+        return Result(path, "MIXED", f"{len(bad)} unmarked hunk(s) outside HONK")
+    return Result(path, "CONTENT-NO-HONK", f"{len(bad)} unmarked content change(s)")
 
 
 def print_summary(results: list[Result], *, verbose: bool) -> None:

--- a/Tools/honk/yaml_drift.py
+++ b/Tools/honk/yaml_drift.py
@@ -39,8 +39,7 @@ from common import (
     pr_new_drift,
     pr_new_inline,
     sh,
-    strip_honk_blocks,
-    whitespace_normalize,
+    unmarked_hunks,
 )
 
 DEFAULT_FORK_REF = "origin/release"
@@ -104,19 +103,16 @@ def classify(path: str, fork_ref: str, upstream_ref: str) -> Result:
         return Result(path, "IDENTICAL")
 
     has_honk = bool(HONK_START.search(release))
+    bad = unmarked_hunks(release, upstream)
 
-    stripped_release = strip_honk_blocks(release)
-    norm_stripped = whitespace_normalize(stripped_release)
-    norm_upstream = whitespace_normalize(upstream)
-
-    if norm_stripped == norm_upstream:
+    if not bad:
         if has_honk:
             return Result(path, "HONK-ONLY")
         return Result(path, "REFORMAT-ONLY")
 
     if has_honk:
-        return Result(path, "MIXED", "drift outside HONK")
-    return Result(path, "CONTENT-NO-HONK", "unmarked content changes")
+        return Result(path, "MIXED", f"{len(bad)} unmarked hunk(s) outside HONK")
+    return Result(path, "CONTENT-NO-HONK", f"{len(bad)} unmarked content change(s)")
 
 
 def print_summary(results: list[Result], *, verbose: bool) -> None:


### PR DESCRIPTION
## About the PR

Rewrites the core "is this file drifting?" check in `Tools/honk/common.py` so the scanner understands that a HONK-wrapped block can *replace* upstream lines, not just sit alongside them. Both `yaml_drift.py` and `cs_audit.py` pick up the new logic.

## Why / Balance

The old check was:

```python
if whitespace_normalize(strip_honk_blocks(release)) == whitespace_normalize(upstream):
    # HONK-ONLY
```

That requires the stripped fork to be byte-identical to upstream, which is only possible when the fork strictly *adds* lines. Any value change (`cost: 560 → cost: 750`, `amount: 8 → 7`, `needsHands: false → true`) left a hole after stripping and the file fell into MIXED even when every diverging line was inside a HONK block.

The fix: walk the diff hunk by hunk (`difflib.SequenceMatcher`). For each non-equal hunk, accept it when:

- the fork side is non-empty and every fork line in the hunk sits inside a HONK block (additions and replacements both), or
- the fork side is empty (upstream-only deletion) and an adjacent fork line is inside a HONK block (intentional removal).

Punctuation-only hunks that SequenceMatcher aligns asymmetrically (many `}` or `};` lines in C#) are filtered as noise.

### Report delta

| | release YAML | release C# |
|---|---|---|
| old MIXED | 3 | 15 |
| new MIXED | 3 | 15 |
| old HONK-ONLY | 49 | 58 |
| new HONK-ONLY | 49 | 58 |

No change on the current release (the two scanners agree when drift is already unmarked). The win is on PRs that wrap replacements:

| | PR #642 YAML | PR #637 C# |
|---|---|---|
| MIXED (old) | 15 | 0 |
| MIXED (new) | 2 | 12 |

PR #642 collapses from 15 MIXED to 2 because twelve value-replacement files now register as HONK-ONLY. PR #637 gains a MIXED count because the old set-based check was *hiding* real drift when changed lines happened to exist elsewhere in the file — the new scanner is position-aware. Those twelve files are genuine drift that needs wrapping.

## Technical details

- New function `unmarked_hunks(fork_text, reference_text)` in `Tools/honk/common.py`. Returns the hunks that still need attention; caller decides category.
- `yaml_drift.classify` and `cs_audit.classify` switch from `drift_lines(strip_honk_blocks(release), upstream)` to `unmarked_hunks(release, upstream)`.
- The old `drift_lines` helper stays around for `pr_new_drift` (PR-mode diff-of-diffs).
- Noise filter: hunks consisting entirely of lines matching `^[\s{}();,\[\]]*$` on both sides are skipped.

## Media

N/A — tooling change.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None for the game. For contributors: a PR that used to pass as "no unmarked drift" because the old set-based check dedup'd changed lines against lines elsewhere in the file will now be flagged. This is the intended behaviour.