### PR TITLE
honksquad: feat: Le S48R4G3 skillchip (sabrage proficiency)

### DIFF
--- a/Content.Shared/RussStation/Skillchips/Consumers/SabrageConstants.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SabrageConstants.cs
@@ -1,0 +1,19 @@
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+public static class SabrageConstants
+{
+    /// <summary>Multiplier on sqrt(weapon damage) feeding the success chance.</summary>
+    public const float SuccessSqrtFactor = 20f;
+
+    /// <summary>Flat offset on the no-chip term; negative so weak weapons don't get a free coin-flip.</summary>
+    public const float BaseOffset = -33f;
+
+    /// <summary>Multiplier applied when the user carries the <c>sabrage_proficiency</c> capability.</summary>
+    public const float SkillchipMultiplier = 2f;
+
+    /// <summary>Minimum weapon damage required to attempt sabrage at all. SS13 force gate is 5.</summary>
+    public const float MinimumDamage = 5f;
+
+    /// <summary>Wind-up swing duration in seconds.</summary>
+    public const int SwingSeconds = 2;
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
@@ -1,0 +1,74 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Marks a bottle that can be sabraged: struck with a sharp item to pop the
+/// cork off in one swing. The Le S48R4G3 skillchip (<c>sabrage_proficiency</c>
+/// capability) bumps the success chance massively. SS13 parallel:
+/// <c>/obj/item/reagent_containers/cup/glass/bottle/champagne</c> with its
+/// <c>sabrage_success_percentile</c> field and <c>TRAIT_SABRAGE_PRO</c> check.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SabrageableComponent : Component
+{
+    /// <summary>
+    /// Per-point-of-weapon-damage success chance, in percent. SS13 default is 5.
+    /// A 15-damage saber against a default bottle yields a 75% base chance, plus
+    /// any chip bonus.
+    /// </summary>
+    [DataField]
+    public float SuccessPerDamage = 5f;
+
+    /// <summary>
+    /// Flat bonus added when the user has the <c>sabrage_proficiency</c>
+    /// capability. SS13 uses 35.
+    /// </summary>
+    [DataField]
+    public float SkillchipBonus = 35f;
+
+    /// <summary>
+    /// Minimum weapon damage required to attempt sabrage at all. SS13 gates on
+    /// item force >= 5; matched here against <see cref="DamageSpecifier.GetTotal"/>.
+    /// </summary>
+    [DataField]
+    public float MinimumDamage = 5f;
+
+    /// <summary>How long the wind-up swing takes.</summary>
+    [DataField]
+    public TimeSpan SwingDuration = TimeSpan.FromSeconds(2);
+
+    /// <summary>Damage dealt to the user on a failed swing (cut yourself on the bottle).</summary>
+    [DataField]
+    public DamageSpecifier FailureDamage = new()
+    {
+        DamageDict = new() { { "Slash", 8 } },
+    };
+
+    /// <summary>Glass shard prototype to spawn on a failed swing.</summary>
+    [DataField]
+    public EntProtoId ShardPrototype = "ShardGlass";
+
+    /// <summary>How many shards to spawn on a failed swing.</summary>
+    [DataField]
+    public int ShardCount = 2;
+
+    /// <summary>Sound that plays on the wind-up.</summary>
+    [DataField]
+    public string SwingSound = "/Audio/Items/unsheath.ogg";
+
+    /// <summary>Sound that plays on a successful sabrage.</summary>
+    [DataField]
+    public string SuccessSound = "/Audio/Weapons/bladeslice.ogg";
+
+    /// <summary>Sound that plays on a failed sabrage (bottle smash).</summary>
+    [DataField]
+    public string FailureSound = "/Audio/Effects/glass_break1.ogg";
+}
+
+[Serializable, NetSerializable]
+public sealed partial class SabrageDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
@@ -49,13 +49,10 @@ public sealed partial class SabrageableComponent : Component
         DamageDict = new() { { "Slash", 8 } },
     };
 
-    /// <summary>Glass shard prototype to spawn on a failed swing.</summary>
+    /// <summary>What to leave behind on a failed swing. Matches the destructible
+    /// drop on a bottle thrown hard enough to break.</summary>
     [DataField]
-    public EntProtoId ShardPrototype = "ShardGlass";
-
-    /// <summary>How many shards to spawn on a failed swing.</summary>
-    [DataField]
-    public int ShardCount = 2;
+    public EntProtoId BrokenPrototype = "BrokenBottle";
 
     /// <summary>Sound that plays on the wind-up.</summary>
     [DataField]

