### PR TITLE
honksquad: fix: HONK-wrap C# drift surfaced by diff-aware scanner (#484)

### DIFF
--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
@@ -51,6 +51,9 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
 
     private DialogWindow? _reasonDialog;
 
+    //HONK START - upstream had `private StationRecordFilterType _currentFilterType;` here; managed by shared filter widget
+    //HONK END
+
     private SecurityStatus _currentCrewListFilter;
 
     public CriminalRecordsConsoleWindow(EntityUid console, uint maxLength, IPlayerManager playerManager, IPrototypeManager prototypeManager, IRobustRandom robustRandom, AccessReaderSystem accessReader)
@@ -66,6 +69,8 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         _spriteSystem = _entManager.System<SpriteSystem>();
 
         _maxLength = maxLength;
+        //HONK START - upstream initialized `_currentFilterType = StationRecordFilterType.Name;` here
+        //HONK END
 
         _currentCrewListFilter = SecurityStatus.None;
 
@@ -103,6 +108,9 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         {
             OnKeySelected?.Invoke(null);
         };
+
+        //HONK START - upstream `FilterType.OnItemSelected` block lived here; replaced by SearchBar.OnFilterChanged below
+        //HONK END
 
         //Select Status to filter crew
         CrewListFilter.OnItemSelected += eventArgs =>
@@ -152,6 +160,8 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         }
 
         _selectedKey = state.SelectedKey;
+        //HONK START - upstream had `FilterType.SelectId((int)_currentFilterType);` here; SearchBar widget owns the type now
+        //HONK END
         CrewListFilter.SelectId((int)_currentCrewListFilter);
         NoRecords.Visible = state.RecordListing == null || state.RecordListing.Count == 0;
         PopulateRecordListing(state.RecordListing);

--- a/Content.Client/StationRecords/GeneralStationRecordConsoleWindow.xaml.cs
+++ b/Content.Client/StationRecords/GeneralStationRecordConsoleWindow.xaml.cs
@@ -21,6 +21,9 @@ public sealed partial class GeneralStationRecordConsoleWindow : DefaultWindow
 
     private bool _isPopulating;
 
+    //HONK START - upstream had `private StationRecordFilterType _currentFilterType;` here; managed by the shared filter widget below
+    //HONK END
+
     public GeneralStationRecordConsoleWindow()
     {
         RobustXamlLoader.Load(this);

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -2,6 +2,8 @@ using System.Numerics;
 using Content.Client.Actions;
 using Content.Client.Actions.UI;
 using Content.Client.Cooldown;
+//HONK START - upstream `using Content.Client.Stylesheets;` removed; label styling handled by HonkLabelFitter below
+//HONK END
 using Content.Shared.Actions.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Examine;

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using Content.Client.Actions;
 using Content.Shared.Input;
+//HONK START - upstream `using Robust.Client.Input;` removed; IInputManager dependency below dropped
+//HONK END
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
@@ -11,6 +13,8 @@ namespace Content.Client.UserInterface.Systems.Actions.Controls;
 public class ActionButtonContainer : GridContainer
 {
     [Dependency] private readonly IEntityManager _entity = default!;
+    //HONK START - upstream had `[Dependency] private readonly IInputManager _input = default!;`; unused after fork refactor
+    //HONK END
 
     public event Action<GUIBoundKeyEventArgs, ActionButton>? ActionPressed;
     public event Action<GUIBoundKeyEventArgs, ActionButton>? ActionUnpressed;

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
@@ -246,6 +246,8 @@ public sealed partial class GunSystem
                 > 15 => BulletRender.BulletType.Normal,
                 _ => BulletRender.BulletType.Large
             };
+            //HONK START - upstream set `_ammoCount.Text = $"x{count:00}";` here; dropped alongside Visible=false above
+            //HONK END
         }
 
         public void PlayAlarmAnimation(Animation animation)

--- a/Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs
@@ -20,6 +20,8 @@ namespace Content.Shared.Construction.Steps
 
         public override ConstructionGuideEntry GenerateGuideEntry()
         {
+            //HONK START - upstream pre-resolved `var stepName = Loc.GetString(Name)` here; removed for the double-lookup fix below
+            //HONK END
             return new ConstructionGuideEntry
             {
                 Localization = "construction-presenter-arbitrary-step",

--- a/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
@@ -41,6 +41,8 @@ namespace Content.Shared.Construction.Steps
         public override ConstructionGuideEntry GenerateGuideEntry()
         {
             var material = IoCManager.Resolve<IPrototypeManager>().Index(MaterialPrototypeId);
+            //HONK START - upstream pre-resolved `var materialName = Loc.GetString(material.Name, ("amount", Amount))` here
+            //HONK END
 
             return new ConstructionGuideEntry()
             {


### PR DESCRIPTION
Contributes to #484. Follow-up to #646 / #651.

## About the PR

The diff-aware scanner introduced in #646 (and tightened in #651) catches drift the old set-based check was hiding via deduplication: when the fork removes an upstream line whose text happens to also exist elsewhere in the same file, the new diff still flags it. This PR HONK-wraps the seven files that lit up under the new scanner.

Files touched:

- \`Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs\` — wrap removed \`using Content.Client.Stylesheets;\`.
- \`Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs\` — wrap removed \`using Robust.Client.Input;\` and \`[Dependency] IInputManager\`.
- \`Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs\` — wrap four removed lines from the \`FilterType\` migration.
- \`Content.Client/StationRecords/GeneralStationRecordConsoleWindow.xaml.cs\` — wrap removed \`_currentFilterType\` field.
- \`Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs\` — wrap removed \`_ammoCount.Text\` assignment.
- \`Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs\` — wrap removed pre-resolve var.
- \`Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs\` — wrap removed pre-resolve var.

All wraps are empty \`//HONK START\` / \`//HONK END\` pairs that mark where upstream content used to sit, with a one-line note describing what's gone and why. No behavior change.

## Why / Balance

Empty HONK markers are ugly but they're the audit's vocabulary for "fork removed this line on purpose." Without them the scanner can't tell intentional removals from accidental drift, and rebase-time reviewers can't either.

### Audit delta on this branch

| Bucket | release | this PR |
|---|---|---|
| MIXED | 12 | 5 |
| HONK-ONLY | 62 | 69 |

The 5 remaining MIXED files are all addressed by other in-flight work — #637 covers \`HealthAnalyzerControl\`, \`HumanoidProfileEditor.Traits\`, \`StorageWindow\`, \`VendingMachineMenu\`; \`SharedStrippableSystem\` has substantial drift that warrants its own PR.

## Technical details

Just markup — no logic changes. \`Content.Client\` and \`Content.Server\` build clean.

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than \`origin/upstream/stable\` or fork branches.
- [x] Every fork-authored commit in this PR uses the \`honksquad:\` subject prefix.

## Breaking changes

None.