### PR TITLE
honksquad: feat: cvars to restyle popup chat log entries

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -28,6 +28,14 @@
                                  Title="{Loc 'honk-options-highlight-sound-cooldown'}"/>
                 <ui:OptionSlider Name="HonkHighlightSoundVolumeSlider"
                                  Title="{Loc 'honk-options-highlight-sound-volume'}"/>
+                <Label Text="{Loc 'honk-options-header-popup-log'}"
+                       StyleClasses="LabelKeyText"/>
+                <CheckBox Name="HonkPopupLogItalicCheckBox" Text="{Loc 'honk-options-popup-log-italic'}"/>
+                <ui:OptionSlider Name="HonkPopupLogFontSizeSlider"
+                                 Title="{Loc 'honk-options-popup-log-font-size'}"/>
+                <ui:OptionColorSlider Name="HonkPopupLogColorSlider"
+                                      Title="{Loc 'honk-options-popup-log-color'}"
+                                      Example="{Loc 'honk-options-popup-log-color-example'}"/>
                 <Label Text="{Loc 'ui-options-header-hover-tooltip'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="HoverTooltipEnabledCheckBox" Text="{Loc 'ui-options-hover-tooltip-enabled'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -30,7 +30,8 @@
                                  Title="{Loc 'honk-options-highlight-sound-volume'}"/>
                 <Label Text="{Loc 'honk-options-header-popup-log'}"
                        StyleClasses="LabelKeyText"/>
-                <CheckBox Name="HonkPopupLogItalicCheckBox" Text="{Loc 'honk-options-popup-log-italic'}"/>
+                <ui:OptionDropDown Name="HonkPopupLogStyleDropDown"
+                                   Title="{Loc 'honk-options-popup-log-style'}"/>
                 <ui:OptionSlider Name="HonkPopupLogFontSizeSlider"
                                  Title="{Loc 'honk-options-popup-log-font-size'}"/>
                 <ui:OptionColorSlider Name="HonkPopupLogColorSlider"

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -55,7 +55,13 @@ public sealed partial class AccessibilityTab : Control
             -20f, 0f, 1f,
             (_, value) => $"{value:F0} dB"));
 
-        Control.AddOptionCheckBox(CCVars.PopupLogItalic, HonkPopupLogItalicCheckBox);
+        Control.AddOptionDropDown(CCVars.PopupLogStyle, HonkPopupLogStyleDropDown, new List<OptionDropDownCVar<string>.ValueOption>
+        {
+            new("normal", Loc.GetString("honk-options-popup-log-style-normal")),
+            new("italic", Loc.GetString("honk-options-popup-log-style-italic")),
+            new("bold", Loc.GetString("honk-options-popup-log-style-bold")),
+            new("bold-italic", Loc.GetString("honk-options-popup-log-style-bold-italic")),
+        });
         Control.AddOption(new OptionSliderIntCVar(
             Control,
             IoCManager.Resolve<IConfigurationManager>(),

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -55,6 +55,16 @@ public sealed partial class AccessibilityTab : Control
             -20f, 0f, 1f,
             (_, value) => $"{value:F0} dB"));
 
