### PR TITLE
honksquad: feat: add Detoxification metabolism stage on the liver (#679 step 1)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -68,7 +68,15 @@ public sealed partial class MetabolizerComponent : Component
         ["Metabolites"] = new()
         {
             SolutionName = BloodstreamComponent.DefaultMetabolitesSolutionName
+        },
+        // HONK START - issue #679 step 1: Detoxification reads the bloodstream so the
+        // liver can scrub toxin-class reagents in place. Step 1 only declares the entry;
+        // the per-tick scrub rate (ToxinScrubRate) and reagent-side opt-in arrive in step 6.
+        ["Detoxification"] = new()
+        {
+            SolutionName = BloodstreamComponent.DefaultBloodSolutionName
         }
+        // HONK END
     };
 
     /// <summary>

--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -72,9 +72,19 @@ public sealed partial class MetabolizerComponent : Component
         // HONK START - issue #679 step 1: Detoxification reads the bloodstream so the
         // liver can scrub toxin-class reagents in place. Step 1 only declares the entry;
         // the per-tick scrub rate (ToxinScrubRate) and reagent-side opt-in arrive in step 6.
+        //
+        // Engine quirk: TryMetabolizeStage's "this reagent has no entry for the stage"
+        // fallback either removes TransferRate units into a transfer solution, or removes
+        // 1 unit flat if there is no transfer solution. Until step 6 adds the toxin opt-in,
+        // we must look like a no-op so we don't quietly siphon Ethanol (and every other
+        // blood reagent waiting for the heart's Bloodstream transfer) before they reach
+        // the metabolites pool. Self-loop the transfer to the same blood solution with
+        // TransferRate = 0 so the fallback is "remove 0, add 0".
         ["Detoxification"] = new()
         {
-            SolutionName = BloodstreamComponent.DefaultBloodSolutionName
+            SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
+            TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
+            TransferRate = 0,
         }
         // HONK END
     };

--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -85,6 +85,18 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferRate = 0,
+        },
+        // HONK END
+        // HONK START - issue #679 step 2: Excretion reads the bloodstream so the kidney
+        // can host the sub-tolerance filter (step 5) and the slow blood drain (step 7).
+        // No reagent declares an Excretion entry yet, so the stage runs and does nothing
+        // until later steps land. Same TransferRate = 0 self-loop as Detoxification so
+        // the no-entry fallback can't drain Ethanol or other bloodstream reagents.
+        ["Excretion"] = new()
+        {
+            SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
+            TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
+            TransferRate = 0,
         }
         // HONK END
     };

--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -58,7 +58,16 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = "stomach",
             SolutionOnBody = false,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
-            TransferEfficacy = 0.5
+            // HONK START - issue #679 step 4: align stomach throughput with SS13.
+            //   * TransferEfficacy 1.0 (was 0.5): SS13 transfers stomach->blood 1:1, so
+            //     a 30u oral dose actually arrives in blood as 30u, reachable for OD.
+            //   * MinTransferPerTick mirrors SS13 STOMACH_METABOLISM_CONSTANT (0.25u).
+            //   * VolumeScaledTransfer mirrors SS13 metabolism_efficiency (0.05) so a
+            //     fuller stomach pushes faster.
+            TransferEfficacy = 1,
+            MinTransferPerTick = 0.25,
+            VolumeScaledTransfer = 0.05f,
+            // HONK END
         },
         ["Bloodstream"] = new()
         {

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -180,7 +180,15 @@ public sealed class MetabolizerSystem : EntitySystem
                     continue;
                 // HONK END
 
-                var mostToTransfer = FixedPoint2.Clamp(solutionData.TransferRate, 0, quantity);
+                // HONK START - issue #679 step 4: apply MinTransferPerTick + VolumeScaledTransfer
+                // to the generic-transfer branch so reagents without a Digestion entry also benefit
+                // from the SS13 stomach pipeline (floor + 5%-of-volume scaling).
+                var rawGeneric = solutionData.TransferRate > solutionData.MinTransferPerTick
+                    ? solutionData.TransferRate
+                    : solutionData.MinTransferPerTick;
+                rawGeneric += quantity * solutionData.VolumeScaledTransfer;
+                var mostToTransfer = FixedPoint2.Clamp(rawGeneric, 0, quantity);
+                // HONK END
 
                 if (transferSolution is not null)
                 {
@@ -196,6 +204,19 @@ public sealed class MetabolizerSystem : EntitySystem
             }
 
             var rate = solutionData.MetabolizeAll ? quantity : entry.MetabolismRate;
+
+            // HONK START - issue #679 step 4: apply MinTransferPerTick + VolumeScaledTransfer to
+            // per-reagent rates too. Mirrors SS13's
+            //     amount = (0.05 * stomach_volume + max(rate, 0.25)) * dt
+            // formula on the stomach. Skipped when MetabolizeAll is on (lungs already process
+            // every reagent in full).
+            if (!solutionData.MetabolizeAll)
+            {
+                if (rate < solutionData.MinTransferPerTick)
+                    rate = solutionData.MinTransferPerTick;
+                rate += quantity * solutionData.VolumeScaledTransfer;
+            }
+            // HONK END
 
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -200,9 +200,17 @@ public sealed class MetabolizerSystem : EntitySystem
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);
 
