### PR TITLE
honksquad: feat: Basketsoft 3000 skillchip (underwater basketweaving)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
@@ -11,3 +11,15 @@
     state: paper
   - type: Skillchip
     chipProto: SkillchipBureaucraticFilingData
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipBasketweaving
+  name: Basketsoft 3000 skillchip
+  description: A small neural interface chip. Underwater edition.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/bureaucracy.rsi
+    state: paper
+  - type: Skillchip
+    chipProto: SkillchipBasketweavingData

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
@@ -23,3 +23,15 @@
     state: paper
   - type: Skillchip
     chipProto: SkillchipBasketweavingData
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipWineTasting
+  name: WINE skillchip
+  description: A small neural interface chip. Wine.Is.Not.Equal version 5.
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/winebottle.rsi
+    state: icon
+  - type: Skillchip
+    chipProto: SkillchipWineTastingData

--- a/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
@@ -7,3 +7,11 @@
   grants:
   - !type:CapabilityTagGrant
     tag: bureaucratic_filing
+
+- type: skillchip
+  id: SkillchipBasketweavingData
+  name: Underwater Basketweaving
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: underwater_basketweaving

--- a/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
@@ -15,3 +15,11 @@
   grants:
   - !type:CapabilityTagGrant
     tag: underwater_basketweaving
+
+- type: skillchip
+  id: SkillchipWineTastingData
+  name: Wine Tasting
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: wine_tasting


### PR DESCRIPTION
## About the PR

Adds two flavour skillchips to the commercial tier: Basketsoft 3000 (`underwater_basketweaving`) and WINE / Wine.Is.Not.Equal v5 (`wine_tasting`). Each grants a capability tag other systems can check. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Both are novelty chips with no combat or mechanical advantage. They are cheap and widely available, and let other systems flag players with a trained palate or a useless party trick (bartender banter, examine text, test targets for capability-tag queries).

## Technical details

YAML only, no C# changes.

- `SkillchipBasketweavingData` and `SkillchipWineTastingData` prototypes in `Resources/Prototypes/@RussStation/Skillchips/commercial.yml`
- `SkillchipBasketweaving` and `SkillchipWineTasting` entities in `Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml`
- Both use `CapabilityTagGrant` (`underwater_basketweaving`, `wine_tasting`)
- WINE entity sprite: `Objects/Consumable/Drinks/winebottle.rsi` `icon` state

## Media

No visual changes.

## Breaking changes

None.

## Changelog

:cl:
- add: Basketsoft 3000 skillchip grants underwater basketweaving knowledge when implanted