### PR TITLE
honksquad: feat: head-Skaven third-person speech for command roles (#481 P5)

### DIFF
--- a/Content.Server/RussStation/Speech/Components/QueekishThirdPersonComponent.cs
+++ b/Content.Server/RussStation/Speech/Components/QueekishThirdPersonComponent.cs
@@ -1,0 +1,9 @@
+// HONK - Issue #481 P5: head-Skaven third-person speech ("Thanquol-speak").
+// Marker component attached to Skaven on command jobs (Captain, HoP, HoS, CE, CMO, RD, QM)
+// so first-person pronouns get rewritten to the speaker's first name before the standard
+// Queekish word replacement runs. Lore-flavour: clan-leadership posturing.
+
+namespace Content.Server.RussStation.Speech;
+
+[RegisterComponent]
+public sealed partial class QueekishThirdPersonComponent : Component;

--- a/Content.Server/RussStation/Speech/EntitySystems/QueekishThirdPersonSystem.cs
+++ b/Content.Server/RussStation/Speech/EntitySystems/QueekishThirdPersonSystem.cs
@@ -1,0 +1,56 @@
+// HONK - Issue #481 P5: head-Skaven third-person speech ("Thanquol-speak"). Rewrites
+// first-person pronouns to the speaker's first name when a Skaven on a command job speaks,
+// e.g. "I am leaving" -> "Thanquol is leaving". Verb conjugation isn't fixed up; the broken
+// grammar reads as authentic posturing.
+//
+// Runs `before` ReplacementAccentSystem so the pronoun swap lands first and the standard
+// Queekish word replacements then operate on the resulting text. Species-guarded to Skaven
+// only via HumanoidProfileComponent so the marker is harmless if it lands on someone else.
+
+using System.Text.RegularExpressions;
+using Content.Server.RussStation.Speech;
+using Content.Server.Speech.EntitySystems;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Speech;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Speech.EntitySystems;
+
+public sealed class QueekishThirdPersonSystem : EntitySystem
+{
+    private static readonly ProtoId<SpeciesPrototype> SkavenSpecies = "Skaven";
+
+    private static readonly Regex Pronouns =
+        new(@"\b(?:I|me|my|mine|myself)\b", RegexOptions.IgnoreCase);
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<QueekishThirdPersonComponent, AccentGetEvent>(
+            OnAccent,
+            before: [typeof(ReplacementAccentSystem)]);
+    }
+
+    private void OnAccent(EntityUid uid, QueekishThirdPersonComponent component, AccentGetEvent args)
+    {
+        // Species guard. Component lives on the entity but the marker is only meaningful for
+        // Skaven; if a job add-component path attaches it to a non-Skaven we silently skip.
+        if (!TryComp<HumanoidProfileComponent>(uid, out var profile) || profile.Species != SkavenSpecies)
+            return;
+
+        var firstName = ResolveFirstName(uid);
+        if (string.IsNullOrEmpty(firstName))
+            return;
+
+        args.Message = Pronouns.Replace(args.Message, firstName);
+    }
+
+    private string ResolveFirstName(EntityUid uid)
+    {
+        // Skaven hyphenate (e.g. "Thanquol-Boneripper") so split on space and hyphen and
+        // take the first segment. Falls back to the full name if there's no separator.
+        var name = MetaData(uid).EntityName;
+        var sep = name.IndexOfAny([' ', '-']);
+        return sep < 0 ? name : name[..sep];
+    }
+}

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -33,6 +33,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: QuartermasterGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -33,6 +33,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -59,6 +59,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -33,6 +33,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: ChiefEngineerGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -34,6 +34,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -28,6 +28,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -39,6 +39,12 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  # HONK START - issue #481 P5: Skaven head-roles speak in third person ("Thanquol-speak").
+  # System guards by species so non-Skaven crew on this job are unaffected.
+  - !type:AddComponentSpecial
+    components:
+      - type: QueekishThirdPerson
+  # HONK END
 
 - type: startingGear
   id: HoSGear


### PR DESCRIPTION
## About the PR

P5 follow-up for the Skaven port (#481). Skaven on command jobs refer to themselves in third person, lore-flavour for clan-leadership posturing in Warhammer Skaven (e.g. "Thanquol is most displeased").

Stacked on #643. Independent of #685 / #686 (the metabolic chain refactor).

## Why / Balance

Pure flavour. The seven command jobs (Captain, HoP, HoS, CE, CMO, RD, QM) get an extra speech filter when filled by a Skaven, replacing first-person pronouns with the speaker's first name before the standard Queekish word replacements run. Non-Skaven crew on those jobs are unaffected.

## Technical details

- `Content.Server/RussStation/Speech/Components/QueekishThirdPersonComponent.cs`: empty marker component.
- `Content.Server/RussStation/Speech/EntitySystems/QueekishThirdPersonSystem.cs`:
  - Subscribes `AccentGetEvent` with `before: [typeof(ReplacementAccentSystem)]` so the pronoun swap lands first and the standard Queekish word replacements operate on the resulting text.
  - Species guard on `HumanoidProfileComponent.Species == "Skaven"`. The marker is harmless when present on a non-Skaven entity.
  - Single regex `\b(?:I|me|my|mine|myself)\b` (case-insensitive) replaces all five pronoun forms with the speaker's first name. Verb conjugation isn't fixed up; broken grammar reads as authentic.
  - First-name lookup is `MetaData(uid).EntityName` split on the first space or hyphen. Skaven names hyphenate (e.g. `Thanquol-Boneripper`), so `Thanquol` falls out naturally.
- Seven HONK-block edits, one per command-job YAML, attaching `QueekishThirdPerson` via a second `AddComponentSpecial` after the existing `CommandStaff` add.

## Verification

- `dotnet build Content.Server` clean.
- Skaven captain says "I will not allow this": chat reads "Thanquol-Boneripper will not allow this", then runs through Queekish word replacement (`I -> I-I` would have applied first, but the pronoun rewrite ran before so the swap consumed the `I`).
- Human captain says the same thing: unchanged. Component present, system guard returns early.
- Skaven QM, RD, etc. each behave the same way as the captain.
- Skaven on a non-command role (e.g. Cargo Tech): pronouns unchanged because no `QueekishThirdPerson` was added.

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

None.

**Changelog**

:cl:
- add: Skaven on Command roles (Captain, HoP, HoS, CE, CMO, RD, QM) now refer to themselves in third person.