### PR TITLE
honksquad: feat: Mast-Angl-Er skillchip (fishing discernment)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/fishing_discernment.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/fishing_discernment.yml
@@ -1,0 +1,13 @@
+# Mast-Angl-Er skillchip entity
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipFishingDiscernment
+  name: Mast-Angl-Er skillchip
+  description: A small neural interface chip. Lists fishes when examining a fishing spot, gives a hint of whatever thing's biting the hook and more.
+  components:
+    - type: Sprite
+      sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+      state: skillchip
+    - type: Skillchip
+      chipProto: SkillchipFishingDiscernmentData

--- a/Resources/Prototypes/@RussStation/Skillchips/fishing_discernment.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/fishing_discernment.yml
@@ -1,0 +1,9 @@
+# Mast-Angl-Er skillchip data prototype
+
+- type: skillchip
+  id: SkillchipFishingDiscernmentData
+  name: Fisherman's Discernment
+  capacityCost: 1
+  grants:
+    - !type:CapabilityTagGrant
+      tag: fishing_discernment


### PR DESCRIPTION
## About the PR

Adds the Mast-Angl-Er skillchip prototype and entity. The chip registers the `fishing_discernment` capability tag and nothing else. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

SS13's Mast-Angl-Er auto-grants four fishing-related traits (reveal-fish, examine-fishing-spot, examine-fish, examine-deeper-fish) plus a Dispense Fishing Tip cooldown action. SS14 has no fishing system to hook against yet, so this PR lands the catalog slot now and the consumer follows in #808 once fishing exists.

## Technical details

- `SkillchipFishingDiscernment` entity and `SkillchipFishingDiscernmentData` prototype in per-chip files (`Entities/Skillchips/fishing_discernment.yml`, `Skillchips/fishing_discernment.yml`), sharing the standard skillchip sprite.
- `CapabilityTagGrant` registers the `fishing_discernment` tag for the consumer in #808 to query.
- No guidebook entry; placeholder chips skip it until they actually do something.

## Media

No visual changes.

## Breaking changes

None.