### PR TITLE
honksquad: feat: BluespaceDust reagent + ore grinder yield (#302)

### DIFF
--- a/Content.Shared/RussStation/Bluespace/BluespaceConstants.cs
+++ b/Content.Shared/RussStation/Bluespace/BluespaceConstants.cs
@@ -12,4 +12,11 @@ public static class BluespaceConstants
     /// <c>blink_range = 8</c> on <c>/obj/item/stack/ore/bluespace_crystal</c>.
     /// </summary>
     public const float DefaultBlinkRange = 8f;
+
+    /// <summary>
+    /// Default blink range (in tiles) when a metabolised reagent forces a
+    /// teleport. Shorter than the active crystal blink so drinking dust feels
+    /// weaker than a deliberate crush. Mirrors SS13's reagent default.
+    /// </summary>
+    public const float DefaultReagentBlinkRange = 5f;
 }

--- a/Content.Shared/RussStation/Bluespace/Components/BluespaceCrushTeleportComponent.cs
+++ b/Content.Shared/RussStation/Bluespace/Components/BluespaceCrushTeleportComponent.cs
@@ -15,7 +15,7 @@ using BluespaceConstants = Content.Shared.RussStation.Bluespace.BluespaceConstan
 namespace Content.Shared.RussStation.Bluespace.Components;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(BluespaceCrushTeleportSystem))]