--- a/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.RussStation.Skillchips.Consumers;
 /// <c>/obj/item/reagent_containers/cup/glass/bottle/champagne</c> with its
 /// <c>sabrage_success_percentile</c> field and <c>TRAIT_SABRAGE_PRO</c> check.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SabrageableComponent : Component
 {
     /// <summary>
@@ -22,8 +22,8 @@ public sealed partial class SabrageableComponent : Component
     /// Combined with <see cref="BaseOffset"/> the bare-knuckle ceiling lands
     /// around the mid-50s.
     /// </summary>
-    [DataField]
-    public float SuccessSqrtFactor = 20f;
+    [DataField, AutoNetworkedField]
+    public float SuccessSqrtFactor = SabrageConstants.SuccessSqrtFactor;
 
     /// <summary>
     /// Flat offset on the no-chip term. Intentionally negative so a low-damage
@@ -31,27 +31,27 @@ public sealed partial class SabrageableComponent : Component
     /// clamped to 0 before the chip multiplier runs, so this only shaves the
     /// low end.
     /// </summary>
-    [DataField]
-    public float BaseOffset = -33f;
+    [DataField, AutoNetworkedField]
+    public float BaseOffset = SabrageConstants.BaseOffset;
 
     /// <summary>
     /// Multiplier applied to the success chance when the user has the
     /// <c>sabrage_proficiency</c> capability. The chip roughly doubles the
     /// odds at every weapon tier, with the final value clamped to 100.
     /// </summary>
-    [DataField]
-    public float SkillchipMultiplier = 2f;
+    [DataField, AutoNetworkedField]
+    public float SkillchipMultiplier = SabrageConstants.SkillchipMultiplier;
 
     /// <summary>
     /// Minimum weapon damage required to attempt sabrage at all. SS13 gates on
     /// item force >= 5; matched here against <see cref="DamageSpecifier.GetTotal"/>.
     /// </summary>
-    [DataField]
-    public float MinimumDamage = 5f;
+    [DataField, AutoNetworkedField]
+    public float MinimumDamage = SabrageConstants.MinimumDamage;
 
     /// <summary>How long the wind-up swing takes.</summary>
-    [DataField]
-    public TimeSpan SwingDuration = TimeSpan.FromSeconds(2);
+    [DataField, AutoNetworkedField]
+    public TimeSpan SwingDuration = TimeSpan.FromSeconds(SabrageConstants.SwingSeconds);
 
     /// <summary>Damage dealt to the user on a failed swing (cut yourself on the bottle).</summary>
     [DataField]

--- a/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs
@@ -17,19 +17,30 @@ namespace Content.Shared.RussStation.Skillchips.Consumers;
 public sealed partial class SabrageableComponent : Component
 {
     /// <summary>
-    /// Per-point-of-weapon-damage success chance, in percent. SS13 default is 5.
-    /// A 15-damage saber against a default bottle yields a 75% base chance, plus
-    /// any chip bonus.
+    /// Multiplier on the square root of weapon damage. Diminishing returns:
+    /// a saber (17 damage) earns ~82 raw points, an energy sword (20) ~89.
+    /// Combined with <see cref="BaseOffset"/> the bare-knuckle ceiling lands
+    /// around the mid-50s.
     /// </summary>
     [DataField]
-    public float SuccessPerDamage = 5f;
+    public float SuccessSqrtFactor = 20f;
 
     /// <summary>
-    /// Flat bonus added when the user has the <c>sabrage_proficiency</c>
-    /// capability. SS13 uses 35.
+    /// Flat offset on the no-chip term. Intentionally negative so a low-damage
+    /// shard doesn't earn a free coin-flip. The pre-multiplier value is
+    /// clamped to 0 before the chip multiplier runs, so this only shaves the
+    /// low end.
     /// </summary>
     [DataField]
-    public float SkillchipBonus = 35f;
+    public float BaseOffset = -33f;
+
+    /// <summary>
+    /// Multiplier applied to the success chance when the user has the
+    /// <c>sabrage_proficiency</c> capability. The chip roughly doubles the
+    /// odds at every weapon tier, with the final value clamped to 100.
+    /// </summary>
+    [DataField]
+    public float SkillchipMultiplier = 2f;
 
     /// <summary>
     /// Minimum weapon damage required to attempt sabrage at all. SS13 gates on

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
@@ -115,6 +115,10 @@ public sealed class SharedSabrageSystem : EntitySystem
         var baseChance = Math.Max(0f, ent.Comp.SuccessSqrtFactor * MathF.Sqrt(damage) + ent.Comp.BaseOffset);
         if (_skillchip.HasCapability(args.User, SabrageTag))
             baseChance *= ent.Comp.SkillchipMultiplier;
+        // TODO: command bonus. SS13 grants captains TRAIT_ROYAL_METABOLISM via
+        // their liver and adds it on top of the chip bonus. Once SS14 has a
+        // captain-specific trait or role check, apply a 1.5x multiplier here
+        // (lands a sabre swing at 75% without the chip, ~100% with both).
         var chance = Math.Clamp(baseChance, 0f, 100f);
 
         if (_random.NextFloat() * 100f < chance)

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
@@ -1,0 +1,153 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Fluids;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Random;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Interaction handler for the Le S48R4G3 skillchip (<c>sabrage_proficiency</c>
+/// capability). Striking a sealed bottle tagged with
+/// <see cref="SabrageableComponent"/> using a sharp melee item rolls for a
+/// clean cork pop; failure smashes the bottle on the user and spills the
+/// solution. Lives in shared so the client can predict the swing and the
+/// success path. SS13 parallel:
+/// <c>/obj/item/reagent_containers/cup/glass/bottle/champagne</c>'s
+/// <c>attackby</c> branch and its 2-second do-after.
+/// </summary>
+public sealed class SharedSabrageSystem : EntitySystem
+{
+    public const string SabrageTag = "sabrage_proficiency";
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly OpenableSystem _openable = default!;
+    [Dependency] private readonly SealableSystem _sealable = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly SharedPuddleSystem _puddle = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SabrageableComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<SabrageableComponent, SabrageDoAfterEvent>(OnSwingFinished);
+    }
+
+    private void OnInteractUsing(Entity<SabrageableComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Only sealed bottles can be sabraged; once popped there is no cork to slice.
+        if (!_sealable.IsSealed(ent.Owner))
+            return;
+
+        // Sharp + at-or-above the minimum effective melee damage. SS13 reads this
+        // off item.force; the SS14 equivalent is the melee component's Damage spec.
+        if (!TryComp<MeleeWeaponComponent>(args.Used, out var melee))
+            return;
+
+        var damage = (float) melee.Damage.GetTotal();
+        if (damage < ent.Comp.MinimumDamage)
+            return;
+
+        if (!_skillchip.HasCapability(args.User, SabrageTag))
+            return;
+
+        args.Handled = true;
+
+        _audio.PlayPredicted(new SoundPathSpecifier(ent.Comp.SwingSound), ent.Owner, args.User);
+        _popup.PopupClient(Loc.GetString("skillchip-sabrage-start"), ent.Owner, args.User);
+
+        var doAfter = new DoAfterArgs(
+            EntityManager,
+            args.User,
+            ent.Comp.SwingDuration,
+            new SabrageDoAfterEvent(),
+            ent.Owner,
+            target: ent.Owner,
+            used: args.Used)
+        {
+            BreakOnMove = true,
+            NeedHand = true,
+        };
+
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnSwingFinished(Entity<SabrageableComponent> ent, ref SabrageDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.User == default)
+            return;
+
+        // Random rolls and entity deletion only run on the server; client would
+        // pick a different roll and pop a misleading message.
+        if (!_net.IsServer)
+        {
+            args.Handled = true;
+            return;
+        }
+
+        if (!TryComp<MeleeWeaponComponent>(args.Used, out var melee))
+            return;
+
+        var damage = (float) melee.Damage.GetTotal();
+        var chance = damage * ent.Comp.SuccessPerDamage + ent.Comp.SkillchipBonus;
+        chance = Math.Clamp(chance, 0f, 100f);
+
+        if (_random.NextFloat() * 100f < chance)
+            Succeed(ent, args.User);
+        else
+            Fail(ent, args.User);
+
+        args.Handled = true;
+    }
+
+    private void Succeed(Entity<SabrageableComponent> ent, EntityUid user)
+    {
+        // TryOpen fires OpenableOpenedEvent, which SealableSystem catches to
+        // flip Sealed = false. The cork pop sound is the openable sound; the
+        // sabrage success sound layers on top.
+        _openable.TryOpen(ent.Owner, user: user);
+        _audio.PlayPvs(new SoundPathSpecifier(ent.Comp.SuccessSound), ent.Owner);
+        _popup.PopupEntity(Loc.GetString("skillchip-sabrage-success", ("user", user), ("bottle", ent.Owner)), ent.Owner);
+    }
+
+    private void Fail(Entity<SabrageableComponent> ent, EntityUid user)
+    {
+        _damageable.TryChangeDamage(user, ent.Comp.FailureDamage, origin: user);
+        _audio.PlayPvs(new SoundPathSpecifier(ent.Comp.FailureSound), ent.Owner);
+        _popup.PopupEntity(Loc.GetString("skillchip-sabrage-fail", ("user", user), ("bottle", ent.Owner)), ent.Owner);
+
+        // Spill whatever was in the bottle onto the user's tile, then shatter
+        // the bottle into shards.
+        var coords = Transform(user).Coordinates;
+        if (_solutionContainer.TryGetDrainableSolution(ent.Owner, out var solutionEnt, out var solution))
+        {
+            var drained = _solutionContainer.SplitSolution(solutionEnt.Value, solution.Volume);
+            _puddle.TrySpillAt(coords, drained, out _);
+        }
+
+        for (var i = 0; i < ent.Comp.ShardCount; i++)
+            Spawn(ent.Comp.ShardPrototype, coords);
+
+        Del(ent.Owner);
+    }
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
@@ -145,9 +145,7 @@ public sealed class SharedSabrageSystem : EntitySystem
             _puddle.TrySpillAt(coords, drained, out _);
         }
 
-        for (var i = 0; i < ent.Comp.ShardCount; i++)
-            Spawn(ent.Comp.ShardPrototype, coords);
-
+        Spawn(ent.Comp.BrokenPrototype, coords);
         Del(ent.Owner);
     }
 }

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs
@@ -68,9 +68,8 @@ public sealed class SharedSabrageSystem : EntitySystem
         if (damage < ent.Comp.MinimumDamage)
             return;
 
