### PR TITLE
honksquad: feat: Cyborg C1-RCU-1T skillchip (cyborg circuitry, job tier)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/cyborg_circuitry.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/cyborg_circuitry.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipCyborgCircuitry
+  name: Cyborg C1-RCU-1T skillchip
+  description: A small neural interface chip. A roboticist's second best friend. Recognise cyborg wire layouts and understand their functionality at a glance.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipCyborgCircuitryData

--- a/Resources/Prototypes/@RussStation/Skillchips/cyborg_circuitry.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/cyborg_circuitry.yml
@@ -1,0 +1,8 @@
+- type: skillchip
+  id: SkillchipCyborgCircuitryData
+  name: Cyborg Circuitry
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: know_robo_wires


### PR DESCRIPTION
## About the PR

Adds the Cyborg C1-RCU-1T skillchip as a capability-tag-only placeholder. Grants `know_robo_wires` (the actual SS13 trait string behind the chip). Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Roboticist job chip. The SS13 consumer is a `can_reveal_wires` hook on borg, mech, and MOD wire datums: holders see wire labels instead of just colors, so they don't need to multitool a borg to find the "lockdown" wire. SS14's wire UI today sends only color and letter to the client, never the action identity, so the consumer is a UI-state change (per-viewer reveal channel), not a one-line hook. The chip lands now with the right tag; the consumer work is tracked in #817.

## Technical details

- Chip prototype and entity at `Resources/Prototypes/@RussStation/Skillchips/cyborg_circuitry.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/cyborg_circuitry.yml`. `capacityCost: 2`, `category: job`, `CapabilityTagGrant` with tag `know_robo_wires`. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: Cyborg C1-RCU-1T skillchip. Implant to register as a roboticist with too many opinions about wire color schemes.