### PR TITLE
honksquad: balance: kidney slow blood drain (#679 step 7)

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -96,11 +96,13 @@ public sealed partial class MetabolizerComponent : Component
             ToxinScrubRate = RussStation.Metabolism.MetabolismConstants.LiverToxinScrubRate,
         },
         // HONK END
-        // HONK START - issue #679 step 2: Excretion reads the bloodstream so the kidney
-        // can host the sub-tolerance filter (step 5) and the slow blood drain (step 7).
-        // No reagent declares an Excretion entry yet, so the stage runs and does nothing
-        // until later steps land. Same TransferRate = 0 self-loop as Detoxification so
-        // the no-entry fallback can't drain Ethanol or other bloodstream reagents.
+        // HONK START - issue #679 steps 2+7: Excretion reads the bloodstream so the kidney
+        // hosts the sub-tolerance filter (step 5, computed inline on the heart's tick) and
+        // the slow blood drain (step 7). PerReagentDrain pulls a small amount of every
+        // bloodstream reagent each kidney tick so chems do not linger forever after their
+        // effects fire; missing kidneys -> drain stops -> reagents accumulate. Same
+        // TransferRate = 0 self-loop as Detoxification so the no-entry fallback can't
+        // drain Ethanol before the heart can transfer it.
         ["Excretion"] = new()
         {
             SolutionName = BloodstreamComponent.DefaultBloodSolutionName,

--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -78,22 +78,22 @@ public sealed partial class MetabolizerComponent : Component
         {
             SolutionName = BloodstreamComponent.DefaultMetabolitesSolutionName
         },
-        // HONK START - issue #679 step 1: Detoxification reads the bloodstream so the
-        // liver can scrub toxin-class reagents in place. Step 1 only declares the entry;
-        // the per-tick scrub rate (ToxinScrubRate) and reagent-side opt-in arrive in step 6.
+        // HONK START - issue #679 steps 1+6: Detoxification reads the bloodstream so the
+        // liver can scrub toxin-class reagents in place. Step 6 wires the actual scrub rate
+        // (LiverToxinScrubRate, see MetabolismConstants) so the liver pulls toxins out of
+        // blood at a steady pace, mirroring SS13's liver filter.
         //
-        // Engine quirk: TryMetabolizeStage's "this reagent has no entry for the stage"
-        // fallback either removes TransferRate units into a transfer solution, or removes
-        // 1 unit flat if there is no transfer solution. Until step 6 adds the toxin opt-in,
-        // we must look like a no-op so we don't quietly siphon Ethanol (and every other
-        // blood reagent waiting for the heart's Bloodstream transfer) before they reach
-        // the metabolites pool. Self-loop the transfer to the same blood solution with
-        // TransferRate = 0 so the fallback is "remove 0, add 0".
+        // Engine quirk also handled here: TryMetabolizeStage's "reagent has no entry for the
+        // stage" fallback removes TransferRate units into a transfer solution, or 1u flat if
+        // no transfer solution. Self-loop the transfer to the same blood solution with
+        // TransferRate = 0 so non-toxin reagents (Ethanol etc.) waiting for the heart's
+        // Bloodstream transfer aren't quietly siphoned before they reach metabolites.
         ["Detoxification"] = new()
         {
             SolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
             TransferRate = 0,
+            ToxinScrubRate = RussStation.Metabolism.MetabolismConstants.LiverToxinScrubRate,
         },
         // HONK END
         // HONK START - issue #679 step 2: Excretion reads the bloodstream so the kidney

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -180,6 +180,21 @@ public sealed class MetabolizerSystem : EntitySystem
             if (ev.Reagents.Contains(reagent))
                 continue;
 
+            // HONK START - issue #679 step 6: liver toxin scrub. Stages that opt in via
+            // ToxinScrubRate (the liver's Detoxification entry) consume toxin-class reagents
+            // at a fixed per-tick rate without firing effects. Skipped on corpses unless the
+            // reagent works on the dead, matching the dead-guard policy elsewhere.
+            if (solutionData.ToxinScrubRate > FixedPoint2.Zero
+                && proto.Group == "Toxins"
+                && (!isDead || proto.WorksOnTheDead))
+            {
+                var scrub = FixedPoint2.Clamp(solutionData.ToxinScrubRate, FixedPoint2.Zero, quantity);
+                if (scrub > FixedPoint2.Zero)
+                    solution.RemoveReagent(reagent, scrub);
+                continue;
+            }
+            // HONK END
+
             if (proto.Metabolisms is null || !proto.Metabolisms.Metabolisms.TryGetValue(stage, out var entry))
             {
                 // HONK START - freeze generic stomach transfer on corpses so revival chems don't drain (#491)

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -195,6 +195,21 @@ public sealed class MetabolizerSystem : EntitySystem
             }
             // HONK END
 
+            // HONK START - issue #679 step 7: kidney slow drain. Stages that opt in via
+            // PerReagentDrain (the kidney's Excretion entry) consume every reagent at a
+            // small per-tick rate without firing effects. Same dead guard as the toxin
+            // scrub above; works in addition to whatever the heart's Bloodstream stage
+            // moves out, so missing kidneys -> reagents linger in blood for longer.
+            if (solutionData.PerReagentDrain > FixedPoint2.Zero
+                && (!isDead || proto.WorksOnTheDead))
+            {
+                var drain = FixedPoint2.Clamp(solutionData.PerReagentDrain, FixedPoint2.Zero, quantity);
+                if (drain > FixedPoint2.Zero)
+                    solution.RemoveReagent(reagent, drain);
+                continue;
+            }
+            // HONK END
+
             if (proto.Metabolisms is null || !proto.Metabolisms.Metabolisms.TryGetValue(stage, out var entry))
             {
                 // HONK START - freeze generic stomach transfer on corpses so revival chems don't drain (#491)

--- a/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
@@ -34,4 +34,20 @@ public static class MetabolismConstants
     /// failure feel noticeable.
     /// </summary>
     public static readonly FixedPoint2 LiverToxinScrubRate = FixedPoint2.New(1);
+
+    /// <summary>
+    /// Default per-stage per-reagent excretion drain. 0 means the stage does not drain on
+    /// its own; the kidney's Excretion entry overrides to a small per-tick value so every
+    /// reagent in blood loses a sliver of itself each interval. Mirrors SS13's "kidneys
+    /// pull from the body's reagent holder" behaviour, except framed per-reagent so it
+    /// doesn't bias against high-volume reagents.
+    /// </summary>
+    public static readonly FixedPoint2 DefaultPerReagentDrain = FixedPoint2.Zero;
+
+    /// <summary>
+    /// Kidney's per-tick drain on each bloodstream reagent. Tuning starting point; tweak
+    /// after play testing. Too high makes chems blast through; too low makes kidneys feel
+    /// decorative again.
+    /// </summary>
+    public static readonly FixedPoint2 KidneyPerReagentDrain = FixedPoint2.New("0.1");
 }

--- a/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismConstants.cs
@@ -20,4 +20,18 @@ public static class MetabolismConstants
     /// to mirror SS13 metabolism_efficiency.
     /// </summary>
     public const float DefaultVolumeScaledTransfer = 0f;
+
+    /// <summary>
+    /// Default per-stage toxin scrub rate. 0 means the stage does no toxin scrubbing; the
+    /// liver's Detoxification stage overrides to 1u/tick so toxin-class reagents in the
+    /// bloodstream get pulled out at a steady rate. Mirrors SS13's liver toxin filter.
+    /// </summary>
+    public static readonly FixedPoint2 DefaultToxinScrubRate = FixedPoint2.Zero;
+
+    /// <summary>
+    /// Liver's per-tick toxin scrub on the bloodstream. Tunable knob; start small enough
+    /// that a healthy liver does not trivialize toxin damage but big enough to make liver
+    /// failure feel noticeable.
+    /// </summary>
+    public static readonly FixedPoint2 LiverToxinScrubRate = FixedPoint2.New(1);
 }

