### PR TITLE
honksquad: fix: floating chat input drives the typing indicator

### DIFF
--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -34,6 +34,7 @@ public sealed class FloatingChatInputControl : Control
 
     private readonly SharedTransformSystem _transform;
     private readonly StyleBoxFlat _backgroundStyle;
+    private readonly ChatUIController _chatUi;
 
     public readonly ChatInputBox InputBox;
 
@@ -59,6 +60,7 @@ public sealed class FloatingChatInputControl : Control
     {
         IoCManager.InjectDependencies(this);
         _transform = _entManager.System<SharedTransformSystem>();
+        _chatUi = _uiManager.GetUIController<ChatUIController>();
 
         // Thicker background than the anchored chat panel — the floating
         // widget overlaps the game world, so a more opaque fill keeps typed
@@ -79,6 +81,8 @@ public sealed class FloatingChatInputControl : Control
         InputBox.Input.OnTextEntered += OnTextEntered;
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
         InputBox.Input.OnTextChanged += OnInputTextChanged;
+        InputBox.Input.OnFocusEnter += OnInputFocusEnter;
+        InputBox.Input.OnFocusExit += OnInputFocusExit;
         InputBox.ChannelSelector.OnChannelSelect += OnChannelSelectorChanged;
 
         // Pick up the accessibility text-opacity knob too so the typed text
@@ -119,6 +123,8 @@ public sealed class FloatingChatInputControl : Control
         {
             _config.UnsubValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
             _config.UnsubValueChanged(CCVars.SpeechBubbleTextOpacity, OnTextOpacityChanged);
+            // Clear the typing indicator if the widget vanishes mid-message so it doesn't stick.
+            _chatUi.NotifyChatFocus(false);
         }
     }
 
@@ -156,6 +162,20 @@ public sealed class FloatingChatInputControl : Control
     private void OnInputTextChanged(LineEditEventArgs args)
     {
         RefreshChannelLabel();
+        // Mirror ChatBox: the typing-indicator system listens for these notifications, so the
+        // floating input has to call them too or bystanders never see the indicator while the
+        // local player is typing here.
+        _chatUi.NotifyChatTextChange();
+    }
+
+    private void OnInputFocusEnter(LineEditEventArgs args)
+    {
+        _chatUi.NotifyChatFocus(true);
+    }
+
+    private void OnInputFocusExit(LineEditEventArgs args)
+    {
+        _chatUi.NotifyChatFocus(false);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR

Wires the floating chat input into the typing-indicator path so other players see the indicator over the player's head while they type, identical to the docked chatbox behaviour.

## Why / Balance

Quality-of-life fix. The docked chat box notifies `ChatUIController` on text-change and focus, which drives the typing indicator. The floating input added in #583 only repainted its channel label and never called those, so bystanders never saw the indicator while a player typed there.

Closes #661.

## Technical details

- `Content.Client/RussStation/Chat/FloatingChatInputControl.cs`
  - Caches `ChatUIController` in the constructor.
  - `OnInputTextChanged` calls `NotifyChatTextChange`.
  - New `OnInputFocusEnter` / `OnInputFocusExit` call `NotifyChatFocus(true/false)`, subscribed to `LineEdit.OnFocusEnter` / `OnFocusExit`.
  - `Dispose` calls `NotifyChatFocus(false)` so the indicator clears if the widget vanishes mid-message.

## Media

N/A, behaviour change.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Typing in the floating chat input now shows the over-head typing indicator to nearby players, same as the docked chat box.