### PR TITLE
honksquad: tweak: drop bystander popup for voluntary eating

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -501,10 +501,13 @@ public sealed partial class IngestionSystem : EntitySystem
         }
         else
         {
-            _popup.PopupPredicted(Loc.GetString(edible.Message, ("food", entity.Owner), ("flavors", flavors), ("satiated", args.Satiated)),
-                Loc.GetString(edible.OtherMessage),
+            //HONK START - issue #658: voluntary eating popped over the eater for every nearby
+            //client, flooding busy areas (kitchen, bar). Drop the others-popup; force-feeding
+            //above still uses PopupEntity for everyone, which is the path that should be loud.
+            _popup.PopupClient(Loc.GetString(edible.Message, ("food", entity.Owner), ("flavors", flavors), ("satiated", args.Satiated)),
                 args.User,
                 args.User);
+            //HONK END
 
             // log successful voluntary eating
             // TODO: Use correct verb


### PR DESCRIPTION
## About the PR

Voluntary eating no longer floats a popup over the eater for every nearby client. Only the eater sees the message. Force-feeding still pops to everyone, unchanged.

## Why / Balance

The eater is the only one who needs feedback for routine eating. Today every bite triggers `PopupPredicted` with an OtherMessage, so any kitchen, bar, or lobby fills with overhead popups whenever someone takes a bite. This is noise. The popup chat tab (#588) still mirrors the local-eater popup for anyone curious enough to scroll back, so the information is not lost.

Force-feeding intentionally goes through `PopupEntity` so it stays visible to bystanders.

Closes #658.

## Technical details

- `Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs` (HONK-block): voluntary `else` branch swaps `PopupPredicted(self, others, ...)` for `PopupClient(self, ...)`. Force-feed branch unchanged.

## Media

N/A, behaviour change.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Eating no longer pops a message over the eater for everyone nearby. The eater still sees their own popup, and force-feeding is loud as before.