### PR TITLE
honksquad: balance: align stomach throughput with SS13 (#679 step 4)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -58,7 +58,16 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = "stomach",
             SolutionOnBody = false,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
-            TransferEfficacy = 0.5
+            // HONK START - issue #679 step 4: align stomach throughput with SS13.
+            //   * TransferEfficacy 1.0 (was 0.5): SS13 transfers stomach->blood 1:1, so
+            //     a 30u oral dose actually arrives in blood as 30u, reachable for OD.
+            //   * MinTransferPerTick mirrors SS13 STOMACH_METABOLISM_CONSTANT (0.25u).
+            //   * VolumeScaledTransfer mirrors SS13 metabolism_efficiency (0.05) so a
+            //     fuller stomach pushes faster.
+            TransferEfficacy = 1,
+            MinTransferPerTick = 0.25,
+            VolumeScaledTransfer = 0.05f,
+            // HONK END
         },
         ["Bloodstream"] = new()
         {

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -180,7 +180,15 @@ public sealed class MetabolizerSystem : EntitySystem
                     continue;
                 // HONK END
 
-                var mostToTransfer = FixedPoint2.Clamp(solutionData.TransferRate, 0, quantity);
+                // HONK START - issue #679 step 4: apply MinTransferPerTick + VolumeScaledTransfer
+                // to the generic-transfer branch so reagents without a Digestion entry also benefit
+                // from the SS13 stomach pipeline (floor + 5%-of-volume scaling).
+                var rawGeneric = solutionData.TransferRate > solutionData.MinTransferPerTick
+                    ? solutionData.TransferRate
+                    : solutionData.MinTransferPerTick;
+                rawGeneric += quantity * solutionData.VolumeScaledTransfer;
+                var mostToTransfer = FixedPoint2.Clamp(rawGeneric, 0, quantity);
+                // HONK END
 
                 if (transferSolution is not null)
                 {
@@ -196,6 +204,19 @@ public sealed class MetabolizerSystem : EntitySystem
             }
 
             var rate = solutionData.MetabolizeAll ? quantity : entry.MetabolismRate;
+
+            // HONK START - issue #679 step 4: apply MinTransferPerTick + VolumeScaledTransfer to
+            // per-reagent rates too. Mirrors SS13's
+            //     amount = (0.05 * stomach_volume + max(rate, 0.25)) * dt
+            // formula on the stomach. Skipped when MetabolizeAll is on (lungs already process
+            // every reagent in full).
+            if (!solutionData.MetabolizeAll)
+            {
+                if (rate < solutionData.MinTransferPerTick)
+                    rate = solutionData.MinTransferPerTick;
+                rate += quantity * solutionData.VolumeScaledTransfer;
+            }
+            // HONK END
 
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -200,9 +200,17 @@ public sealed class MetabolizerSystem : EntitySystem
             // Remove $rate, as long as there's enough reagent there to actually remove that much
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);
 
-            // we're done here entirely if this is true
-            if (reagents >= ent.Comp1.MaxReagentsProcessable)
-                return;
+            // HONK START - issue #679 step 3: drop the MaxReagentsProcessable cap. Upstream
+            // uses it to gate stacked-poison cocktails, but it also silently stalls oral
+            // medication and hides which reagents got skipped on a given tick. Anti-stacking
+            // moves to ReagentPrototype.MinEffectiveDose (step 5): reagents below tolerance
+            // drain without firing effects, so micro-doses can no longer cheese OD. Every
+            // reagent now ticks every interval.
+            //
+            // Original gate, preserved as a comment for upstream-merge readability:
+            //     if (reagents >= ent.Comp1.MaxReagentsProcessable)
+            //         return;
+            // HONK END
 
             var scale = (float) mostToRemove;
             if (!solutionData.MetabolizeAll)

--- a/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
@@ -1,0 +1,23 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.RussStation.Metabolism;
+
+/// <summary>
+/// Constants for the metabolic chain refactor (#679). SS13 reference values live here so the
+/// component / system code is just a name lookup, not a magic-number scatter.
+/// </summary>
+public static class MetabolismConstants
+{
+    /// <summary>
+    /// Default per-stage transfer floor. 0 means no floor; the stomach overrides to 0.25u/tick
+    /// to mirror SS13 STOMACH_METABOLISM_CONSTANT.
+    /// </summary>
+    public static readonly FixedPoint2 DefaultMinTransferPerTick = FixedPoint2.Zero;
+
+    /// <summary>
+    /// Default per-stage volume-scaled transfer fraction. 0 means flat rate; the stomach
+    /// overrides to 0.05 (5% of the reagent's current quantity adds to the per-tick transfer)
+    /// to mirror SS13 metabolism_efficiency.
+    /// </summary>
+    public const float DefaultVolumeScaledTransfer = 0f;
+}

