### PR TITLE
feat: species-aware Accentless trait + generic trait species gating

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Appearance.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Appearance.cs
@@ -187,6 +187,22 @@ public sealed partial class HumanoidProfileEditor
         RefreshJobs();
         // In case there's species restrictions for loadouts
         RefreshLoadouts();
+        //HONK START - #634: drop trait preferences whose SpeciesWhitelist excludes
+        // the new species (e.g. Accentless selected on Dwarf, then species changed
+        // to Human). Mirrors RefreshJobs/RefreshLoadouts species pruning above so
+        // the trait isn't carried into a profile where it can't be applied.
+        if (Profile is { } profile)
+        {
+            foreach (var traitId in profile.TraitPreferences.ToList())
+            {
+                if (!_prototypeManager.TryIndex<Content.Shared.Traits.TraitPrototype>(traitId, out var trait))
+                    continue;
+                if (trait.SpeciesWhitelist != null && !trait.SpeciesWhitelist.Contains(newSpecies))
+                    Profile = Profile?.WithoutTraitPreference(traitId, _prototypeManager);
+            }
+        }
+        RefreshTraits();
+        //HONK END
         UpdateSexControls(); // update sex for new species
         UpdateSpeciesGuidebookIcon();
         ReloadPreview();

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -24,6 +24,11 @@ public sealed partial class HumanoidProfileEditor
         TraitsList.RemoveAllChildren();
 
         var traits = _prototypeManager.EnumeratePrototypes<TraitPrototype>().OrderBy(t => Loc.GetString(t.Name)).ToList();
+
+        // HONK START - #634: hide traits whose SpeciesWhitelist excludes the current species (e.g. Accentless on Human).
+        if (Profile?.Species is { } speciesId)
+            traits = traits.Where(t => t.SpeciesWhitelist == null || t.SpeciesWhitelist.Contains(speciesId)).ToList();
+        // HONK END
         TabContainer.SetTabTitle(3, Loc.GetString("humanoid-profile-editor-traits-tab"));
 
         if (traits.Count < 1)
@@ -222,7 +227,9 @@ public sealed partial class HumanoidProfileEditor
             foreach (var traitProto in categoryTraits)
             {
                 var trait = _prototypeManager.Index<TraitPrototype>(traitProto);
-                var selector = new TraitPreferenceSelector(trait);
+                // HONK START - #634: forward species for per-species description override.
+                var selector = new TraitPreferenceSelector(trait, Profile?.Species);
+                // HONK END
 
                 selector.Preference = Profile?.TraitPreferences.Contains(trait.ID) == true;
                 if (selector.Preference)

--- a/Content.Client/Lobby/UI/Roles/TraitPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/Roles/TraitPreferenceSelector.xaml.cs
@@ -6,6 +6,9 @@ using Robust.Client.UserInterface.XAML;
 //HONK START - ProtoId<TraitPrototype> for trait tracking
 using Robust.Shared.Prototypes;
 //HONK END
+// HONK START - #634: per-species description override.
+using Content.Shared.Humanoid.Prototypes;
+// HONK END
 
 namespace Content.Client.Lobby.UI.Roles;
 
@@ -44,6 +47,18 @@ public sealed partial class TraitPreferenceSelector : Control
             Checkbox.ToolTip = Loc.GetString(desc);
         }
     }
+
+    // HONK START - #634: species-aware overload that applies per-species description overrides.
+    public TraitPreferenceSelector(TraitPrototype trait, ProtoId<SpeciesPrototype>? species) : this(trait)
+    {
+        if (species is { } s
+            && trait.DescriptionOverrides is { } overrides
+            && overrides.TryGetValue(s, out var speciesDesc))
+        {
+            Checkbox.ToolTip = Loc.GetString(speciesDesc);
+        }
+    }
+    // HONK END
 
     private void OnCheckBoxToggled(BaseButton.ButtonToggledEventArgs args)
     {

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -3,6 +3,9 @@ using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Server.Speech.Prototypes;
 using Content.Shared.Speech;
+// HONK START - #634: Accentless strip-list event handling.
+using Content.Shared.Traits.Assorted;
+// HONK END
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -27,6 +30,9 @@ namespace Content.Server.Speech.EntitySystems
             SubscribeLocalEvent<ReplacementAccentComponent, AccentGetEvent>(OnAccent);
             // HONK START - #634: fold legacy single `accent:` yaml field into the list so callers only read Accents.
             SubscribeLocalEvent<ReplacementAccentComponent, ComponentInit>(OnInit);
+            // Accentless dispatches this when a per-species strip list fires; handled here because
+            // ReplacementAccentComponent lives in Content.Server.
+            SubscribeLocalEvent<ReplacementAccentComponent, AccentlessStripReplacementAccentsEvent>(OnAccentlessStrip);
             // HONK END
 
             _proto.PrototypesReloaded += OnPrototypesReloaded;
@@ -42,6 +48,12 @@ namespace Content.Server.Speech.EntitySystems
             if (!component.Accents.Contains(id))
                 component.Accents.Add(id);
             component.Accent = null;
+        }
+
+        private void OnAccentlessStrip(EntityUid uid, ReplacementAccentComponent component, ref AccentlessStripReplacementAccentsEvent args)
+        {
+            foreach (var accentId in args.AccentIds)
+                component.Accents.Remove(accentId);
         }
         // HONK END
 

