### PR TITLE
honksquad: fix: forward link/anchor clicks from the popped-out guidebook

### DIFF
--- a/Content.Client/RussStation/Guidebook/GuidebookPopoutWindow.cs
+++ b/Content.Client/RussStation/Guidebook/GuidebookPopoutWindow.cs
@@ -2,14 +2,22 @@
 // The docked GuidebookWindow's SplitContainer is reparented into this window
 // while popout mode is active, then returned when the window closes.
 using System;
+using Content.Client.Guidebook.Controls;
+using Content.Client.Guidebook.RichText;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client.RussStation.Guidebook;
 
-public sealed class GuidebookPopoutWindow : OSWindow
+public sealed class GuidebookPopoutWindow : OSWindow, ILinkClickHandler, IAnchorClickHandler
 {
+    // The link/anchor click tags walk up the visual tree looking for a handler. Once the
+    // guidebook content is reparented under this OSWindow the walk never reaches the docked
+    // GuidebookWindow, so the popout has to satisfy both interfaces and forward to the
+    // original window which holds the entry/prototype state.
+    private GuidebookWindow? _source;
+
     public GuidebookPopoutWindow()
     {
         Title = Loc.GetString("honk-guidebook-popout-title");
@@ -18,14 +26,16 @@ public sealed class GuidebookPopoutWindow : OSWindow
         StartupLocation = WindowStartupLocation.CenterOwner;
     }
 
-    public void HostContent(Control content)
+    public void HostContent(GuidebookWindow source, Control content)
     {
+        _source = source;
         content.Orphan();
         AddChild(content);
     }
 
     public Control? ReleaseContent()
     {
+        _source = null;
         if (ChildCount == 0)
             return null;
 
@@ -33,4 +43,8 @@ public sealed class GuidebookPopoutWindow : OSWindow
         content.Orphan();
         return content;
     }
+
+    public void HandleClick(string link) => _source?.HandleClick(link);
+
+    public void HandleAnchor(IPrototypeLinkControl prototypeLinkControl) => _source?.HandleAnchor(prototypeLinkControl);
 }

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -298,7 +298,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         }
 
         _popoutWindow ??= CreatePopoutWindow();
-        _popoutWindow.HostContent(_guideWindow.PopoutContent);
+        _popoutWindow.HostContent(_guideWindow, _guideWindow.PopoutContent);
         _popoutWindow.Show();
     }
 


### PR DESCRIPTION
## About the PR

Makes guidebook links and anchor jumps work after popping the guidebook out into its own window.

## Why / Balance

Once the guidebook is popped out, clicking any link inside it does nothing and the client logs `No valid ILinkClickHandler found.`. The link/anchor click tags walk up the visual tree looking for an `ILinkClickHandler` / `IAnchorClickHandler`. The popout reparents the guidebook content under `GuidebookPopoutWindow`, which did not implement either interface, so the walk never reached the docked `GuidebookWindow` and clicks went nowhere.

Closes #657.

## Technical details

- `Content.Client/RussStation/Guidebook/GuidebookPopoutWindow.cs`
  - Implements `ILinkClickHandler` and `IAnchorClickHandler`.
  - Stores the source `GuidebookWindow` passed in via `HostContent` and forwards `HandleClick(string)` and `HandleAnchor(IPrototypeLinkControl)` to it. `ReleaseContent` clears the reference.
- `Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs`
  - Existing HONK popout block now passes `_guideWindow` alongside its content into `HostContent`.

Re-docking still works because the docked `GuidebookWindow` keeps its own handler implementations.

## Media

N/A, bugfix.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Guidebook links and anchor jumps now work while the guidebook is popped out into its own window.