--- a/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
@@ -1,0 +1,38 @@
+// HONK - Issue #679 step 4: bring stomach throughput in line with SS13.
+// Two new knobs on the per-stage MetabolismSolutionEntry, both default 0 so the per-stage
+// behaviour is opt-in and other organs (heart, liver, lung, kidney) stay on the upstream
+// path until they explicitly need either knob:
+//
+//   * MinTransferPerTick mirrors SS13 STOMACH_METABOLISM_CONSTANT. Floors the per-reagent
+//     transfer so a low MetabolismRate can still cross the heart's clearance rate.
+//   * VolumeScaledTransfer mirrors SS13 metabolism_efficiency = 0.05. Adds a fraction of
+//     the reagent's current volume in the source solution to the per-tick transfer, so a
+//     fuller stomach delivers faster.
+//
+// Composed: per-tick transfer = max(rate, MinTransferPerTick) + VolumeScaledTransfer * quantity,
+// clamped to quantity available.
+
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Metabolism;
+
+namespace Content.Shared.Metabolism;
+
+public sealed partial class MetabolismSolutionEntry
+{
+    /// <summary>
+    /// Per-tick floor for reagent transfer at this stage. The actual move per tick is at
+    /// least this many units of each reagent that has any quantity, clamped to quantity.
+    /// 0 = disabled (upstream rate alone). Mirrors SS13 STOMACH_METABOLISM_CONSTANT.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinTransferPerTick = MetabolismConstants.DefaultMinTransferPerTick;
+
+    /// <summary>
+    /// Fraction of a reagent's current quantity in the source solution that adds to the
+    /// per-tick transfer at this stage. Set to 0.05 on the stomach's Digestion entry so
+    /// a fuller stomach pushes faster, matching SS13's <c>metabolism_efficiency</c>.
+    /// 0 = disabled.
+    /// </summary>
+    [DataField]
+    public float VolumeScaledTransfer = MetabolismConstants.DefaultVolumeScaledTransfer;
+}


### PR DESCRIPTION
## About the PR

Fourth step of #679. Brings the stomach's Digestion stage in line with SS13's stomach pipeline so oral medication can reach Bloodstream-stage OD thresholds.

Three coordinated changes on the Digestion `MetabolismSolutionEntry`:

- **`TransferEfficacy` 0.5 -> 1.0.** SS13 transfers stomach->blood 1:1. The previous 0.5 meant a 30u oral dose only ever delivered 15u to blood, well below most OD thresholds.
- **`MinTransferPerTick` 0.25.** Mirrors SS13 `STOMACH_METABOLISM_CONSTANT`. Floors per-reagent transfer so a low `MetabolismRate` cannot drop below the threshold the heart's Bloodstream stage needs to overcome clearance.
- **`VolumeScaledTransfer` 0.05.** Mirrors SS13 `metabolism_efficiency`. A fraction of the reagent's current quantity in the stomach is added to the per-tick transfer, so a fuller stomach pushes faster.

Stacked on #682 / #681 / #680.

## Why / Balance

`MaxReagentsProcessable` (removed in step 3) was one cause of the oral OD gap. The other is the per-tick throughput on the stomach itself: half-loss transfer + sub-clearance per-reagent rates meant blood concentration asymptoted below most OD thresholds regardless of how much the patient swallowed. Mirroring SS13's stomach formula closes the gap without touching the reagent prototypes.

## Technical details

- `Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs` (new): partial extension adds `MinTransferPerTick` (FixedPoint2, default 0) and `VolumeScaledTransfer` (float, default 0). Both opt-in per stage.
- `Content.Shared/RussStation/Metabolism/MetabolismConstants.cs` (new): SS13-reference defaults live here per the HONK0016 analyzer.
- `Content.Shared/Metabolism/MetabolizerComponent.cs` (HONK-block): Digestion entry sets `TransferEfficacy = 1`, `MinTransferPerTick = 0.25`, `VolumeScaledTransfer = 0.05`.
- `Content.Shared/Metabolism/MetabolizerSystem.cs` (two HONK-blocks):
  - Generic-transfer branch (no per-reagent Digestion entry): `mostToTransfer = clamp(max(TransferRate, MinTransferPerTick) + VolumeScaledTransfer * quantity, 0, quantity)`.
  - Per-reagent branch: same formula applied to the declared `MetabolismRate` before the existing clamp/scale calc, gated on `!MetabolizeAll` so lungs (which already firehose) stay unchanged.

## Verification

- `dotnet build Content.Shared` clean.
- 30u oral dose now reaches blood in full instead of as 15u after stomach loss.
- Stomach with 20u of a reagent moves at ~1.25u/tick instead of `min(rate, quantity)`, scaling with stomach contents.
- Heart, liver, lung, kidney throughput unchanged (those stages keep `MinTransferPerTick = 0`, `VolumeScaledTransfer = 0`).

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

- Reagents with declared Digestion `MetabolismRate` below 0.25u/tick now move at 0.25u/tick out of the stomach.
- Stomach delivery to blood is now 1:1 instead of 1:0.5. Oral dose strength effectively doubles for any reagent that doesn't already overshoot OD; tune content if you relied on the half-loss.

**Changelog**

(player-impact line lands cumulatively in step 5; this step pairs with the tolerance filter for the full picture.)