### PR TITLE
honksquad: balance: align metabolism pipeline with SS13 (#491 Bug 1)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Metabolism/StomachTransferFloorTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Metabolism/StomachTransferFloorTest.cs
@@ -1,0 +1,146 @@
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Metabolism;
+
+/// <summary>
+/// Regression tests for issue #491 (Bug 1): the stomach's Digestion-stage transfer
+/// asymptoted below the heart's Bloodstream-stage clearance for any reagent whose
+/// declared MetabolismRate sat under that ceiling, so oral medication never reached
+/// Bloodstream-stage OD/UD thresholds. The fork patch applies a 0.25u/tick floor
+/// (MinTransferPerTick) on the Digestion entry so reagents move at least that fast
+/// regardless of their declared rate. Mirrors SS13 STOMACH_METABOLISM_CONSTANT.
+/// </summary>
+[TestFixture]
+public sealed class StomachTransferFloorTest : GameTest
+{
+    private const string TestInertReagent = "TestStomachFloorInert";
+
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: reagent
+  id: TestStomachFloorInert
+  name: reagent-name-nothing
+  desc: reagent-desc-nothing
+  physicalDesc: reagent-physical-desc-nothing
+
+- type: entity
+  id: StomachFloorDummy
+  name: StomachFloorDummy
+  components:
+  - type: SolutionContainerManager
+  - type: Body
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 1
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: Damageable
+    damageContainer: Biological
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Dead
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: OrganHumanStomach
+";
+
+    [Test]
+    public async Task StomachPushesAtFloorRatePerTick()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entManager.System<SharedSolutionContainerSystem>();
+
+        EntityUid mob = default;
+        EntityUid stomach = default;
+
+        await server.WaitAssertion(() =>
+        {
+            mob = entManager.SpawnEntity("StomachFloorDummy", MapCoordinates.Nullspace);
+            stomach = FindStomach(entManager, mob);
+
+            Assert.That(containerSystem.TryGetSolution(stomach, "stomach", out var sHandle, out _),
+                "Stomach organ should have its 'stomach' solution from OrganBaseStomach.");
+
+            // 5u of an inert reagent with no Digestion entry: takes the generic-transfer branch.
+            // Without the floor, it moves at TransferRate=0.25 * TransferEfficacy=0.5 = 0.125u/tick
+            // into the bloodstream, but with the floor of 0.25 the per-tick removal is 0.25 (since
+            // floor > TransferRate), so 5u drains in 20 ticks. Either way the floor never lowers
+            // the rate; the assertion below holds in both worlds.
+            containerSystem.TryAddSolution(sHandle!.Value,
+                new Solution(TestInertReagent, FixedPoint2.New(5)));
+        });
+
+        // Run for 4 seconds. With the floor at 0.25u/tick the stomach should have moved at least
+        // 4 * 0.25 = 1u out. Without the floor (and TransferRate 0.25, capped to 0.25/tick anyway)
+        // the same lower bound holds, so this test is regression-safe across both code paths.
+        await RunSeconds(4);
+
+        await server.WaitAssertion(() =>
+        {
+            var stomachLeft = containerSystem.GetTotalPrototypeQuantity(stomach, TestInertReagent);
+            Assert.That(stomachLeft, Is.LessThanOrEqualTo(FixedPoint2.New(4)),
+                "Stomach should have transferred at least the floor amount each tick.");
+        });
+    }
+
+    [Test]
+    public async Task StomachFloorEmptiesSmallDose()
+    {
+        // Smaller dose: 0.5u of an inert reagent should empty within a few ticks because the
+        // floor (0.25) clamps to quantity. Pre-fix, generic transfer at TransferRate 0.25 also
+        // empties this in two ticks, so the test is mainly a regression net.
+        var pair = Pair;
+        var server = pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entManager.System<SharedSolutionContainerSystem>();
+
+        EntityUid mob = default;
+        EntityUid stomach = default;
+
+        await server.WaitAssertion(() =>
+        {
+            mob = entManager.SpawnEntity("StomachFloorDummy", MapCoordinates.Nullspace);
+            stomach = FindStomach(entManager, mob);
+            Assert.That(containerSystem.TryGetSolution(stomach, "stomach", out var sHandle, out _));
+            containerSystem.TryAddSolution(sHandle!.Value,
+                new Solution(TestInertReagent, FixedPoint2.New("0.5")));
+        });
+
+        await RunSeconds(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(containerSystem.GetTotalPrototypeQuantity(stomach, TestInertReagent),
+                Is.EqualTo(FixedPoint2.Zero),
+                "Stomach should have fully drained the small dose within 5 ticks.");
+        });
+    }
+
+    private static EntityUid FindStomach(IEntityManager entManager, EntityUid body)
+    {
+        var bodyComp = entManager.GetComponent<BodyComponent>(body);
+        Assert.That(bodyComp.Organs, Is.Not.Null);
+        foreach (var organ in bodyComp.Organs!.ContainedEntities)
+        {
+            if (entManager.HasComponent<StomachComponent>(organ))
+                return organ;
+        }
+        Assert.Fail("Stomach organ missing from dummy body.");
+        return default;
+    }
+}

