### PR TITLE
honksquad: fix: diff scanner trims alignment noise from hunk edges

### DIFF
--- a/Tools/honk/common.py
+++ b/Tools/honk/common.py
@@ -207,10 +207,45 @@ def unmarked_hunks(
     def _all_noise(lines: list[str], lo: int, hi: int) -> bool:
         return all(_is_noise(lines[k]) for k in range(lo, hi))
 
+    def _trim(
+        lo_fork: int, hi_fork: int, lo_ref: int, hi_ref: int
+    ) -> tuple[int, int, int, int]:
+        # SequenceMatcher will pull noise lines (closing braces, HONK markers)
+        # into the fork-side of an insertion/replacement when identical anchor
+        # lines exist further along on either side. Trim those off each end so
+        # they don't register as "drift outside HONK" just because the match
+        # algorithm picked the wrong anchor.
+        while (
+            hi_fork > lo_fork
+            and hi_ref > lo_ref
+            and _is_noise(fork_norm[hi_fork - 1])
+            and _is_noise(ref_norm[hi_ref - 1])
+        ):
+            hi_fork -= 1
+            hi_ref -= 1
+        while (
+            hi_fork > lo_fork and _is_noise(fork_norm[hi_fork - 1]) and lo_ref == hi_ref
+        ):
+            hi_fork -= 1
+        while (
+            hi_fork > lo_fork
+            and lo_fork < hi_fork
+            and _is_noise(fork_norm[lo_fork])
+            and lo_ref < hi_ref
+            and _is_noise(ref_norm[lo_ref])
+        ):
+            lo_fork += 1
+            lo_ref += 1
+        return lo_fork, hi_fork, lo_ref, hi_ref
+
     bad: list[tuple[int, int, int, int]] = []
     matcher = difflib.SequenceMatcher(a=fork_norm, b=ref_norm, autojunk=False)
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "equal":
+            continue
+
+        i1, i2, j1, j2 = _trim(i1, i2, j1, j2)
+        if i1 == i2 and j1 == j2:
             continue
 
         if _all_noise(fork_norm, i1, i2) and _all_noise(ref_norm, j1, j2):


### PR DESCRIPTION
Follow-up to #646.

## About the PR

The diff-aware scanner lands hunks from \`difflib.SequenceMatcher\` and checks that the fork side of each non-equal hunk sits inside a HONK block. The problem: SequenceMatcher picks anchors by longest matching subsequence, which means a trailing \`}\` or \`// HONK END\` line on the fork side often gets pulled into an insertion hunk because an identical \`}\` line appears further down. That flagged files as MIXED purely because the closing brace of a fork-added method didn't sit inside the HONK block wrapping the method.

Adds a trim step: before the HONK-coverage check, shave noise lines (whitespace, pure punctuation, HONK markers) off each end of the hunk as long as both sides have a matching noise line to drop.

## Why / Balance

Five files flipped from MIXED to HONK-ONLY on release with no source changes. Real fork drift is still caught — only alignment-induced noise is filtered.

Release baseline moves from 14 MIXED to 12 MIXED; HONK-ONLY goes from 60 to 62 (the noise-marker commit already in flight accounted for two; this commit adds two more).

## Technical details

- New inner helper \`_trim(lo_fork, hi_fork, lo_ref, hi_ref)\` in \`unmarked_hunks\`.
- Trim passes: matching noise lines off the tail; matching noise lines off the head; trailing fork-noise when the upstream side of the hunk is empty (pure insertion that dragged noise in).
- Hunks that shrink to empty after trimming are dropped.

## Media

N/A — tooling.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.