### PR TITLE
honksquad: feat: bluespace plant teleport + backfire traits (#697 parent)

### DIFF
--- a/Content.Shared/RussStation/Bluespace/BluespaceConstants.cs
+++ b/Content.Shared/RussStation/Bluespace/BluespaceConstants.cs
@@ -1,9 +1,9 @@
 namespace Content.Shared.RussStation.Bluespace;
 
 /// <summary>
-/// Tunable constants for the Bluespace crystal mechanics introduced by issue #302.
-/// SS13 reference values live here so the component code is just a name lookup, not a
-/// scatter of magic numbers.
+/// Tunable constants for the Bluespace mechanics introduced by issue #302 and its
+/// follow-ups. SS13 reference values live here so the component code is a name
+/// lookup rather than a scatter of magic numbers.
 /// </summary>
 public static class BluespaceConstants
 {
@@ -19,4 +19,18 @@ public static class BluespaceConstants
     /// weaker than a deliberate crush. Mirrors SS13's reagent default.
     /// </summary>
     public const float DefaultReagentBlinkRange = 5f;
+
+    /// <summary>
+    /// Default blink range (in tiles) for bluespace plants. SS13 scales by
+    /// <c>potency / 10</c> on <c>/datum/plant_gene/trait/teleport</c>; this is
+    /// the flat per-fruit equivalent. 5 lands between the raw ore (8) and a
+    /// typical SS13 mid-potency plant.
+    /// </summary>
+    public const float PlantBlinkRange = 5f;
+
+    /// <summary>
+    /// Default fumble probability for the bluespace tomato hold-backfire. SS13
+    /// rolls 50% per attempted use on <c>/datum/plant_gene/trait/backfire/bluespace</c>.
+    /// </summary>
+    public const float PlantBackfireProbability = 0.5f;
 }

--- a/Content.Shared/RussStation/Bluespace/Components/BluespacePlantBackfireComponent.cs
+++ b/Content.Shared/RussStation/Bluespace/Components/BluespacePlantBackfireComponent.cs
@@ -1,0 +1,31 @@
+// HONK - Issue #697 parent: bluespace tomato hold-backfire trait. Mirrors SS13's
+// /datum/plant_gene/trait/backfire/bluespace ("Bluespace Volatility"). On UseInHand
+// the entity rolls a probability and, on success, drops itself, fires a teleport on
+// the user, and is consumed (mimicking the squash_plant call SS13 makes). The user
+// is the target both because they're holding it unprotected and because the
+// fumble lands the squash on them, not on a tile.
+
+using Content.Shared.RussStation.Bluespace.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Bluespace.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(BluespacePlantTeleportSystem))]
+public sealed partial class BluespacePlantBackfireComponent : Component
+{
+    /// <summary>
+    /// Probability per UseInHand that the fumble fires.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Probability = BluespaceConstants.PlantBackfireProbability;
+
+    /// <summary>
+    /// Teleport range applied to the user when the fumble fires. Defaults to the
+    /// same range as <see cref="BluespacePlantTeleportComponent.BlinkRange"/>; can
+    /// be tuned independently if backfire ought to feel weaker than the
+    /// regular squash.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BlinkRange = BluespaceConstants.PlantBlinkRange;
+}

--- a/Content.Shared/RussStation/Bluespace/Components/BluespacePlantTeleportComponent.cs
+++ b/Content.Shared/RussStation/Bluespace/Components/BluespacePlantTeleportComponent.cs
@@ -1,0 +1,37 @@
+// HONK - Issue #697 parent: shared bluespace plant teleport trait. Mirrors SS13's
+// /datum/plant_gene/trait/teleport ("Bluespace Activity"). Attached to a fork plant
+// entity (food, peel) to teleport the target on slip and on throw-impact.
+
+using Content.Shared.RussStation.Bluespace.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Bluespace.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(BluespacePlantTeleportSystem))]
+public sealed partial class BluespacePlantTeleportComponent : Component
+{
+    /// <summary>
+    /// Maximum random teleport offset (in tiles). SS13's
+    /// <c>/datum/plant_gene/trait/teleport</c> scales by potency / 10; this is the
+    /// flat per-entity equivalent for the fork.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BlinkRange = BluespaceConstants.PlantBlinkRange;
+
+    /// <summary>
+    /// Fire on slip events (someone slipping on this entity). Mirrors the
+    /// <c>slip_teleport</c> branch of the SS13 trait, used when the parent plant
+    /// has the slip gene without squash (banana peel).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool OnSlip = true;
+
+    /// <summary>
+    /// Fire on throw-impact (this entity hits a target). Mirrors the
+    /// <c>squash_teleport</c> branch of the SS13 trait, used when the parent plant
+    /// has the squash gene (bluespace tomato).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool OnThrowImpact = true;
+}

