### PR TITLE
honksquad: balance: drop MetabolizerComponent.MaxReagentsProcessable gate (#679 step 3)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -200,9 +200,17 @@ public sealed class MetabolizerSystem : EntitySystem
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);
 
-            // we're done here entirely if this is true
-            if (reagents >= ent.Comp1.MaxReagentsProcessable)
-                return;
+            // HONK START - issue #679 step 3: drop the MaxReagentsProcessable cap. Upstream
+            // uses it to gate stacked-poison cocktails, but it also silently stalls oral
+            // medication and hides which reagents got skipped on a given tick. Anti-stacking
+            // moves to ReagentPrototype.MinEffectiveDose (step 5): reagents below tolerance
+            // drain without firing effects, so micro-doses can no longer cheese OD. Every
+            // reagent now ticks every interval.
+            //
+            // Original gate, preserved as a comment for upstream-merge readability:
+            //     if (reagents >= ent.Comp1.MaxReagentsProcessable)
+            //         return;
+            // HONK END
 
             var scale = (float) mostToRemove;
             if (!solutionData.MetabolizeAll)


### PR DESCRIPTION
## About the PR

Third step of #679. Removes the early-return that caps how many reagents each organ processes per tick. Anti-stacking responsibility moves to the tolerance filter (step 5), which gates effects on dose rather than slot count.

Stacked on #681 / #680.

## Why / Balance

Upstream's `MaxReagentsProcessable` was anti-stacked-poison design. The comment on the field says so directly: "Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low quantity, would be muuuuch better than just one poison acting." The implementation drops random reagents off each tick until the cap is satisfied.

Side effects of the cap:

- Invisible. Players can't see which reagents got stalled this tick.
- Dose-blind. 1u of a poison and 20u of the same poison compete for the same slot.
- Interacts with the stomach. Per-reagent Digestion rates already throttle stomach output; stacking that throttle with the heart's slot cap is the dominant reason oral medication can never reach Bloodstream-stage OD thresholds (#491 Bug 1).

The replacement is the sub-tolerance filter coming in step 5: reagents below their tolerance floor drain without firing effects, so 10x 1u poisons each filter (no damage) but a single 5u dose fires normally. Same anti-stacking outcome, dose-aware behaviour, visible to players via the scanner once organ-damage surfacing lands.

## Technical details

- `Content.Shared/Metabolism/MetabolizerSystem.cs` (HONK-block): comments out the `if (reagents >= ent.Comp1.MaxReagentsProcessable) return;` early return inside `TryMetabolizeStage`. The original line is preserved in the HONK comment for upstream-merge readability. The `MaxReagentsProcessable` field stays on the component for now (other call sites would need an audit before removing the field outright); it's just unread at runtime.

## Verification

- `dotnet build Content.Shared` clean.
- All reagents in any solution now tick every metabolizer interval, not just N where N is the per-organ cap.
- Oral OD threshold becomes reachable for medications whose Digestion rate is non-zero (full closure of #491 Bug 1 needs steps 4+5 too).

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

Reagent cocktails in shared organs no longer round-robin past the cap; every reagent ticks every interval. Content tuned around the cap may behave differently. The `MinEffectiveDose` filter from step 5 is the intended landing surface for this change to feel correct in play.

**Changelog**

(no isolated player-facing change worth a line; the chain refactor's player impact lands cumulatively across steps 4-7.)