### PR TITLE
honksquad: balance: liver scrubs toxins from bloodstream (#679 step 6)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -78,22 +78,22 @@ public sealed partial class MetabolizerComponent : Component
         {
             SolutionName = BloodstreamComponent.DefaultMetabolitesSolutionName
         },
-        // HONK START - issue #679 step 1: Detoxification reads the bloodstream so the
-        // liver can scrub toxin-class reagents in place. Step 1 only declares the entry;
-        // the per-tick scrub rate (ToxinScrubRate) and reagent-side opt-in arrive in step 6.
+        // HONK START - issue #679 steps 1+6: Detoxification reads the bloodstream so the
+        // liver can scrub toxin-class reagents in place. Step 6 wires the actual scrub rate
+        // (LiverToxinScrubRate, see MetabolismConstants) so the liver pulls toxins out of
+        // blood at a steady pace, mirroring SS13's liver filter.
         //
-        // Engine quirk: TryMetabolizeStage's "this reagent has no entry for the stage"
-        // fallback either removes TransferRate units into a transfer solution, or removes
-        // 1 unit flat if there is no transfer solution. Until step 6 adds the toxin opt-in,
-        // we must look like a no-op so we don't quietly siphon Ethanol (and every other
-        // blood reagent waiting for the heart's Bloodstream transfer) before they reach
-        // the metabolites pool. Self-loop the transfer to the same blood solution with
-        // TransferRate = 0 so the fallback is "remove 0, add 0".
+        // Engine quirk also handled here: TryMetabolizeStage's "reagent has no entry for the
+        // stage" fallback removes TransferRate units into a transfer solution, or 1u flat if
+        // no transfer solution. Self-loop the transfer to the same blood solution with
+        // TransferRate = 0 so non-toxin reagents (Ethanol etc.) waiting for the heart's
+        // Bloodstream transfer aren't quietly siphoned before they reach metabolites.
         ["Detoxification"] = new()
         {
             SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferRate = 0,
+            ToxinScrubRate = RussStation.Metabolism.MetabolismConstants.LiverToxinScrubRate,
         },
         // HONK END
         // HONK START - issue #679 step 2: Excretion reads the bloodstream so the kidney

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -180,6 +180,21 @@ public sealed class MetabolizerSystem : EntitySystem
             if (ev.Reagents.Contains(reagent))
                 continue;
 
+            // HONK START - issue #679 step 6: liver toxin scrub. Stages that opt in via
+            // ToxinScrubRate (the liver's Detoxification entry) consume toxin-class reagents
+            // at a fixed per-tick rate without firing effects. Skipped on corpses unless the
+            // reagent works on the dead, matching the dead-guard policy elsewhere.
+            if (solutionData.ToxinScrubRate > FixedPoint2.Zero
+                && proto.Group == "Toxins"
+                && (!isDead || proto.WorksOnTheDead))
+            {
+                var scrub = FixedPoint2.Clamp(solutionData.ToxinScrubRate, FixedPoint2.Zero, quantity);
+                if (scrub > FixedPoint2.Zero)
+                    solution.RemoveReagent(reagent, scrub);
+                continue;
+            }
+            // HONK END
+
             if (proto.Metabolisms is null || !proto.Metabolisms.Metabolisms.TryGetValue(stage, out var entry))
             {
                 // HONK START - freeze generic stomach transfer on corpses so revival chems don't drain (#491)

--- a/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
@@ -20,4 +20,18 @@ public static class MetabolismConstants
     /// to mirror SS13 metabolism_efficiency.
     /// </summary>
     public const float DefaultVolumeScaledTransfer = 0f;
+
+    /// <summary>
+    /// Default per-stage toxin scrub rate. 0 means the stage does no toxin scrubbing; the
+    /// liver's Detoxification stage overrides to 1u/tick so toxin-class reagents in the
+    /// bloodstream get pulled out at a steady rate. Mirrors SS13's liver toxin filter.
+    /// </summary>
+    public static readonly FixedPoint2 DefaultToxinScrubRate = FixedPoint2.Zero;
+
+    /// <summary>
+    /// Liver's per-tick toxin scrub on the bloodstream. Tunable knob; start small enough
+    /// that a healthy liver does not trivialize toxin damage but big enough to make liver
+    /// failure feel noticeable.
+    /// </summary>
+    public static readonly FixedPoint2 LiverToxinScrubRate = FixedPoint2.New(1);
 }

--- a/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
@@ -35,4 +35,13 @@ public sealed partial class MetabolismSolutionEntry
     /// </summary>
     [DataField]
     public float VolumeScaledTransfer = MetabolismConstants.DefaultVolumeScaledTransfer;
+
+    /// <summary>
+    /// Per-tick removal applied to toxin-class reagents (group "Toxins") in this stage's
+    /// solution. The reagent is consumed at this rate without firing effects. Set on the
+    /// liver's Detoxification entry so the liver scrubs toxins from the bloodstream;
+    /// other stages stay at 0. Mirrors SS13's liver-driven toxin filter.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 ToxinScrubRate = MetabolismConstants.DefaultToxinScrubRate;
 }


