### PR TITLE
honksquad: tweak: tighten popup log radius to local-chat range

### DIFF
--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,7 +1,6 @@
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
-using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
@@ -27,8 +26,12 @@ public sealed class PopupLogSystem : EntitySystem
 {
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
-    [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
+
+    // Matches SharedChatSystem.VoiceRange so popups log at roughly the same radius as local speech,
+    // instead of the 16-tile examine range that lets popups two screens away into the log.
+    private const float LogRange = SharedChatSystem.VoiceRange;
 
     private const int MinFontSize = 8;
     private const int MaxFontSize = 16;
@@ -85,15 +88,15 @@ public sealed class PopupLogSystem : EntitySystem
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
     {
-        // Filter out popups the player shouldn't be able to perceive. Server PVS may ship popups
-        // for entities outside the player's line of sight (proximity filters, broad broadcast);
-        // gate those behind the same visibility rule the examine system uses. Self-sourced popups
-        // (combat mode, spit, ActionGun text) and popups that don't carry an entity source always
-        // log since those are directly addressed to the local player.
+        // Drop popups whose source is further than local-chat range. Server PVS ships popups for
+        // entities well outside the player's chat radius (proximity filters, broad broadcast), and
+        // the previous examine-range gate (16 tiles) was wider than VoiceRange (10 tiles), so the
+        // popup tab filled with text from people two screens over. Self-sourced popups and popups
+        // without an entity source always log since those are addressed to the local player.
         if (ev.Source is { } sourceUid
             && _player.LocalEntity is { } examiner
             && sourceUid != examiner
-            && !_examine.CanExamine(examiner, sourceUid))
+            && !_transform.InRange(examiner, sourceUid, LogRange))
         {
             return;
         }


### PR DESCRIPTION
## About the PR

Tightens the radius at which popups land in the Popup chat tab from examine range (16t) to local-chat range (10t).

## Why / Balance

The Popup tab was logging anything within examine range, including popups happening across the room or behind walls that the player could never read off the floating text. Because `ExamineRange` (16t) is 60% wider than `SharedChatSystem.VoiceRange` (10t), the tab filled with text from people roughly two screens over. Aligning the log radius with local chat matches the player's mental model: if you can't hear them, you don't see their popup in the log either.

Closes #659.

## Technical details

- `Content.Client/RussStation/Popups/PopupLogSystem.cs`: drops the `ExamineSystemShared` dependency, swaps the gate for `SharedTransformSystem.InRange` at `SharedChatSystem.VoiceRange`. Self-sourced popups and coordinate-only popups still always log.

## Media

N/A, behaviour change with no visual.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Popup chat tab now logs popups within local-chat range instead of examine range, so it stops collecting noise from across the room.