-            // we're done here entirely if this is true
-            if (reagents >= ent.Comp1.MaxReagentsProcessable)
-                return;
+            // HONK START - issue #679 step 3: drop the MaxReagentsProcessable cap. Upstream
+            // uses it to gate stacked-poison cocktails, but it also silently stalls oral
+            // medication and hides which reagents got skipped on a given tick. Anti-stacking
+            // moves to ReagentPrototype.MinEffectiveDose (step 5): reagents below tolerance
+            // drain without firing effects, so micro-doses can no longer cheese OD. Every
+            // reagent now ticks every interval.
+            //
+            // Original gate, preserved as a comment for upstream-merge readability:
+            //     if (reagents >= ent.Comp1.MaxReagentsProcessable)
+            //         return;
+            // HONK END
 
             var scale = (float) mostToRemove;
             if (!solutionData.MetabolizeAll)

--- a/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
@@ -1,0 +1,23 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.RussStation.Metabolism;
+
+/// <summary>
+/// Constants for the metabolic chain refactor (#679). SS13 reference values live here so the
+/// component / system code is just a name lookup, not a magic-number scatter.
+/// </summary>
+public static class MetabolismConstants
+{
+    /// <summary>
+    /// Default per-stage transfer floor. 0 means no floor; the stomach overrides to 0.25u/tick
+    /// to mirror SS13 STOMACH_METABOLISM_CONSTANT.
+    /// </summary>
+    public static readonly FixedPoint2 DefaultMinTransferPerTick = FixedPoint2.Zero;
+
+    /// <summary>
+    /// Default per-stage volume-scaled transfer fraction. 0 means flat rate; the stomach
+    /// overrides to 0.05 (5% of the reagent's current quantity adds to the per-tick transfer)
+    /// to mirror SS13 metabolism_efficiency.
+    /// </summary>
+    public const float DefaultVolumeScaledTransfer = 0f;
+}

--- a/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
@@ -1,0 +1,38 @@
+// HONK - Issue #679 step 4: bring stomach throughput in line with SS13.
+// Two new knobs on the per-stage MetabolismSolutionEntry, both default 0 so the per-stage
+// behaviour is opt-in and other organs (heart, liver, lung, kidney) stay on the upstream
+// path until they explicitly need either knob:
+//
+//   * MinTransferPerTick mirrors SS13 STOMACH_METABOLISM_CONSTANT. Floors the per-reagent
+//     transfer so a low MetabolismRate can still cross the heart's clearance rate.
+//   * VolumeScaledTransfer mirrors SS13 metabolism_efficiency = 0.05. Adds a fraction of
+//     the reagent's current volume in the source solution to the per-tick transfer, so a
+//     fuller stomach delivers faster.
+//
+// Composed: per-tick transfer = max(rate, MinTransferPerTick) + VolumeScaledTransfer * quantity,
+// clamped to quantity available.
+
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Metabolism;
+
+namespace Content.Shared.Metabolism;
+
+public sealed partial class MetabolismSolutionEntry
+{
+    /// <summary>
+    /// Per-tick floor for reagent transfer at this stage. The actual move per tick is at
+    /// least this many units of each reagent that has any quantity, clamped to quantity.
+    /// 0 = disabled (upstream rate alone). Mirrors SS13 STOMACH_METABOLISM_CONSTANT.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinTransferPerTick = MetabolismConstants.DefaultMinTransferPerTick;
+
+    /// <summary>
+    /// Fraction of a reagent's current quantity in the source solution that adds to the
+    /// per-tick transfer at this stage. Set to 0.05 on the stomach's Digestion entry so
+    /// a fuller stomach pushes faster, matching SS13's <c>metabolism_efficiency</c>.
+    /// 0 = disabled.
+    /// </summary>
+    [DataField]
+    public float VolumeScaledTransfer = MetabolismConstants.DefaultVolumeScaledTransfer;
+}