--- a/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
@@ -44,4 +44,14 @@ public sealed partial class MetabolismSolutionEntry
     /// </summary>
     [DataField]
     public FixedPoint2 ToxinScrubRate = MetabolismConstants.DefaultToxinScrubRate;
+
+    /// <summary>
+    /// Per-tick removal applied to every reagent in this stage's solution, without firing
+    /// effects. Set on the kidney's Excretion entry so the kidney slowly drains the
+    /// bloodstream beyond what the heart's Bloodstream-stage transfer moves out. 0 = no
+    /// drain. Mirrors the body's natural excretion path; missing kidneys -> reagents
+    /// linger in blood for longer.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 PerReagentDrain = MetabolismConstants.DefaultPerReagentDrain;
 }

--- a/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
+++ b/Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs
@@ -35,4 +35,13 @@ public sealed partial class MetabolismSolutionEntry
     /// </summary>
     [DataField]
     public float VolumeScaledTransfer = MetabolismConstants.DefaultVolumeScaledTransfer;
+
+    /// <summary>
+    /// Per-tick removal applied to toxin-class reagents (group "Toxins") in this stage's
+    /// solution. The reagent is consumed at this rate without firing effects. Set on the
+    /// liver's Detoxification entry so the liver scrubs toxins from the bloodstream;
+    /// other stages stay at 0. Mirrors SS13's liver-driven toxin filter.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 ToxinScrubRate = MetabolismConstants.DefaultToxinScrubRate;
 }


