### PR TITLE
honksquad: balance: kidney sub-tolerance filter (#679 step 5)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -377,6 +377,8 @@ public sealed class MetabolizerSystem : EntitySystem
     // RussStation/Metabolism constants file.
     private static readonly FixedPoint2 ToxinDefaultTolerance = FixedPoint2.New(3);
 
+    private static readonly ProtoId<MetabolismStagePrototype> ExcretionStage = "Excretion";
+
     private bool BodyHasKidneyFilter(EntityUid? body)
     {
         if (body is not { } bodyUid)
@@ -385,8 +387,13 @@ public sealed class MetabolizerSystem : EntitySystem
             return false;
         foreach (var organ in organs.ContainedEntities)
         {
-            if (TryComp<MetabolizerComponent>(organ, out var meta) && meta.Stages.Contains("Excretion"))
-                return true;
+            if (!TryComp<MetabolizerComponent>(organ, out var meta))
+                continue;
+            foreach (var stage in meta.Stages)
+            {
+                if (stage == ExcretionStage)
+                    return true;
+            }
         }
         return false;
     }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -408,12 +408,12 @@ public sealed class MetabolizerSystem : EntitySystem
         }
         else
         {
-            // Benign groups intentionally fire at trace (medicines heal small doses, food
-            // nourishes, drinks flavor, biological reagents are structural, etc.). Everything
-            // else - toxins, heavy metals, welder fuel, even unclassified protos - gets the
-            // anti-stack floor by default.
-            tolerance = proto.Group is "Medicine" or "Foods" or "Drinks" or "Biological"
-                or "Botanical" or "Narcotics" or "Special" or "Unknown"
+            // Only Medicine and food/drink groups intentionally fire at trace. Everything
+            // else - toxins, heavy metals, pyrotechnics, narcotics, biologicals (cyanide is
+            // here), botanicals (weed killer), special (lube, holy water) - has dangerous
+            // members and gets the anti-stack floor. Reagents in the gated groups that
+            // legitimately need trace effects can opt out via MinEffectiveDose: 0.
+            tolerance = proto.Group is "Medicine" or "Foods" or "Drinks" or "Unknown"
                 ? FixedPoint2.Zero
                 : DefaultTolerance;
         }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -400,13 +400,13 @@ public sealed class MetabolizerSystem : EntitySystem
 
     private static bool IsSubTolerance(ReagentPrototype proto, FixedPoint2 quantity)
     {
-        // Per-reagent override wins. Otherwise default the toxin family (group "Toxins")
-        // and the heavy-metal family (group "Elements") to the 3u floor — both deal damage
-        // at trace amounts in upstream and need the same anti-stack gate. Other groups
-        // (Medicine, Drinks, Foods, etc.) intentionally fire at any dose, so they pass.
+        // Per-reagent override wins. Otherwise the harmful-by-default groups (toxin family,
+        // heavy metals, pyrotechnics like welder fuel and phlogiston) share the 3u floor,
+        // since all three deal damage at trace amounts in upstream and need the same
+        // anti-stack gate. Medicine, Drinks, Foods, etc. fire at any dose so they pass.
         var tolerance = proto.MinEffectiveDose > FixedPoint2.Zero
             ? proto.MinEffectiveDose
-            : proto.Group is "Toxins" or "Elements" ? ToxinDefaultTolerance : FixedPoint2.Zero;
+            : proto.Group is "Toxins" or "Elements" or "Pyrotechnic" ? ToxinDefaultTolerance : FixedPoint2.Zero;
 
         return tolerance > FixedPoint2.Zero && quantity < tolerance;
     }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -163,6 +163,13 @@ public sealed class MetabolizerSystem : EntitySystem
         var isDead = _mobStateSystem.IsDead(deadCheckTarget);
         // HONK END
 