--- a/Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl
+++ b/Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl
@@ -1,0 +1,2 @@
+# HONK - Issue #679 metabolism stage names.
+metabolism-stage-detoxification = Detoxification

--- a/Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl
+++ b/Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl
@@ -1,2 +1,3 @@
 # HONK - Issue #679 metabolism stage names.
 metabolism-stage-detoxification = Detoxification
+metabolism-stage-excretion = Excretion

--- a/Resources/Prototypes/@RussStation/Metabolism/stages.yml
+++ b/Resources/Prototypes/@RussStation/Metabolism/stages.yml
@@ -1,0 +1,9 @@
+# HONK - Issue #679 step 1: define metabolism stages introduced by the chain refactor.
+# Detoxification: liver pass over the bloodstream that scrubs toxin-class reagents at a
+# per-tick rate. This step only declares the stage; the toxin scrubbing logic lands in
+# step 6 (ToxinScrubRate on the Detoxification solution entry). Until then the stage
+# runs and does nothing per reagent because no reagent declares a Detoxification entry.
+
+- type: metabolismStage
+  id: Detoxification
+  name: metabolism-stage-detoxification

--- a/Resources/Prototypes/@RussStation/Metabolism/stages.yml
+++ b/Resources/Prototypes/@RussStation/Metabolism/stages.yml
@@ -7,3 +7,10 @@
 - type: metabolismStage
   id: Detoxification
   name: metabolism-stage-detoxification
+
+# Excretion: kidney pass over the bloodstream. Step 2 declares the stage and routes the
+# kidney's Metabolizer at it. Sub-tolerance filtering (#679 step 5) and the slow blood
+# drain (#679 step 7) land in later steps; until then the stage runs and does nothing.
+- type: metabolismStage
+  id: Excretion
+  name: metabolism-stage-excretion

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -401,7 +401,11 @@
     heldPrefix: liver
   - type: Metabolizer
     maxReagents: 1
-    stages: [ Metabolites ]
+    # HONK START - issue #679 step 1: liver also runs Detoxification, the new fork stage
+    # reserved for toxin scrubbing on the bloodstream. No reagents declare a Detoxification
+    # entry yet, so the stage is a no-op until step 6 adds ToxinScrubRate.
+    stages: [ Metabolites, Detoxification ]
+    # HONK END
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -424,6 +424,11 @@
     heldPrefix: kidneys
   - type: Metabolizer
     maxReagents: 5
+    # HONK START - issue #679 step 2: kidneys run the new Excretion stage on the
+    # bloodstream. Sub-tolerance filtering (step 5) and the slow blood drain (step 7)
+    # land later; for now the stage runs and does nothing per reagent.
+    stages: [ Excretion ]
+    # HONK END
 
 - type: entity
   id: OrganSpriteHumanInternal


### PR DESCRIPTION
## About the PR

First step of the metabolic chain refactor in #679. Declares a new `Detoxification` metabolism stage, gives it a default `Solutions` entry that reads the bloodstream, and adds it to the liver's stages list so the liver runs `Metabolites` and `Detoxification` each tick.

This step alone is structural: no reagent declares a `Detoxification` entry yet, so the stage runs and does nothing per reagent. The `ToxinScrubRate` and the toxin reagent class arrive in later steps.

## Why / Balance

#679 reframes the metabolic chain so every organ has a distinct, observable purpose. Today the liver only owns the `Metabolites` stage, where alcohol and food fire. Adding `Detoxification` gives the liver the second responsibility it's missing: a per-tick pass over the bloodstream that scrubs toxin-class reagents. Step 1 only sets up the structure so step 6 can land the scrub mechanic without revisiting upstream YAML.

## Technical details

- `Resources/Prototypes/@RussStation/Metabolism/stages.yml` (new): declares the `Detoxification` stage prototype.
- `Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl` (new): locale string for the stage name.
- `Content.Shared/Metabolism/MetabolizerComponent.cs` (HONK-block): adds a `Detoxification` entry to the default `Solutions` dictionary, reading from the bloodstream solution.
- `Resources/Prototypes/Body/base_organs.yml` (HONK-block): `OrganBaseLiver` Metabolizer `stages: [ Metabolites, Detoxification ]`.

## Verification

- `dotnet build Content.Shared` clean.
- The liver still ticks Metabolites with no behaviour change (alcohol, nutriment, vitamin, protein).
- Detoxification runs every interval but no reagent has a Detoxification entry, so the per-reagent loop does nothing.

## Media

N/A, structural setup.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

(no player-facing changes in this step)