### PR TITLE
honksquad: balance: bring free upstream traits into the points budget

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -267,10 +267,13 @@ public sealed partial class HumanoidProfileEditor
 
             // HONK END
 
-            //HONK START - 2-column grid for trait selectors, routed to the per-category column
+            //HONK START - 2-column grid for trait selectors, routed to the per-category column.
+            // Single-entry categories collapse to one column so the lone trait doesn't render
+            // beside an empty grid cell that visibly takes up half the column.
+            var nonNullCount = selectors.Count(s => s != null);
             var traitGrid = new GridContainer
             {
-                Columns = 2,
+                Columns = nonNullCount <= 1 ? 1 : 2,
                 HorizontalExpand = true,
             };
 

--- a/Resources/Prototypes/@RussStation/Traits/movement/freerunning.yml
+++ b/Resources/Prototypes/@RussStation/Traits/movement/freerunning.yml
@@ -2,7 +2,7 @@
   id: Freerunning
   name: trait-freerunning-name
   description: trait-freerunning-desc
-  category: Body
+  category: Movement
   cost: 8
   tags:
     - climbing

--- a/Resources/Prototypes/@RussStation/Traits/movement/light_step.yml
+++ b/Resources/Prototypes/@RussStation/Traits/movement/light_step.yml
@@ -2,7 +2,7 @@
   id: LightStep
   name: trait-lightstep-name
   description: trait-lightstep-desc
-  category: Social
+  category: Movement
   cost: 4
   tags:
     - footsteps

--- a/Resources/Prototypes/@RussStation/Traits/quirks.yml
+++ b/Resources/Prototypes/@RussStation/Traits/quirks.yml
@@ -2,7 +2,7 @@
   id: Pushover
   name: trait-pushover-name
   description: trait-pushover-desc
-  category: Quirks
+  category: Body
   cost: -8
   components:
     - type: Pushover

--- a/Resources/Prototypes/@RussStation/Traits/speech/loud_voice.yml
+++ b/Resources/Prototypes/@RussStation/Traits/speech/loud_voice.yml
@@ -4,7 +4,7 @@
   id: BoomingVoice
   name: trait-booming-voice-name
   description: trait-booming-voice-desc
-  category: Social
+  category: SpeechTraits
   cost: 2
   tags:
     - speech

--- a/Resources/Prototypes/@RussStation/Traits/speech/soft_spoken.yml
+++ b/Resources/Prototypes/@RussStation/Traits/speech/soft_spoken.yml
@@ -2,7 +2,7 @@
   id: SoftSpoken
   name: trait-softspoken-name
   description: trait-softspoken-desc
-  category: Social
+  category: SpeechTraits
   cost: -2
   tags:
     - speech

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -1,11 +1,7 @@
-# HONK START - #655: Disabilities drained when its 13 entries moved into priced
-# domain categories (Senses, Body, SpeechTraits, Social, Diet, Quirks). Removing
-# the empty prototype so the editor doesn't reserve a column slot for it.
+# HONK START - #655: Disabilities and Quirks drained as their entries moved into
+# priced domain categories (Senses, Body, SpeechTraits, Social, Diet, Movement).
+# Removing both empty prototypes so the editor doesn't reserve column slots.
 - type: traitCategory
   id: SpeechTraits
   name: trait-category-speech
-
-- type: traitCategory
-  id: Quirks
-  name: trait-category-quirks
 # HONK END

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -1,7 +1,6 @@
-- type: traitCategory
-  id: Disabilities
-  name: trait-category-disabilities
-
+# HONK START - #655: Disabilities drained when its 13 entries moved into priced
+# domain categories (Senses, Body, SpeechTraits, Social, Diet, Quirks). Removing
+# the empty prototype so the editor doesn't reserve a column slot for it.
 - type: traitCategory
   id: SpeechTraits
   name: trait-category-speech
@@ -9,3 +8,4 @@
 - type: traitCategory
   id: Quirks
   name: trait-category-quirks