-        if (!_skillchip.HasCapability(args.User, SabrageTag))
-            return;
-
+        // Chip-as-bonus: anyone with a sharp can try; the chip just dramatically
+        // improves the odds. The capability check moves to the resolution step.
         args.Handled = true;
 
         _audio.PlayPredicted(new SoundPathSpecifier(ent.Comp.SwingSound), ent.Owner, args.User);
@@ -109,8 +108,14 @@ public sealed class SharedSabrageSystem : EntitySystem
             return;
 
         var damage = (float) melee.Damage.GetTotal();
-        var chance = damage * ent.Comp.SuccessPerDamage + ent.Comp.SkillchipBonus;
-        chance = Math.Clamp(chance, 0f, 100f);
+
+        // Base curve: 20·sqrt(d) - 33, clamped to >= 0. Hits ~12% at d=5,
+        // ~30% at a knife, ~50% at a saber. The chip doubles whatever the
+        // base lands on, clamped to 100.
+        var baseChance = Math.Max(0f, ent.Comp.SuccessSqrtFactor * MathF.Sqrt(damage) + ent.Comp.BaseOffset);
+        if (_skillchip.HasCapability(args.User, SabrageTag))
+            baseChance *= ent.Comp.SkillchipMultiplier;
+        var chance = Math.Clamp(baseChance, 0f, 100f);
 
         if (_random.NextFloat() * 100f < chance)
             Succeed(ent, args.User);