+        Control.AddOptionCheckBox(CCVars.PopupLogItalic, HonkPopupLogItalicCheckBox);
+        Control.AddOption(new OptionSliderIntCVar(
+            Control,
+            IoCManager.Resolve<IConfigurationManager>(),
+            CCVars.PopupLogFontSize,
+            HonkPopupLogFontSizeSlider,
+            8, 16,
+            (_, value) => $"{value}px"));
+        Control.AddOptionColorSlider(CCVars.PopupLogColor, HonkPopupLogColorSlider);
+
         Control.AddOptionCheckBox(CCVars.HoverTooltipEnabled, HoverTooltipEnabledCheckBox);
         Control.AddOption(new OptionSliderFloatCVar(
             Control,

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -1,10 +1,13 @@
 using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Popups;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Content.Client.RussStation.Popups;
@@ -25,6 +28,15 @@ public sealed class PopupLogSystem : EntitySystem
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    private const int MinFontSize = 8;
+    private const int MaxFontSize = 16;
+    private const string FallbackColor = "#9999aa";
+
+    private bool _italic;
+    private int _fontSize;
+    private string _color = FallbackColor;
 
     private ChatUIController? _chat;
     private ChatUIController Chat => _chat ??= _ui.GetUIController<ChatUIController>();
@@ -36,6 +48,31 @@ public sealed class PopupLogSystem : EntitySystem
         // PopupMessage / PopupCursorInternal (HONK blocks), so network-sent popups, client-predicted
         // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
+
+        _italic = _config.GetCVar(CCVars.PopupLogItalic);
+        _fontSize = ClampFontSize(_config.GetCVar(CCVars.PopupLogFontSize));
+        _color = SanitizeColor(_config.GetCVar(CCVars.PopupLogColor));
+
+        _config.OnValueChanged(CCVars.PopupLogItalic, v => _italic = v);
+        _config.OnValueChanged(CCVars.PopupLogFontSize, v => _fontSize = ClampFontSize(v));
+        _config.OnValueChanged(CCVars.PopupLogColor, v => _color = SanitizeColor(v));
+    }
+
+    public override void Shutdown()
+    {
+        // OnValueChanged handlers are weak via the lambdas, but the controller cleans them up
+        // anyway when the system is destroyed; nothing to do here yet beyond the base call.
+        base.Shutdown();
+    }
+
+    private static int ClampFontSize(int v) => Math.Clamp(v, MinFontSize, MaxFontSize);
+
+    private static string SanitizeColor(string raw)
+    {
+        // Trip-wire against malformed user input: an unparseable color would corrupt the rich
+        // text. Fall back to the original dim grey if Color.TryFromHex rejects it.
+        var trimmed = raw.Trim();
+        return Color.TryFromHex(trimmed) is null ? FallbackColor : trimmed;
     }
 
     private void OnCategorizedPopup(CategorizedPopupRaisedEvent ev)
@@ -63,9 +100,17 @@ public sealed class PopupLogSystem : EntitySystem
             return;
 
         var escaped = FormattedMessage.EscapeText(message);
-        var wrapped = category is { } cat
-            ? $"[color=#9999aa]\\[{cat}\\][/color] {escaped}"
+        var body = category is { } cat
+            ? $"\\[{cat}\\] {escaped}"
             : escaped;
+
+        // Apply user-tunable formatting last so all three knobs compose: color wraps the line,
+        // italic wraps the colored line, font size wraps everything. Default values reproduce
+        // the pre-cvar look (dim grey prefix, no italic, default size).
+        var wrapped = $"[color={_color}]{body}[/color]";
+        if (_italic)
+            wrapped = $"[italic]{wrapped}[/italic]";
+        wrapped = $"[font size={_fontSize}]{wrapped}[/font]";
 
         var mirror = new ChatMessage(
             ChatChannel.Popup,

--- a/Content.Client/RussStation/Popups/PopupLogSystem.cs
+++ b/Content.Client/RussStation/Popups/PopupLogSystem.cs
@@ -34,7 +34,7 @@ public sealed class PopupLogSystem : EntitySystem
     private const int MaxFontSize = 16;
     private const string FallbackColor = "#9999aa";
 
-    private bool _italic;
+    private string _style = "normal";
     private int _fontSize;
     private string _color = FallbackColor;
 
@@ -49,11 +49,11 @@ public sealed class PopupLogSystem : EntitySystem
         // popups, and fork categorized calls all land here exactly once.
         SubscribeLocalEvent<CategorizedPopupRaisedEvent>(OnCategorizedPopup);
 
-        _italic = _config.GetCVar(CCVars.PopupLogItalic);
+        _style = SanitizeStyle(_config.GetCVar(CCVars.PopupLogStyle));
         _fontSize = ClampFontSize(_config.GetCVar(CCVars.PopupLogFontSize));
         _color = SanitizeColor(_config.GetCVar(CCVars.PopupLogColor));
 
-        _config.OnValueChanged(CCVars.PopupLogItalic, v => _italic = v);
+        _config.OnValueChanged(CCVars.PopupLogStyle, v => _style = SanitizeStyle(v));
         _config.OnValueChanged(CCVars.PopupLogFontSize, v => _fontSize = ClampFontSize(v));
         _config.OnValueChanged(CCVars.PopupLogColor, v => _color = SanitizeColor(v));
     }
@@ -66,6 +66,14 @@ public sealed class PopupLogSystem : EntitySystem
     }
 
     private static int ClampFontSize(int v) => Math.Clamp(v, MinFontSize, MaxFontSize);