--- a/Content.Shared/RussStation/Bluespace/EntitySystems/BluespacePlantTeleportSystem.cs
+++ b/Content.Shared/RussStation/Bluespace/EntitySystems/BluespacePlantTeleportSystem.cs
@@ -1,0 +1,78 @@
+// HONK - Issue #697 parent: shared bluespace plant teleport + backfire mechanics.
+// See BluespacePlantTeleportComponent and BluespacePlantBackfireComponent for the
+// per-component design. The actual blink (range + tile filter + VFX + audio +
+// predicted RNG) is delegated to BluespaceBlinkSystem.TryBlink so plants behave
+// identically to crushing a crystal in hand or drinking bluespace dust.
+
+using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Bluespace.Components;
+using Content.Shared.Slippery;
+using Content.Shared.Throwing;
+using Robust.Shared.Network;
+using Robust.Shared.Random;
+
+namespace Content.Shared.RussStation.Bluespace.EntitySystems;
+
+public sealed class BluespacePlantTeleportSystem : EntitySystem
+{
+    [Dependency] private readonly BluespaceBlinkSystem _blink = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BluespacePlantTeleportComponent, ThrowDoHitEvent>(OnThrowHit);
+        SubscribeLocalEvent<BluespacePlantTeleportComponent, SlipEvent>(OnSlip);
+        SubscribeLocalEvent<BluespacePlantBackfireComponent, UseInHandEvent>(OnUseInHand);
+    }
+
+    private void OnThrowHit(Entity<BluespacePlantTeleportComponent> ent, ref ThrowDoHitEvent args)
+    {
+        if (!ent.Comp.OnThrowImpact)
+            return;
+
+        // Only blink living mobs; throwing the fruit at a wall or item shouldn't fire.
+        if (!HasComp<MobStateComponent>(args.Target))
+            return;
+
+        _blink.TryBlink(args.Target, ent.Comp.BlinkRange);
+    }
+
+    private void OnSlip(Entity<BluespacePlantTeleportComponent> ent, ref SlipEvent args)
+    {
+        if (!ent.Comp.OnSlip)
+            return;
+
+        _blink.TryBlink(args.Slipped, ent.Comp.BlinkRange);
+    }
+
+    private void OnUseInHand(Entity<BluespacePlantBackfireComponent> ent, ref UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!_random.Prob(ent.Comp.Probability))
+            return;
+
+        // Fumble: pop the message client-side via predicted popup, blink the user, and
+        // delete the fruit (mimics SS13's squash_plant on the holder).
+        _popup.PopupPredicted(
+            Loc.GetString("bluespace-plant-backfire-self"),
+            Loc.GetString("bluespace-plant-backfire-others", ("user", args.User)),
+            args.User,
+            args.User);
+
+        _blink.TryBlink(args.User, ent.Comp.BlinkRange);
+
+        // Server owns entity destruction; client just marks the use as handled.
+        if (_net.IsServer)
+            QueueDel(ent.Owner);
+
+        args.Handled = true;
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/materials/bluespace.ftl
+++ b/Resources/Locale/en-US/@RussStation/materials/bluespace.ftl
@@ -15,3 +15,6 @@ entity-effect-guidebook-bluespace-teleport =
         [1] Teleports
         *[other] teleport
     } the drinker up to { $range } tiles in a random direction
+
+bluespace-plant-backfire-self = The fruit slips out of your hand!
+bluespace-plant-backfire-others = { $user } fumbles a bluespace fruit!

--- a/Resources/Prototypes/@RussStation/Entities/Objects/Specific/Bluespace/bluespace_test_plant.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Objects/Specific/Bluespace/bluespace_test_plant.yml
@@ -1,0 +1,30 @@
+# HONK - Issue #697 parent: throwaway test entity so the plant teleport + backfire
+# components can be exercised in admin before any actual crop content (tomato,
+# banana) lands. Spawn one of these and use it in hand to fumble, throw it at a
+# mob to teleport them, slip on it (when paired with a Slippery component) to
+# teleport the slipper. Subsequent crop PRs declare the same components on real
+# entities; this preview entity is removed once those land.
+
+- type: entity
+  id: BluespaceTestPlant
+  name: bluespace test fruit
+  description: A debug entity exposing the bluespace plant teleport + backfire mechanics. Crush, throw, or slip.
+  suffix: DEBUG
+  components:
+    - type: Sprite
+      sprite: "@RussStation/Objects/Materials/bluespace_crystal.rsi"
+      state: bluespace_crystal
+    - type: Item
+    - type: Slippery
+    - type: Physics
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 20
+          mask:
+            - ItemMask
+    - type: BluespacePlantTeleport
+    - type: BluespacePlantBackfire

--- a/Resources/Prototypes/@RussStation/Entities/Objects/Specific/Bluespace/bluespace_test_plant.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Objects/Specific/Bluespace/bluespace_test_plant.yml
@@ -1,11 +1,12 @@
 # HONK - Issue #697 parent: throwaway test entity so the plant teleport + backfire
 # components can be exercised in admin before any actual crop content (tomato,
 # banana) lands. Spawn one of these and use it in hand to fumble, throw it at a
