### PR TITLE
honksquad: feat: synthesise species blood from a plasma intermediate

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/reagents/meta/biological.ftl
@@ -33,3 +33,8 @@ reagent-desc-vomit = You can see a few chunks of someone's last meal in it.
 
 reagent-name-grey-matter = grey matter
 reagent-desc-grey-matter = Thought juice, the stuff that leaks out of your ears.
+
+# HONK START - issue #645: synth species blood
+reagent-name-blood-plasma = blood plasma
+reagent-desc-blood-plasma = Cell-free blood serum. Inert on its own, but combined with the right element it becomes whatever blood the patient is missing.
+# HONK END

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1017,8 +1017,11 @@
       food:
         maxVol: 14
         reagents:
-        - ReagentId: Blood
+        # HONK START - issue #645: blood tomato yields species-agnostic plasma so non-humans
+        # can eat it without a poison tick and chemists can grind it as a transfusion stock.
+        - ReagentId: BloodPlasma
           Quantity: 10
+        # HONK END
         - ReagentId: Vitamin
           Quantity: 4
   - type: Sprite
@@ -1031,8 +1034,10 @@
     grindableSolutionName: food
     juiceSolution:
       reagents:
-      - ReagentId: Blood
+      # HONK START - issue #645: blood tomato juice grinds out as plasma, see solution above.
+      - ReagentId: BloodPlasma
         Quantity: 10
+      # HONK END
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -610,7 +610,10 @@
   idealHeat: 298
   splatPrototype: PuddleSplatter
   chemicals:
-    Blood:
+    # HONK START - issue #645: blood tomato now produces species-agnostic plasma instead
+    # of human-specific Blood; downstream synth recipes turn it into the right species blood.
+    BloodPlasma:
+    # HONK END
       Min: 1
       Max: 10
       PotencyDivisor: 10

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -261,3 +261,16 @@
         damage:
           types:
             Cellular: 2
+
+# HONK START - issue #645: synth species blood. BloodPlasma is the shared root
+# compound; specific species bloods are made from plasma plus a defining element.
+- type: reagent
+  id: BloodPlasma
+  name: reagent-name-blood-plasma
+  group: Biological
+  desc: reagent-desc-blood-plasma
+  physicalDesc: reagent-physical-desc-viscous
+  flavor: metallic
+  color: "#c9b26c"
+  recognizable: true
+# HONK END

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -28,6 +28,8 @@
     CarbonDioxide: 5.5
     Protein: 6
 
+# HONK START - issue #645: rebalance Slime breakdown to the 20u species-blood template.
+# Old 5u yield made the synth recipe a net loss and broke parity with other bloods.
 - type: reaction
   id: SlimeBloodBreakdown
   source: true
@@ -35,11 +37,18 @@
   - Centrifuge
   reactants:
     Slime:
-      amount: 5
+      amount: 20
   products:
-    Water: 4
-    Nitrogen: 1
+    Water: 11
+    Nitrogen: 0.5
+    Sugar: 2
+    CarbonDioxide: 3
+    Protein: 4
+# HONK END
 
+# HONK START - issue #645: rebalance Sap breakdown to the 20u species-blood template.
+# Folds the defining-element Sugar into a higher single output and adds the
+# Protein/CO2 pair so synth -> centrifuge -> synth is no longer a Protein laundry.
 - type: reaction
   id: SapBloodBreakdown
   source: true
@@ -47,10 +56,13 @@
   - Centrifuge
   reactants:
     Sap:
-      amount: 10
+      amount: 20
   products:
-    Water: 9
-    Sugar: 1
+    Water: 11
+    Sugar: 2.5
+    CarbonDioxide: 3
+    Protein: 4
+# HONK END
 
 - type: reaction
   id: CopperBloodBreakdown
@@ -108,3 +120,97 @@
     Mold: 2
     Protein: 1
     Toxin: 1
+
+# HONK START - issue #645: chemistry can now synthesise species blood from a shared
+# plasma intermediate. Plasma reaction is electrolyser-gated so it does not re-form
+# inside centrifuge breakdowns, patient bloodstreams, or food prep where the same
+# constituents naturally co-occur. Downstream (plasma + element) reactions are
+# transitively gated because the only path to plasma is the electrolyser.
+- type: reaction
+  id: BloodPlasma
+  requiredMixerCategories:
+  - Electrolysis
+  reactants:
+    Water:
+      amount: 3
+    Protein:
+      amount: 2
+    Sugar:
+      amount: 1
+  products:
+    BloodPlasma: 6
+
+- type: reaction
+  id: BloodSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Iron:
+      amount: 1
+  products:
+    Blood: 7
+
+- type: reaction
+  id: CopperBloodSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Copper:
+      amount: 1
+  products:
+    CopperBlood: 7
+
+- type: reaction
+  id: SulfurBloodSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Sulfur:
+      amount: 1
+    Hydrogen:
+      amount: 1
+  products:
+    SulfurBlood: 8
+
+- type: reaction
+  id: AmmoniaBloodSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Ammonia:
+      amount: 2
+  products:
+    AmmoniaBlood: 8
+
+- type: reaction
+  id: InsectBloodSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Sodium:
+      amount: 1
+    Chlorine:
+      amount: 1
+  products:
+    InsectBlood: 8
+
+- type: reaction
+  id: SlimeSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Nitrogen:
+      amount: 1
+  products:
+    Slime: 7
+
+- type: reaction
+  id: SapSynth
+  reactants:
+    BloodPlasma:
+      amount: 6
+    Sugar:
+      amount: 1
+  products:
+    Sap: 7
+# HONK END

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -122,14 +122,13 @@
     Toxin: 1
 
 # HONK START - issue #645: chemistry can now synthesise species blood from a shared