--- a/Content.Shared/Traits/Assorted/AccentlessComponent.cs
+++ b/Content.Shared/Traits/Assorted/AccentlessComponent.cs
@@ -1,5 +1,8 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+// HONK START - #634: species-aware Accentless needs SpeciesPrototype.
+using Content.Shared.Humanoid.Prototypes;
+// HONK END
 
 namespace Content.Shared.Traits.Assorted;
 
@@ -9,9 +12,39 @@ namespace Content.Shared.Traits.Assorted;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class AccentlessComponent : Component
 {
+    // HONK START - #634: required dropped so trait yaml can provide speciesEffects instead of removes.
     /// <summary>
     ///     The accents removed by the accentless trait.
     /// </summary>
-    [DataField("removes", required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("removes"), ViewVariables(VVAccess.ReadWrite)]
     public ComponentRegistry RemovedAccents = new();
+
+    /// <summary>
+    ///     Per-species rules for what Accentless strips on that species. Keyed by SpeciesPrototype id.
+    ///     If the wearer's species has no entry here, Accentless does nothing (on top of RemovedAccents).
+    ///     Used by player-facing Accentless. NPC entity prototypes typically use RemovedAccents.
+    /// </summary>
+    [DataField("speciesEffects"), ViewVariables(VVAccess.ReadWrite)]
+    public Dictionary<ProtoId<SpeciesPrototype>, AccentlessSpeciesEffect> SpeciesEffects = new();
+    // HONK END
 }
+
+// HONK START - #634
+[DataDefinition]
+public sealed partial class AccentlessSpeciesEffect
+{
+    /// <summary>
+    ///     Component types on the wearer to RemComp. Same semantics as AccentlessComponent.RemovedAccents.
+    /// </summary>
+    [DataField("strips")]
+    public ComponentRegistry Strips = new();
+
+    /// <summary>
+    ///     ReplacementAccentPrototype ids to remove from ReplacementAccentComponent.Accents on the wearer.
+    ///     String-typed because ReplacementAccentPrototype lives in Content.Server; AccentlessSystem (Shared)
+    ///     passes the list over to the Server-side handler that touches the list.
+    /// </summary>
+    [DataField("stripsReplacementAccents")]
+    public List<string> StripsReplacementAccents = new();
+}
+// HONK END

--- a/Content.Shared/Traits/Assorted/AccentlessSystem.cs
+++ b/Content.Shared/Traits/Assorted/AccentlessSystem.cs
@@ -1,4 +1,7 @@
 using Robust.Shared.Serialization.Manager;
+// HONK START - #634: species lookup for species-aware Accentless.
+using Content.Shared.Humanoid;
+// HONK END
 
 namespace Content.Shared.Traits.Assorted;
 
@@ -22,5 +25,29 @@ public sealed class AccentlessSystem : EntitySystem
             var accentComponent = accent.Component;
             RemComp(uid, accentComponent.GetType());
         }
+
+        // HONK START - #634: species-aware removals on humanoids.
+        if (component.SpeciesEffects.Count > 0
+            && TryComp<HumanoidProfileComponent>(uid, out var humanoid)
+            && component.SpeciesEffects.TryGetValue(humanoid.Species, out var effect))
+        {
+            foreach (var strip in effect.Strips.Values)
+                RemComp(uid, strip.Component.GetType());
+
+            // Dispatch the replacement-accent list cleanup to a shared event handled server-side
+            // where ReplacementAccentComponent lives.
+            if (effect.StripsReplacementAccents.Count > 0)
+            {
+                var ev = new AccentlessStripReplacementAccentsEvent(effect.StripsReplacementAccents);
+                RaiseLocalEvent(uid, ref ev);
+            }
+        }
+        // HONK END
     }
 }
+
+// HONK START - #634: raised when Accentless needs to remove specific accent ids from
+// ReplacementAccentComponent.Accents on a humanoid. Handled server-side only.
+[ByRefEvent]
+public readonly record struct AccentlessStripReplacementAccentsEvent(List<string> AccentIds);
+// HONK END

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -1,6 +1,9 @@
 using Content.Shared.Roles;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
+// HONK START - #634: species-aware trait visibility + per-species description overrides.
+using Content.Shared.Humanoid.Prototypes;
+// HONK END
 
 namespace Content.Shared.Traits;
 
@@ -85,4 +88,20 @@ public sealed partial class TraitPrototype : IPrototype
     [DataField]
     public List<string> ExcludedTags { get; private set; } = new();
     //HONK END