--- a/Resources/Locale/en-US/@RussStation/skillchips/sabrage.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/sabrage.ftl
@@ -1,0 +1,3 @@
+skillchip-sabrage-start = You wind up to slice the cork off...
+skillchip-sabrage-success = {CAPITALIZE(THE($user))} cleanly slices the cork off {THE($bottle)}, sending it flying.
+skillchip-sabrage-fail = {CAPITALIZE(THE($user))} fumbles the sabrage and cuts {THE($bottle)} in half all over themselves.

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/chefs_kiss.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/chefs_kiss.yml
@@ -1,0 +1,13 @@
+# K1SS skillchip entity
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipChefKiss
+  name: K1SS skillchip
+  description: A small neural interface chip. Recall your grandmother's secret for baking with love.
+  components:
+    - type: Sprite
+      sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+      state: skillchip
+    - type: Skillchip
+      chipProto: SkillchipChefKissData

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/sabrage.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/sabrage.yml
@@ -1,0 +1,13 @@
+# Le S48R4G3 skillchip entity
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipSabrage
+  name: Le S48R4G3 skillchip
+  description: A small neural interface chip. Lop the neck off a champagne bottle with a single deft strike, no broken glass, no spilled bubbles. The bar will love you.
+  components:
+    - type: Sprite
+      sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+      state: skillchip
+    - type: Skillchip
+      chipProto: SkillchipSabrageData

