### PR TITLE
honksquad: feat: CL34NM4ST.R skillchip (cleanbot whisperer, job tier)

### DIFF
--- a/Content.Server/RussStation/Skillchips/Consumers/CleanbotWhispererSystem.cs
+++ b/Content.Server/RussStation/Skillchips/Consumers/CleanbotWhispererSystem.cs
@@ -1,0 +1,74 @@
+using Content.Server.Chat.Systems;
+using Content.Shared.Chat;
+using Content.Shared.Humanoid;
+using Content.Shared.RussStation.Skillchips.Consumers;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Cleanbot consumer for the <c>cleanbot_whisperer</c> capability tag.
+/// Periodically picks a nearby chip-holder and emits a flavor emote, mirroring
+/// SS13's <c>befriend_janitors</c> AI subtree. SS14 cleanbots have no hostile
+/// mode wired up, so the SS13 faction-add half is purely flavor here too.
+/// </summary>
+public sealed class CleanbotWhispererSystem : EntitySystem
+{
+    public const string CleanbotWhispererTag = "cleanbot_whisperer";
+
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+
+    private static readonly string[] CommonGreetings =
+    {
+        "skillchip-cleanbot-whisperer-greet-1",
+        "skillchip-cleanbot-whisperer-greet-2",
+        "skillchip-cleanbot-whisperer-greet-3",
+        "skillchip-cleanbot-whisperer-greet-4",
+        "skillchip-cleanbot-whisperer-greet-5",
+    };
+
+    private const string RareGreeting = "skillchip-cleanbot-whisperer-greet-rare";
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<CleanbotWhispererBotComponent>();
+        while (query.MoveNext(out var bot, out var comp))
+        {
+            if (now < comp.NextGreeting)
+                continue;
+
+            comp.NextGreeting = now + comp.Interval;
+            TryGreetNearbyHolder(bot, comp);
+        }
+    }
+
+    private void TryGreetNearbyHolder(EntityUid bot, CleanbotWhispererBotComponent comp)
+    {
+        var holderPresent = false;
+        foreach (var humanoid in _lookup.GetEntitiesInRange<HumanoidProfileComponent>(Transform(bot).Coordinates, comp.Range))
+        {
+            if (_skillchip.HasCapability(humanoid.Owner, CleanbotWhispererTag))
+            {
+                holderPresent = true;
+                break;
+            }
+        }
+
+        if (!holderPresent)
+            return;
+
+        var rare = comp.RareOneIn > 0 && _random.Next(comp.RareOneIn) == 0;
+        var line = Loc.GetString(rare ? RareGreeting : _random.Pick(CommonGreetings));
+
+        _chat.TrySendInGameICMessage(bot, line, InGameICChatType.Emote, hideChat: false, hideLog: true);
+    }
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/CleanbotWhispererBotComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/CleanbotWhispererBotComponent.cs
@@ -1,0 +1,25 @@
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Marker for cleanbots that respond to nearby holders of the
+/// <c>cleanbot_whisperer</c> capability tag. Server-side
+/// CleanbotWhispererSystem polls these and emits a friendly greeting.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CleanbotWhispererBotComponent : Component
+{
+    [DataField]
+    public float Range = CleanbotWhispererConstants.Range;
+
+    [DataField]
+    public TimeSpan Interval = TimeSpan.FromSeconds(CleanbotWhispererConstants.IntervalSeconds);
+
+    [DataField]
+    public TimeSpan NextGreeting;
+
+    /// <summary>
+    /// 1-in-N chance to roll the rare greeting instead of the common pool.
+    /// </summary>
+    [DataField]
+    public int RareOneIn = CleanbotWhispererConstants.RareOneIn;
+}