+
+    // HONK START - #634: species-aware trait visibility + per-species description overrides.
+    /// <summary>
+    /// If set, the trait is only offered in the character editor when the selected species is in this list.
+    /// Used to hide traits that have no effect on certain species (e.g. Accentless on Human).
+    /// </summary>
+    [DataField]
+    public List<ProtoId<SpeciesPrototype>>? SpeciesWhitelist;
+
+    /// <summary>
+    /// Optional per-species override for the trait's description, shown in the character editor.
+    /// Keyed by SpeciesPrototype id. Falls back to <see cref="Description"/> when no entry matches.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<SpeciesPrototype>, LocId>? DescriptionOverrides;
+    // HONK END
 }

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -29,6 +29,12 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 
 trait-accentless-name = Accentless
 trait-accentless-desc = You don't have the accent that your species would usually have.
+# HONK START - #634 per-species description overrides
+trait-accentless-desc-reptilian = Removes your lizard accent.
+trait-accentless-desc-moth = Removes your moth accent.
+trait-accentless-desc-dwarf = Removes your Scottish accent.
+trait-accentless-desc-skeleton = Removes your skeleton accent.
+# HONK END
 
 trait-frontal-lisp-name = Lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -5,7 +5,6 @@
 - type: traitCategory
   id: SpeechTraits
   name: trait-category-speech
-  maxTraitPoints: 2
 
 - type: traitCategory
   id: Quirks

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -8,13 +8,30 @@
   description: trait-accentless-desc
   category: SpeechTraits
   cost: 2
+  # HONK START - #634: species-aware Accentless. Per-species strip lists instead of one flat list.
+  speciesWhitelist: [ Reptilian, Moth, Dwarf, Skeleton ]
+  descriptionOverrides:
+    Reptilian: trait-accentless-desc-reptilian
+    Moth: trait-accentless-desc-moth
+    Dwarf: trait-accentless-desc-dwarf
+    Skeleton: trait-accentless-desc-skeleton
+  # HONK END
   components:
   - type: Accentless
-    removes:
-    - type: LizardAccent
-    - type: MothAccent
-    - type: ReplacementAccent
-      accent: scottish
+    # HONK START - #634
+    speciesEffects:
+      Reptilian:
+        strips:
+        - type: LizardAccent
+      Moth:
+        strips:
+        - type: MothAccent
+      Dwarf:
+        stripsReplacementAccents: [ scottish ]
+      Skeleton:
+        strips:
+        - type: SkeletonAccent
+    # HONK END
 
 # 1 Cost
 


### PR DESCRIPTION
Second slice of #634, stacked on top of #644. Depends on the ReplacementAccent list refactor.

## About the PR

Accentless stops being a flat list remover and becomes species-aware. On a Dwarf it removes just the scottish entry from the new `ReplacementAccentComponent.Accents` list; on a Reptilian it RemComps `LizardAccent`; on a Moth, `MothAccent`; on a Skeleton, `SkeletonAccent` (previously missing). On Humans and other species without a baseline accent, Accentless is hidden from the character editor entirely.

Generalises two fields onto `TraitPrototype` that are useful beyond Accentless:
- `SpeciesWhitelist` - trait is only offered when the selected species matches.
- `DescriptionOverrides` - per-species description override shown in the picker.

## Why / Balance

Sets up the composition goal from #634 so that players can take Accentless on any species that has a baseline, and the trait description tells them exactly what it'll strip. No other trait uses these new fields today, so nothing else visibly changes.

## Technical details

- `AccentlessComponent` gains `SpeciesEffects: Dictionary<ProtoId<SpeciesPrototype>, AccentlessSpeciesEffect>`. Each effect has `strips: ComponentRegistry` and `stripsReplacementAccents: List<string>`. Legacy `removes:` kept for NPC usage (wizard spider is the current consumer).
- `AccentlessSystem.RemoveAccents` applies legacy `RemovedAccents` first, then matches the current species via `HumanoidProfileComponent.Species` and applies the per-species effect. Replacement-accent list pruning is dispatched via a `[ByRefEvent] AccentlessStripReplacementAccentsEvent` to `ReplacementAccentSystem` (Server-side, because `ReplacementAccentComponent` lives there).
- `TraitPrototype`: adds `SpeciesWhitelist` (optional species allowlist) and `DescriptionOverrides` (species -> LocId map).
- `HumanoidProfileEditor.Traits`: filters the trait list by `SpeciesWhitelist` at render time. Passes the current species into `TraitPreferenceSelector`.
- `TraitPreferenceSelector`: species-aware overload that applies the description override.
- Accentless trait yaml: moves its removals into `speciesEffects` for Reptilian/Moth/Dwarf/Skeleton, adds the whitelist + per-species description overrides. Legacy `removes:` block dropped from the player trait (still used by NPC prototypes).
- Locale: four per-species description keys in `traits.ftl`.
- HONK discipline clean in both cs and yaml audits.

## Media

Would benefit from a tiny screenshot of the Accentless trait on a Dwarf showing "Removes your Scottish accent" vs the same trait absent on a Human. Will attach when I test in-game.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None at the yaml level for non-player consumers. Player trait yaml for Accentless has moved shape; any fork-downstream content relying on the old `removes:` shape for player Accentless would need to migrate to `speciesEffects:`.

**Changelog**

:cl:
- tweak: Accentless now works on Skeletons, shows what it removes per species, and hides itself for species that don't have a baseline accent.