### PR TITLE
honksquad: feat: Skaven payday at 25% of standard wages (#481 P4)

### DIFF
--- a/Content.Server/RussStation/Economy/EconomyConstants.cs
+++ b/Content.Server/RussStation/Economy/EconomyConstants.cs
@@ -31,4 +31,12 @@ public static class EconomyConstants
     /// new account starts empty as an intentional penalty.
     /// </summary>
     public const int NewAccountStartingBalance = 0;
+
+    /// <summary>
+    /// Wage multiplier applied to Skaven characters via <c>SkavenPaydayComponent</c>
+    /// (issue #481 P4). 0.25 mirrors the SS13 RussStation
+    /// <c>skaven_payday_multiplier</c>: lore-flavour for skaven being treated as
+    /// disposable underclass labour.
+    /// </summary>
+    public const float SkavenPaydayMultiplier = 0.25f;
 }

--- a/Content.Server/RussStation/Economy/SkavenPaydayComponent.cs
+++ b/Content.Server/RussStation/Economy/SkavenPaydayComponent.cs
@@ -1,0 +1,9 @@
+// HONK - Issue #481 P4: Skaven payday modifier. Skaven get a fraction of standard wages
+// per SS13 lore (skaven_payday_multiplier = 0.25). The actual multiplier lives in
+// EconomyConstants and is read by SkavenPaydaySystem on every GetWageEvent the entity
+// raises.
+
+namespace Content.Server.RussStation.Economy;
+
+[RegisterComponent]
+public sealed partial class SkavenPaydayComponent : Component;

--- a/Content.Server/RussStation/Economy/SkavenPaydaySystem.cs
+++ b/Content.Server/RussStation/Economy/SkavenPaydaySystem.cs
@@ -1,0 +1,21 @@
+// HONK - Issue #481 P4: scale Skaven wages to 25% of the standard rate. Hooks the
+// existing GetWageEvent that PayrollSystem raises before depositing a paycheck, the
+// same mechanism Negotiator and Indebted traits use.
+
+using Content.Shared.RussStation.Economy;
+
+namespace Content.Server.RussStation.Economy;
+
+public sealed class SkavenPaydaySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SkavenPaydayComponent, GetWageEvent>(OnGetWage);
+    }
+
+    private void OnGetWage(EntityUid uid, SkavenPaydayComponent component, ref GetWageEvent args)
+    {
+        args.Wage = (int)(args.Wage * EconomyConstants.SkavenPaydayMultiplier);
+    }
+}

--- a/Resources/Prototypes/@RussStation/Body/Species/skaven.yml
+++ b/Resources/Prototypes/@RussStation/Body/Species/skaven.yml
@@ -88,6 +88,7 @@
       accents: [queekish]
     - type: Wagging
       action: ActionToggleWaggingSkaven
+    - type: SkavenPayday
     - type: Bloodstream
       bloodReferenceSolution:
         reagents:


### PR DESCRIPTION
## About the PR

P4 polish for the Skaven port (#481). Skaven get 25% of the standard paycheck per the SS13 RussStation `skaven_payday_multiplier` lore.

Stacked on #643. Independent of #687 (P5 Thanquol-speak) so they can ship in either order.

## Why / Balance

Lore-flavour. SS13 RussStation treats skaven as disposable underclass labour, and the 0.25 wage multiplier is the in-fiction expression. Doesn't change anything else about how skaven play; just nudges economy gameplay around them.

Since heads-of-staff already pay better via `WageCommand`, a Skaven captain still earns above a human assistant. The multiplier just bites at the per-tier wage.

## Technical details

- `Content.Server/RussStation/Economy/SkavenPaydayComponent.cs`: empty server-only marker.
- `Content.Server/RussStation/Economy/EconomyConstants.cs`: adds `SkavenPaydayMultiplier = 0.25f`.
- `Content.Server/RussStation/Economy/SkavenPaydaySystem.cs`: subscribes `GetWageEvent`, multiplies wage by the constant. Same hook the Negotiator / Indebted traits already use.
- `Resources/Prototypes/@RussStation/Body/Species/skaven.yml`: `MobSkaven` gets a `SkavenPayday` component.

No upstream files touched.

## Verification

- `dotnet build Content.Server` clean.
- Skaven assistant paycheck: 25% of crew wage.
- Skaven captain paycheck: 25% of command wage.
- Human captain paycheck: unchanged.
- Skaven character with the Negotiator trait: paycheck composes the two multipliers (e.g. `0.25 * 1.x`), since both are subscribers on the same event.

## Media

N/A.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] This PR does not merge from any branch other than `origin/upstream/stable` or fork branches.
- [x] Every fork-authored commit in this PR uses the `honksquad:` subject prefix.

## Breaking changes

Skaven characters' paychecks drop to 25% of what they were before the multiplier. Players have to factor that into role selection.

**Changelog**

:cl:
- tweak: Skaven characters now earn 25% of the standard wage on every job, reflecting their underclass standing.