--- a/Content.Shared/RussStation/Skillchips/Consumers/CleanbotWhispererConstants.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/CleanbotWhispererConstants.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+public static class CleanbotWhispererConstants
+{
+    /// <summary>Tile radius scanned around each bot for chip-holders.</summary>
+    public const float Range = 4f;
+
+    /// <summary>Seconds between greeting attempts on each bot.</summary>
+    public const int IntervalSeconds = 45;
+
+    /// <summary>1-in-N chance to roll the rare easter-egg line instead of a common one.</summary>
+    public const int RareOneIn = 20;
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -9,3 +9,4 @@ guide-entry-skillchip-id-appraisal = GENUINE ID Appraisal Now!
 guide-entry-skillchip-drunken-brawler = F0RC3 4DD1CT10N
 guide-entry-skillchip-kommand = Kommand
 guide-entry-skillchip-detective-taste = DET.ekt
+guide-entry-skillchip-cleanbot-whisperer = CL34NM4ST.R

--- a/Resources/Locale/en-US/@RussStation/skillchips/cleanbot_whisperer.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/cleanbot_whisperer.ftl
@@ -1,0 +1,6 @@
+skillchip-cleanbot-whisperer-greet-1 = empathetically acknowledges your hard work.
+skillchip-cleanbot-whisperer-greet-2 = beeps approvingly in your direction.
+skillchip-cleanbot-whisperer-greet-3 = hums a quiet appreciation at the ankles of the nearest janitor.
+skillchip-cleanbot-whisperer-greet-4 = salutes with a stiff little nozzle-bow.
+skillchip-cleanbot-whisperer-greet-5 = nudges itself reassuringly against a boot.
+skillchip-cleanbot-whisperer-greet-rare = confides, in a tone meant only for you, that the floor remembers everything you have ever spilled on it.

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/cleanbot_whisperer.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/cleanbot_whisperer.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipCleanbotWhisperer
+  name: CL34NM4ST.R skillchip
+  description: A small neural interface chip. Become a cleanbot whisperer. Gain the affection of all thankless, hardworking cleanbots on the station.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipCleanbotWhispererData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -5,6 +5,7 @@
   filterEnabled: True
   children:
     - SkillchipStation
+    - SkillchipCleanbotWhisperer
     - SkillchipDetectiveTaste
     - SkillchipDiskVerifier
     - SkillchipDrunkenBrawler
@@ -64,3 +65,8 @@
   id: SkillchipDetectiveTaste
   name: guide-entry-skillchip-detective-taste
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipDetectiveTaste.xml"
+
+- type: guideEntry
+  id: SkillchipCleanbotWhisperer
+  name: guide-entry-skillchip-cleanbot-whisperer
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipCleanbotWhisperer.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/cleanbot_whisperer.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/cleanbot_whisperer.yml
@@ -1,0 +1,8 @@
+- type: skillchip
+  id: SkillchipCleanbotWhispererData
+  name: Voice Of The Voiceless
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: cleanbot_whisperer

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -306,6 +306,9 @@
     interactFailureString: petting-failure-cleanbot
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
+  # HONK START - CL34NM4ST.R skillchip consumer
+  - type: CleanbotWhispererBot
+  # HONK END
 
 - type: entity
   parent:

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipCleanbotWhisperer.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipCleanbotWhisperer.xml
@@ -1,0 +1,11 @@
+<Document>
+# CL34NM4ST.R
+
+Become a cleanbot whisperer. Gain the affection of all thankless, hardworking cleanbots on the station.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipCleanbotWhisperer"/>
+</Box>
+
+Stand near any working [color=#a4885c]cleanbot[/color]. Every so often, one within a few tiles will pause to acknowledge you with a small flavor emote. There is also a much rarer line that only a patient holder will ever hear.
+</Document>


### PR DESCRIPTION
## About the PR

Adds the CL34NM4ST.R skillchip and a small cleanbot consumer that responds to its holder. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Janitor job chip. Cleanbots quietly acknowledge anyone running the chip, no mechanical bite, just flavor.

## Technical details

- Chip prototype and entity at `Resources/Prototypes/@RussStation/Skillchips/cleanbot_whisperer.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/cleanbot_whisperer.yml`. `capacityCost: 2`, `category: job`, `CapabilityTagGrant` with tag `cleanbot_whisperer`. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.
- `CleanbotWhispererBotComponent` (Content.Shared) marks a bot as responsive, with a 45 second interval and 4 tile range.
- `CleanbotWhispererSystem` (Content.Server) ticks each marked bot, scans for nearby humanoids with the capability tag, and on a match emits a friendly third-person emote. Five common lines plus a 1-in-20 rare easter egg.
- `MobCleanBot` in `Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml` gets the component wired in via HONK markers.
- Guidebook entry under the Skillchips index.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: CL34NM4ST.R skillchip. Cleanbots quietly acknowledge anyone running it.