### PR TITLE
honksquad: feat: WINE skillchip (wine tasting)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
@@ -23,3 +23,15 @@
     state: paper
   - type: Skillchip
     chipProto: SkillchipBasketweavingData
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipWineTasting
+  name: WINE skillchip
+  description: A small neural interface chip. Wine.Is.Not.Equal version 5.
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/winebottle.rsi
+    state: icon
+  - type: Skillchip
+    chipProto: SkillchipWineTastingData

--- a/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
@@ -15,3 +15,11 @@
   grants:
   - !type:CapabilityTagGrant
     tag: underwater_basketweaving
+
+- type: skillchip
+  id: SkillchipWineTastingData
+  name: Wine Tasting
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: wine_tasting


### PR DESCRIPTION
## About the PR

Adds the WINE skillchip (Wine.Is.Not.Equal v5), granting the `wine_tasting` capability tag. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

A flavour chip for social and culinary roleplay. Lets other systems distinguish players with trained palates (bartender banter, examine text, etc.) without any mechanical advantage.

## Technical details

- `SkillchipWineTastingData` prototype in `Resources/Prototypes/@RussStation/Skillchips/commercial.yml`
- `SkillchipWineTasting` entity in `Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml`
- Uses `CapabilityTagGrant` with tag `wine_tasting`
- Sprite: `Objects/Consumable/Drinks/winebottle.rsi` `icon` state

## Media

No visual changes.

## Requirements

- [x] I have read and am following the [Contributing Guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added/updated relevant YAML prototypes and locale strings
- [x] No C# changes; YAML only

## Breaking changes

None.

:cl:
- add: WINE skillchip grants wine tasting knowledge when implanted