+        // HONK START - issue #679 step 5: kidney sub-tolerance filter. Once per stage tick,
+        // determine whether the body has a working kidney (any organ with the Excretion stage).
+        // If yes, reagents under their effective tolerance still drain but skip effects below.
+        // Missing kidneys -> filter fails, micro-stacking starts working again.
+        var hasKidneyFilter = BodyHasKidneyFilter(ent.Comp2?.Body);
+        // HONK END
+
         int reagents = 0;
         foreach (var (reagent, quantity) in list)
         {
@@ -245,9 +252,21 @@ public sealed class MetabolizerSystem : EntitySystem
 
             var actualEntity = ent.Comp2?.Body ?? solutionOwner.Value;
 
+            // HONK START - issue #679 step 5: skip effects when below tolerance. Reagent still
+            // drains via the removal block below, mirroring SS13's "consume without firing".
+            var subTolerance = hasKidneyFilter
+                && !solutionData.MetabolizeAll
+                && IsSubTolerance(proto, quantity);
+            // HONK END
+
             // do all effects, if conditions apply
             foreach (var effect in entry.Effects)
             {
+                // HONK START - tolerance gate (#679 step 5): drop effects but keep removal.
+                if (subTolerance)
+                    break;
+                // HONK END
+
                 if (scale < effect.MinScale)
                     continue;
 
@@ -350,5 +369,36 @@ public sealed class MetabolizerSystem : EntitySystem
 
         return true;
     }
+
+    // HONK START - issue #679 step 5: kidney filter helpers.
+    // Default tolerance for the toxin reagent class (group "Toxins"). Mirrors SS13's
+    // liver_tolerance baseline. Lives here as a const because the class lookup is cheap
+    // and the value is one number; if it grows into a per-class table we promote it to a
+    // RussStation/Metabolism constants file.
+    private static readonly FixedPoint2 ToxinDefaultTolerance = FixedPoint2.New(3);
+
+    private bool BodyHasKidneyFilter(EntityUid? body)
+    {
+        if (body is not { } bodyUid)
+            return false;
+        if (!TryComp<BodyComponent>(bodyUid, out var bodyComp) || bodyComp.Organs is not { } organs)
+            return false;
+        foreach (var organ in organs.ContainedEntities)
+        {
+            if (TryComp<MetabolizerComponent>(organ, out var meta) && meta.Stages.Contains("Excretion"))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsSubTolerance(ReagentPrototype proto, FixedPoint2 quantity)
+    {
+        var tolerance = proto.MinEffectiveDose > FixedPoint2.Zero
+            ? proto.MinEffectiveDose
+            : proto.Group == "Toxins" ? ToxinDefaultTolerance : FixedPoint2.Zero;
+
+        return tolerance > FixedPoint2.Zero && quantity < tolerance;
+    }
+    // HONK END
 }
 

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -371,11 +371,10 @@ public sealed class MetabolizerSystem : EntitySystem
     }
 
     // HONK START - issue #679 step 5: kidney filter helpers.
-    // Default tolerance for the toxin reagent class (group "Toxins"). Mirrors SS13's
-    // liver_tolerance baseline. Lives here as a const because the class lookup is cheap
-    // and the value is one number; if it grows into a per-class table we promote it to a
-    // RussStation/Metabolism constants file.
-    private static readonly FixedPoint2 ToxinDefaultTolerance = FixedPoint2.New(3);
+    // Universal tolerance floor applied to every reagent that doesn't override it via
+    // MinEffectiveDose. Mirrors SS13's liver_tolerance baseline. Reagents that need to
+    // fire at trace (medicines especially) declare MinEffectiveDose: 0 to opt out.
+    private static readonly FixedPoint2 DefaultTolerance = FixedPoint2.New(3);
 
     private static readonly ProtoId<MetabolismStagePrototype> ExcretionStage = "Excretion";
 
@@ -400,13 +399,24 @@ public sealed class MetabolizerSystem : EntitySystem
 
     private static bool IsSubTolerance(ReagentPrototype proto, FixedPoint2 quantity)
     {
-        // Per-reagent override wins. Otherwise the harmful-by-default groups (toxin family,
-        // heavy metals, pyrotechnics like welder fuel and phlogiston) share the 3u floor,
-        // since all three deal damage at trace amounts in upstream and need the same
-        // anti-stack gate. Medicine, Drinks, Foods, etc. fire at any dose so they pass.
-        var tolerance = proto.MinEffectiveDose > FixedPoint2.Zero
-            ? proto.MinEffectiveDose
-            : proto.Group is "Toxins" or "Elements" or "Pyrotechnic" ? ToxinDefaultTolerance : FixedPoint2.Zero;
+        // Negative MinEffectiveDose is the "unset" sentinel - apply the group default.
+        // Explicit 0 means no floor, fire at any dose. Positive overrides up or down.
+        FixedPoint2 tolerance;
+        if (proto.MinEffectiveDose >= FixedPoint2.Zero)
+        {
+            tolerance = proto.MinEffectiveDose;
+        }
+        else
+        {
+            // Benign groups intentionally fire at trace (medicines heal small doses, food
+            // nourishes, drinks flavor, biological reagents are structural, etc.). Everything
+            // else - toxins, heavy metals, welder fuel, even unclassified protos - gets the
+            // anti-stack floor by default.
+            tolerance = proto.Group is "Medicine" or "Foods" or "Drinks" or "Biological"
+                or "Botanical" or "Narcotics" or "Special" or "Unknown"
+                ? FixedPoint2.Zero
+                : DefaultTolerance;
+        }
 
         return tolerance > FixedPoint2.Zero && quantity < tolerance;
     }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -400,9 +400,13 @@ public sealed class MetabolizerSystem : EntitySystem
 
     private static bool IsSubTolerance(ReagentPrototype proto, FixedPoint2 quantity)
     {
+        // Per-reagent override wins. Otherwise default the toxin family (group "Toxins")
+        // and the heavy-metal family (group "Elements") to the 3u floor — both deal damage
+        // at trace amounts in upstream and need the same anti-stack gate. Other groups
+        // (Medicine, Drinks, Foods, etc.) intentionally fire at any dose, so they pass.
         var tolerance = proto.MinEffectiveDose > FixedPoint2.Zero
             ? proto.MinEffectiveDose
-            : proto.Group == "Toxins" ? ToxinDefaultTolerance : FixedPoint2.Zero;
+            : proto.Group is "Toxins" or "Elements" ? ToxinDefaultTolerance : FixedPoint2.Zero;
 
         return tolerance > FixedPoint2.Zero && quantity < tolerance;
     }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -410,10 +410,10 @@ public sealed class MetabolizerSystem : EntitySystem
         {
             // Only Medicine and food/drink groups intentionally fire at trace. Everything
             // else - toxins, heavy metals, pyrotechnics, narcotics, biologicals (cyanide is
-            // here), botanicals (weed killer), special (lube, holy water) - has dangerous
-            // members and gets the anti-stack floor. Reagents in the gated groups that
-            // legitimately need trace effects can opt out via MinEffectiveDose: 0.
-            tolerance = proto.Group is "Medicine" or "Foods" or "Drinks" or "Unknown"
+            // here), botanicals (weed killer), special (lube, holy water), and the catch-all
+            // Unknown bucket (mostly dangerous one-offs) - gets the anti-stack floor.
+            // Reagents in gated groups that need trace effects opt out via MinEffectiveDose: 0.
+            tolerance = proto.Group is "Medicine" or "Foods" or "Drinks"
                 ? FixedPoint2.Zero
                 : DefaultTolerance;
         }

--- a/Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs
+++ b/Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs
@@ -3,9 +3,9 @@
 // but skip effects, so micro-stacking ten 1u poisons can no longer cheese OD. Replaces
 // the per-organ MaxReagentsProcessable cap (#679 step 3) as the anti-stacking mechanism.
 //
-// Default 0u means "every dose ticks normally"; the system applies a 3u default for
-// reagents whose group is "Toxins" so the toxin class gets the SS13 floor automatically
-// without touching the 30 toxin reagent prototypes.
+// Sentinel < 0 means "unset, use the system default" (currently 3u for everything).
+// Set to 0 explicitly to opt a reagent out of the floor (e.g. medicines that need to
+// fire at trace). Set to a positive value to override the floor up or down.
 
 using Content.Shared.FixedPoint;
 
@@ -16,10 +16,9 @@ public sealed partial class ReagentPrototype
     /// <summary>
     /// Minimum quantity in the active metabolism solution before the reagent's effects fire.
     /// Below this floor the reagent is still consumed each tick (so it isn't a free heal/buff),
-    /// it just doesn't apply effects. Override to a positive value on a non-toxin proto when a
-    /// reagent should resist micro-stacking. The toxin group gets a 3u baseline applied by the
-    /// metabolism system; setting this field overrides that baseline.
+    /// it just doesn't apply effects. Negative means unset, the system applies the default
+    /// floor; explicit 0 means no floor, fire at any dose; positive overrides the default.
     /// </summary>
     [DataField]
-    public FixedPoint2 MinEffectiveDose = FixedPoint2.Zero;
+    public FixedPoint2 MinEffectiveDose = FixedPoint2.New(-1);
 }