-# mob to teleport them, slip on it (when paired with a Slippery component) to
-# teleport the slipper. Subsequent crop PRs declare the same components on real
-# entities; this preview entity is removed once those land.
+# mob to teleport them, slip on it to teleport the slipper. Subsequent crop PRs
+# declare the same components on real entities; this preview entity is removed
+# once those land.
 
 - type: entity
+  parent: BaseItem
   id: BluespaceTestPlant
   name: bluespace test fruit
   description: A debug entity exposing the bluespace plant teleport + backfire mechanics. Crush, throw, or slip.
@@ -15,15 +16,30 @@
       sprite: "@RussStation/Objects/Materials/bluespace_crystal.rsi"
       state: bluespace_crystal
     - type: Item
+    # Slip plumbing mirrors TrashBananaPeel: a SlipLayer fixture for the
+    # StepTrigger to watch, plus the regular ItemMask fixture so the fruit can
+    # still be picked up and thrown.
     - type: Slippery
+    - type: StepTrigger
+      intersectRatio: 0.2
+    - type: CollisionWake
+      enabled: false
     - type: Physics
       bodyType: Dynamic
     - type: Fixtures
       fixtures:
+        slips:
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.2,-0.2,0.2,0.2"
+          hard: false
+          layer:
+            - SlipLayer
         fix1:
-          shape: !type:PhysShapeCircle
-            radius: 0.2
-          density: 20
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.2,-0.2,0.2,0.2"
+          density: 30
           mask:
             - ItemMask
     - type: BluespacePlantTeleport


### PR DESCRIPTION
## About the PR

Parent PR for the bluespace crops effort. Ships the two components, the system, and a throwaway test entity that the bluespace tomato (#699) and bluespace banana (#700) will both build on. Closes the trait scaffolding half of #697.

The actual blink behaviour (range, tile filter, VFX, audio, predicted RNG) reuses `BluespaceBlinkSystem.TryBlink` so plant teleports look and feel identical to crushing a crystal in hand or drinking bluespace dust.

## Why / Balance

SS13 reference (`russstation/code/datums/plant_genes/genes_misc.dm`):

- `/datum/plant_gene/trait/teleport` ("Bluespace Activity"): on `slip_teleport`, the slipper teleports up to `potency / 10` tiles. On `squash_teleport` (the fruit lands a hit), the target teleports.
- `/datum/plant_gene/trait/backfire/bluespace`: 50% chance per use that the holder fumbles, gets teleported, and the fruit is destroyed.

The fork ships flat values rather than potency-driven ones because there's no plant-genetics layer behind these yet. 5 tiles is a reasonable mid-potency stand-in (between the 8-tile crystal blink and the 5-tile reagent metabolism blink). 50% backfire matches the SS13 gene exactly.

## Technical details

### Components

- `Content.Shared/RussStation/Bluespace/Components/BluespacePlantTeleportComponent.cs` (new, networked):
  - `BlinkRange` (default `BluespaceConstants.PlantBlinkRange = 5`).
  - `OnSlip`, `OnThrowImpact` toggles. The banana peel will declare the component with `OnThrowImpact: false` (slip only), the tomato will keep both true.
- `Content.Shared/RussStation/Bluespace/Components/BluespacePlantBackfireComponent.cs` (new, networked):
  - `Probability` (default `BluespaceConstants.PlantBackfireProbability = 0.5`).
  - `BlinkRange` (defaults to `PlantBlinkRange` but is independently tunable for variants like the artificial tomato).

### System

- `Content.Shared/RussStation/Bluespace/EntitySystems/BluespacePlantTeleportSystem.cs` (new):
  - `ThrowDoHitEvent` on `BluespacePlantTeleportComponent`: filters to `MobStateComponent` targets, then calls `_blink.TryBlink(target, range)`.
  - `SlipEvent` on `BluespacePlantTeleportComponent`: blinks the slipper.
  - `UseInHandEvent` on `BluespacePlantBackfireComponent`: rolls the probability, on success pops the fumble message, blinks the user, and `QueueDel`s the fruit on the server.

### Test entity

`Resources/Prototypes/@RussStation/Entities/Objects/Specific/Bluespace/bluespace_test_plant.yml`: `BluespaceTestPlant` (suffix DEBUG) carries both components plus the canonical `Slippery` + `StepTrigger` + `SlipLayer` fixture pattern from `TrashBananaPeel`, so all three trigger paths can be exercised in admin without crop content. Removed by the bluespace tomato / banana PRs once they land.

### Constants

`BluespaceConstants.cs` gains `PlantBlinkRange = 5f` and `PlantBackfireProbability = 0.5f` next to the existing crystal and reagent constants.

### Locale

`bluespace-plant-backfire-self` and `bluespace-plant-backfire-others` for the fumble popup.

## Media

N/A.

## Breaking changes

None. New components on a new debug entity; the components live unused until the crop PRs attach them.

## Changelog

:cl:

- add: Bluespace plants now share a teleport behaviour: slipping on one, getting hit by a thrown one, or fumbling one in your hand can blink you a few tiles in a random direction with the same flash and sound as a crushed bluespace crystal. The bluespace tomato and bluespace banana PRs will plug into this.
