### PR TITLE
honksquad: feat: HONK0018 flag fork networked components missing [Access]

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkNetworkedComponentAccessAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkNetworkedComponentAccessAnalyzerTest.cs
@@ -1,0 +1,173 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkNetworkedComponentAccessAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkNetworkedComponentAccessAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class Component { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class RegisterComponentAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+            public sealed class AccessAttribute : System.Attribute
+            {
+                public AccessAttribute(System.Type type) { }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class AutoGenerateComponentStateAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class AutoNetworkedFieldAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/SomeForkComponent.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    Stubs,
+                    (filePath, code),
+                },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task NetworkedComponent_WithoutAccess_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+
+            [RegisterComponent, NetworkedComponent]
+            public sealed partial class FooComponent : Component { }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0018", Microsoft.CodeAnalysis.DiagnosticSeverity.Info)
+                .WithSpan(ForkPath, 5, 29, 5, 41)
+                .WithArguments("FooComponent"));
+    }
+
+    [Test]
+    public async Task NetworkedComponent_WithAccess_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+
+            public sealed class FooSystem { }
+
+            [RegisterComponent, NetworkedComponent, Access(typeof(FooSystem))]
+            public sealed partial class FooComponent : Component { }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task AutoGenerateComponentState_WithoutAccess_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            [RegisterComponent, AutoGenerateComponentState]
+            public sealed partial class FooComponent : Component { }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0018", Microsoft.CodeAnalysis.DiagnosticSeverity.Info)
+                .WithSpan(ForkPath, 4, 29, 4, 41)
+                .WithArguments("FooComponent"));
+    }
+
+    [Test]
+    public async Task AutoNetworkedField_WithoutAccess_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            [RegisterComponent]
+            public sealed partial class FooComponent : Component
+            {
+                [AutoNetworkedField]
+                public int Value;
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0018", Microsoft.CodeAnalysis.DiagnosticSeverity.Info)
+                .WithSpan(ForkPath, 4, 29, 4, 41)
+                .WithArguments("FooComponent"));
+    }
+
+    [Test]
+    public async Task NonNetworkedComponent_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            [RegisterComponent]
+            public sealed partial class TagComponent : Component { }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task UpstreamFile_NetworkedWithoutAccess_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+
+            [RegisterComponent, NetworkedComponent]
+            public sealed partial class UpstreamComponent : Component { }
+            """;
+
+        await Verify(code, "Content.Shared/Body/UpstreamComponent.cs");
+    }
+
+    [Test]
+    public async Task HonkPartial_NetworkedWithoutAccess_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.GameStates;
+
+            [RegisterComponent, NetworkedComponent]
+            public sealed partial class FooComponent : Component { }
+            """;
+
+        const string path = "Content.Shared/Body/FooComponent.Honk.cs";
+        await Verify(code, path,
+            new DiagnosticResult("HONK0018", Microsoft.CodeAnalysis.DiagnosticSeverity.Info)
+                .WithSpan(path, 5, 29, 5, 41)
+                .WithArguments("FooComponent"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkNetworkedComponentAccessAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkNetworkedComponentAccessAnalyzer.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0018: a fork class deriving from <c>Robust.Shared.GameObjects.Component</c> that
+/// participates in network state replication should carry an <c>[Access(typeof(...))]</c>
+/// attribute so external writers fail at build time. "Networked" here means the class is
+/// itself <c>[NetworkedComponent]</c>, opts into <c>[AutoGenerateComponentState]</c>, or
+/// holds a member tagged <c>[AutoNetworkedField]</c>; non-networked tag/marker components
+/// are out of scope (#639). Severity is <c>Info</c>: plenty of legitimate fork components
+/// don't need <c>[Access]</c>, so this surfaces in the IDE without breaking builds.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkNetworkedComponentAccessAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0018",
+        title: "Networked fork component missing [Access]",
+        messageFormat: "Networked fork component '{0}' has no [Access] attribute. Consider [Access(typeof(<OwningSystem>))] so missed Dirty() calls and external writes fail at build time.",
+        category: "Honk.Component",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Fork components that replicate state via [NetworkedComponent], [AutoGenerateComponentState], or [AutoNetworkedField] should declare an owning system via [Access]. Without it, any code path can write fields that need a Dirty() call, and invariants tied to the owning system can drift silently. Tag/marker components are out of scope.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(Analyze, SymbolKind.NamedType);
+    }
+
+    private static void Analyze(SymbolAnalysisContext context)
+    {
+        if (context.Symbol is not INamedTypeSymbol type)
+            return;
+
+        if (type.TypeKind != TypeKind.Class)
+            return;
+
+        if (!HasForkDeclaration(type))
+            return;
+
+        if (!InheritsComponent(type))
+            return;
+
+        if (HasAccessAttribute(type))
+            return;
+
+        if (!IsNetworked(type))
+            return;
+
+        foreach (var location in type.Locations)
+        {
+            if (location.IsInSource && IsForkFile(location.SourceTree?.FilePath))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, type.Name));
+                return;
+            }
+        }
+    }
+
+    private static bool HasForkDeclaration(INamedTypeSymbol type)
+    {
+        foreach (var location in type.Locations)
+        {
+            if (location.IsInSource && IsForkFile(location.SourceTree?.FilePath))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var norm = path!.Replace('\\', '/');
+        return norm.Contains("/RussStation/") || norm.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool InheritsComponent(INamedTypeSymbol type)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "Component" &&
+                current.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasAccessAttribute(INamedTypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is null)
+                continue;
+            if (attrClass.Name is "AccessAttribute" or "Access")
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsNetworked(INamedTypeSymbol type)
+    {
+        if (HasAttribute(type, "NetworkedComponentAttribute", "Robust.Shared.GameObjects")
+            || HasAttribute(type, "NetworkedComponentAttribute", "Robust.Shared.GameStates")
+            || HasAttribute(type, "AutoGenerateComponentStateAttribute", null))
+        {
+            return true;
+        }
+
+        foreach (var member in type.GetMembers())
+        {
+            if (member is not IFieldSymbol && member is not IPropertySymbol)
+                continue;
+
+            foreach (var attribute in member.GetAttributes())
+            {
+                var name = attribute.AttributeClass?.Name;
+                if (name is "AutoNetworkedFieldAttribute")
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAttribute(INamedTypeSymbol type, string name, string? requiredNamespace)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is null)
+                continue;
+            if (attrClass.Name != name && attrClass.Name != name.Replace("Attribute", string.Empty))
+                continue;
+            if (requiredNamespace is null)
+                return true;
+            if (attrClass.ContainingNamespace?.ToDisplayString() == requiredNamespace)
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

New analyzer in `Content.Analyzers.Honk/`. Surfaces fork networked components that have no `[Access]` attribute as `Info`-severity diagnostics in the IDE so missed `Dirty()` calls and external writes get a chance to be caught at build time.

Follow-up to #602 / replaces the on-demand shell heuristic in `docs/tmp/audit-access-candidates.sh`.

## Why / Balance

Networked components without `[Access]` are the ones where forgetting `Dirty()` actually has consequences (state divergence between client and server). The shell audit catches them but only when run; an analyzer catches them as the component is being written. Tag and marker components are out of scope per the issue, so the rule is restricted to classes that actually opt into networking.

`Info` keeps the rule out of CI: warnings would be too loud for legitimate cases where the writing path is tightly scoped.

Closes #639.

## Technical details

- `Content.Analyzers.Honk/HonkNetworkedComponentAccessAnalyzer.cs` - new analyzer.
  - Fires when a class deriving from `Robust.Shared.GameObjects.Component` lives in a fork file (`*/RussStation/*` or `*.Honk.cs`), has no `[Access(...)]` attribute, and is "networked" by any of:
    - class-level `[NetworkedComponent]` (in either `Robust.Shared.GameObjects` or `Robust.Shared.GameStates`)
    - class-level `[AutoGenerateComponentState]`
    - any `[AutoNetworkedField]` on a field or property.
  - Reports once per type even when split across partials.
- `Content.Analyzers.Honk.Tests/HonkNetworkedComponentAccessAnalyzerTest.cs` - 7 tests covering the positive cases (each network signal), the `[Access]` opt-out, the upstream-file scope rule, the `.Honk.cs` partial path, and a non-networked tag component as a negative case.

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None. New rule is `Info` severity and never breaks the build.

**Changelog**

(no player-facing changes)