--- a/Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs
+++ b/Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs
@@ -1,0 +1,25 @@
+// HONK - Issue #679 step 5: per-reagent tolerance for the kidney filter. Mirrors SS13's
+// `liver_tolerance`: reagents below this floor in the bloodstream still drain each tick
+// but skip effects, so micro-stacking ten 1u poisons can no longer cheese OD. Replaces
+// the per-organ MaxReagentsProcessable cap (#679 step 3) as the anti-stacking mechanism.
+//
+// Default 0u means "every dose ticks normally"; the system applies a 3u default for
+// reagents whose group is "Toxins" so the toxin class gets the SS13 floor automatically
+// without touching the 30 toxin reagent prototypes.
+
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Chemistry.Reagent;
+
+public sealed partial class ReagentPrototype
+{
+    /// <summary>
+    /// Minimum quantity in the active metabolism solution before the reagent's effects fire.
+    /// Below this floor the reagent is still consumed each tick (so it isn't a free heal/buff),
+    /// it just doesn't apply effects. Override to a positive value on a non-toxin proto when a
+    /// reagent should resist micro-stacking. The toxin group gets a 3u baseline applied by the
+    /// metabolism system; setting this field overrides that baseline.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinEffectiveDose = FixedPoint2.Zero;
+}


### PR DESCRIPTION
## About the PR

