### PR TITLE
honksquad: feat: skillchip system Phase 1 framework

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
@@ -1,0 +1,243 @@
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Skillchips;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.RussStation.Skillchips;
+
+/// <summary>
+/// Tests that skillchip grants apply and revert symmetrically across install, remove,
+/// and brain-body transfer scenarios.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SharedSkillchipSystem))]
+public sealed class SkillchipGrantTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: skillchip
+  id: TestChipData
+  name: Test Chip
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: test_capability
+
+- type: entity
+  id: TestBrain
+  components:
+  - type: Brain
+  - type: Organ
+    category: Brain
+  - type: SkillchipHolder
+
+- type: entity
+  id: TestBody
+  components:
+  - type: Body
+";
+
+    /// <summary>
+    /// Installing a chip on a brain that is not inside a body should not crash,
+    /// and the chip should be recorded on the holder.
+    /// </summary>
+    [Test]
+    public async Task Install_WithoutBody_RecordsChipOnly()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            var installed = skillchips.TryInstall((brain, holder), "TestChipData");
+
+            Assert.That(installed, Is.True, "TryInstall should succeed with capacity available");
+            Assert.That(holder.ImplantedChips, Contains.Item(new ProtoId<SkillchipPrototype>("TestChipData")),
+                "Chip should be recorded in ImplantedChips");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Installing a chip then inserting the brain into a body should apply the capability tag.
+    /// </summary>
+    [Test]
+    public async Task BrainInserted_AppliesChipGrants()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var body = em.SpawnEntity("TestBody", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            skillchips.TryInstall((brain, holder), "TestChipData");
+
+            // Simulate surgery: insert organ into body container
+            var organContainer = containers.EnsureContainer<Container>(body, BodyComponent.ContainerID);
+            containers.Insert(brain, organContainer);
+
+            Assert.That(holder.CapabilityTags, Contains.Item("test_capability"),
+                "Capability tag should be active after brain is inserted into body");
+            Assert.That(skillchips.HasCapability(body, "test_capability"), Is.True,
+                "HasCapability should return true via the body lookup");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Removing a chip from a brain inside a body should revert the capability tag.
+    /// </summary>
+    [Test]
+    public async Task Remove_RevertsGrantSymmetrically()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var body = em.SpawnEntity("TestBody", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            skillchips.TryInstall((brain, holder), "TestChipData");
+            var organContainer = containers.EnsureContainer<Container>(body, BodyComponent.ContainerID);
+            containers.Insert(brain, organContainer);
+
+            Assert.That(holder.CapabilityTags, Contains.Item("test_capability"),
+                "Tag should be active before removal");
+
+            skillchips.TryRemove((brain, holder), "TestChipData");
+
+            Assert.That(holder.CapabilityTags, Does.Not.Contain("test_capability"),
+                "Tag should be removed after TryRemove");
+            Assert.That(skillchips.HasCapability(body, "test_capability"), Is.False,
+                "HasCapability should return false after chip removal");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Removing the brain from the body should revert active chip grants.
+    /// </summary>
+    [Test]
+    public async Task BrainRemoved_RevertsGrants()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var body = em.SpawnEntity("TestBody", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            skillchips.TryInstall((brain, holder), "TestChipData");
+            var organContainer = containers.EnsureContainer<Container>(body, BodyComponent.ContainerID);
+            containers.Insert(brain, organContainer);
+
+            Assert.That(holder.CapabilityTags, Contains.Item("test_capability"));
+
+            containers.Remove(brain, organContainer);
+
+            Assert.That(holder.CapabilityTags, Does.Not.Contain("test_capability"),
+                "Tag should be reverted when brain is removed from body");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Transferring a chipped brain to a new body should carry the grants across.
+    /// The old body loses the capability and the new body gains it.
+    /// </summary>
+    [Test]
+    public async Task BrainTransfer_CarriesGrantsToNewBody()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var bodyA = em.SpawnEntity("TestBody", mapData.GridCoords);
+            var bodyB = em.SpawnEntity("TestBody", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            skillchips.TryInstall((brain, holder), "TestChipData");
+
+            var containerA = containers.EnsureContainer<Container>(bodyA, BodyComponent.ContainerID);
+            containers.Insert(brain, containerA);
+            Assert.That(skillchips.HasCapability(bodyA, "test_capability"), Is.True);
+
+            // Transplant brain to body B
+            containers.Remove(brain, containerA);
+            var containerB = containers.EnsureContainer<Container>(bodyB, BodyComponent.ContainerID);
+            containers.Insert(brain, containerB);
+
+            Assert.That(skillchips.HasCapability(bodyA, "test_capability"), Is.False,
+                "Old body should lose capability after brain removal");
+            Assert.That(skillchips.HasCapability(bodyB, "test_capability"), Is.True,
+                "New body should gain capability after brain insertion");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Installing the same chip twice should return false and not double-apply.
+    /// </summary>
+    [Test]
+    public async Task Install_Duplicate_ReturnsFalse()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipData"), Is.True);
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipData"), Is.False,
+                "Second install of the same chip should fail");
+            Assert.That(holder.ImplantedChips.Count, Is.EqualTo(1),
+                "Only one entry should exist after duplicate install attempt");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Body;
 using Content.Shared.Body.Components;
+using Content.Shared.Emp;
 using Content.Shared.RussStation.Skillchips;
 using Content.Shared.RussStation.Skillchips.Systems;
 using Robust.Shared.Containers;
@@ -26,6 +27,14 @@ public sealed class SkillchipGrantTest
   - !type:CapabilityTagGrant
     tag: test_capability
 
+- type: skillchip
+  id: TestChipData2
+  name: Test Chip 2
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: test_capability_2
+
 - type: entity
   id: TestBrain
   components:
@@ -33,6 +42,15 @@ public sealed class SkillchipGrantTest
   - type: Organ
     category: Brain
   - type: SkillchipHolder
+
+- type: entity
+  id: TestBrainSmall
+  components:
+  - type: Brain
+  - type: Organ
+    category: Brain
+  - type: SkillchipHolder
+    maxCapacity: 1
 
 - type: entity
   id: TestBody
@@ -236,6 +254,73 @@ public sealed class SkillchipGrantTest
                 "Second install of the same chip should fail");
             Assert.That(holder.ImplantedChips.Count, Is.EqualTo(1),
                 "Only one entry should exist after duplicate install attempt");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Adding EmpDisabledComponent to a mob that has a chipped brain should revert grants,
+    /// and removing it should restore them.
+    /// </summary>
+    [Test]
+    public async Task Emp_RevertsAndRestoresGrants()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var body = em.SpawnEntity("TestBody", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            skillchips.TryInstall((brain, holder), "TestChipData");
+            var organContainer = containers.EnsureContainer<Container>(body, BodyComponent.ContainerID);
+            containers.Insert(brain, organContainer);
+
+            Assert.That(holder.CapabilityTags, Contains.Item("test_capability"),
+                "Tag should be active before EMP");
+
+            em.AddComponent<EmpDisabledComponent>(body);
+
+            Assert.That(holder.CapabilityTags, Does.Not.Contain("test_capability"),
+                "Tag should be reverted while EMP-disabled");
+
+            em.RemoveComponent<EmpDisabledComponent>(body);
+
+            Assert.That(holder.CapabilityTags, Contains.Item("test_capability"),
+                "Tag should be restored after EMP clears");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Installing beyond max capacity should be rejected.
+    /// </summary>
+    [Test]
+    public async Task Install_OverCapacity_ReturnsFalse()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrainSmall", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipData"), Is.True,
+                "First chip should install within capacity");
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipData2"), Is.False,
+                "Second chip should be rejected when at capacity");
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
@@ -1,7 +1,41 @@
+using Content.Shared.Emp;
+using Content.Shared.RussStation.Skillchips;
 using Content.Shared.RussStation.Skillchips.Systems;
 
 namespace Content.Server.RussStation.Skillchips;
 
 public sealed class SkillchipSystem : SharedSkillchipSystem
 {
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // EmpDisabledComponent is added to the mob entity when hit by an EMP pulse.
+        // Walk the mob's direct children to find any implanted brain and revert/restore grants.
+        SubscribeLocalEvent<EmpDisabledComponent, ComponentInit>(OnEmpInit);
+        SubscribeLocalEvent<EmpDisabledComponent, ComponentRemove>(OnEmpRemove);
+    }
+
+    private void OnEmpInit(Entity<EmpDisabledComponent> mob, ref ComponentInit args)
+    {
+        ForEachImplantedBrain(mob, (brain, holder) => RevertAllGrants((brain, holder), mob));
+    }
+
+    private void OnEmpRemove(Entity<EmpDisabledComponent> mob, ref ComponentRemove args)
+    {
+        if (LifeStage(mob) >= EntityLifeStage.Terminating)
+            return;
+
+        ForEachImplantedBrain(mob, (brain, holder) => ApplyAllGrants((brain, holder), mob));
+    }
+
+    private void ForEachImplantedBrain(EntityUid mob, Action<EntityUid, SkillchipHolderComponent> action)
+    {
+        var enumerator = Transform(mob).ChildEnumerator;
+        while (enumerator.MoveNext(out var child))
+        {
+            if (TryComp<SkillchipHolderComponent>(child, out var holder))
+                action(child, holder);
+        }
+    }
 }