+
+    private static string SanitizeStyle(string raw) => raw switch
+    {
+        "italic" => "italic",
+        "bold" => "bold",
+        "bold-italic" => "bold-italic",
+        _ => "normal",
+    };
 
     private static string SanitizeColor(string raw)
     {
@@ -105,11 +113,13 @@ public sealed class PopupLogSystem : EntitySystem
             : escaped;
 
         // Apply user-tunable formatting last so all three knobs compose: color wraps the line,
-        // italic wraps the colored line, font size wraps everything. Default values reproduce
-        // the pre-cvar look (dim grey prefix, no italic, default size).
+        // style (italic/bold) wraps the colored line, font size wraps everything. Default values
+        // reproduce the pre-cvar look (dim grey prefix, no style, default size).
         var wrapped = $"[color={_color}]{body}[/color]";
-        if (_italic)
+        if (_style == "italic" || _style == "bold-italic")
             wrapped = $"[italic]{wrapped}[/italic]";
+        if (_style == "bold" || _style == "bold-italic")
+            wrapped = $"[bold]{wrapped}[/bold]";
         wrapped = $"[font size={_fontSize}]{wrapped}[/font]";
 
         var mirror = new ChatMessage(

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -59,4 +59,24 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> ChatHighlightSoundCooldown =
         CVarDef.Create("honk.chat.highlight_sound_cooldown", 2f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// When true, popup chat log entries render in italics so they read distinct from speech.
+    /// </summary>
+    public static readonly CVarDef<bool> PopupLogItalic =
+        CVarDef.Create("honk.chat.popup_log_italic", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Font size for popup chat log entries. Clamped to a sane range at apply-time.
+    /// 12 matches the chat default; 8-16 is the supported window.
+    /// </summary>
+    public static readonly CVarDef<int> PopupLogFontSize =
+        CVarDef.Create("honk.chat.popup_log_font_size", 12, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Hex color (e.g. <c>#9999aa</c>) applied to popup chat log entries. Default matches the
+    /// pre-cvar dimmed prefix color so the out-of-the-box look is unchanged.
+    /// </summary>
+    public static readonly CVarDef<string> PopupLogColor =
+        CVarDef.Create("honk.chat.popup_log_color", "#9999aa", CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/RussStation/CCVar/CCVars.Chat.cs
@@ -61,10 +61,11 @@ public sealed partial class CCVars
         CVarDef.Create("honk.chat.highlight_sound_cooldown", 2f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
-    /// When true, popup chat log entries render in italics so they read distinct from speech.
+    /// Text style applied to popup chat log entries. One of <c>normal</c>, <c>italic</c>,
+    /// <c>bold</c>, <c>bold-italic</c>. Unknown values fall back to <c>normal</c>.
     /// </summary>
-    public static readonly CVarDef<bool> PopupLogItalic =
-        CVarDef.Create("honk.chat.popup_log_italic", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+    public static readonly CVarDef<string> PopupLogStyle =
+        CVarDef.Create("honk.chat.popup_log_style", "normal", CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
     /// Font size for popup chat log entries. Clamped to a sane range at apply-time.

--- a/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
@@ -3,3 +3,9 @@ honk-options-highlight-sound-enabled = Play sound on radio match
 honk-options-highlight-sound-enabled-tooltip = Plays a short ping when one of your highlight words arrives over radio. Path is honk.chat.highlight_sound_path.
 honk-options-highlight-sound-cooldown = Highlight sound cooldown
 honk-options-highlight-sound-volume = Highlight sound volume
+
+honk-options-header-popup-log = Popup chat tab
+honk-options-popup-log-italic = Italicize popup entries
+honk-options-popup-log-font-size = Popup entry font size
+honk-options-popup-log-color = Popup entry color
+honk-options-popup-log-color-example = popup text

--- a/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
@@ -4,8 +4,8 @@ honk-options-highlight-sound-enabled-tooltip = Plays a short ping when one of yo
 honk-options-highlight-sound-cooldown = Highlight sound cooldown
 honk-options-highlight-sound-volume = Highlight sound volume
 
-honk-options-header-popup-log = Popup chat tab
-honk-options-popup-log-italic = Italicize popup entries
-honk-options-popup-log-font-size = Popup entry font size
-honk-options-popup-log-color = Popup entry color
+honk-options-header-popup-log = Popups
+honk-options-popup-log-italic = Italicize
+honk-options-popup-log-font-size = Font size
+honk-options-popup-log-color = Color
 honk-options-popup-log-color-example = popup text

--- a/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
+++ b/Resources/Locale/en-US/@RussStation/chat/highlight-options.ftl
@@ -5,7 +5,11 @@ honk-options-highlight-sound-cooldown = Highlight sound cooldown
 honk-options-highlight-sound-volume = Highlight sound volume
 
 honk-options-header-popup-log = Popups
-honk-options-popup-log-italic = Italicize
+honk-options-popup-log-style = Style
+honk-options-popup-log-style-normal = Normal
+honk-options-popup-log-style-italic = Italic
+honk-options-popup-log-style-bold = Bold
+honk-options-popup-log-style-bold-italic = Bold italic
 honk-options-popup-log-font-size = Font size
 honk-options-popup-log-color = Color
 honk-options-popup-log-color-example = popup text


### PR DESCRIPTION
## About the PR

Adds three popup-tab style options exposed in the Accessibility tab and as cvars: text style (normal/italic/bold/bold italic), font size, and color. Defaults match the previous look.

## Why / Balance

Players who rely on the popup tab want those lines to look distinct from speech and emotes so the eye can skip them when scanning chat. The fixed `[color=#9999aa]` wrap was the only knob, so this PR opens up the three useful axes. Closes #662.

## Technical details

- `Content.Shared/RussStation/CCVar/CCVars.Chat.cs`
  - `honk.chat.popup_log_style` (string, default `normal`, accepts `normal`/`italic`/`bold`/`bold-italic`)
  - `honk.chat.popup_log_font_size` (int, default `12`, clamped to 8-16)
  - `honk.chat.popup_log_color` (string hex, default `#9999aa`, sanitized via `Color.TryFromHex`)
- `Content.Client/RussStation/Popups/PopupLogSystem.cs` reads the three cvars on `Initialize`, listens for `OnValueChanged` so retuning takes effect without reconnect, and wraps every popup line with `[color]`, optional `[italic]` / `[bold]`, and `[font size]`.
- Accessibility tab (HONK block) gains a "Popups" subsection with a Style dropdown, font size slider, and color slider, all live-updating.

## Media

<!-- screenshot of accessibility tab to add -->

## Breaking changes

None. All cvars default to the previous behaviour.

## Changelog

:cl:
- add: Popup chat tab entries can be restyled in Options > Accessibility (text style, font size, color).