### PR TITLE
honksquad: feat: GENUINE ID Appraisal Now! skillchip (ID appraisal)

### DIFF
--- a/Content.Shared/RussStation/Skillchips/Consumers/CentcomIssuedComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/CentcomIssuedComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Marks an ID card prototype as one issued by Central Command rather than
+/// printed at a station ID console. Read by the GENUINE ID Appraisal Now!
+/// skillchip consumer. Applied via HONK markers to the CentCom, Death Squad,
+/// and ERT card prototypes upstream.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CentcomIssuedComponent : Component
+{
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/IdAppraisableComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/IdAppraisableComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Tags an ID card entity as something the <c>id_appraisal</c> skillchip
+/// capability can read on examine. Added fork-side to <c>IDCardStandard</c>
+/// so every ID inherits the hook without us touching each preset card.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class IdAppraisableComponent : Component
+{
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedIdAppraiserSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedIdAppraiserSystem.cs
@@ -1,0 +1,48 @@
+using Content.Shared.Examine;
+using Content.Shared.RussStation.Skillchips.Systems;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Examine hook for the GENUINE ID Appraisal Now! skillchip
+/// (<c>id_appraisal</c> capability). When a chip holder examines a tagged
+/// <see cref="IdAppraisableComponent"/> ID card inside details range, append
+/// a chip-only line stating whether the card came out of CentCom or a
+/// station ID console. CentCom cards are flagged with
+/// <see cref="CentcomIssuedComponent"/> directly on the prototype; the
+/// <see cref="Content.Shared.Access.Components.IdCardComponent.JobPrototype"/>
+/// field can't be used here because the preset card system never populates
+/// it (only the ID console does). Lives in shared so the client sees the
+/// line on its predicted examine.
+/// </summary>
+public sealed class SharedIdAppraiserSystem : EntitySystem
+{
+    public const string IdAppraisalTag = "id_appraisal";
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IdAppraisableComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<IdAppraisableComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        if (!_skillchip.HasCapability(args.Examiner, IdAppraisalTag))
+            return;
+
+        string loc;
+        if (HasComp<CentcomIssuedComponent>(ent))
+            loc = "skillchip-id-appraisal-examine-centcom";
+        else if (HasComp<SyndicateIssuedComponent>(ent))
+            loc = "skillchip-id-appraisal-examine-syndicate";
+        else
+            loc = "skillchip-id-appraisal-examine-station";
+
+        args.PushMarkup(Loc.GetString(loc));
+    }
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/SyndicateIssuedComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SyndicateIssuedComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Marks an ID card prototype as Syndicate-issued (genuine syndicate cards
+/// and agent IDs). Read by the GENUINE ID Appraisal Now! skillchip consumer
+/// as the "not from any console you've ever seen" signal. Applied via HONK
+/// markers to the AgentIDCard and SyndicateIDCard families upstream.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SyndicateIssuedComponent : Component
+{
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -4,3 +4,4 @@ guide-entry-skillchip-hedge3 = Hedge 3
 guide-entry-skillchip-lightbulb = N16H7M4R3
 guide-entry-skillchip-disk-verifier = K33P-TH4T-D15K
 guide-entry-skillchip-entrails-reader = 3NTR41LS
+guide-entry-skillchip-id-appraisal = GENUINE ID Appraisal Now!

--- a/Resources/Locale/en-US/@RussStation/skillchips/id_appraisal.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/id_appraisal.ftl
@@ -1,0 +1,3 @@
+skillchip-id-appraisal-examine-centcom = Hmm... yes, this ID was issued from Central Command!
+skillchip-id-appraisal-examine-station = This ID was created in this sector, not by Central Command.
+skillchip-id-appraisal-examine-syndicate = Curious, this ID wasn't printed at any console you've ever seen.

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/id_appraisal.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/id_appraisal.yml
@@ -1,0 +1,13 @@
+# GENUINE ID Appraisal Now! skillchip entity
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipIdAppraisal
+  name: GENUINE ID Appraisal Now! skillchip
+  description: A small neural interface chip. Appraise an ID and see if it's issued from CentCom, or just a cruddy station-printed one.
+  components:
+    - type: Sprite
+      sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+      state: skillchip
+    - type: Skillchip
+      chipProto: SkillchipIdAppraisalData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -5,25 +5,16 @@
   filterEnabled: True
   children:
   - SkillchipStation
-  - SkillchipHedge3
-  - SkillchipLightbulb
   - SkillchipDiskVerifier
   - SkillchipEntrailsReader
+  - SkillchipHedge3
+  - SkillchipIdAppraisal
+  - SkillchipLightbulb
 
 - type: guideEntry
   id: SkillchipStation
   name: guide-entry-skillchip-station
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipStation.xml"
-
-- type: guideEntry
-  id: SkillchipHedge3
-  name: guide-entry-skillchip-hedge3
-  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipHedge3.xml"
-
-- type: guideEntry
-  id: SkillchipLightbulb
-  name: guide-entry-skillchip-lightbulb
-  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml"
 
 - type: guideEntry
   id: SkillchipDiskVerifier
@@ -34,3 +25,18 @@
   id: SkillchipEntrailsReader
   name: guide-entry-skillchip-entrails-reader
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipEntrailsReader.xml"
+
+- type: guideEntry
+  id: SkillchipHedge3
+  name: guide-entry-skillchip-hedge3
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipHedge3.xml"
+
+- type: guideEntry
+  id: SkillchipIdAppraisal
+  name: guide-entry-skillchip-id-appraisal
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipIdAppraisal.xml"
+
+- type: guideEntry
+  id: SkillchipLightbulb
+  name: guide-entry-skillchip-lightbulb
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/id_appraisal.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/id_appraisal.yml
@@ -1,0 +1,9 @@
+# GENUINE ID Appraisal Now! skillchip data prototype
+
+- type: skillchip
+  id: SkillchipIdAppraisalData
+  name: ID Appraisal
+  capacityCost: 1
+  grants:
+    - !type:CapabilityTagGrant
+      tag: id_appraisal

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -17,6 +17,9 @@
     storedRotation: -90
   - type: Access
   - type: IdCard
+  # HONK START - GENUINE ID Appraisal Now! skillchip examine hook
+  - type: IdAppraisable
+  # HONK END
   - type: StationRecordKeyStorage
   - type: Tag
     tags:
@@ -928,6 +931,9 @@
     - Maintenance
     - SyndicateAgent
   - type: AgentIDCard
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as Syndicate-issued
+  - type: SyndicateIssued
+  # HONK END
   - type: UIRequiresLock
   - type: ActivatableUI
     key: enum.AgentIDCardUiKey.Key
@@ -980,6 +986,9 @@
     tags:
     - NuclearOperative
     - SyndicateAgent
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as Syndicate-issued
+  - type: SyndicateIssued
+  # HONK END
 
 - type: entity
   parent: [ SyndicateIDCard, BaseSyndicateContraband ]
@@ -1131,6 +1140,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: CentralCommandOfficial
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1151,6 +1163,9 @@
     heldPrefix: gold
   - type: PresetIdCard
     job: ERTLeader
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1171,6 +1186,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: ERTChaplain
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1191,6 +1209,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: ERTEngineer
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1211,6 +1232,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: ERTJanitor
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1231,6 +1255,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: ERTMedical
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1251,6 +1278,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: ERTSecurity
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1269,6 +1299,9 @@
       state: DeathSquad
   - type: PresetIdCard
     job: DeathSquad
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard
@@ -1290,6 +1323,9 @@
     heldPrefix: blue
   - type: PresetIdCard
     job: CBURN
+  # HONK START - GENUINE ID Appraisal Now! skillchip flags this as CentCom-issued
+  - type: CentcomIssued
+  # HONK END
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipIdAppraisal.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipIdAppraisal.xml
@@ -1,0 +1,11 @@
+<Document>
+# GENUINE ID Appraisal Now!
+
+Tell a card stamped at Central Command apart from one a passenger ran through a station ID console. The chip won't out a forger by itself, but it tells you which half of the room to start asking questions in.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipIdAppraisal"/>
+</Box>
+
+Examine any [color=#a4885c]ID card[/color] up close. The chip flags whether the card bears CentCom's seal or came off the station printer.
+</Document>


### PR DESCRIPTION
## About the PR

Adds the GENUINE ID Appraisal Now! skillchip. The chip holder gets a chip-only line on examining any ID card, telling them whether it came from Central Command, a station ID console, or somewhere else entirely (agent and syndicate cards). Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

A security and detective roleplay tool. Spies forging credentials get caught the moment someone with the chip looks closely; the chip won't out them on its own but it tells the holder which half of the room to start asking questions in. Examine flavor follows the SS13 voice.

## Technical details

- `SkillchipIdAppraisalData` data and `SkillchipIdAppraisal` entity in per-chip files under `Resources/Prototypes/@RussStation/Skillchips/id_appraisal.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/id_appraisal.yml`. Sprite is the shared `@RussStation/Objects/Misc/skillchip.rsi`.
- New shared `IdAppraisableComponent` marker added to `IDCardStandard` via HONK markers, so every ID card inherits the examine hook through prototype inheritance.
- New shared `CentcomIssuedComponent` stamped onto the eight CentCom, ERT, Death Squad, and CBURN preset cards. New shared `SyndicateIssuedComponent` stamped onto the `AgentIDCard` and `SyndicateIDCard` families; their children (`NukieAgentIDCard`, `SyndiOperativeIDCard`) inherit the marker.
- `SharedIdAppraiserSystem` hooks `ExaminedEvent` on tagged cards. When the examiner holds the `id_appraisal` capability inside details range, it pushes one of three locale strings based on which marker is present. Lives in shared so the client predicts the line.
- Guidebook entry added under the Skillchips guide tree.

`IdCardComponent.JobPrototype` would have been the obvious signal but `PresetIdCardSystem` never populates it (only the ID console does), so prototype-side markers are the clean alternative.

## Media

No visual changes outside the new examine line.

## Breaking changes

None.

:cl:
- add: GENUINE ID Appraisal Now! skillchip. Implanted users can tell a Central Command ID, a station-printed one, and a syndicate or agent ID apart on examine.