### PR TITLE
honksquad: tweak: halon air alarms warn at 2.5%, danger at 5%

### DIFF
--- a/Resources/Prototypes/@RussStation/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/@RussStation/Atmospherics/Thresholds/airalarms.yml
@@ -1,0 +1,9 @@
+# Fork-side air alarm thresholds for gases that should warn rather than scream
+# the moment a single mole shows up.
+
+- type: alarmThreshold
+  id: stationHalon
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.05 # 5% halon, danger above this
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5 # warn at 2.5%

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -30,7 +30,7 @@
       Helium: danger
       BZ: danger
       Pluoxium: danger
-      Halon: danger
+      Halon: stationHalon
       Antinoblium: danger
       Healium: danger
       Nitrium: danger

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -20,7 +20,7 @@
       Helium: danger
       BZ: danger
       Pluoxium: danger
-      Halon: danger
+      Halon: stationHalon
       Antinoblium: danger
       Healium: danger
       Nitrium: danger


### PR DESCRIPTION
## About the PR

Adds a fork-side `stationHalon` air-alarm threshold and points the station and vox air sensors at it instead of the generic `danger` threshold.

## Why / Balance

Halon is the station's fire-suppressant gas, so atmos releases it on purpose during fires. Today it is mapped to `danger` (0.0001 mol fraction), which means any halon at all instantly trips a red alarm across the room and drowns out signals that actually matter (plasma leak, breach, pressure). The new threshold warns at 2.5% and only goes red above 5%, comfortably below the levels needed for fire suppression to remain effective but high enough that small leaks and post-suppression residue do not pin the alarm.

Closes #660.

## Technical details

- New prototype `stationHalon` in `Resources/Prototypes/@RussStation/Atmospherics/Thresholds/airalarms.yml`.
- `sensor.yml` and `vox.yml` swap `Halon: danger` for `Halon: stationHalon`, both inside the existing fork HONK block that already covers the new gases.

## Media

N/A, balance tweak.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Air alarms no longer panic at the first whiff of halon. Warns at 2.5%, danger at 5%.