--- a/Resources/Prototypes/@RussStation/Skillchips/chefs_kiss.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/chefs_kiss.yml
@@ -1,0 +1,9 @@
+# K1SS skillchip data prototype
+
+- type: skillchip
+  id: SkillchipChefKissData
+  name: Chef's Kiss
+  capacityCost: 1
+  grants:
+    - !type:CapabilityTagGrant
+      tag: chefs_kiss

--- a/Resources/Prototypes/@RussStation/Skillchips/sabrage.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/sabrage.yml
@@ -1,0 +1,9 @@
+# Le S48R4G3 skillchip data prototype
+
+- type: skillchip
+  id: SkillchipSabrageData
+  name: Sabrage
+  capacityCost: 1
+  grants:
+    - !type:CapabilityTagGrant
+      tag: sabrage_proficiency

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles_glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles_glass.yml
@@ -150,6 +150,9 @@
     closeable: false # Champagne corks are fat. Not worth the effort.
   - type: Sealable
     examineTextUnsealed: "sealable-component-on-examine-is-unsealed-no-cork" # tell the player why it can't close
+  # HONK START - Le S48R4G3 skillchip consumer (sabrage_proficiency)
+  - type: Sabrageable
+  # HONK END
 
 - type: entity
   parent: [DrinkVisualsAllFilled, DrinkBottleGlassBaseFull]


### PR DESCRIPTION
## About the PR

Adds the Le S48R4G3 skillchip and its champagne-sabrage consumer. Striking a sealed champagne bottle with any sharp melee item rolls for a clean cork pop. The chip is what makes the swing reliable, without it most attempts shatter the bottle on you.

## Why / Balance

Prestige social chip ported from SS13 russ-station. Part of the chip catalog tracked in #703. No combat value, just a party trick.

Success chance follows `max(0, 20·sqrt(damage) - 33)`, doubled if the user has the chip, clamped to 100. Concretely:

| Weapon (damage) | No chip | With chip |
|---|---|---|
| Glass shard (5) | 12% | 23% |
| Kitchen knife (10) | 30% | 60% |
| Combat knife (12) | 36% | 73% |
| Machete (15) | 44% | 89% |
| Captain's sabre (17) | 50% | 99% |
| Energy sword (20) | 56% | 100% |

The chip-as-bonus split matches SS13: anyone with a sharp can try, the chip just makes it work. SS13's captain-only royal-metabolism +20 is parked as a `TODO` in the consumer (a 1.5x multiplier on the base, which lands a sabre swing at 75% without the chip), waiting on a captain-specific trait or role check in SS14.

## Technical details

- `Resources/Prototypes/@RussStation/Skillchips/sabrage.yml`, `SkillchipSabrageData` (capacityCost 1, `CapabilityTagGrant` for `sabrage_proficiency`).
- `Resources/Prototypes/@RussStation/Entities/Skillchips/sabrage.yml`, `SkillchipSabrage` entity using the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.
- `Content.Shared/RussStation/Skillchips/Consumers/SabrageableComponent.cs`, per-bottle tunables (sqrt factor, base offset, chip multiplier, min damage, swing duration, failure damage spec, broken-bottle proto, sounds).
- `Content.Shared/RussStation/Skillchips/Consumers/SharedSabrageSystem.cs`, `InteractUsingEvent` handler. Gates on `SealableSystem.IsSealed` + `MeleeWeaponComponent` + min damage. Runs a 2s `DoAfter`, rolls on completion using the curve above. Success calls `OpenableSystem.TryOpen`; failure deals slash damage, spills the solution via `SharedPuddleSystem.TrySpillAt`, spawns a `BrokenBottle` (the same drop a thrown bottle leaves), and deletes the source. Random + entity deletion guarded behind `_net.IsServer`.
- HONK-marked addition of `- type: Sabrageable` to `DrinkChampagneBottleFull` (`drinks_bottles_glass.yml`).
- Locale at `Resources/Locale/en-US/@RussStation/skillchips/sabrage.ftl`.

## Media

<!-- screenshots attached -->

## Breaking changes

None.

## Changelog

:cl:
- add: Le S48R4G3 skillchip grants sabrage proficiency, lets a holder pop the cork off a sealed champagne bottle with a sharp swing. Anyone can attempt without the chip, but the odds are bad.
