### PR TITLE
honksquad: feat: bluespace ore credits research-server points (#302)

### DIFF
--- a/Content.Server/RussStation/Bluespace/Components/BluespaceResearchInsertComponent.cs
+++ b/Content.Server/RussStation/Bluespace/Components/BluespaceResearchInsertComponent.cs
@@ -1,0 +1,27 @@
+// HONK - Issue #302 follow-up: research-server points for bluespace crystals.
+// Mirrors SS13's points = 50 per crystal on /obj/item/stack/ore/bluespace_crystal.
+// Stack-aware: each AfterInteract on a research server consumes one from the stack
+// and credits the server with Points. Upstream's ResearchDiskComponent QueueDels
+// the whole entity on use, so a stack-aware variant is needed for the unified
+// bluespace crystal entity.
+
+namespace Content.Server.RussStation.Bluespace.Components;
+
+[RegisterComponent]
+public sealed partial class BluespaceResearchInsertComponent : Component
+{
+    /// <summary>
+    /// Research points credited per crystal consumed. SS13's
+    /// <c>points = 50</c> on <c>/obj/item/stack/ore/bluespace_crystal</c>.
+    /// </summary>
+    [DataField]
+    public int Points = BluespaceResearchInsertConstants.PointsPerCrystal;
+}
+
+internal static class BluespaceResearchInsertConstants
+{
+    /// <summary>
+    /// Default research points per bluespace crystal, matches SS13.
+    /// </summary>
+    public const int PointsPerCrystal = 50;
+}

--- a/Content.Server/RussStation/Bluespace/EntitySystems/BluespaceResearchInsertSystem.cs
+++ b/Content.Server/RussStation/Bluespace/EntitySystems/BluespaceResearchInsertSystem.cs
@@ -29,11 +29,14 @@ public sealed class BluespaceResearchInsertSystem : EntitySystem
         if (args.Target is not { } target || !TryComp<ResearchServerComponent>(target, out var server))
             return;
 
-        // Stack-aware consumption: take one off the stack, credit one crystal's worth of
-        // points. Stacked entities without StackComponent are treated as single-use.
+        // Consume the whole stack in one interaction and credit Points per
+        // crystal. Non-stack callers fall through to a single-shot QueueDel
+        // crediting one crystal's worth.
+        var consumed = 1;
         if (TryComp<StackComponent>(ent.Owner, out var stack))
         {
-            if (!_stack.TryUse((ent.Owner, stack), 1))
+            consumed = stack.Count;
+            if (consumed <= 0 || !_stack.TryUse((ent.Owner, stack), consumed))
                 return;
         }
         else
@@ -41,9 +44,10 @@ public sealed class BluespaceResearchInsertSystem : EntitySystem
             QueueDel(ent.Owner);
         }
 
-        _research.ModifyServerPoints(target, ent.Comp.Points, server);
+        var points = ent.Comp.Points * consumed;
+        _research.ModifyServerPoints(target, points, server);
         _popup.PopupEntity(
-            Loc.GetString("research-disk-inserted", ("points", ent.Comp.Points)),
+            Loc.GetString("research-disk-inserted", ("points", points)),
             target,
             args.User);
 

--- a/Content.Server/RussStation/Bluespace/EntitySystems/BluespaceResearchInsertSystem.cs
+++ b/Content.Server/RussStation/Bluespace/EntitySystems/BluespaceResearchInsertSystem.cs
@@ -1,0 +1,52 @@
+// HONK - Issue #302 follow-up: see BluespaceResearchInsertComponent for design.
+
+using Content.Server.Popups;
+using Content.Server.Research.Systems;
+using Content.Server.RussStation.Bluespace.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Research.Components;
+using Content.Shared.Stacks;
+
+namespace Content.Server.RussStation.Bluespace.EntitySystems;
+
+public sealed class BluespaceResearchInsertSystem : EntitySystem
+{
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly ResearchSystem _research = default!;
+    [Dependency] private readonly SharedStackSystem _stack = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BluespaceResearchInsertComponent, AfterInteractEvent>(OnAfterInteract);
+    }
+
+    private void OnAfterInteract(Entity<BluespaceResearchInsertComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach)
+            return;
+
+        if (args.Target is not { } target || !TryComp<ResearchServerComponent>(target, out var server))
+            return;
+
+        // Stack-aware consumption: take one off the stack, credit one crystal's worth of
+        // points. Stacked entities without StackComponent are treated as single-use.
+        if (TryComp<StackComponent>(ent.Owner, out var stack))
+        {
+            if (!_stack.TryUse((ent.Owner, stack), 1))
+                return;
+        }
+        else
+        {
+            QueueDel(ent.Owner);
+        }
+
+        _research.ModifyServerPoints(target, ent.Comp.Points, server);
+        _popup.PopupEntity(
+            Loc.GetString("research-disk-inserted", ("points", ent.Comp.Points)),
+            target,
+            args.User);
+
+        args.Handled = true;
+    }
+}

--- a/Resources/Prototypes/@RussStation/Entities/Objects/Materials/bluespace.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Objects/Materials/bluespace.yml
@@ -33,6 +33,7 @@
           reagents:
             - ReagentId: BluespaceDust
               Quantity: 20
+    - type: BluespaceResearchInsert
 
 - type: entity
   parent: MaterialBluespace


### PR DESCRIPTION
## About the PR

Lets a research server eat a bluespace crystal stack for points, mirroring SS13's `points = 50` on `/obj/item/stack/ore/bluespace_crystal`. Click a research server with a stack in hand and the server credits `50 * count` points, consuming the whole stack in one interaction. Stacked on #693.

## Why / Balance

SS13 source (`russstation/code/game/objects/items/stacks/bscrystal.dm:11`):

```
/obj/item/stack/ore/bluespace_crystal
    points = 50
```

The points-on-insert behaviour is a panic-button conversion path so that a salvager who pulls a small amount of bluespace off lavaland always has somewhere to spend it, even if no department wants to buy the crystals. 50 points per crystal is the SS13 figure; with the fork's Diamond-tier rarity (about 6 per salvage hit) one mission converts to roughly 300 research points.

## Technical details

- `Content.Server/RussStation/Bluespace/Components/BluespaceResearchInsertComponent.cs` (new, server-side): marker with a `Points` datafield (default 50 from `BluespaceResearchInsertConstants.PointsPerCrystal`).
- `Content.Server/RussStation/Bluespace/EntitySystems/BluespaceResearchInsertSystem.cs` (new, server-side):
  - Subscribes `AfterInteractEvent`. Bails on uncanned reach or on a non-`ResearchServerComponent` target.
  - Reads the `StackComponent` count if present, calls `SharedStackSystem.TryUse` for the whole stack, and credits `ResearchSystem.ModifyServerPoints` with `Points * count`.
  - Falls through to `QueueDel` for non-stack callers, crediting one crystal's worth. Same shape as upstream's `ResearchDiskSystem`.
  - Pops `research-disk-inserted` with the total points so the player sees the credit.
- `Resources/Prototypes/@RussStation/Entities/Objects/Materials/bluespace.yml`: adds `- type: BluespaceResearchInsert` to `MaterialBluespace`. The block is fork-only and lives in a fork-only file, so no HONK-marker wrapper is needed.

## Media

N/A.

## Breaking changes

None. New component on an existing fork-only entity.

## Changelog

:cl:

- add: Bluespace crystals can now be handed in at a research server. Each crystal in the stack credits 50 research points, and the whole stack is consumed in a single click.
