### PR TITLE
honksquad: feat: add Excretion metabolism stage on the kidneys (#679 step 2)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -85,6 +85,18 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferRate = 0,
+        },
+        // HONK END
+        // HONK START - issue #679 step 2: Excretion reads the bloodstream so the kidney
+        // can host the sub-tolerance filter (step 5) and the slow blood drain (step 7).
+        // No reagent declares an Excretion entry yet, so the stage runs and does nothing
+        // until later steps land. Same TransferRate = 0 self-loop as Detoxification so
+        // the no-entry fallback can't drain Ethanol or other bloodstream reagents.
+        ["Excretion"] = new()
+        {
+            SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
+            TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
+            TransferRate = 0,
         }
         // HONK END
     };

--- a/Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl
+++ b/Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl
@@ -1,2 +1,3 @@
 # HONK - Issue #679 metabolism stage names.
 metabolism-stage-detoxification = Detoxification
+metabolism-stage-excretion = Excretion

--- a/Resources/Prototypes/@RussStation/Metabolism/stages.yml
+++ b/Resources/Prototypes/@RussStation/Metabolism/stages.yml
@@ -7,3 +7,10 @@
 - type: metabolismStage
   id: Detoxification
   name: metabolism-stage-detoxification
+
+# Excretion: kidney pass over the bloodstream. Step 2 declares the stage and routes the
+# kidney's Metabolizer at it. Sub-tolerance filtering (#679 step 5) and the slow blood
+# drain (#679 step 7) land in later steps; until then the stage runs and does nothing.
+- type: metabolismStage
+  id: Excretion
+  name: metabolism-stage-excretion

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -424,6 +424,11 @@
     heldPrefix: kidneys
   - type: Metabolizer
     maxReagents: 5
+    # HONK START - issue #679 step 2: kidneys run the new Excretion stage on the
+    # bloodstream. Sub-tolerance filtering (step 5) and the slow blood drain (step 7)
+    # land later; for now the stage runs and does nothing per reagent.
+    stages: [ Excretion ]
+    # HONK END
 
 - type: entity
   id: OrganSpriteHumanInternal


### PR DESCRIPTION
## About the PR

Second step of the metabolic chain refactor in #679. Declares an `Excretion` stage prototype, adds a default `Solutions` entry that reads the bloodstream, and wires the kidney's Metabolizer to it so the kidneys actually tick.

Stacked on #680 (step 1). Land 1 first, then this. No-op on the player side until step 5 (sub-tolerance filter) and step 7 (slow drain) hook into the stage.

## Why / Balance

Today the kidneys have `maxReagents: 5` and an empty `Stages` list, so they tick zero times. That leaves them as decorative organs with no failure mode. #679 gives them the body's filter role: sub-tolerance reagent gating now (step 5) and a slow blood drain later (step 7). Both of those need a stage to live on, which is what this PR sets up.

## Technical details

- `Resources/Prototypes/@RussStation/Metabolism/stages.yml` (HONK-block append): adds the `Excretion` stage prototype next to the `Detoxification` stage from step 1.
- `Resources/Locale/en-US/@RussStation/metabolism/metabolism-stages.ftl` (HONK-block append): locale string for the stage name.
- `Content.Shared/Metabolism/MetabolizerComponent.cs` (HONK-block): adds an `Excretion` entry to the default `Solutions` dictionary, reading from the bloodstream solution.
- `Resources/Prototypes/Body/base_organs.yml` (HONK-block): `OrganBaseKidneys` Metabolizer `stages: [ Excretion ]`.

## Verification

- `dotnet build Content.Shared` clean.
- Kidneys tick the Excretion stage every interval, but no reagent declares an Excretion entry, so the per-reagent loop does nothing.
- Existing organs unaffected.

## Media

N/A, structural setup.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

(no player-facing changes in this step)