### PR TITLE
honksquad: fix: highlight @-mentions on radio after upstream curly-quote swap

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -118,14 +118,19 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
             // Make sure the character's name is highlighted only when mentioned directly (eg. it's said by someone),
             // for example in 'Name Surname says, "..."' 'Name Surname' won't be highlighted.
-            //HONK START - issue #656: upstream 6a1c1f3f50 narrowed the @-keyword lookbehind to
-            //(?<=^.?OOC:.*:.*)|(?<=,.*".*)|(?<=\n.*), which dropped highlighting of literal
-            //"@Name" mentions in radio, emotes, dead chat, and popups (none have a `, "..."`
-            //preamble or a leading newline). Restore the older permissive form: match anywhere
-            //the position is preceded by a `, "..."` quoted-speech preface OR is not inside the
-            //speaker's own [Name][/Name] tag, so the speaker is not highlighted in their own
-            //byline but everyone else's @-mentions still light up.
-            keyword = StartAtSign.Replace(keyword, @"(?<=(?<=,.*"".*)|(?<!\[Name].*))");
+            //HONK START - issue #656: upstream's @-keyword lookbehind only matches in OOC, after
+            //a `, "..."` quoted-speech preface, or after a literal newline. Two regressions
+            //collide there:
+            //  1. The `, "..."` clause uses ASCII `"`, but upstream 5bd9d21cb6 swapped chat
+            //     wrappers to curly quotes (“ ”), so even say-wrap mentions miss now.
+            //  2. Radio, dead chat, emotes, and popups never carried any of those prefaces, so
+            //     literal "@Name" mentions in those channels stopped highlighting outright.
+            //Add curly-quote support to the comma-quote clause and bring back the older
+            //"not inside the speaker's own [Name] tag" fallback as a fourth alternative. Keeps
+            //the speaker un-highlighted in their own byline while letting every other channel
+            //match again. The audible-ping path in HonkHighlightSound is unaffected (it strips
+            //the @ and substring-matches msg.Message directly).
+            keyword = StartAtSign.Replace(keyword, @"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*[""“].*)|(?<=\n.*)|(?<!\[Name].*))");
             //HONK END
 
             _highlights.Add(keyword);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -123,14 +123,17 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             //collide there:
             //  1. The `, "..."` clause uses ASCII `"`, but upstream 5bd9d21cb6 swapped chat
             //     wrappers to curly quotes (“ ”), so even say-wrap mentions miss now.
-            //  2. Radio, dead chat, emotes, and popups never carried any of those prefaces, so
-            //     literal "@Name" mentions in those channels stopped highlighting outright.
-            //Add curly-quote support to the comma-quote clause and bring back the older
-            //"not inside the speaker's own [Name] tag" fallback as a fourth alternative. Keeps
-            //the speaker un-highlighted in their own byline while letting every other channel
-            //match again. The audible-ping path in HonkHighlightSound is unaffected (it strips
-            //the @ and substring-matches msg.Message directly).
-            keyword = StartAtSign.Replace(keyword, @"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*[""“].*)|(?<=\n.*)|(?<!\[Name].*))");
+            //  2. Radio and dead-chat never carried any of those prefaces, so literal "@Name"
+            //     mentions in those channels stopped highlighting outright.
+            //Add curly-quote support to the comma-quote clause and a fourth alternative that
+            //anchors after the speaker's closing `[/bold]` tag. Radio (`[bold]Bob[/bold]
+            //says, "..."`) and dead-chat (`Dead: [bold]Bob[/bold]: ...`) both have `[/bold]`
+            //sitting between byline and message, so the byline itself can't match (it's BEFORE
+            //its own `[/bold]`). Emote and popup channels don't have a `[/bold]` and so won't
+            //match @-prefixed highlights, which is the same as pre-curly-quote behaviour.
+            //The audible-ping path in HonkHighlightSound is unaffected (it strips the @ and
+            //substring-matches msg.Message directly).
+            keyword = StartAtSign.Replace(keyword, @"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*[""“].*)|(?<=\n.*)|(?<=\[/bold\].*))");
             //HONK END
 
             _highlights.Add(keyword);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -118,7 +118,15 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
             // Make sure the character's name is highlighted only when mentioned directly (eg. it's said by someone),
             // for example in 'Name Surname says, "..."' 'Name Surname' won't be highlighted.
-            keyword = StartAtSign.Replace(keyword, @"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*"".*)|(?<=\n.*))");
+            //HONK START - issue #656: upstream 6a1c1f3f50 narrowed the @-keyword lookbehind to
+            //(?<=^.?OOC:.*:.*)|(?<=,.*".*)|(?<=\n.*), which dropped highlighting of literal
+            //"@Name" mentions in radio, emotes, dead chat, and popups (none have a `, "..."`
+            //preamble or a leading newline). Restore the older permissive form: match anywhere
+            //the position is preceded by a `, "..."` quoted-speech preface OR is not inside the
+            //speaker's own [Name][/Name] tag, so the speaker is not highlighted in their own
+            //byline but everyone else's @-mentions still light up.
+            keyword = StartAtSign.Replace(keyword, @"(?<=(?<=,.*"".*)|(?<!\[Name].*))");
+            //HONK END
 
             _highlights.Add(keyword);
         }


### PR DESCRIPTION
## About the PR

Restores chat-highlight matching for the auto-filled `@PlayerName` keyword on radio (and the other channels that never had a matching preface), after the upstream curly-quote swap silently broke it.

## Why / Balance

The accessibility setting that auto-adds the local character's name to the highlights list prefixes each entry with `@` so the matcher only fires on direct mentions, not on the speaker's own byline. The lookbehind that anchors `@` to a "this is dialogue" preface only accepts three contexts: an OOC line, a `, "..."` quoted-speech preface, or a leading newline.

Upstream `bed228f37f` ("Fix radio quotes", Apr 5) swapped the radio wrapper from ASCII `"` to curly `“ ”`. The fork pulled it in via the Apr 13 release sync. The comma-quote clause uses ASCII `"` so it stopped matching the radio wrapper, and radio carries no other preface that the regex accepts, so `@PlayerName` mentions over headset went silent. Same story for dead chat, emotes, and popups, which never carried any of the supported prefaces.

The audible-ping path in `HonkHighlightSound` is unaffected. It strips the `@` and substring-matches `msg.Message` directly, so it never went through the broken visual matcher.

Closes #656.

## Technical details

- `Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs` (HONK-block):
  - Comma-quote clause becomes `(?<=,.*["“].*)` so either ASCII or left curly counts.
  - Adds a fourth alternative `(?<![Name].*)` so channels without any preface at all (radio, dead, emote, popup) match again. The `[Name][/Name]` tag in say/whisper wrappers keeps the speaker's own byline from highlighting itself.

## Verification

- Manual highlight `Bob`: matches everywhere (no `@` prefix, no preface gating).
- Auto-fill highlight `@Bob`: matches everyone else's `@Bob` mention in say, radio, OOC, dead, emote, popup. Does not match Bob's own byline in say/whisper.

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Auto-fill `@PlayerName` chat highlights work on radio again, alongside dead chat, emotes, and popups.