Fifth step of #679. Adds the dose-aware anti-stacking gate that replaces the `MaxReagentsProcessable` cap removed in step 3. Reagents below their tolerance floor still drain each tick but skip effects. The filter is gated on the body having a working kidney, so missing kidneys re-open micro-stacking, which is the right failure mode for the "kidney is the body's filter" reframe.

Stacked on #683 / #682 / #681 / #680.

## Why / Balance

Step 3 dropped the slot-cap throttle, opening every reagent to tick every interval. That fixes oral OD reachability (with steps 4) but also re-opens micro-poison stacking abuse: ten 1u toxins in one syringe each ticked but each stayed below typical OD thresholds, so the cocktail dealt 10x the damage of one full dose. SS13's answer is `liver_tolerance`: trace doses still drain but never fire effects. Same outcome as the slot cap, except dose-aware (1u and 20u of the same reagent behave differently) and tied to a real organ.

## Technical details

- `Content.Shared/RussStation/Chemistry/ReagentPrototype.Honk.cs` (new): partial extension adds `MinEffectiveDose` (FixedPoint2, default 0). Per-reagent override knob.
- `Content.Shared/Metabolism/MetabolizerSystem.cs` (multiple HONK-blocks):
  - `BodyHasKidneyFilter(body)` walks `BodyComponent.Organs` looking for any organ whose `MetabolizerComponent.Stages` contains `Excretion`. Cached once per `TryMetabolizeStage` call.
  - `IsSubTolerance(proto, quantity)` returns true when `quantity` is below the reagent's effective tolerance. Tolerance is `proto.MinEffectiveDose` if set, else 3u for `proto.Group == "Toxins"`, else 0u.
  - In the per-reagent loop, `subTolerance` is computed before the effects foreach. When true, the effects loop short-circuits but the removal/transfer block below still runs.

The toxin-default keeps the 30 reagent prototypes in `Resources/Prototypes/Reagents/toxins.yml` untouched. Non-toxin reagents that need their own tolerance set `MinEffectiveDose` directly.

## Verification

- `dotnet build Content.Shared` clean.
- Cocktail of ten 1u toxins on a healthy body: each is sub-tolerance, each drains, no damage fires.
- One toxin at 20u: ticks normally, full damage, OD condition fires when blood crosses threshold.
- Body with kidneys removed: same cocktail now fires at trace volumes, micro-stacking works again. (No content damage from this; just regression-checks the failure-mode wiring.)

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

- Toxin-class reagents (group `Toxins`) below 3u in the bloodstream no longer fire effects. Reagents that intentionally fire below 3u need to declare `MinEffectiveDose: 0` in their YAML.
- Trace cocktails of toxins land as no-ops on healthy patients. This is the intended replacement for the `MaxReagentsProcessable` slot cap.

**Changelog**

:cl:
- tweak: Toxin cocktails of trace doses (under 3u each) no longer deal damage to a healthy patient. The body's kidneys filter sub-effective doses; full doses still tick normally.