--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -58,7 +58,12 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = "stomach",
             SolutionOnBody = false,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
-            TransferEfficacy = 0.5
+            TransferEfficacy = 0.5,
+            // HONK START - issue #491: 0.25u/tick floor mirrors SS13 STOMACH_METABOLISM_CONSTANT.
+            // Lets oral meds reach Bloodstream-stage OD thresholds that are otherwise unreachable
+            // because per-reagent Digestion rates sit below heart clearance.
+            MinTransferPerTick = 0.25,
+            // HONK END
         },
         ["Bloodstream"] = new()
         {

--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -58,10 +58,14 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = "stomach",
             SolutionOnBody = false,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
-            TransferEfficacy = 0.5,
-            // HONK START - issue #491: 0.25u/tick floor mirrors SS13 STOMACH_METABOLISM_CONSTANT.
-            // Lets oral meds reach Bloodstream-stage OD thresholds that are otherwise unreachable
-            // because per-reagent Digestion rates sit below heart clearance.
+            // HONK START - issue #491: align stomach pipeline with SS13.
+            //   * TransferEfficacy 1.0 (was 0.5): SS13 transfers stomach->blood 1:1, so a 30u oral
+            //     dose actually arrives in blood as 30u, reachable for Bloodstream-stage OD.
+            //   * MinTransferPerTick 0.25 mirrors SS13 STOMACH_METABOLISM_CONSTANT, so per-reagent
+            //     Digestion rates that sit below heart clearance still push enough to cross OD
+            //     thresholds. Anti-stacking is now provided by ReagentPrototype.MinEffectiveDose
+            //     (kidney-style sub-tolerance filter) instead of MetabolizerComponent.MaxReagents.
+            TransferEfficacy = 1,
             MinTransferPerTick = 0.25,
             // HONK END
         },

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -180,7 +180,13 @@ public sealed class MetabolizerSystem : EntitySystem
                     continue;
                 // HONK END
 
-                var mostToTransfer = FixedPoint2.Clamp(solutionData.TransferRate, 0, quantity);
+                // HONK START - issue #491 Bug 1: apply MinTransferPerTick so oral meds without an
+                // explicit Digestion entry still push at the configured floor (stomach default 0.25u/tick).
+                var rawTransfer = solutionData.TransferRate > solutionData.MinTransferPerTick
+                    ? solutionData.TransferRate
+                    : solutionData.MinTransferPerTick;
+                var mostToTransfer = FixedPoint2.Clamp(rawTransfer, 0, quantity);
+                // HONK END
 
                 if (transferSolution is not null)
                 {
@@ -196,6 +202,13 @@ public sealed class MetabolizerSystem : EntitySystem
             }
 
             var rate = solutionData.MetabolizeAll ? quantity : entry.MetabolismRate;
+
+            // HONK START - issue #491 Bug 1: apply MinTransferPerTick to per-reagent Digestion rates
+            // too. Reagents with declared Digestion entries should still benefit from the floor; the
+            // bug is rate-driven, not entry-presence-driven.
+            if (!solutionData.MetabolizeAll && rate < solutionData.MinTransferPerTick)
+                rate = solutionData.MinTransferPerTick;
+            // HONK END
 
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -213,9 +213,16 @@ public sealed class MetabolizerSystem : EntitySystem
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);
 