+# HONK END

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -5,7 +5,10 @@
   name: trait-blindness-name
   description: trait-blindness-desc
   traitGear: WhiteCane
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Senses
+  cost: -3
+  # HONK END
   # HONK START - fork tag-exclusion system: ScarredEye shares the sight domain
   tags:
     - sight
@@ -23,7 +26,10 @@
   name: trait-poor-vision-name
   description: trait-poor-vision-desc
   traitGear: ClothingEyesGlasses
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Senses
+  cost: -1
+  # HONK END
   whitelist:
     components:
       - Blindable
@@ -35,7 +41,10 @@
   id: Narcolepsy
   name: trait-narcolepsy-name
   description: trait-narcolepsy-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Body
+  cost: -2
+  # HONK END
   components:
     - type: Narcolepsy
       maxTimeBetweenIncidents: 600
@@ -47,7 +56,10 @@
   id: Unrevivable
   name: trait-unrevivable-name
   description: trait-unrevivable-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Body
+  cost: -3
+  # HONK END
   components:
     - type: Unrevivable
       cloneable: true
@@ -56,7 +68,10 @@
   id: Monochromacy
   name: trait-monochromacy-name
   description: trait-monochromacy-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Senses
+  cost: -1
+  # HONK END
   components:
   - type: BlackAndWhiteOverlay
 
@@ -64,7 +79,10 @@
   id: Muted
   name: trait-muted-name
   description: trait-muted-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: SpeechTraits
+  cost: -2
+  # HONK END
   # HONK START - fork tag-exclusion system: blocks BoomingVoice + other speech quirks
   tags:
     - speech
@@ -81,7 +99,10 @@
   id: Paracusia
   name: trait-paracusia-name
   description: trait-paracusia-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Senses
+  cost: -1
+  # HONK END
   components:
     - type: Paracusia
       minTimeBetweenIncidents: 0.1
@@ -94,7 +115,10 @@
   id: PainNumbness
   name: trait-painnumbness-name
   description: trait-painnumbness-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Body
+  cost: -1
+  # HONK END
   # HONK START - fork tag-exclusion system: SelfAware is the functional opposite
   tags:
     - awareness
@@ -110,7 +134,10 @@
   id: Hemophilia
   name: trait-hemophilia-name
   description: trait-hemophilia-desc
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Body
+  cost: -2
+  # HONK END
   specials:
   - !type:ApplyStatusEffectSpecial
     statusEffects:
@@ -121,7 +148,10 @@
   name: trait-impaired-mobility-name
   description: trait-impaired-mobility-desc
   traitGear: OffsetCane
-  category: Disabilities
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Body
+  cost: -2
+  # HONK END
   # HONK START - fork tag-exclusion system: blocks Skittish's sprint speed-up
   tags:
     - mobility

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -116,7 +116,7 @@
   name: trait-painnumbness-name
   description: trait-painnumbness-desc
   # HONK START - issue #655: bring free trait into the points budget
-  category: Body
+  category: Senses
   cost: -1
   # HONK END
   # HONK START - fork tag-exclusion system: SelfAware is the functional opposite
@@ -149,7 +149,7 @@
   description: trait-impaired-mobility-desc
   traitGear: OffsetCane
   # HONK START - issue #655: bring free trait into the points budget
-  category: Body
+  category: Movement
   cost: -2
   # HONK END
   # HONK START - fork tag-exclusion system: blocks Skittish's sprint speed-up

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -15,9 +15,14 @@
   id: LightweightDrunk
   name: trait-lightweight-name
   description: trait-lightweight-desc
-  # HONK START - issue #655: bring free trait into the points budget
+  # HONK START - issue #655: bring free trait into the points budget,
+  # plus alcohol tag-exclusion so it mutexes with AlcoholTolerance.
   category: Diet
   cost: -1
+  tags:
+    - alcohol
+  excludedTags:
+    - alcohol
   # HONK END
   components:
   - type: LightweightDrunk

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -28,7 +28,7 @@
   name: trait-snoring-name
   description: trait-snoring-desc
   # HONK START - issue #655: bring free trait into the points budget
