### PR TITLE
honksquad: feat: F0RC3 4DD1CT10N skillchip (drunken unarmed proficiency)

### DIFF
--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedDrunkenBrawlerSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedDrunkenBrawlerSystem.cs
@@ -1,0 +1,90 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Drunk;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Content.Shared.StatusEffectNew;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Melee.Components;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Combat handler for the F0RC3 4DD1CT10N skillchip
+/// (<c>drunken_brawler</c> capability). While the carrier is intoxicated,
+/// their unarmed swings hit harder and their incoming unarmed damage is
+/// reduced. Mirrors SS13's <c>TRAIT_DRUNKEN_BRAWLER</c> branches in
+/// <c>_species.dm</c>; the SS13 offense bonus continuously scales with
+/// damage taken, but we settle for a flat multiplier so we can stay off
+/// the obsolete <c>GetTotalDamage</c> API. The defense reduction stands
+/// in for <c>armor_block += 20</c>.
+///
+/// Anchored on <see cref="MeleeWeaponComponent"/> because every
+/// <c>MobCombat</c> mob carries one, so a single subscription covers both
+/// "the user about to swing" and "the target about to be hit". Lives in
+/// shared so the client predicts the same damage figures as the server.
+/// </summary>
+public sealed class SharedDrunkenBrawlerSystem : EntitySystem
+{
+    public const string DrunkenBrawlerTag = "drunken_brawler";
+
+    /// <summary>Flat multiplier on unarmed damage dealt while drunk. SS13's floor was 1.3x.</summary>
+    private const float OffenseMultiplier = 1.3f;
+
+    /// <summary>
+    /// Incoming-damage coefficient applied to drunken-brawler defenders. SS13 adds 20 flat
+    /// armor on a 100-scale; the equivalent here is a 20% reduction on the incoming hit.
+    /// </summary>
+    private const float DefenseMultiplier = 0.8f;
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+    [Dependency] private readonly StatusEffectsSystem _status = default!;
+    [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<MeleeWeaponComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
+        SubscribeLocalEvent<MeleeWeaponComponent, DamageModifyEvent>(OnDamageModify);
+    }
+
+    private void OnGetMeleeDamage(Entity<MeleeWeaponComponent> ent, ref GetMeleeDamageEvent args)
+    {
+        // Held-weapon swings raise the event on the weapon entity, not the user. Unarmed swings
+        // resolve to the mob's own MeleeWeaponComponent, so user == weapon means unarmed.
+        if (args.User != args.Weapon)
+            return;
+
+        if (!IsDrunkenBrawler(args.User))
+            return;
+
+        args.Damage *= OffenseMultiplier;
+    }
+
+    private void OnDamageModify(Entity<MeleeWeaponComponent> ent, ref DamageModifyEvent args)
+    {
+        if (args.Origin is not { } attacker)
+            return;
+
+        if (!IsAttackerUnarmed(attacker))
+            return;
+
+        if (!IsDrunkenBrawler(ent.Owner))
+            return;
+
+        args.Damage *= DefenseMultiplier;
+    }
+
+    private bool IsDrunkenBrawler(EntityUid mob)
+    {
+        return _status.HasStatusEffect(mob, SharedDrunkSystem.Drunk)
+               && _skillchip.HasCapability(mob, DrunkenBrawlerTag);
+    }
+
+    private bool IsAttackerUnarmed(EntityUid attacker)
+    {
+        // DamageModifyEvent.Origin is always the mob (TryChangeDamage passes user, not weapon),
+        // so resolve the active weapon and check whether it's the mob itself.
+        return _melee.TryGetWeapon(attacker, out var weapon, out _) && weapon == attacker;
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -6,3 +6,4 @@ guide-entry-skillchip-disk-verifier = K33P-TH4T-D15K
 guide-entry-skillchip-entrails-reader = 3NTR41LS
 guide-entry-skillchip-flavour-calculus = INTJ
 guide-entry-skillchip-id-appraisal = GENUINE ID Appraisal Now!
+guide-entry-skillchip-drunken-brawler = F0RC3 4DD1CT10N

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/drunken_brawler.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/drunken_brawler.yml
@@ -1,0 +1,13 @@
+# F0RC3 4DD1CT10N skillchip entity
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipDrunkenBrawler
+  name: F0RC3 4DD1CT10N skillchip
+  description: A small neural interface chip. When intoxicated, you gain increased unarmed effectiveness.
+  components:
+    - type: Sprite
+      sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+      state: skillchip
+    - type: Skillchip
+      chipProto: SkillchipDrunkenBrawlerData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -6,6 +6,7 @@
   children:
     - SkillchipStation
     - SkillchipDiskVerifier
+    - SkillchipDrunkenBrawler
     - SkillchipEntrailsReader
     - SkillchipFlavourCalculus
     - SkillchipHedge3
@@ -46,3 +47,8 @@
   id: SkillchipLightbulb
   name: guide-entry-skillchip-lightbulb
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipLightbulb.xml"
+
+- type: guideEntry
+  id: SkillchipDrunkenBrawler
+  name: guide-entry-skillchip-drunken-brawler
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipDrunkenBrawler.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/drunken_brawler.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/drunken_brawler.yml
@@ -1,0 +1,9 @@
+# F0RC3 4DD1CT10N skillchip data prototype
+
+- type: skillchip
+  id: SkillchipDrunkenBrawlerData
+  name: Drunken Unarmed Proficiency
+  capacityCost: 1
+  grants:
+    - !type:CapabilityTagGrant
+      tag: drunken_brawler

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDrunkenBrawler.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDrunkenBrawler.xml
@@ -1,0 +1,14 @@
+<Document>
+# F0RC3 4DD1CT10N
+
+Turns sobriety into a liability. Throw a few drinks down before a bar fight and your fists hit harder, and the other guy's fists land softer.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipDrunkenBrawler"/>
+</Box>
+
+## Using it
+1. Get [color=#a4885c]drunk[/color].\n2. Punch people for a flat damage bonus.\n3. Take reduced damage from anyone trying to put you down with their fists.
+
+[color=#a4885c]Combat.[/color] No effect while sober. Held weapons swing the same as ever, this is fists only.
+</Document>

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDrunkenBrawler.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDrunkenBrawler.xml
@@ -1,7 +1,7 @@
 <Document>
 # F0RC3 4DD1CT10N
 
-Turns sobriety into a liability. Throw a few drinks down before a bar fight and your fists hit harder, and the other guy's fists land softer.
+When intoxicated, you gain increased unarmed effectiveness.
 
 <Box>
 <GuideEntityEmbed Entity="SkillchipDrunkenBrawler"/>


### PR DESCRIPTION
## About the PR

Adds the F0RC3 4DD1CT10N skillchip and its drunken-combat consumer. While the carrier is intoxicated, unarmed swings hit at 1.3x and incoming unarmed damage is reduced to 0.8x. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

A combat chip that turns sobriety into a liability. Useless to anyone not actively drinking, so it lands as a sidegrade for bartenders and barflies rather than a flat upgrade. Mirrors SS13's TRAIT_DRUNKEN_BRAWLER (`_species.dm`) on the offense and defense sides. SS13 scales offense continuously with damage taken; this port settles for a flat multiplier so the consumer stays off the obsolete `GetTotalDamage` API.

## Technical details

- `SkillchipDrunkenBrawler` entity and `SkillchipDrunkenBrawlerData` prototype in per-chip files (`Entities/Skillchips/drunken_brawler.yml`, `Skillchips/drunken_brawler.yml`), sharing the standard skillchip sprite.
- `SharedDrunkenBrawlerSystem` (Content.Shared) anchors both event handlers on `MeleeWeaponComponent` so one subscription per side covers every `MobCombat` mob.
  - Offense: subscribes `GetMeleeDamageEvent`, gates on `args.User == args.Weapon` so held weapons are untouched, then checks drunk status + `drunken_brawler` capability and multiplies the damage spec by 1.3.
  - Defense: subscribes `DamageModifyEvent`, resolves the attacker's current weapon via `TryGetWeapon` to confirm an unarmed hit, then checks the target for drunk status + capability and multiplies incoming damage by 0.8.
- Guidebook entry registered under the existing `Skillchips` parent (`SkillchipDrunkenBrawler.xml` plus locale string).

## Media

No visual changes.

## Breaking changes

None.

:cl:
- add: F0RC3 4DD1CT10N skillchip. While drunk it boosts your unarmed damage and reduces incoming unarmed damage.