### PR TITLE
feat: trait accents compose with species baselines

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -5,6 +5,9 @@ using Content.Shared.Roles;
 using Content.Shared.Traits;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
+// HONK START - #634: merge ReplacementAccent list instead of skip-if-exists.
+using Content.Server.Speech.Components;
+// HONK END
 
 namespace Content.Server.Traits;
 
@@ -46,7 +49,14 @@ public sealed class TraitSystem : EntitySystem
 
             // Add all components required by the prototype
             if (traitPrototype.Components.Count > 0)
+            {
+                // HONK START - #634: ReplacementAccent is a list component now. AddComponents would skip it
+                // because the entity may already have one from the species baseline (e.g. Dwarf scottish).
+                // Instead merge the trait's accent ids into the existing list so they compose.
+                MergeTraitReplacementAccents(args.Mob, traitPrototype.Components);
+                // HONK END
                 EntityManager.AddComponents(args.Mob, traitPrototype.Components, false);
+            }
 
             // Add all JobSpecials required by the prototype
             foreach (var special in traitPrototype.Specials)
@@ -69,4 +79,33 @@ public sealed class TraitSystem : EntitySystem
                 handsComp: handsComponent);
         }
     }
+
+    // HONK START - #634: merge a trait's ReplacementAccent entries into the existing list on the mob so accents
+    // compose (Dwarf + Liar = scottish + liar, not one clobbering the other). Runs before AddComponents - when
+    // the mob already has a ReplacementAccent, AddComponents will skip re-adding the trait's copy thanks to its
+    // skip-if-exists behaviour with removeExisting=false, and the merged list sticks.
+    private void MergeTraitReplacementAccents(EntityUid mob, ComponentRegistry components)
+    {
+        if (!TryComp<ReplacementAccentComponent>(mob, out var existing))
+            return;
+
+        var name = Factory.GetComponentName(typeof(ReplacementAccentComponent));
+        if (!components.TryGetValue(name, out var entry))
+            return;
+
+        if (entry.Component is not ReplacementAccentComponent traitComp)
+            return;
+
+        // Legacy singular form needs folding too - the trait's ComponentInit would have done it after AddComp,
+        // but we're merging into an existing component here so handle both shapes.
+        if (traitComp.Accent is { } legacy && !existing.Accents.Contains(legacy))
+            existing.Accents.Add(legacy);
+
+        foreach (var accentId in traitComp.Accents)
+        {
+            if (!existing.Accents.Contains(accentId))
+                existing.Accents.Add(accentId);
+        }
+    }
+    // HONK END
 }


### PR DESCRIPTION
Third slice of #634, stacked on #648. Needs the list refactor from #644 and (indirectly) the species-aware Accentless from #648.

## About the PR

Before: a Dwarf who took the Liar trait silently stayed scottish because `AddComponents(..., removeExisting: false)` skips components the entity already has - and the Dwarf already has a `ReplacementAccentComponent` from its species baseline.

After: `TraitSystem` folds the trait's accent ids into the mob's existing `ReplacementAccent.Accents` list before the normal `AddComponents` call. `AddComponents` still skips re-adding the component, but the merged list sticks.

## Why / Balance

Unblocks the core composition goal from #634. Taking an accent trait on a species that already has a baseline accent now actually applies the trait, instead of being a silent no-op. This is the concrete user-visible payoff of the list refactor.

Balance: no change. The player already paid the trait cost; they now actually get the effect they bought.

## Technical details

- `TraitSystem.MergeTraitReplacementAccents(mob, registry)` runs just before `AddComponents`. When the mob has `ReplacementAccentComponent` and the trait's registry contains one too, it copies the trait's accent ids (both legacy singular `Accent` and new `Accents` list) into the existing component, deduplicating.
- After the merge, the existing `AddComponents(..., false)` call sees the component already exists and skips it - which is now the correct behaviour because we already merged the data.
- Only ReplacementAccent needs this treatment. Other accent components (LizardAccent, MothAccent, SouthernAccent, FrontalLisp, etc.) are distinct component types, so stacking with species baselines already works fine via the normal AddComponents path.
- HONK-block scoped, 1 file, ~40 lines including the helper.

## Media

Same note as #648: will attach a before/after screenshot of a Dwarf saying a line with Liar selected after in-game testing.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Accent traits (Liar, Scottish, etc.) now actually apply on species that have a built-in accent, instead of being silently ignored.