### PR DESCRIPTION
## About the PR

Sixth step of #679. Wires the liver's Detoxification stage (added in step 1) to actually consume toxin-class reagents from the bloodstream at a per-tick rate. This is what gives the liver its real failure mode: a healthy liver removes toxins faster than they can stack; a failing liver lets them through.

Stacked on #684 / #683 / #682 / #681 / #680.

## Why / Balance

The chain refactor needs each organ to have a meaningful failure mode the player can diagnose and treat. After step 5, the liver only owned the Metabolites stage (alcohol and food effects). Removing it mostly affected drinking and nutrition, while medical chems and toxin damage routed entirely through the heart and felt unrelated. Step 6 puts the SS13 liver-driven toxin filter onto the Detoxification stage so the liver becomes the body's poison scrubber.

The scrub rate is a tunable knob (`MetabolismConstants.LiverToxinScrubRate`, currently 1u/tick). Start small enough that a healthy liver does not trivialize toxin damage but big enough that a missing or failing liver feels noticeably worse for the patient.

## Technical details

- `Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs` (HONK-block append): adds `ToxinScrubRate` (FixedPoint2, default 0). Per-stage opt-in.
- `Content.Shared/RussStation/Metabolism/MetabolismConstants.cs` (HONK-block append): adds `DefaultToxinScrubRate = 0` and `LiverToxinScrubRate = 1u`.
- `Content.Shared/Metabolism/MetabolizerComponent.cs` (HONK-block): liver's `Detoxification` entry now sets `ToxinScrubRate = MetabolismConstants.LiverToxinScrubRate`.
- `Content.Shared/Metabolism/MetabolizerSystem.cs` (HONK-block): in the per-reagent loop inside `TryMetabolizeStage`, before the metabolisms-entry check, intercepts toxin-class reagents on stages with `ToxinScrubRate > 0`. Removes `min(rate, quantity)` per tick without firing effects, then `continue`s. Skipped on corpses unless the reagent works on the dead.

## Verification

- `dotnet build Content.Shared` clean.
- Inject 30u of Toxin (group `Toxins`) into a healthy patient: bloodstream Toxin drains at the heart's normal Bloodstream rate plus 1u/tick from the liver's Detoxification scrub. Damage accumulates more slowly than before.
- Same patient with no liver: Toxin only drains via the heart, damage accumulates at the upstream rate.
- Inject 30u of a non-toxin medical chem (e.g. Bicaridine): no scrub interference, behaves as in step 5.
- Corpse with Toxin in blood: not scrubbed (dead guard).

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

Toxin damage on patients with a healthy liver lands more slowly than before because 1u/tick of any toxin in their bloodstream is silently consumed. Numbers are tunable; start point may need adjustment after play testing.

**Changelog**

:cl:
- tweak: A healthy liver now scrubs toxins from the bloodstream at a steady rate, so poisons take longer to deal their full damage. A patient with a damaged or missing liver feels poisons closer to full strength.