### PR TITLE
fix: add SurgicalTray to medical lathe recipes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -36,8 +36,9 @@
   - Drill
   - Saw
   - Hemostat
-  # HONK START - Surgical drape recipe
+  # HONK START - Surgical drape and tray recipes
   - SurgicalDrape
+  - SurgicalTray
   # HONK END
 
 - type: latheRecipePack


### PR DESCRIPTION
## About the PR

Adds `SurgicalTray` to the `SurgeryStatic` lathe recipe pack so the medical techfab can actually print it. Closes #653.

## Why / Balance

The `SurgicalTray` recipe was already defined under `Resources/Prototypes/@RussStation/Recipes/Lathes/surgery.yml` with the same costs as the drape recipe alongside it, but the tray was never added to the techfab's pack. So the recipe existed in the codebase but was unreachable in-game. Surgical trays are a routine medbay request, no balance shift, just unblocks an oversight.

## Technical details

One-line addition inside the existing HONK block in `Resources/Prototypes/Recipes/Lathes/Packs/medical.yml`. HONK comment now reads "Surgical drape and tray recipes" to cover both lines.

## Media

n/a

## Requirements

- [x] I have read and am following this repo's Contribution Guidelines.
- [x] I have tested all added content.
- [x] I have added the relevant labels.

## Breaking changes

None.

## Changelog

:cl:
- add: Surgical trays can now be printed at the medical techfab.