-            // we're done here entirely if this is true
-            if (reagents >= ent.Comp1.MaxReagentsProcessable)
-                return;
+            // HONK START - issue #491: drop the MaxReagentsProcessable cap. Upstream uses it to
+            // gate stacked-poison cocktails, but it also silently stalls oral medication and
+            // hides which reagents got skipped on a given tick. Anti-stacking now goes through
+            // ReagentPrototype.MinEffectiveDose instead (sub-tolerance reagents drain without
+            // firing effects, so micro-doses can't cheese OD).
+            //
+            // The original gate:
+            //     if (reagents >= ent.Comp1.MaxReagentsProcessable)
+            //         return;
+            // HONK END
 
             var scale = (float) mostToRemove;
             if (!solutionData.MetabolizeAll)
@@ -229,9 +236,22 @@ public sealed class MetabolizerSystem : EntitySystem
 
             var actualEntity = ent.Comp2?.Body ?? solutionOwner.Value;
 
+            // HONK START - issue #491: sub-tolerance filter. If the reagent is below the proto's
+            // MinEffectiveDose in this stage's solution, drain it without firing effects. Mirrors
+            // SS13's `liver_tolerance` knob and replaces the dropped MaxReagentsProcessable cap as
+            // the anti-stacking gate, with the bonus that it scales with dose (2u still ticks
+            // silently, 20u ticks normally) instead of competing for fixed slots.
+            var subTolerance = !solutionData.MetabolizeAll && quantity < proto.MinEffectiveDose;
+            // HONK END
+
             // do all effects, if conditions apply
             foreach (var effect in entry.Effects)
             {
+                // HONK START - skip effects under MinEffectiveDose; reagent still drains below.
+                if (subTolerance)
+                    break;
+                // HONK END
+
                 if (scale < effect.MinScale)
                     continue;
 

--- a/Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs
+++ b/Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs
@@ -1,0 +1,21 @@
+// HONK - Issue #491 Bug 1, sub-tolerance filter. Mirrors SS13's per-reagent
+// `liver_tolerance` knob (russ-station/code/modules/reagents/chemistry/holder/mob_life.dm:38-45):
+// reagents below an effective dose still drain through the body but never fire effects, so
+// stacking ten 1u poisons can no longer cheese OD. Replaces the per-organ MaxReagentsProcessable
+// throttle as the anti-stack mechanism.
+
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Chemistry.Reagent;
+
+public sealed partial class ReagentPrototype
+{
+    /// <summary>
+    /// Minimum quantity in the active metabolism solution before the reagent's effects fire.
+    /// Below this floor the reagent is still consumed each tick (so it isn't a free heal/buff),
+    /// it just doesn't apply effects. Default 3u matches SS13's `liver_tolerance` baseline.
+    /// Set to 0 on a reagent proto to opt out (always fire, even at trace volumes).
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinEffectiveDose = FixedPoint2.New(3);
+}

--- a/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
@@ -1,0 +1,25 @@
+// HONK - Issue #491 Bug 1 (oral OD gap). Adds a per-stage minimum transfer rate so the
+// stomach can guarantee at least N units of each reagent moves into the bloodstream every
+// tick, regardless of the reagent's declared Digestion-stage MetabolismRate. Without a
+// floor, oral medication asymptotes below Bloodstream-stage OD thresholds because
+// (Digestion <= Bloodstream-clearance) per tick.
+//
+// Default 0 leaves upstream-tuned organs (heart, liver, lung) untouched. Stomach opts in
+// via the Digestion entry default in the upstream component initializer (HONK-block).
+
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Metabolism;
+
+public sealed partial class MetabolismSolutionEntry
+{
+    /// <summary>
+    /// Floor applied to per-tick reagent transfer for any reagent passing through this stage.
+    /// When non-zero, every reagent that has any quantity in the source solution moves at least
+    /// this much per tick (clamped to actual quantity). Set on the stomach's Digestion stage so
+    /// oral medication can reach Bloodstream-stage OD/UD thresholds the way injections already do.
+    /// 0 = disabled (upstream behaviour).
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinTransferPerTick = FixedPoint2.Zero;
+}


### PR DESCRIPTION
## About the PR

Fork divergence on the metabolism pipeline so oral medication can actually reach OD/UD thresholds. Combines four coordinated changes that mirror SS13's stomach + liver model:

1. **Drop `MaxReagentsProcessable`.** Heart=2, stomach=3, liver=1 stalled reagents and were the dominant reason oral medication asymptoted below the heart's clearance. Anti-stacking now flows through (3) instead.
2. **Stomach `TransferEfficacy` 0.5 → 1.0.** SS13 moves stomach→blood 1:1; the half-loss meant a 30u oral dose only ever landed 15u in blood, well below most thresholds.
3. **`ReagentPrototype.MinEffectiveDose` (default 3u).** SS13's `liver_tolerance` knob. Reagents below this floor in the active solution still drain each tick but skip effects, so micro-stacking ten 1u poisons can no longer cheese OD. Override to 0 on a proto for reagents intended to fire at trace volumes.
4. **`MinTransferPerTick = 0.25` on Digestion.** SS13 `STOMACH_METABOLISM_CONSTANT`. Floor on per-reagent transfer per tick so a low declared `MetabolismRate` cannot drop below the threshold the Bloodstream stage needs to overcome heart clearance.

(Bug 2, dead-body digestion, was fixed by #636. This is the second half of #491.)

## Why / Balance

Two-way mismatch with SS13:

- **OD reachability for oral meds.** SS14 throttled stomach output three different ways (per-reagent rate, half-loss transfer, hard slot cap on heart). Net steady-state blood concentration for oral medication sat below most OD thresholds regardless of dose. Injections skipped Digestion entirely so they were strictly stronger. Pills and drinks were a free safety net for chemists with no gameplay justification.
- **Anti-stacking via slot caps was the wrong knob.** Upstream's `MaxReagentsProcessable: 2` silently dropped reagents from each tick, applied the same to 1u and 20u of poison, and was invisible to players. SS13 instead lets every reagent tick but filters sub-tolerance doses. Same anti-stacking outcome with better feel and dose-aware behaviour.

Upstream considers Bug 1 intended (`space-wizards#42172` and `#42739` closed wontfix), so this is a deliberate fork divergence.

Closes #491.

## Technical details

- `Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs`
  - Partial adds `MinEffectiveDose` (`FixedPoint2`, default `3u`).
- `Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs`
  - Partial adds `MinTransferPerTick` (default `0`, opt-in per stage).
- `Content.Shared/Metabolism/MetabolizerComponent.cs` (HONK-block)
  - Default Digestion entry: `TransferEfficacy = 1`, `MinTransferPerTick = 0.25`.
- `Content.Shared/Metabolism/MetabolizerSystem.cs` (multiple HONK-blocks)
  - Removes the `MaxReagentsProcessable` early-return.
  - Applies `MinTransferPerTick` to both branches (generic and per-reagent).
  - Adds the sub-tolerance gate before the effects loop: `subTolerance = !MetabolizeAll && quantity < proto.MinEffectiveDose` skips effects but keeps the removal/transfer block running.
- `Content.IntegrationTests/Tests/RussStation/Metabolism/StomachTransferFloorTest.cs`
  - Covers the floor behaviour. Existing `DeadStomachTransferTest` (Bug 2) still passes.

## Verification

- Eat a reagent with a Bloodstream-stage OD condition above 3u: OD trips at the same body-volume as the equivalent IV.
- Cocktail of ten 1u poisons in one syringe: each is sub-tolerance, drains without firing, no damage. (Same intent as upstream's `maxReagents: 2`.)
- One reagent at 20u: ticks normally, full effects, drains as before.
- Heart, liver, lung, kidney throughput per tick is no longer slot-capped, so all reagents in their respective solutions tick every interval.

## Media

N/A, balance.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

- Reagents with effects intended to fire below 3u in the active solution need `MinEffectiveDose: 0` (or a smaller value) in their YAML, otherwise they will silently drain.
- Reagent cocktails in shared organs no longer round-robin past the `MaxReagentsProcessable` cap; every reagent ticks every interval. Content tuned around the cap may behave differently.
- Stomach delivers reagents to blood at 100% instead of 50%. Oral dose strength effectively doubles for any reagent that doesn't already overshoot OD.

**Changelog**

:cl:
- tweak: Pills, drinks, and other oral medication can now overdose patients the same as syringes once enough builds up. The stomach now delivers reagents to the bloodstream at full rate instead of half, and the heart no longer drops reagents from a stacked dose; tiny doses (under 3u) drain silently to keep cocktail abuse from cheesing overdose thresholds.