### PR TITLE
honksquad: feat: TUNN3L_R4T skillchip (battlebot enthusiast, job tier)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/battlebot_enthusiast.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/battlebot_enthusiast.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipBattlebotEnthusiast
+  name: TUNN3L_R4T skillchip
+  description: A small neural interface chip. Lead minebots into war.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipBattlebotEnthusiastData

--- a/Resources/Prototypes/@RussStation/Skillchips/battlebot_enthusiast.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/battlebot_enthusiast.yml
@@ -1,0 +1,8 @@
+- type: skillchip
+  id: SkillchipBattlebotEnthusiastData
+  name: Battlebot Enthusiast
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: rock_stoner


### PR DESCRIPTION
## About the PR

Adds the TUNN3L_R4T skillchip as a capability-tag-only placeholder. Grants `rock_stoner` (the actual SS13 trait name behind the chip). Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Miner job chip. The SS13 consumer lives in minebot AI: nearby minebots scan for trait-holders and queue a friendly greeting, the same befriend pattern that ships for cleanbots in #720. SS14 has no minebot yet, so the consumer cannot be written. The chip lands now with the right tag; the consumer is tracked in #815.

## Technical details

- Chip prototype and entity at `Resources/Prototypes/@RussStation/Skillchips/battlebot_enthusiast.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/battlebot_enthusiast.yml`. `capacityCost: 2`, `category: job`, `CapabilityTagGrant` with tag `rock_stoner`. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: TUNN3L_R4T skillchip. Implant to register as a minebot enthusiast.