+[Access(typeof(BluespaceBlinkSystem))]
 public sealed partial class BluespaceCrushTeleportComponent : Component
 {
     /// <summary>

--- a/Content.Shared/RussStation/Bluespace/EntityEffects/BluespaceTeleportEntityEffectSystem.cs
+++ b/Content.Shared/RussStation/Bluespace/EntityEffects/BluespaceTeleportEntityEffectSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.RussStation.Bluespace.EntityEffects;
 public sealed partial class BluespaceTeleportEntityEffectSystem
     : EntityEffectSystem<TransformComponent, BluespaceTeleport>
 {
-    [Dependency] private readonly BluespaceCrushTeleportSystem _blink = default!;
+    [Dependency] private readonly BluespaceBlinkSystem _blink = default!;
 
     protected override void Effect(Entity<TransformComponent> entity, ref EntityEffectEvent<BluespaceTeleport> args)
     {

--- a/Content.Shared/RussStation/Bluespace/EntityEffects/BluespaceTeleportEntityEffectSystem.cs
+++ b/Content.Shared/RussStation/Bluespace/EntityEffects/BluespaceTeleportEntityEffectSystem.cs
@@ -1,0 +1,54 @@
+// HONK - Issue #302 follow-up: reagent-driven random teleport for BluespaceDust.
+// Reuses the same blink path as the crystal's UseInHand and ThrowDoHit so the
+// VFX, audio, tile-blocked filter, and predicted RNG all match what players see
+// when crushing a crystal in hand.
+
+using Content.Shared.EntityEffects;
+using Content.Shared.RussStation.Bluespace.EntitySystems;
+using Robust.Shared.Prototypes;
+using BluespaceConstants = Content.Shared.RussStation.Bluespace.BluespaceConstants;
+
+namespace Content.Shared.RussStation.Bluespace.EntityEffects;
+
+public sealed partial class BluespaceTeleportEntityEffectSystem
+    : EntityEffectSystem<TransformComponent, BluespaceTeleport>
+{
+    [Dependency] private readonly BluespaceCrushTeleportSystem _blink = default!;
+
+    protected override void Effect(Entity<TransformComponent> entity, ref EntityEffectEvent<BluespaceTeleport> args)
+    {
+        _blink.TryBlink(
+            entity,
+            args.Effect.Range * args.Scale,
+            args.Effect.SourceEffect,
+            args.Effect.DestinationEffect);
+    }
+}
+
+public sealed partial class BluespaceTeleport : EntityEffectBase<BluespaceTeleport>
+{
+    /// <summary>
+    /// Maximum random offset (in tiles) the teleport throws the drinker.
+    /// Mirrors SS13's reagent default of 5 tiles, which is shorter than the
+    /// crystal's 8-tile crush blink to keep the metabolism trigger weaker than
+    /// the active use.
+    /// </summary>
+    [DataField]
+    public float Range = BluespaceConstants.DefaultReagentBlinkRange;
+
+    /// <summary>
+    /// Visual effect spawned on the tile the drinker leaves. Defaults match
+    /// the crystal blink so reagent and item teleports look identical.
+    /// </summary>
+    [DataField]
+    public EntProtoId? SourceEffect = "EffectPhaseOut";
+
+    /// <summary>
+    /// Visual effect spawned on the tile the drinker arrives at.
+    /// </summary>
+    [DataField]
+    public EntProtoId? DestinationEffect = "EffectPhaseIn";
+
+    public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("entity-effect-guidebook-bluespace-teleport", ("chance", Probability), ("range", Range));
+}

--- a/Content.Shared/RussStation/Bluespace/EntitySystems/BluespaceBlinkSystem.cs
+++ b/Content.Shared/RussStation/Bluespace/EntitySystems/BluespaceBlinkSystem.cs
@@ -23,7 +23,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.Bluespace.EntitySystems;
 
-public sealed class BluespaceCrushTeleportSystem : EntitySystem
+public sealed class BluespaceBlinkSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;

--- a/Content.Shared/RussStation/Bluespace/EntitySystems/BluespaceCrushTeleportSystem.cs
+++ b/Content.Shared/RussStation/Bluespace/EntitySystems/BluespaceCrushTeleportSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
@@ -133,6 +134,21 @@ public sealed class BluespaceCrushTeleportSystem : EntitySystem
 
     private void Blink(EntityUid target, BluespaceCrushTeleportComponent comp)
     {
+        TryBlink(target, comp.BlinkRange, comp.BlinkEffectSource, comp.BlinkEffectDestination);
+    }
+
+    /// <summary>
+    /// Public blink entry point so non-component callers (reagent metabolism, gas
+    /// reactions, future fork mechanics) can fire the same teleport that the
+    /// crystal's UseInHand and ThrowDoHit use, with matching VFX, audio,
+    /// tile-blocked filter, and predicted RNG.
+    /// </summary>
+    public bool TryBlink(
+        EntityUid target,
+        float range,
+        EntProtoId? sourceEffect = null,
+        EntProtoId? destEffect = null)
+    {
         var sourceXform = Transform(target);
         var coords = sourceXform.Coordinates;
 
@@ -143,13 +159,13 @@ public sealed class BluespaceCrushTeleportSystem : EntitySystem
         // EntityUid.Id is local rather than network-stable.
         var rng = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(target));
 
-        if (!TryFindBlinkDestination(rng, coords, comp.BlinkRange, out var dest))
-            return;
+        if (!TryFindBlinkDestination(rng, coords, range, out var dest))
+            return false;
 
         // Spawn the departure VFX + sound at the source tile (matches SS13's
         // attack_self / throw_impact sparks + SFX_PORTAL_ENTER).
-        if (comp.BlinkEffectSource is { } sourceEffect)
-            PredictedSpawnAtPosition(sourceEffect, coords);
+        if (sourceEffect is { } src)
+            PredictedSpawnAtPosition(src, coords);
         _audio.PlayPredicted(DepartureSound, coords, target);
 
         _xform.AttachToGridOrMap(target);
@@ -158,9 +174,10 @@ public sealed class BluespaceCrushTeleportSystem : EntitySystem
 
         // And again at the destination (matches do_teleport's phasein.ogg
         // arrival cue).
-        if (comp.BlinkEffectDestination is { } destEffect)
-            PredictedSpawnAtPosition(destEffect, dest);
+        if (destEffect is { } dst)
+            PredictedSpawnAtPosition(dst, dest);
         _audio.PlayPredicted(ArrivalSound, target, target);
+        return true;
     }
 
     private bool TryFindBlinkDestination(System.Random rng, EntityCoordinates source, float range, out EntityCoordinates dest)

--- a/Resources/Locale/en-US/@RussStation/materials/bluespace.ftl
+++ b/Resources/Locale/en-US/@RussStation/materials/bluespace.ftl
@@ -5,3 +5,7 @@ stack-bluespace = bluespace crystal
 
 bluespace-crystal-crush-self = You crush the bluespace crystal!
 bluespace-crystal-crush-others = { $user } crushes a bluespace crystal!
+
+reagent-name-bluespace-dust = bluespace dust
+reagent-desc-bluespace-dust = A dust composed of microscopic bluespace crystals, with minor space-warping properties.
+reagent-physical-desc-fizzling-blue = fizzling blue

--- a/Resources/Locale/en-US/@RussStation/materials/bluespace.ftl
+++ b/Resources/Locale/en-US/@RussStation/materials/bluespace.ftl
@@ -9,3 +9,9 @@ bluespace-crystal-crush-others = { $user } crushes a bluespace crystal!
 reagent-name-bluespace-dust = bluespace dust
 reagent-desc-bluespace-dust = A dust composed of microscopic bluespace crystals, with minor space-warping properties.
 reagent-physical-desc-fizzling-blue = fizzling blue
+
+entity-effect-guidebook-bluespace-teleport =
+    { $chance ->
+        [1] Teleports
+        *[other] teleport
+    } the drinker up to { $range } tiles in a random direction

--- a/Resources/Prototypes/@RussStation/Entities/Objects/Materials/bluespace.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Objects/Materials/bluespace.yml
@@ -8,7 +8,7 @@
   parent: MaterialBase
   id: MaterialBluespace
   name: bluespace crystal
-  description: A shard of crystallized bluespace. Hums faintly with non-Euclidean intent. Crushing one teleports you a short distance; thrown into a target it does the same to them.
+  description: A shard of crystallized bluespace. Hums faintly with non-Euclidean intent. Crushing one teleports you a short distance; thrown into a target it does the same to them. Grinds into bluespace dust.
   suffix: Full
   components:
     - type: Stack
@@ -25,6 +25,14 @@
     - type: BluespaceCrushTeleport
     - type: UseDelay
       delay: 1.0
+    - type: Extractable
+      grindableSolutionName: bluespace
+    - type: SolutionContainerManager
+      solutions:
+        bluespace:
+          reagents:
+            - ReagentId: BluespaceDust
+              Quantity: 20
 
 - type: entity
   parent: MaterialBluespace

--- a/Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml
+++ b/Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml
@@ -4,10 +4,17 @@
 # grind_results to the raw ore form; the fork unifies ore and refined into the
 # one MaterialBluespace entity, so the grind path moves with it).
 #
-# Effects: jitter on metabolism (the "feel unstable" pulse from SS13's
-# on_mob_life). The teleport-on-tick mechanic from SS13 is deferred to a follow-up
-# because it needs a fork-side EntityEffect class. The crush/throw teleport on
-# the crystal (#694) covers the "active blink" use case.
+# Effects per metabolism tick:
+# - 7.5% chance to jitter (the "feel unstable" pulse from SS13's on_mob_life).
+# - 7.5% chance to blink up to 5 tiles in a random direction, reusing the same
+#   path as the crystal's UseInHand and ThrowDoHit
+#   (BluespaceCrushTeleportSystem.TryBlink), so VFX, audio, and tile-blocked
+#   filtering match what players see on a crush.
+#
+# SS13 ties jitter and teleport to the same 7.5% roll with a 3s delay between
+# them. The fork rolls each effect independently for simplicity; the average
+# tick-to-tick experience is close enough and the implementation skips a
+# delayed-callback component.
 
 - type: reagent
   id: BluespaceDust
@@ -21,3 +28,7 @@
     Bloodstream:
       effects:
         - !type:Jitter
+          probability: 0.075
+        - !type:BluespaceTeleport
+          probability: 0.075
+          range: 5

--- a/Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml
+++ b/Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml
@@ -1,0 +1,23 @@
+# HONK - Issue #302 follow-up: Bluespace Dust reagent. Mirrors SS13's
+# /datum/reagent/bluespace from russstation/code/modules/reagents/chemistry/reagents/other_reagents.dm.
+# Grindable from MaterialBluespace at 20u per crystal (SS13 attached the
+# grind_results to the raw ore form; the fork unifies ore and refined into the
+# one MaterialBluespace entity, so the grind path moves with it).
+#
+# Effects: jitter on metabolism (the "feel unstable" pulse from SS13's
+# on_mob_life). The teleport-on-tick mechanic from SS13 is deferred to a follow-up
+# because it needs a fork-side EntityEffect class. The crush/throw teleport on
+# the crystal (#694) covers the "active blink" use case.
+
+- type: reagent
+  id: BluespaceDust
+  name: reagent-name-bluespace-dust
+  group: Special
+  desc: reagent-desc-bluespace-dust
+  physicalDesc: reagent-physical-desc-fizzling-blue
+  flavor: bitter
+  color: "#0000CC"
+  metabolisms:
+    Bloodstream:
+      effects:
+        - !type:Jitter

--- a/Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml
+++ b/Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml
@@ -8,7 +8,7 @@
 # - 7.5% chance to jitter (the "feel unstable" pulse from SS13's on_mob_life).
 # - 7.5% chance to blink up to 5 tiles in a random direction, reusing the same
 #   path as the crystal's UseInHand and ThrowDoHit
-#   (BluespaceCrushTeleportSystem.TryBlink), so VFX, audio, and tile-blocked
+#   (BluespaceBlinkSystem.TryBlink), so VFX, audio, and tile-blocked
 #   filtering match what players see on a crush.
 #
 # SS13 ties jitter and teleport to the same 7.5% roll with a 3s delay between


### PR DESCRIPTION
## About the PR

Adds the SS13 bluespace dust reagent, wires `MaterialBluespace` to grind into 20u of it, and gives the reagent an occasional teleport on metabolism that reuses the same blink path as the crystal in #694. Stacked on #693.

## Why / Balance

SS13 reference (`russstation/code/modules/reagents/chemistry/reagents/other_reagents.dm`):

```
/datum/reagent/bluespace
    name = "Bluespace Dust"
    color = "#0000CC"
    description = "A dust composed of microscopic bluespace crystals, with minor space-warping properties."
```

The 20u figure comes from SS13 directly. `/obj/item/stack/ore/bluespace_crystal` and `/obj/item/stack/sheet/bluespace_crystal` both ship `grind_results = list(/datum/reagent/bluespace = 20)`. Plasma's SS13 sheet grinds at the same 20u; SS14's 10u plasma-ore figure is an SS14-side downscale. Anchoring on SS13 keeps bluespace's grind tier consistent with the rest of the #302 design (Diamond-tier rarity, salvage-only, 12u sheet price).

The metabolism teleport puts back the defining "drinking dust feels chaotic" effect of SS13 bluespace dust, instead of leaving the reagent as just a jitter source.

## Technical details

### Reagent and grind

- `Resources/Prototypes/@RussStation/Reagents/bluespace_dust.yml` (new): `BluespaceDust` reagent. Color `#0000CC`, group Special, bitter flavor. Bloodstream metabolism rolls 7.5% jitter and 7.5% blink each tick, independently.
- `Resources/Prototypes/@RussStation/Entities/Objects/Materials/bluespace.yml`: `MaterialBluespace` gets `Extractable` (`grindableSolutionName: bluespace`) plus a `SolutionContainerManager` holding 20u of `BluespaceDust`. Mirrors how `MaterialDiamond` carries Carbon. SS13 attaches `grind_results` to the raw ore form; the fork unifies ore and refined into one entity in #693, so the grind path moves to the unified crystal.
- `Resources/Locale/en-US/@RussStation/materials/bluespace.ftl`: reagent name, description, physical desc, plus `entity-effect-guidebook-bluespace-teleport` for the reagent guidebook tooltip.

### Metabolism teleport

The reagent should look identical to crushing a crystal in hand when it triggers a teleport: same phaseout / phasein VFX, same departure / arrival sounds, same tile-blocked filter, same predicted RNG. Achieved by:

- `Content.Shared/RussStation/Bluespace/EntitySystems/BluespaceBlinkSystem.cs`: rename of the old `BluespaceCrushTeleportSystem`. Refactored its private `Blink` helper into a public `TryBlink(target, range, sourceEffect, destEffect)` so non-component callers can request the same blink. The crystal's UseInHand and ThrowDoHit handlers still feed the component fields through the wrapper. Component stays `BluespaceCrushTeleportComponent` because that contract (UseInHand + ThrowDoHit + UseDelay + stack consume) is genuinely crystal-specific.
- `Content.Shared/RussStation/Bluespace/EntityEffects/BluespaceTeleportEntityEffectSystem.cs` (new): `BluespaceTeleport` entity effect plus its `EntityEffectSystem<TransformComponent, BluespaceTeleport>`. Calls `TryBlink` with a per-effect range and effect-prototype overrides.
- `Content.Shared/RussStation/Bluespace/BluespaceConstants.cs`: new `DefaultReagentBlinkRange = 5f` (vs the crystal's 8f), matching SS13's reagent default. Shorter range so chugging dust feels weaker than a deliberate crush.

### Scope notes

The refined-vs-ore split for grinding doesn't apply: there is no separate raw-ore form in this fork (#693 unified them). SS13's 3-second delay between the jitter pulse and the teleport is collapsed: jitter and teleport roll independently each tick. The vapor / touch exposure path from SS13 (`reac_volume / 5` tiles) is not included; only metabolism triggers the blink.

## Media

N/A.

## Breaking changes

None. New reagent + new component on an existing fork-only entity.

## Changelog

:cl:

- add: Bluespace crystals can now be ground in a reagent grinder, yielding 20u of bluespace dust per crystal. Drinking the dust makes you jittery and occasionally teleports you a few tiles in a random direction.
