### PR TITLE
honksquad: feat: Engineering C1-RCU-1T skillchip (engineering circuitry, job tier)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/engineering_circuitry.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/engineering_circuitry.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipEngineeringCircuitry
+  name: Engineering C1-RCU-1T skillchip
+  description: A small neural interface chip. Endorsed by Poly. Recognise airlock and APC wire layouts and understand their functionality at a glance.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipEngineeringCircuitryData

--- a/Resources/Prototypes/@RussStation/Skillchips/engineering_circuitry.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/engineering_circuitry.yml
@@ -1,0 +1,8 @@
+- type: skillchip
+  id: SkillchipEngineeringCircuitryData
+  name: Engineering Circuitry
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: know_engi_wires


### PR DESCRIPTION
## About the PR

Adds the Engineering C1-RCU-1T skillchip as a capability-tag-only placeholder. Grants `know_engi_wires` (the actual SS13 trait string behind the chip). Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Station engineer job chip. The SS13 consumer is a `can_reveal_wires` hook on airlock and APC wire datums: holders see wire labels instead of just colors, so they don't need to multitool an airlock to find the backup power wire. SS14's wire UI today sends only color and letter to the client, never the action identity, so the consumer is a UI-state change (per-viewer reveal channel), not a one-line hook. The chip lands now with the right tag; the consumer work is tracked in #818, and shares its infrastructure with #817.

## Technical details

- Chip prototype and entity at `Resources/Prototypes/@RussStation/Skillchips/engineering_circuitry.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/engineering_circuitry.yml`. `capacityCost: 2`, `category: job`, `CapabilityTagGrant` with tag `know_engi_wires`. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: Engineering C1-RCU-1T skillchip. Implant to register as a station engineer endorsed by Poly.