-  category: Quirks
+  category: SpeechTraits
   cost: -1
   # HONK END
   components:

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -4,7 +4,10 @@
   id: Pacifist
   name: trait-pacifist-name
   description: trait-pacifist-desc
-  category: Quirks
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Social
+  cost: -2
+  # HONK END
   components:
   - type: Pacified
 
@@ -12,7 +15,10 @@
   id: LightweightDrunk
   name: trait-lightweight-name
   description: trait-lightweight-desc
-  category: Quirks
+  # HONK START - issue #655: bring free trait into the points budget
+  category: Diet
+  cost: -1
+  # HONK END
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 2
@@ -21,6 +27,9 @@
   id: Snoring
   name: trait-snoring-name
   description: trait-snoring-desc
+  # HONK START - issue #655: bring free trait into the points budget
   category: Quirks
+  cost: -1
+  # HONK END
   components:
   - type: Snoring


### PR DESCRIPTION
## About the PR

Assigns refund costs to every previously-free upstream trait, rebuckets them into priced domain categories, and prunes the now-empty Disabilities and Quirks category prototypes so the editor doesn't reserve column slots for them.

## Why / Balance

13 upstream traits were slipping through the points budget for free because their YAML omitted `cost:`. Players could pick Blindness, Pacifist, Narcolepsy, etc. with zero impact while every fork-side downside actually refunded points. Closes #655.

First-pass costs (expect a balance pass during review):

| Trait            | Cost | Category |
|------------------|------|----------|
| Blindness        | -3   | Senses |
| PoorVision       | -1   | Senses |
| Monochromacy     | -1   | Senses |
| Paracusia        | -1   | Senses |
| PainNumbness     | -1   | Senses |
| Narcolepsy       | -2   | Body |
| Unrevivable      | -3   | Body |
| Hemophilia       | -2   | Body |
| ImpairedMobility | -2   | Movement |
| Muted            | -2   | SpeechTraits |
| Snoring          | -1   | SpeechTraits |
| Pacifist         | -2   | Social |
| LightweightDrunk | -1   | Diet |

Other touch-ups while this was open:

- Single-entry trait categories now render in a 1-column grid so a lone trait doesn't sit beside an empty cell.
- Several fork traits rebucketed to match the priced layout: `Freerunning`, `LightStep` to Movement; `BoomingVoice`, `SoftSpoken` to SpeechTraits; `Pushover` to Body. Their files moved to matching subfolders.
- `LightweightDrunk` gains the `alcohol` tag and self-exclusion so it mutexes with `AlcoholTolerance` (matching the existing self-exclusion on `AlcoholTolerance`).
- Disabilities and Quirks category prototypes removed since both drained.

## Technical details

- `disabilities.yml` and `quirks.yml`: each entry's `category:` line is replaced with a HONK-marked block that sets the new category and the refund cost. Indentation matches the surrounding upstream YAML.
- `categories.yml`: HONK-wrapped removal of `Disabilities` and `Quirks` traitCategory prototypes.
- `HumanoidProfileEditor.Traits.cs`: HONK-wrapped switch from a hardcoded `Columns = 2` grid to `Columns = nonNullCount <= 1 ? 1 : 2`, so a single-entry category shows that one trait full-width.

## Media

N/A, balance/UI tweak.

## Breaking changes

Players who saved a character preset with the listed downsides will see their points balance shifted (refunds at character editor open). No prototype IDs are renamed, so save data stays compatible.

## Changelog

:cl:
- tweak: Blindness, Pacifist, Narcolepsy, and 10 other downside traits now refund points in the character editor instead of being free.
- tweak: Trait editor categories: traits regrouped across Senses, Body, Movement, SpeechTraits, Social, Diet to match the priced layout.
- tweak: Lightweight Drunk and Hard Drinker now mutually exclude in the trait editor.
- fix: Single-entry trait categories no longer leave an empty cell beside their lone trait.