### PR DESCRIPTION
## About the PR

Final mechanic step of #679. Wires the kidney's Excretion stage (added in step 2) to consume a small per-tick amount of every reagent in the bloodstream without firing effects. This is what gives the kidney its real failure mode: a healthy kidney pulls chems out steadily; a missing kidney lets them linger.

Stacked on #685 / #684 / #683 / #682 / #681 / #680.

## Why / Balance

Steps 1-6 reframe the chain so each organ has a job. The kidney got the sub-tolerance filter (step 5, computed inline on heart tick), but its own tick was still a no-op. Step 7 puts the second half of the kidney's role in: a slow drain on every reagent in blood, so failing kidneys translate to longer-lasting chem effects (good and bad).

Per the design call, drain rate starts at 0.1u/tick per reagent and is the explicit tuning knob. Too high and chems blast through; too low and kidneys feel decorative again. Will need play-test review.

## Technical details

- `Content.Shared/RussStation/Metabolism/MetabolismSolutionEntry.Honk.cs` (HONK-block append): adds `PerReagentDrain` (FixedPoint2, default 0). Per-stage opt-in.
- `Content.Shared/RussStation/Metabolism/MetabolismConstants.cs` (HONK-block append): adds `DefaultPerReagentDrain = 0` and `KidneyPerReagentDrain = 0.1u`.
- `Content.Shared/Metabolism/MetabolizerComponent.cs` (HONK-block): kidney's `Excretion` entry now sets `PerReagentDrain = MetabolismConstants.KidneyPerReagentDrain`.
- `Content.Shared/Metabolism/MetabolizerSystem.cs` (HONK-block): in the per-reagent loop, after the toxin-scrub intercept, drains every reagent at the configured rate without firing effects. `continue`s past the rest of the per-reagent processing for the stage.

The drain is independent of the sub-tolerance filter; both are kidney duties but they live on different ticks (filter on heart's Bloodstream tick gated by kidney presence, drain on kidney's own Excretion tick).

## Verification

- `dotnet build Content.Shared` clean.
- Inject 30u of any reagent (toxin or not) into a healthy patient: bloodstream now drops at the upstream rate plus 0.1u/tick from the kidney.
- Same patient with no kidneys: bloodstream only clears via the heart's Bloodstream-stage transfer to Metabolites, so the same 30u dose lingers visibly longer. Sub-tolerance filter also fails (per step 5), so micro-stacking works again.
- Healthy kidney + healthy liver: a 30u toxin clears via heart Bloodstream + 1u/tick liver scrub + 0.1u/tick kidney drain. Damage tail is short.
- Corpse with reagents: not drained (dead guard).

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

Every reagent in the bloodstream now loses 0.1u/tick to kidney excretion. Heal rates and OD durations shorten slightly because reagents clear faster. Numbers are tunable; first-pass.

**Changelog**

:cl:
- tweak: Kidneys now slowly drain reagents from the bloodstream on top of the body's existing clearance. Patients with damaged or missing kidneys hold onto chems (and poisons) for longer.