-# plasma intermediate. Plasma reaction is electrolyser-gated so it does not re-form
+# plasma intermediate. Plasma reaction needs heat (hotplate) so it does not re-form
 # inside centrifuge breakdowns, patient bloodstreams, or food prep where the same
-# constituents naturally co-occur. Downstream (plasma + element) reactions are
-# transitively gated because the only path to plasma is the electrolyser.
+# constituents naturally co-occur at room temperature. Downstream (plasma + element)
+# reactions are transitively gated because the only path to plasma is heat-gated.
 - type: reaction
   id: BloodPlasma
-  requiredMixerCategories:
-  - Electrolysis
+  minTemp: 370
   reactants:
     Water:
       amount: 3
@@ -205,11 +204,14 @@
     Slime: 7
 
 - type: reaction
+  # Phosphorus rather than Sugar so leftover Sugar from the BloodPlasma reaction
+  # doesn't auto-cascade Plasma -> Sap inside the same beaker. Phosphorus is also
+  # the plant-fertilizer thematic match (NPK).
   id: SapSynth
   reactants:
     BloodPlasma:
       amount: 6
-    Sugar:
+    Phosphorus:
       amount: 1
   products:
     Sap: 7


### PR DESCRIPTION
## About the PR

Adds a chemistry path for building species blood from a shared `BloodPlasma` root compound plus one defining element. Each station species (human, arachnid, vox/skaven, vulpkanin, moth, slime, diona) has its own synth recipe.

## Why / Balance

Today chemists can break species blood down in a centrifuge but the reverse direction does not exist. Emergency transfusions and IV restocks need a live donor of the right species, which is brittle on lowpop or when the only patient is a Skaven. Synth chemistry closes the loop and makes botany a quiet transfusion-stock supplier through blood tomatoes.

The plasma intermediate is heat-gated (hotplate, 370K minimum). Cold beakers with the same Water+Protein+Sugar mix sit inert in centrifuge output, patient bloodstreams, and shared food-prep beakers. Downstream synth recipes (`plasma + element -> X blood`) are transitively gated because the only path to plasma is heat. SapSynth uses Phosphorus rather than Sugar so leftover Sugar from the plasma reaction does not auto-cascade Plasma into Sap inside the same beaker (Phosphorus is also the plant-fertilizer thematic match).

Closes #645.

## Technical details

- `Resources/Prototypes/Reagents/biological.yml` adds the `BloodPlasma` reagent.
- `Resources/Prototypes/Recipes/Reactions/biological.yml`
  - `BloodPlasma` reaction: `minTemp: 370`, takes Water+Protein+Sugar.
  - 7 `*Synth` reactions covering Blood, CopperBlood, SulfurBlood, AmmoniaBlood, InsectBlood, Slime, Sap. Output volume conserves reactant total per recipe.
  - `SlimeBloodBreakdown` and `SapBloodBreakdown` rebalanced to the 20u species-blood template so they match the rest of the table and so `synth -> centrifuge -> synth` is a net reactant loss instead of a duplicator.
  - All edits and additions live inside HONK blocks.
- `Resources/Locale/en-US/reagents/meta/biological.ftl` adds name + desc for `BloodPlasma`.
- `Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml` swaps `FoodBloodTomato.juiceSolution` from `Blood: 10` to `BloodPlasma: 10`. Side effect: non-humans no longer take a poison tick from eating one.
- `Resources/Prototypes/Hydroponics/seeds.yml` swaps `bloodTomato` seed chemicals key from `Blood` to `BloodPlasma`. Min/Max/PotencyDivisor unchanged.

`ZombieBlood` is not synthable on purpose, it is an infection marker.

## Media

N/A, recipe definitions and one botany swap.

## Breaking changes

- `bloodTomato` seeds and `FoodBloodTomato` items now hold `BloodPlasma` instead of `Blood`. Anything in saves or maps that grinds a blood tomato for human-specific `Blood` will need to run the new `BloodSynth` step.
- `SlimeBloodBreakdown` (5u to 20u) and `SapBloodBreakdown` (10u to 20u) need 4x and 2x reactant respectively to fire.

## Changelog

:cl:
- add: Chemistry can synthesise blood for any station species from a `BloodPlasma` base plus a defining element. Plasma itself is brewed on a hotplate.
- tweak: Blood tomatoes now contain blood plasma instead of human blood. Non-humans can eat them without a poison tick, and grinding a tomato yields plasma directly.
- tweak: Slime and Sap centrifuge breakdowns now use the 20u species-blood template, matching the other bloods.