### PR TITLE
honksquad: feat: HYPERG1G4 skillchip (supermatter cognition, job tier)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/supermatter_cognition.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/supermatter_cognition.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipSupermatterCognition
+  name: HYPERG1G4 skillchip
+  description: A small neural interface chip. Learn to bend the abyss to your will. Understand the correct mental patterns to keep in mind around matter in a hyperfractal state, causing immunity to visions and making the matter in question "calmer".
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipSupermatterCognitionData

--- a/Resources/Prototypes/@RussStation/Skillchips/supermatter_cognition.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/supermatter_cognition.yml
@@ -1,0 +1,10 @@
+- type: skillchip
+  id: SkillchipSupermatterCognitionData
+  name: Supermatter Cognition Theory
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: supermatter_soother
+  - !type:CapabilityTagGrant
+    tag: supermatter_madness_immune


### PR DESCRIPTION
## About the PR

Adds the HYPERG1G4 skillchip as a capability-tag-only placeholder. Grants `supermatter_soother` and `supermatter_madness_immune` (the actual SS13 trait strings behind the chip). Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Psychologist job chip. The SS13 consumers live on the supermatter crystal: the soother trait calms the crystal when a holder is in view, the madness-immune trait skips supermatter-induced hallucinations. SS14 has no supermatter yet, so neither consumer can be written. The chip lands now with the right tag strings; the consumer work is tracked in #816.

## Technical details

- Chip prototype and entity at `Resources/Prototypes/@RussStation/Skillchips/supermatter_cognition.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/supermatter_cognition.yml`. `capacityCost: 2`, `category: job`, two `CapabilityTagGrant` entries. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: HYPERG1G4 skillchip. Implant to register as a supermatter cognition theorist.