### PR TITLE
honksquad: feat: N16H7M4R3 skillchip (lightbulb removing)

### DIFF
--- a/Content.Shared/RussStation/Skillchips/Consumers/LightbulbRemovingSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/LightbulbRemovingSystem.cs
@@ -1,0 +1,49 @@
+using Content.Shared.Body;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Light.Components;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Skillchips.Systems;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Burn-suppression for the N16H7M4R3 skillchip (<c>lightbulb_removing</c> capability).
+/// Zeroes the heat damage <see cref="DamageOnInteractSystem"/> deals when a chip
+/// holder grabs a lit bulb. We gate on the origin entity being a powered light so
+/// other <c>DamageOnInteract</c> sources (hot produce, heat anomalies, strobe
+/// lights) still burn as normal. Lives in shared so the client also zeroes the
+/// predicted damage; otherwise client-side <c>DamageOnInteractSystem</c> still
+/// predicts the burn popup and sound even though the server applies no damage.
+/// SS13 parallel: TRAIT_LIGHTBULB_REMOVER on /obj/machinery/light handling.
+/// </summary>
+public sealed class LightbulbRemovingSystem : EntitySystem
+{
+    public const string LightbulbRemovingTag = "lightbulb_removing";
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // BodyComponent anchors the subscription on chip-eligible mobs. DamageModifyEvent
+        // runs before the damage is applied, so zeroing args.Damage here also nukes the
+        // popup / sound / paralyze branch in DamageOnInteractSystem (it only fires when
+        // totalDamage.AnyPositive() after the return from ChangeDamage).
+        SubscribeLocalEvent<BodyComponent, DamageModifyEvent>(OnDamageModify);
+    }
+
+    private void OnDamageModify(EntityUid mob, BodyComponent _, DamageModifyEvent args)
+    {
+        if (args.Origin is not { } origin || !HasComp<PoweredLightComponent>(origin))
+            return;
+
+        if (!_skillchip.HasCapability(mob, LightbulbRemovingTag))
+            return;
+
+        args.Damage = new DamageSpecifier();
+        _popup.PopupClient(Loc.GetString("skillchip-lightbulb-removing-shrug"), mob, mob);
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -1,3 +1,4 @@
 guide-entry-skillchips = Skillchips
 guide-entry-skillchip-station = Skillchip Station
 guide-entry-skillchip-hedge3 = Hedge 3
+guide-entry-skillchip-lightbulb = N16H7M4R3

--- a/Resources/Locale/en-US/@RussStation/skillchips/lightbulb_removing.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/lightbulb_removing.ftl
@@ -1,0 +1,1 @@
+skillchip-lightbulb-removing-shrug = The bulb is hot, but your fingers barely register it.

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
@@ -47,3 +47,15 @@
     state: skillchip
   - type: Skillchip
     chipProto: SkillchipHedgetrimmingData
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipLightbulbRemoving
+  name: N16H7M4R3 skillchip
+  description: A small neural interface chip. Stop failing to take out lightbulbs today, no gloves needed!
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipLightbulbRemovingData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -6,6 +6,7 @@
   children:
   - SkillchipStation
   - SkillchipHedge3
+  - SkillchipLightbulb
 
 - type: guideEntry
   id: SkillchipStation
@@ -16,3 +17,8 @@
   id: SkillchipHedge3
   name: guide-entry-skillchip-hedge3
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipHedge3.xml"
+
+- type: guideEntry
+  id: SkillchipLightbulb
+  name: guide-entry-skillchip-lightbulb
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
@@ -31,3 +31,11 @@
   grants:
   - !type:CapabilityTagGrant
     tag: hedgetrimming
+
+- type: skillchip
+  id: SkillchipLightbulbRemovingData
+  name: Lightbulb Removing
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: lightbulb_removing

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml
@@ -1,18 +1,14 @@
 <Document>
 # N16H7M4R3
 
-Stop failing to take out lightbulbs today, no gloves needed. With the chip installed, hot lightbulbs come out clean instead of burning your hand.
+Stop failing to take out lightbulbs today, no gloves needed!
 
 <Box>
 <GuideEntityEmbed Entity="SkillchipLightbulbRemoving"/>
 </Box>
 
 ## Using it
-- Click a [color=#a4885c]lit or recently-lit bulb[/color] with an empty hand.
-- The bulb comes out into your hand without a burn.
+1. Click a [color=#a4885c]lit bulb[/color] with an empty hand.\n2. The bulb comes out without burning you.
 
-[color=#a4885c]Quality of life.[/color] Without the chip the same grab on a hot bulb [color=#a4885c]burns[/color] you unless you are wearing insulated gloves.
-
-## Notes
-The bulb itself is unchanged. Cold bulbs were always safe to remove bare-handed.
+[color=#a4885c]Quality of life.[/color] Without the chip the same grab [color=#a4885c]burns[/color] you unless you are wearing gloves.
 </Document>

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml
@@ -1,0 +1,18 @@
+<Document>
+# N16H7M4R3
+
+Stop failing to take out lightbulbs today, no gloves needed. With the chip installed, hot lightbulbs come out clean instead of burning your hand.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipLightbulbRemoving"/>
+</Box>
+
+## Using it
+- Click a [color=#a4885c]lit or recently-lit bulb[/color] with an empty hand.
+- The bulb comes out into your hand without a burn.
+
+[color=#a4885c]Quality of life.[/color] Without the chip the same grab on a hot bulb [color=#a4885c]burns[/color] you unless you are wearing insulated gloves.
+
+## Notes
+The bulb itself is unchanged. Cold bulbs were always safe to remove bare-handed.
+</Document>


### PR DESCRIPTION
## About the PR

Adds the N16H7M4R3 skillchip and its consumer. With the chip implanted, grabbing a lit bulb with an empty hand no longer burns the user, while every other DamageOnInteract source still hurts. Ships the chip prototype, the physical chip item using the shared SS13 skillchip sprite, and a References guidebook entry. Part of the #703 catalog.

## Why / Balance

SS13's TRAIT_LIGHTBULB_REMOVER lets a holder pull hot bulbs without burning their hand, which would otherwise need gloves. The base glove already covers this with `Heat: 5` flat reduction (the average bulb is `Heat: 2`), so the chip is a glove-replacement for the slot rather than a meaningful damage shortcut. Part of #703.

## Technical details

- New `SkillchipLightbulbRemovingData` prototype with a `CapabilityTagGrant` on tag `lightbulb_removing` (`Resources/Prototypes/@RussStation/Skillchips/commercial.yml`).
- New `SkillchipLightbulbRemoving` entity using the shared `@RussStation/Objects/Misc/skillchip.rsi` art (`Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml`).
- New `LightbulbRemovingSystem` in `Content.Shared/RussStation/Skillchips/Consumers/`. Subscribes `DamageModifyEvent` on `BodyComponent`. When the damage `Origin` has `PoweredLightComponent` and the user `HasCapability("lightbulb_removing")`, it zeroes `args.Damage` and pops a client-predicted shrug. Zeroing through `DamageModifyEvent` also suppresses `DamageOnInteractSystem`'s post-damage popup, sound, and stun branch (those only run when `totalDamage.AnyPositive()` after `ChangeDamage` returns). Lives in shared so the client predicts the suppression too; a server-only version still let the client predict the burn popup and sound.
- New guidebook page `Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml`, registered under the Skillchips References entry in `Resources/Prototypes/@RussStation/Guidebook/skillchips.yml`, locale string in `Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl`.
- New popup string `skillchip-lightbulb-removing-shrug` in `Resources/Locale/en-US/@RussStation/skillchips/lightbulb_removing.ftl`.

## Media

The chip item uses the SS13 skillchip art shared across the catalog. <!-- screenshot attached -->

## Breaking changes

None.

## Changelog

:cl:
- add: N16H7M4R3 skillchip. With it implanted, hot lightbulbs come out without burning you.