### PR TITLE
honksquad: feat: skillchip category restriction (one per category)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
@@ -35,6 +35,24 @@ public sealed class SkillchipGrantTest
   - !type:CapabilityTagGrant
     tag: test_capability_2
 
+- type: skillchip
+  id: TestChipCategoryA1
+  name: Category A Chip 1
+  capacityCost: 1
+  category: test_category_a
+  grants:
+  - !type:CapabilityTagGrant
+    tag: test_cat_a1
+
+- type: skillchip
+  id: TestChipCategoryA2
+  name: Category A Chip 2
+  capacityCost: 1
+  category: test_category_a
+  grants:
+  - !type:CapabilityTagGrant
+    tag: test_cat_a2
+
 - type: entity
   id: TestBrain
   components:
@@ -321,6 +339,36 @@ public sealed class SkillchipGrantTest
                 "First chip should install within capacity");
             Assert.That(skillchips.TryInstall((brain, holder), "TestChipData2"), Is.False,
                 "Second chip should be rejected when at capacity");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Installing two chips of the same category should be rejected.
+    /// Installing a chip of a different category should succeed.
+    /// </summary>
+    [Test]
+    public async Task Install_SameCategory_ReturnsFalse()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipCategoryA1"), Is.True,
+                "First chip in category should install");
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipCategoryA2"), Is.False,
+                "Second chip in same category should be rejected");
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipData"), Is.True,
+                "Chip with no category should still install alongside a categorized chip");
+            Assert.That(holder.ImplantedChips.Count, Is.EqualTo(2));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/RussStation/Skillchips/SkillchipPrototype.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipPrototype.cs
@@ -21,6 +21,13 @@ public sealed partial class SkillchipPrototype : IPrototype
     public int CapacityCost = SkillchipsConstants.DefaultCapacityCost;
 
     /// <summary>
+    /// Optional category string. Only one chip of a given category may be implanted at a time.
+    /// Null means no category restriction.
+    /// </summary>
+    [DataField]
+    public string? Category;
+
+    /// <summary>
     /// Grants applied to the mob when this chip is active.
     /// </summary>
     [DataField]

--- a/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
@@ -46,6 +46,9 @@ public abstract class SharedSkillchipSystem : EntitySystem
         if (UsedCapacity(brain.Comp) + prototype.CapacityCost > brain.Comp.MaxCapacity)
             return false;
 
+        if (prototype.Category != null && HasCategoryInstalled(brain.Comp, prototype.Category))
+            return false;
+
         // Apply grants first so a thrown grant leaves the holder untouched. Recording the chip
         // last keeps capacity accounting consistent with what is actually active on the mob.
         if (GetBody(brain) is { } body)
@@ -238,6 +241,17 @@ public abstract class SharedSkillchipSystem : EntitySystem
         foreach (var chipProto in holder.ImplantedChips)
             total += _proto.Index(chipProto).CapacityCost;
         return total;
+    }
+
+    private bool HasCategoryInstalled(SkillchipHolderComponent holder, string category)
+    {
+        foreach (var installed in holder.ImplantedChips)
+        {
+            if (_proto.Index(installed).Category == category)
+                return true;
+        }
+
+        return false;
     }
 
     private EntityUid? GetBody(Entity<SkillchipHolderComponent> brain)


### PR DESCRIPTION
## About the PR

Adds a `Category` field to `SkillchipPrototype`. `TryInstall` rejects a chip if another chip in the same category is already implanted. Foundation for job chips, which need a one-per-category rule.

## Why / Balance

Job chips in the SS13 roster use a mutual-exclusion rule: at most one chef chip, one janitor chip, etc. The category field implements that restriction without per-chip logic. Existing chips have no category and behave exactly as before.

## Technical details

- `SkillchipPrototype.Category` is a nullable `string` `[DataField]`. Null means no restriction.
- `SharedSkillchipSystem.TryInstall` calls a new `HasCategoryInstalled` helper after the duplicate and capacity gates; the helper scans implanted chips and compares categories.
- Integration test `Install_SameCategory_ReturnsFalse` covers same-category rejection, different-category install still succeeding, and a null-category chip coexisting with everything.

## Breaking changes

None. Every current chip prototype has a null category, so the gate is a no-op for them.

:cl:
- add: Skillchips can declare a category; only one chip per category can be implanted at a time.