### PR TITLE
fix: FrontalLisp runs after LizardAccent for stable output

### DIFF
--- a/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
@@ -16,7 +16,11 @@ public sealed class FrontalLispSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FrontalLispComponent, AccentGetEvent>(OnAccent);
+        // HONK START - #634: run after LizardAccent so Reptilian + FrontalLisp yields stable output.
+        // Without an explicit order, dispatch interleaves with LizardAccent's s->sss transform
+        // and the message varies across sessions for the same player.
+        SubscribeLocalEvent<FrontalLispComponent, AccentGetEvent>(OnAccent, after: [typeof(LizardAccentSystem)]);
+        // HONK END
     }
 
     private void OnAccent(EntityUid uid, FrontalLispComponent component, AccentGetEvent args)


### PR DESCRIPTION
Fourth slice of #634, stacked on #649. Smallest slice.

## About the PR

Reptilian characters with the FrontalLisp trait can see their speech text vary across sessions because both `LizardAccentSystem` and `FrontalLispSystem` transform the letter `s` and neither declares a subscription order on `AccentGetEvent`. Pinning lisp to run after lizard makes the output deterministic.

## Why / Balance

Not a balance change, just determinism. Same two accents, same rules, now applied in a fixed order.

## Technical details

Single subscription change in `FrontalLispSystem.Initialize` - `after: [typeof(LizardAccentSystem)]`. That's it. The broader four-tier ordering discussed in the #634 spec is deferred; this is the only pair of accents that both target the same phoneme via components players can actually stack today.

## Media

None - internal behaviour, no visible UI change.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

No :cl: entry. Determinism fix, not player-visible as a feature.