--- a/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
@@ -12,8 +12,10 @@ public sealed class SkillchipSystem : SharedSkillchipSystem
 
         // EmpDisabledComponent is added to the mob entity when hit by an EMP pulse.
         // Walk the mob's direct children to find any implanted brain and revert/restore grants.
+        // Use EmpDisabledRemovedEvent instead of ComponentRemove: SharedEmpSystem already owns
+        // that subscription and the engine forbids duplicate (component, event) subscriptions.
         SubscribeLocalEvent<EmpDisabledComponent, ComponentInit>(OnEmpInit);
-        SubscribeLocalEvent<EmpDisabledComponent, ComponentRemove>(OnEmpRemove);
+        SubscribeLocalEvent<EmpDisabledRemovedEvent>(OnEmpRemove);
     }
 
     private void OnEmpInit(Entity<EmpDisabledComponent> mob, ref ComponentInit args)
@@ -21,7 +23,7 @@ public sealed class SkillchipSystem : SharedSkillchipSystem
         ForEachImplantedBrain(mob, (brain, holder) => RevertAllGrants((brain, holder), mob));
     }
 
-    private void OnEmpRemove(Entity<EmpDisabledComponent> mob, ref ComponentRemove args)
+    private void OnEmpRemove(EntityUid mob, ref EmpDisabledRemovedEvent args)
     {
         if (LifeStage(mob) >= EntityLifeStage.Terminating)
             return;

--- a/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Body;
 using Content.Shared.Emp;
 using Content.Shared.RussStation.Skillchips;
 using Content.Shared.RussStation.Skillchips.Systems;
@@ -10,12 +11,13 @@ public sealed class SkillchipSystem : SharedSkillchipSystem
     {
         base.Initialize();
 
-        // EmpDisabledComponent is added to the mob entity when hit by an EMP pulse.
-        // Walk the mob's direct children to find any implanted brain and revert/restore grants.
-        // Use EmpDisabledRemovedEvent instead of ComponentRemove: SharedEmpSystem already owns
-        // that subscription and the engine forbids duplicate (component, event) subscriptions.
+        // EmpDisabledComponent is added to the mob when hit by an EMP, so the disable side can
+        // filter on it (ComponentInit fires before the component is fully attached, but the
+        // entity uid is available). For the remove side, the directed EmpDisabledRemovedEvent
+        // fires after the engine has torn the component back off, so we filter on BodyComponent
+        // (always present on the mob) to receive the directed dispatch.
         SubscribeLocalEvent<EmpDisabledComponent, ComponentInit>(OnEmpInit);
-        SubscribeLocalEvent<EmpDisabledRemovedEvent>(OnEmpRemove);
+        SubscribeLocalEvent<BodyComponent, EmpDisabledRemovedEvent>(OnEmpRemove);
     }
 
     private void OnEmpInit(Entity<EmpDisabledComponent> mob, ref ComponentInit args)
@@ -23,7 +25,7 @@ public sealed class SkillchipSystem : SharedSkillchipSystem
         ForEachImplantedBrain(mob, (brain, holder) => RevertAllGrants((brain, holder), mob));
     }
 
