### PR TITLE
honksquad: feat: B@L00NY skillchip (balloon sutra, job tier)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/job.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/job.yml
@@ -1,0 +1,13 @@
+# Skillchip entity items -- job tier (powerful, restricted to one per category)
+
+- type: entity
+  parent: BaseItem
+  id: SkillchipBalloonSutra
+  name: B@L00NY skillchip
+  description: A small neural interface chip. Contains several terabytes of uncannily religious, Honkmother-praising guides on how to reshape balloons into silly animals.
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/Balloons/nanotrasen.rsi
+    state: icon
+  - type: Skillchip
+    chipProto: SkillchipBalloonSutraData

--- a/Resources/Prototypes/@RussStation/Skillchips/job.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/job.yml
@@ -1,0 +1,10 @@
+# Skillchip data prototypes -- job tier (one per category)
+
+- type: skillchip
+  id: SkillchipBalloonSutraData
+  name: Balloon Sutra
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: balloon_sutra


### PR DESCRIPTION
## About the PR

Adds the B@L00NY skillchip prototype and entity. The chip registers the `balloon_sutra` capability tag and nothing else. First job-tier chip, uses the category restriction merged in #717. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Clown job chip. SS13's balloon sutra trait bypasses material requirements on balloon-themed apparel and the balloon mallet, adds flavor examine on the mallet, and lets the holder twist two long balloons together into a balloon-animal toy. SS14 has none of the entities or recipes those consumers need, so this PR lands the catalog slot now and the consumer follows in #812 once the supporting assets and the #784 recipe gate exist.

Costs 2 capacity slots and uses `category: job`, so installing it blocks any other job chip from going in alongside.

## Technical details

- `SkillchipBalloonSutra` entity and `SkillchipBalloonSutraData` prototype in per-chip files (`Entities/Skillchips/job.yml`, `Skillchips/job.yml`).
- `capacityCost: 2`, `category: job`.
- `CapabilityTagGrant` registers the `balloon_sutra` tag for the consumer in #812 to query.
- Sprite reuses `Objects/Fun/Balloons/nanotrasen.rsi` `icon` so the item reads at a glance as a balloon-themed chip.
- No guidebook entry; placeholder chips skip it until they actually do something.

## Media

No visual changes.

## Breaking changes

None.