### PR TITLE
honksquad: feat: DET.ekt skillchip (detective's taste, job tier)

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -18,6 +18,9 @@ using Content.Shared.Inventory;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Popups;
+//HONK START - issue #719: fork hook namespace for IngestionFlavorRewriteEvent
+using Content.Shared.RussStation.Nutrition;
+//HONK END
 using Content.Shared.Tools.EntitySystems;
 using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
@@ -486,6 +489,14 @@ public sealed partial class IngestionSystem : EntitySystem
         _audio.PlayPredicted(entity.Comp.UseSound ?? edible.UseSound, args.Target, args.User);
 
         var flavors = _flavorProfile.GetLocalizedFlavorsMessage(entity.Owner, args.Target, args.Split);
+
+        //HONK START - issue #719: fork hook for chips/traits that want to rewrite the eat
+        //popup's taste portion. Raised on the eater (args.Target); subscribers mutate
+        //ev.Flavors. First consumer is the DET.ekt skillchip's reagent readout.
+        var flavorRewrite = new IngestionFlavorRewriteEvent(args.Target, args.Split, flavors);
+        RaiseLocalEvent(args.Target, ref flavorRewrite);
+        flavors = flavorRewrite.Flavors;
+        //HONK END
 
         if (args.ForceFed)
         {

--- a/Content.Shared/RussStation/Nutrition/IngestionFlavorRewriteEvent.cs
+++ b/Content.Shared/RussStation/Nutrition/IngestionFlavorRewriteEvent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Chemistry.Components;
+
+namespace Content.Shared.RussStation.Nutrition;
+
+/// <summary>
+/// Fork hook raised on the eater inside <c>IngestionSystem.OnEdibleIngested</c>
+/// after the upstream flavor message is built and before it is rendered into the
+/// eat / force-feed popup. Subscribers may overwrite <see cref="Flavors"/> to
+/// substitute a different string (e.g. a skillchip-driven readout).
+///
+/// First consumer is the DET.ekt skillchip (#719), which replaces taste
+/// descriptions with reagent names for <c>detective_taste</c> carriers. Other
+/// chips or traits that want to rebind the popup's taste line can subscribe
+/// without IngestionSystem learning about each of them.
+/// </summary>
+/// <param name="Eater">Mob doing the eating (target in force-feed).</param>
+/// <param name="Solution">Reagent split being ingested this bite.</param>
+[ByRefEvent]
+public record struct IngestionFlavorRewriteEvent(EntityUid Eater, Solution Solution, string Flavors)
+{
+    /// <summary>
+    /// Mutable. Starts at the upstream-built flavor string; subscribers may
+    /// replace it. Last writer wins (no ordering between subscribers today).
+    /// </summary>
+    public string Flavors = Flavors;
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/SharedDetectiveTasteSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/SharedDetectiveTasteSystem.cs
@@ -1,0 +1,59 @@
+using Content.Shared.Body;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.RussStation.Nutrition;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Ingestion hook for the DET.ekt skillchip (<c>detective_taste</c> capability).
+/// When a chip holder eats or drinks, replace the upstream taste line with a
+/// reagent-name listing. Mirrors SS13's <c>TRAIT_DETECTIVES_TASTE</c> override
+/// in <c>reagents.dm</c>: <c>get_taste_description</c> returns the reagent's
+/// <c>name</c> when the taster has the trait.
+///
+/// Subscribes to <see cref="IngestionFlavorRewriteEvent"/>, a fork-side hook
+/// IngestionSystem raises just before formatting the eat / force-feed popup.
+/// Avoids the engine's ordered-event trap (unordered handlers fire before
+/// ordered ones, so a <c>before:[IngestionSystem]</c> directed sub on a
+/// different food-side component does not actually run first), and keeps
+/// IngestionSystem free of fork-consumer dependencies.
+///
+/// TODO: SS13 also overrides this for blood, returning the blood type. SS14 has
+/// no blood-type metadata on the reagent yet, so the blood branch is deferred.
+/// </summary>
+public sealed class SharedDetectiveTasteSystem : EntitySystem
+{
+    public const string DetectiveTasteTag = "detective_taste";
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BodyComponent, IngestionFlavorRewriteEvent>(OnRewriteFlavor);
+    }
+
+    private void OnRewriteFlavor(Entity<BodyComponent> ent, ref IngestionFlavorRewriteEvent args)
+    {
+        if (args.Solution.Volume <= 0)
+            return;
+
+        if (!_skillchip.HasCapability(ent.Owner, DetectiveTasteTag))
+            return;
+
+        var names = new List<string>();
+        foreach (var reagent in args.Solution.Contents)
+        {
+            if (_proto.TryIndex<ReagentPrototype>(reagent.Reagent.Prototype, out var proto))
+                names.Add(proto.LocalizedName);
+        }
+
+        if (names.Count == 0)
+            return;
+
+        args.Flavors = Loc.GetString("skillchip-detective-taste-line", ("reagents", string.Join(", ", names)));
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -8,3 +8,4 @@ guide-entry-skillchip-flavour-calculus = INTJ
 guide-entry-skillchip-id-appraisal = GENUINE ID Appraisal Now!
 guide-entry-skillchip-drunken-brawler = F0RC3 4DD1CT10N
 guide-entry-skillchip-kommand = Kommand
+guide-entry-skillchip-detective-taste = DET.ekt

--- a/Resources/Locale/en-US/@RussStation/skillchips/detective_taste.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/detective_taste.ftl
@@ -1,0 +1,1 @@
+skillchip-detective-taste-line = You discern its composition: { $reagents }.

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/detective_taste.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/detective_taste.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipDetectiveTaste
+  name: DET.ekt skillchip
+  description: A small neural interface chip. Detective "Encyclopedic Knowledge of Tastes" v1.21. Deduce the minute chemical compositions of any liquid substance just by swishing it around your mouth.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipDetectiveTasteData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -5,6 +5,7 @@
   filterEnabled: True
   children:
     - SkillchipStation
+    - SkillchipDetectiveTaste
     - SkillchipDiskVerifier
     - SkillchipDrunkenBrawler
     - SkillchipEntrailsReader
@@ -58,3 +59,8 @@
   id: SkillchipDrunkenBrawler
   name: guide-entry-skillchip-drunken-brawler
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipDrunkenBrawler.xml"
+
+- type: guideEntry
+  id: SkillchipDetectiveTaste
+  name: guide-entry-skillchip-detective-taste
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipDetectiveTaste.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/detective_taste.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/detective_taste.yml
@@ -1,0 +1,8 @@
+- type: skillchip
+  id: SkillchipDetectiveTasteData
+  name: Detective's Taste
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: detective_taste

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDetectiveTaste.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipDetectiveTaste.xml
@@ -1,0 +1,11 @@
+<Document>
+# DET.ekt
+
+Detective "Encyclopedic Knowledge of Tastes" v1.21. Deduce the minute chemical compositions of any liquid substance just by swishing it around your mouth.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipDetectiveTaste"/>
+</Box>
+
+Take a bite of any [color=#a4885c]food or drink[/color]. The chip names the reagents in that mouthful by their chemical IDs, so a glass of vodka reads as "ethanol, water" rather than "stinging".
+</Document>


### PR DESCRIPTION
## About the PR

Adds the DET.ekt skillchip and its ingestion consumer. Holders see the reagent names of anything they eat or drink instead of the usual taste descriptions. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Detective job chip. Mirrors SS13's `TRAIT_DETECTIVES_TASTE`, a forensic nudge for detectives and chemists who want to know what's actually in the cup. Inert against anyone without the chip.

## Technical details

- `SkillchipDetectiveTasteData` prototype in `Resources/Prototypes/@RussStation/Skillchips/detective_taste.yml`
- `SkillchipDetectiveTaste` entity in `Resources/Prototypes/@RussStation/Entities/Skillchips/detective_taste.yml`
- `capacityCost: 2`, `category: job`, `CapabilityTagGrant` with tag `detective_taste`
- `SharedDetectiveTasteSystem` subscribes to `IngestedEvent` on `EdibleComponent`; on a holder it pops a client-predicted line listing the reagent prototypes in the bite (`Content.Shared/RussStation/Skillchips/Consumers/SharedDetectiveTasteSystem.cs`)
- Guidebook entry under `Skillchips`, locale line `skillchip-detective-taste-line`
- Sprite: shared `@RussStation/Objects/Misc/skillchip.rsi` `skillchip` state
- SS13's blood-type override is deferred (no blood-type metadata on the reagent yet); marked TODO in the system file

## Media

No visual changes.

## Breaking changes

None.

:cl:
- add: DET.ekt skillchip lists reagent names of anything you eat or drink