### PR TITLE
honksquad: feat: K33P-TH4T-D15K skillchip (nuclear disk verification)

### DIFF
--- a/Content.Shared/RussStation/Skillchips/Consumers/NukeDiskVerifiableComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/NukeDiskVerifiableComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Tags a nuclear authentication disk (real or forged) as something the
+/// <c>disk_verifier</c> skillchip capability can identify on examine. Added
+/// fork-side to both <c>NukeDisk</c> and <c>NukeDiskFake</c> so a chip holder
+/// can spot the difference without us touching upstream's examine handlers.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class NukeDiskVerifiableComponent : Component
+{
+    /// <summary>True if this disk is a forgery; false if it is the genuine article.</summary>
+    [DataField, AutoNetworkedField]
+    public bool IsForgery;
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedDiskVerifierSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedDiskVerifierSystem.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Examine;
+using Content.Shared.RussStation.Skillchips.Systems;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Examine hook for the K33P-TH4T-D15K skillchip (<c>disk_verifier</c> capability).
+/// When a chip holder examines a tagged <see cref="NukeDiskVerifiableComponent"/>
+/// entity inside details range, append a warning line if the disk is a forgery.
+/// Genuine disks get no line (silence is the "all good" signal), matching SS13's
+/// <c>/obj/item/disk/nuclear/examine</c> behaviour on <c>TRAIT_DISK_VERIFIER</c>.
+/// Lives in shared so the client also sees the warning on its predicted examine.
+/// </summary>
+public sealed class SharedDiskVerifierSystem : EntitySystem
+{
+    public const string DiskVerifierTag = "disk_verifier";
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<NukeDiskVerifiableComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<NukeDiskVerifiableComponent> ent, ref ExaminedEvent args)
+    {
+        if (!ent.Comp.IsForgery)
+            return;
+
+        if (!args.IsInDetailsRange)
+            return;
+
+        if (!_skillchip.HasCapability(args.Examiner, DiskVerifierTag))
+            return;
+
+        args.PushMarkup(Loc.GetString("skillchip-disk-verifier-forgery"));
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -2,3 +2,4 @@ guide-entry-skillchips = Skillchips
 guide-entry-skillchip-station = Skillchip Station
 guide-entry-skillchip-hedge3 = Hedge 3
 guide-entry-skillchip-lightbulb = N16H7M4R3
+guide-entry-skillchip-disk-verifier = K33P-TH4T-D15K

--- a/Resources/Locale/en-US/@RussStation/skillchips/disk_verifier.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/disk_verifier.ftl
@@ -1,0 +1,1 @@
+skillchip-disk-verifier-forgery = The serial numbers on this disk are [color=red]incorrect[/color].

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/commercial.yml
@@ -59,3 +59,15 @@
     state: skillchip
   - type: Skillchip
     chipProto: SkillchipLightbulbRemovingData
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipDiskVerifier
+  name: K33P-TH4T-D15K skillchip
+  description: A small neural interface chip. Nuclear authentication disks have an extremely long serial number for verification. This skillchip stores that number, which allows the user to automatically spot forgeries.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipDiskVerifierData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -7,6 +7,7 @@
   - SkillchipStation
   - SkillchipHedge3
   - SkillchipLightbulb
+  - SkillchipDiskVerifier
 
 - type: guideEntry
   id: SkillchipStation
@@ -22,3 +23,8 @@
   id: SkillchipLightbulb
   name: guide-entry-skillchip-lightbulb
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml"
+
+- type: guideEntry
+  id: SkillchipDiskVerifier
+  name: guide-entry-skillchip-disk-verifier
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipDiskVerifier.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/commercial.yml
@@ -39,3 +39,11 @@
   grants:
   - !type:CapabilityTagGrant
     tag: lightbulb_removing
+
+- type: skillchip
+  id: SkillchipDiskVerifierData
+  name: Nuclear Disk Verification
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: disk_verifier

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -26,6 +26,10 @@
     - GhostOnlyWarp
   - type: StealTarget
     stealGroup: NukeDisk
+  # HONK START - K33P-TH4T-D15K skillchip examine hook
+  - type: NukeDiskVerifiable
+    isForgery: false
+  # HONK END
 
 - type: entity
   name: nuclear authentication disk
@@ -42,3 +46,7 @@
   - type: Tag
     tags:
     - FakeNukeDisk
+  # HONK START - K33P-TH4T-D15K skillchip examine hook
+  - type: NukeDiskVerifiable
+    isForgery: true
+  # HONK END

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDiskVerifier.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDiskVerifier.xml
@@ -1,0 +1,11 @@
+<Document>
+# K33P-TH4T-D15K
+
+Nuclear authentication disks have an extremely long serial number for verification. This skillchip stores that number, which allows the user to automatically spot forgeries.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipDiskVerifier"/>
+</Box>
+
+Examine a [color=#a4885c]nuclear authentication disk[/color]. If the serial numbers are wrong, the chip flags it as a [color=red]forgery[/color]. Genuine disks examine as normal.
+</Document>


### PR DESCRIPTION
## About the PR

Adds the K33P-TH4T-D15K skillchip, with its proper port sprite, an examine consumer for nuke auth disks, and a guidebook entry. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Flavour chip for nukies and security. A chip holder examining a forged nuclear authentication disk sees a warning that the serial numbers are wrong; genuine disks examine normally. Mirrors SS13's `TRAIT_DISK_VERIFIER` behaviour on `/obj/item/disk/nuclear/examine`.

## Technical details

- `SkillchipDiskVerifier` entity and `SkillchipDiskVerifierData` data prototype under `Resources/Prototypes/@RussStation/`, using the shared skillchip world sprite (`@RussStation/Objects/Misc/skillchip.rsi` state `skillchip`, same as Hedge 3). Entity description is the SS13 `skill_description`.
- `NukeDiskVerifiableComponent` (shared, networked) tags a disk as identifiable, with `IsForgery: bool` distinguishing real from fake.
- `SharedDiskVerifierSystem` subscribes to `ExaminedEvent` on that component, returns early on non-forgeries, and gates the remaining branch on `IsInDetailsRange` and `SharedSkillchipSystem.HasCapability(_, "disk_verifier")` before pushing the warning via `PushMarkup`. Lives in shared so the client agrees on the predicted examine.
- HONK-marked additions to `Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml` attach the component to both `NukeDisk` (`isForgery: false`) and `NukeDiskFake` (`isForgery: true`).
- Guidebook entry `SkillchipDiskVerifier.xml` wired into `skillchips.yml` under the existing Skillchips parent.

## Media

No visual changes; examine text only.

## Breaking changes

None.

:cl:
- add: K33P-TH4T-D15K skillchip. Holders see a warning on examine when a nuclear authentication disk is a forgery.