-    private void OnEmpRemove(EntityUid mob, ref EmpDisabledRemovedEvent args)
+    private void OnEmpRemove(Entity<BodyComponent> mob, ref EmpDisabledRemovedEvent args)
     {
         if (LifeStage(mob) >= EntityLifeStage.Terminating)
             return;

--- a/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.RussStation.Skillchips.Systems;
+
+namespace Content.Server.RussStation.Skillchips;
+
+public sealed class SkillchipSystem : SharedSkillchipSystem
+{
+}

--- a/Content.Shared/RussStation/Skillchips/SkillchipComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Skillchips;
+
+/// <summary>
+/// Marks an entity as a skillchip item that can be implanted into a brain.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedSkillchipSystem))]
+public sealed partial class SkillchipComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<SkillchipPrototype> ChipProto;
+}

--- a/Content.Shared/RussStation/Skillchips/SkillchipGrant.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipGrant.cs
@@ -1,0 +1,49 @@
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.Skillchips;
+
+/// <summary>
+/// Base class for all grants a skillchip can apply to the mob it is implanted in.
+/// Subclass and implement Apply/Revert to add new grant types.
+/// </summary>
+[ImplicitDataDefinitionForInheritors, Serializable, NetSerializable]
+public abstract partial class SkillchipGrant
+{
+    public abstract void Apply(EntityUid mob, EntityUid brain, SharedSkillchipSystem system);
+    public abstract void Revert(EntityUid mob, EntityUid brain, SharedSkillchipSystem system);
+}
+
+/// <summary>
+/// Adds a prototyped action to the mob's action bar.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class ActionGrant : SkillchipGrant
+{
+    [DataField(required: true)]
+    public EntProtoId ActionProto;
+
+    public override void Apply(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.ApplyActionGrant(mob, brain, ActionProto);
+
+    public override void Revert(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.RevertActionGrant(mob, brain, ActionProto);
+}
+
+/// <summary>
+/// Registers a capability tag on the holder's SkillchipHolderComponent.
+/// Other systems query it via SkillchipSystem.HasCapability(mob, tag).
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class CapabilityTagGrant : SkillchipGrant
+{
+    [DataField(required: true)]
+    public string Tag = string.Empty;
+
+    public override void Apply(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.ApplyCapabilityTag(brain, Tag);
+
+    public override void Revert(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.RevertCapabilityTag(brain, Tag);
+}

--- a/Content.Shared/RussStation/Skillchips/SkillchipGrant.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipGrant.cs
@@ -1,6 +1,5 @@
 using Content.Shared.RussStation.Skillchips.Systems;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.RussStation.Skillchips;
 
@@ -8,7 +7,7 @@ namespace Content.Shared.RussStation.Skillchips;
 /// Base class for all grants a skillchip can apply to the mob it is implanted in.
 /// Subclass and implement Apply/Revert to add new grant types.
 /// </summary>
-[ImplicitDataDefinitionForInheritors, Serializable, NetSerializable]
+[ImplicitDataDefinitionForInheritors]
 public abstract partial class SkillchipGrant
 {
     public abstract void Apply(EntityUid mob, EntityUid brain, SharedSkillchipSystem system);
@@ -18,7 +17,6 @@ public abstract partial class SkillchipGrant
 /// <summary>
 /// Adds a prototyped action to the mob's action bar.
 /// </summary>
-[Serializable, NetSerializable]
 public sealed partial class ActionGrant : SkillchipGrant
 {
     [DataField(required: true)]
@@ -35,7 +33,6 @@ public sealed partial class ActionGrant : SkillchipGrant
 /// Registers a capability tag on the holder's SkillchipHolderComponent.
 /// Other systems query it via SkillchipSystem.HasCapability(mob, tag).
 /// </summary>
-[Serializable, NetSerializable]
 public sealed partial class CapabilityTagGrant : SkillchipGrant
 {
     [DataField(required: true)]

--- a/Content.Shared/RussStation/Skillchips/SkillchipHolderComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipHolderComponent.cs
@@ -1,0 +1,40 @@
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Skillchips;
+
+/// <summary>
+/// Placed on brain entities. Tracks which skillchips are implanted and which capability
+/// tags are currently active. Lives on the brain so it travels with body transfers and cloning.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedSkillchipSystem))]
+public sealed partial class SkillchipHolderComponent : Component
+{
+    /// <summary>
+    /// Chips currently implanted in this brain.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<SkillchipPrototype>> ImplantedChips = new();
+
+    /// <summary>
+    /// Action entity UIDs spawned by chip grants, keyed by chip proto + action proto.
+    /// Populated at runtime; not serialized.
+    /// </summary>
+    [DataField]
+    public Dictionary<string, EntityUid> ActionEntities = new();
+
+    /// <summary>
+    /// Capability tags currently active on this brain.
+    /// Systems query these via SharedSkillchipSystem.HasCapability.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> CapabilityTags = new();
+
+    /// <summary>
+    /// Maximum total capacity cost of implanted chips.
+    /// </summary>
+    [DataField]
+    public int MaxCapacity = SkillchipsConstants.DefaultMaxCapacity;
+}

--- a/Content.Shared/RussStation/Skillchips/SkillchipHolderComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipHolderComponent.cs
@@ -20,9 +20,8 @@ public sealed partial class SkillchipHolderComponent : Component
 
     /// <summary>
     /// Action entity UIDs spawned by chip grants, keyed by chip proto + action proto.
-    /// Populated at runtime; not serialized.
+    /// Runtime-only; EntityUid has no stable YAML representation.
     /// </summary>
-    [DataField]
     public Dictionary<string, EntityUid> ActionEntities = new();
 
     /// <summary>

--- a/Content.Shared/RussStation/Skillchips/SkillchipPrototype.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipPrototype.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Skillchips;
+
+[Prototype]
+public sealed partial class SkillchipPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public string Name = string.Empty;
+
+    /// <summary>
+    /// How many brain capacity slots this chip occupies.
+    /// </summary>
+    [DataField]
+    public int CapacityCost = SkillchipsConstants.DefaultCapacityCost;
+
+    /// <summary>
+    /// Grants applied to the mob when this chip is active.
+    /// </summary>
+    [DataField]
+    public List<SkillchipGrant> Grants = new();
+}

--- a/Content.Shared/RussStation/Skillchips/SkillchipsConstants.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipsConstants.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.RussStation.Skillchips;
+
+public static class SkillchipsConstants
+{
+    public const int DefaultMaxCapacity = 3;
+    public const int DefaultCapacityCost = 1;
+}

--- a/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
@@ -22,7 +22,7 @@ public abstract class SharedSkillchipSystem : EntitySystem
 
     private void OnBrainInserted(Entity<SkillchipHolderComponent> brain, ref OrganGotInsertedEvent args)
     {
-        ApplyAll(brain, args.Target);
+        ApplyAllGrants(brain, args.Target);
     }
 
     private void OnBrainRemoved(Entity<SkillchipHolderComponent> brain, ref OrganGotRemovedEvent args)
@@ -30,7 +30,7 @@ public abstract class SharedSkillchipSystem : EntitySystem
         if (LifeStage(args.Target) >= EntityLifeStage.Terminating)
             return;
 
-        RevertAll(brain, args.Target);
+        RevertAllGrants(brain, args.Target);
     }
 
     // ── Install / Remove ─────────────────────────────────────────────────────
@@ -51,7 +51,7 @@ public abstract class SharedSkillchipSystem : EntitySystem
         Dirty(brain);
 
         if (GetBody(brain) is { } body)
-            ApplyChip(brain, body, prototype);
+            ApplyChipGrants(brain, body, prototype);
 
         return true;
     }
@@ -67,7 +67,7 @@ public abstract class SharedSkillchipSystem : EntitySystem
         Dirty(brain);
 
         if (GetBody(brain) is { } body)
-            RevertChip(brain, body, _proto.Index(chipProto));
+            RevertChipGrants(brain, body, _proto.Index(chipProto));
 
         return true;
     }
@@ -149,25 +149,25 @@ public abstract class SharedSkillchipSystem : EntitySystem
 
     // ── Internals ────────────────────────────────────────────────────────────
 
-    private void ApplyAll(Entity<SkillchipHolderComponent> brain, EntityUid mob)
+    protected void ApplyAllGrants(Entity<SkillchipHolderComponent> brain, EntityUid mob)
     {
         foreach (var chipProto in brain.Comp.ImplantedChips)
-            ApplyChip(brain, mob, _proto.Index(chipProto));
+            ApplyChipGrants(brain, mob, _proto.Index(chipProto));
     }
 
-    private void RevertAll(Entity<SkillchipHolderComponent> brain, EntityUid mob)
+    protected void RevertAllGrants(Entity<SkillchipHolderComponent> brain, EntityUid mob)
     {
         foreach (var chipProto in brain.Comp.ImplantedChips)
-            RevertChip(brain, mob, _proto.Index(chipProto));
+            RevertChipGrants(brain, mob, _proto.Index(chipProto));
     }
 
-    private void ApplyChip(Entity<SkillchipHolderComponent> brain, EntityUid mob, SkillchipPrototype prototype)
+    private void ApplyChipGrants(Entity<SkillchipHolderComponent> brain, EntityUid mob, SkillchipPrototype prototype)
     {
         foreach (var grant in prototype.Grants)
             grant.Apply(mob, brain, this);
     }
 
-    private void RevertChip(Entity<SkillchipHolderComponent> brain, EntityUid mob, SkillchipPrototype prototype)
+    private void RevertChipGrants(Entity<SkillchipHolderComponent> brain, EntityUid mob, SkillchipPrototype prototype)
     {
         foreach (var grant in prototype.Grants)
             grant.Revert(mob, brain, this);

--- a/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Actions;
-using Content.Shared.Body.Components;
 using Content.Shared.Body;
 using Robust.Shared.Prototypes;
 
@@ -47,11 +46,13 @@ public abstract class SharedSkillchipSystem : EntitySystem
         if (UsedCapacity(brain.Comp) + prototype.CapacityCost > brain.Comp.MaxCapacity)
             return false;
 
-        brain.Comp.ImplantedChips.Add(chipProto);
-        Dirty(brain);
-
+        // Apply grants first so a thrown grant leaves the holder untouched. Recording the chip
+        // last keeps capacity accounting consistent with what is actually active on the mob.
         if (GetBody(brain) is { } body)
             ApplyChipGrants(brain, body, prototype);
+
+        brain.Comp.ImplantedChips.Add(chipProto);
+        Dirty(brain);
 
         return true;
     }
@@ -183,7 +184,6 @@ public abstract class SharedSkillchipSystem : EntitySystem
 
     private EntityUid? GetBody(Entity<SkillchipHolderComponent> brain)
     {
-        var parent = Transform(brain).ParentUid;
-        return parent.IsValid() && HasComp<BodyComponent>(parent) ? parent : null;
+        return TryComp<OrganComponent>(brain, out var organ) ? organ.Body : null;
     }
 }

--- a/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
@@ -1,0 +1,189 @@
+using Content.Shared.Actions;
+using Content.Shared.Body.Components;
+using Content.Shared.Body;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Skillchips.Systems;
+
+public abstract class SharedSkillchipSystem : EntitySystem
+{
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SkillchipHolderComponent, OrganGotInsertedEvent>(OnBrainInserted);
+        SubscribeLocalEvent<SkillchipHolderComponent, OrganGotRemovedEvent>(OnBrainRemoved);
+    }
+
+    // ── Brain lifecycle ──────────────────────────────────────────────────────
+
+    private void OnBrainInserted(Entity<SkillchipHolderComponent> brain, ref OrganGotInsertedEvent args)
+    {
+        ApplyAll(brain, args.Target);
+    }
+
+    private void OnBrainRemoved(Entity<SkillchipHolderComponent> brain, ref OrganGotRemovedEvent args)
+    {
+        if (LifeStage(args.Target) >= EntityLifeStage.Terminating)
+            return;
+
+        RevertAll(brain, args.Target);
+    }
+
+    // ── Install / Remove ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Installs a chip into the brain. Returns false if over capacity or already installed.
+    /// </summary>
+    public bool TryInstall(Entity<SkillchipHolderComponent> brain, ProtoId<SkillchipPrototype> chipProto)
+    {
+        if (brain.Comp.ImplantedChips.Contains(chipProto))
+            return false;
+
+        var prototype = _proto.Index(chipProto);
+        if (UsedCapacity(brain.Comp) + prototype.CapacityCost > brain.Comp.MaxCapacity)
+            return false;
+
+        brain.Comp.ImplantedChips.Add(chipProto);
+        Dirty(brain);
+
+        if (GetBody(brain) is { } body)
+            ApplyChip(brain, body, prototype);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a chip from the brain. Returns false if the chip is not installed.
+    /// </summary>
+    public bool TryRemove(Entity<SkillchipHolderComponent> brain, ProtoId<SkillchipPrototype> chipProto)
+    {
+        if (!brain.Comp.ImplantedChips.Remove(chipProto))
+            return false;
+
+        Dirty(brain);
+
+        if (GetBody(brain) is { } body)
+            RevertChip(brain, body, _proto.Index(chipProto));
+
+        return true;
+    }
+
+    // ── Capability query ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns true if the brain entity has the given capability tag active.
+    /// </summary>
+    public bool BrainHasCapability(EntityUid brain, string tag)
+    {
+        return TryComp<SkillchipHolderComponent>(brain, out var holder)
+               && holder.CapabilityTags.Contains(tag);
+    }
+
+    /// <summary>
+    /// Returns true if any SkillchipHolderComponent child of the mob has the given capability tag.
+    /// </summary>
+    public bool HasCapability(EntityUid mob, string tag)
+    {
+        var enumerator = Transform(mob).ChildEnumerator;
+        while (enumerator.MoveNext(out var child))
+        {
+            if (BrainHasCapability(child, tag))
+                return true;
+        }
+
+        return false;
+    }
+
+    // ── Grant application helpers (called by SkillchipGrant subclasses) ──────
+
+    public void ApplyActionGrant(EntityUid mob, EntityUid brain, EntProtoId actionProto)
+    {
+        if (!TryComp<SkillchipHolderComponent>(brain, out var holder))
+            return;
+
+        var key = $"{brain}:{actionProto}";
+        if (holder.ActionEntities.ContainsKey(key))
+            return;
+
+        EntityUid? actionEnt = null;
+        _actions.AddAction(mob, ref actionEnt, actionProto);
+
+        if (actionEnt != null)
+            holder.ActionEntities[key] = actionEnt.Value;
+    }
+
+    public void RevertActionGrant(EntityUid mob, EntityUid brain, EntProtoId actionProto)
+    {
+        if (!TryComp<SkillchipHolderComponent>(brain, out var holder))
+            return;
+
+        var key = $"{brain}:{actionProto}";
+        if (!holder.ActionEntities.TryGetValue(key, out var actionEnt))
+            return;
+
+        _actions.RemoveAction(mob, actionEnt);
+        holder.ActionEntities.Remove(key);
+    }
+
+    public void ApplyCapabilityTag(EntityUid brain, string tag)
+    {
+        if (!TryComp<SkillchipHolderComponent>(brain, out var holder))
+            return;
+
+        holder.CapabilityTags.Add(tag);
+        Dirty(brain, holder);
+    }
+
+    public void RevertCapabilityTag(EntityUid brain, string tag)
+    {
+        if (!TryComp<SkillchipHolderComponent>(brain, out var holder))
+            return;
+
+        holder.CapabilityTags.Remove(tag);
+        Dirty(brain, holder);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    private void ApplyAll(Entity<SkillchipHolderComponent> brain, EntityUid mob)
+    {
+        foreach (var chipProto in brain.Comp.ImplantedChips)
+            ApplyChip(brain, mob, _proto.Index(chipProto));
+    }
+
+    private void RevertAll(Entity<SkillchipHolderComponent> brain, EntityUid mob)
+    {
+        foreach (var chipProto in brain.Comp.ImplantedChips)
+            RevertChip(brain, mob, _proto.Index(chipProto));
+    }
+
+    private void ApplyChip(Entity<SkillchipHolderComponent> brain, EntityUid mob, SkillchipPrototype prototype)
+    {
+        foreach (var grant in prototype.Grants)
+            grant.Apply(mob, brain, this);
+    }
+
+    private void RevertChip(Entity<SkillchipHolderComponent> brain, EntityUid mob, SkillchipPrototype prototype)
+    {
+        foreach (var grant in prototype.Grants)
+            grant.Revert(mob, brain, this);
+    }
+
+    private int UsedCapacity(SkillchipHolderComponent holder)
+    {
+        var total = 0;
+        foreach (var chipProto in holder.ImplantedChips)
+            total += _proto.Index(chipProto).CapacityCost;
+        return total;
+    }
+
+    private EntityUid? GetBody(Entity<SkillchipHolderComponent> brain)
+    {
+        var parent = Transform(brain).ParentUid;
+        return parent.IsValid() && HasComp<BodyComponent>(parent) ? parent : null;
+    }
+}

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
@@ -1,0 +1,13 @@
+# Skillchip entity items -- commercial tier (weak, widely available)
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipBureaucraticFiling
+  name: bureaucratic filing chip
+  description: A small neural interface chip. Implanting it grants the user comprehensive knowledge of station filing procedures.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/bureaucracy.rsi
+    state: paper
+  - type: Skillchip
+    chipProto: SkillchipBureaucraticFilingData

--- a/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
@@ -1,0 +1,9 @@
+# Skillchip data prototypes -- commercial tier
+
+- type: skillchip
+  id: SkillchipBureaucraticFilingData
+  name: Bureaucratic Filing
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: bureaucratic_filing

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -259,6 +259,9 @@
     entries:
       Burger: Brain
       Taco: Brain
+  # HONK START - skillchip system: holder lives on brain so it survives body transfer/cloning
+  - type: SkillchipHolder
+  # HONK END
 
 - type: entity
   parent: OrganBase


### PR DESCRIPTION
## About the PR

Adds the core skillchip infrastructure for #293 together with its EMP and capacity layer. The framework is the component and system code, YAML prototype definitions, brain lifecycle wiring, and integration tests. On top of that: capacity enforcement (each chip has a cost, each brain has a cap) and EMP suppression (an EMP disables a brain's installed chips and their grants until the disable clears).

## Why / Balance

SS14 has no numeric skill system to port from TGstation directly. Chips grant capabilities declaratively via three grant types: ActionGrant (adds an action to the mob's bar), CapabilityTagGrant (registers a string tag other systems query), and an abstract base for exotic grants. The holder component lives on the brain entity rather than the mob so it survives body transfers and cloning without special-casing. Capacity stops a brain stacking unlimited chips; EMP suppression gives them a counterplay.

Part of #293 (framework, capacity, and EMP suppression).

## Technical details

- `SkillchipHolderComponent` (on brain entities) tracks implanted chips, active capability tags, and spawned action entity UIDs. Brain-level placement is intentional: the brain moves with body swaps and cloning, so all grants travel with it automatically.
- `SkillchipComponent` marks chip item entities and points to a `SkillchipPrototype`.
- `SkillchipPrototype` is a YAML-driven data prototype listing grants and capacity cost.
- `SharedSkillchipSystem` handles install/remove and subscribes to `OrganGotInsertedEvent` / `OrganGotRemovedEvent` to apply/revert grants as the brain enters and leaves a body. Every Apply has a matching Revert; grants cannot enter a half-applied state.
- Capacity enforcement: `TryInstall` rejects a chip when `UsedCapacity` plus `CapacityCost` exceeds the holder's `MaxCapacity`.
- EMP suppression: an EMP disables a brain's installed chips and reverts their grants, restoring them when the disable ends. Keyed off the EMP disable lifecycle rather than component removal.
- Three grant types: `ActionGrant`, `CapabilityTagGrant`, abstract `SkillchipGrant` base.
- `SkillchipsConstants.cs` holds default capacity values to satisfy HONK0016.
- `Resources/Prototypes/Body/base_organs.yml`: `SkillchipHolder` added to `OrganBaseBrain` with HONK markers (single upstream touch).
- `Resources/Prototypes/@RussStation/Skillchips/commercial.yml` plus matching entity: one proof-of-concept chip (bureaucratic filing) that grants a `bureaucratic_filing` capability tag. Exercises the full grant path, intentionally useless.
- 8 integration tests in `SkillchipGrantTest.cs`: install without body, apply on brain insertion, revert on removal, brain transplant carry-across, duplicate install guard, capacity cap, and EMP suppression.

## Media

Framework only, no in-game visuals.

## Breaking changes

None.