### PR TITLE
honksquad: feat: SS13 Musical skillchip

### DIFF
--- a/Content.Server/RussStation/Skillchips/SingAccentSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SingAccentSystem.cs
@@ -1,0 +1,68 @@
+using Content.Shared.RussStation.Skillchips;
+using Content.Shared.Speech;
+
+namespace Content.Server.RussStation.Skillchips;
+
+/// <summary>
+/// Reshapes speech to sound sung: holds the last vowel of the final word and adds punctuation.
+/// Applied when a mob has SingAccentComponent (granted by the SS13 Musical skillchip).
+/// </summary>
+public sealed class SingAccentSystem : EntitySystem
+{
+    private static readonly char[] Vowels = ['a', 'e', 'i', 'o', 'u'];
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SingAccentComponent, AccentGetEvent>(OnAccentGet);
+    }
+
+    private void OnAccentGet(Entity<SingAccentComponent> ent, ref AccentGetEvent args)
+    {
+        args.Message = Singify(args.Message);
+    }
+
+    private static string Singify(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return message;
+
+        var words = message.Split(' ');
+        var last = words[^1];
+        words[^1] = ReshapeWord(last);
+        return string.Join(' ', words);
+    }
+
+    private static string ReshapeWord(string word)
+    {
+        if (string.IsNullOrEmpty(word))
+            return word;
+
+        // Find the last vowel in the word.
+        var lastVowelIndex = -1;
+        for (var i = word.Length - 1; i >= 0; i--)
+        {
+            if (Array.IndexOf(Vowels, char.ToLower(word[i])) >= 0)
+            {
+                lastVowelIndex = i;
+                break;
+            }
+        }
+
+        if (lastVowelIndex < 0)
+            return word + "~";
+
+        // Hold the vowel by repeating it four times.
+        var result = word[..lastVowelIndex]
+                     + new string(word[lastVowelIndex], 4)
+                     + word[(lastVowelIndex + 1)..];
+
+        // Replace a trailing period with an exclamation mark; add one if missing.
+        if (result.EndsWith('.') && !result.EndsWith("..."))
+            result = result[..^1] + "!";
+        else if (!result.EndsWith('!') && !result.EndsWith('?') && !result.EndsWith("..."))
+            result += "!";
+
+        return result;
+    }
+}

--- a/Content.Shared/RussStation/Skillchips/Grants/SingAccentGrant.cs
+++ b/Content.Shared/RussStation/Skillchips/Grants/SingAccentGrant.cs
@@ -1,0 +1,16 @@
+using Content.Shared.RussStation.Skillchips.Systems;
+
+namespace Content.Shared.RussStation.Skillchips.Grants;
+
+/// <summary>
+/// Adds a SingAccentComponent to the mob, causing speech to be reshaped into song.
+/// </summary>
+[Serializable]
+public sealed partial class SingAccentGrant : SkillchipGrant
+{
+    public override void Apply(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.EnsureMobComponent<SingAccentComponent>(mob);
+
+    public override void Revert(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.RemoveMobComponent<SingAccentComponent>(mob);
+}

--- a/Content.Shared/RussStation/Skillchips/SingAccentComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/SingAccentComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Skillchips;
+
+/// <summary>
+/// Added to a mob by the SS13 Musical skillchip. Causes speech to be reshaped into song.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SingAccentComponent : Component
+{
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -10,3 +10,4 @@ guide-entry-skillchip-drunken-brawler = F0RC3 4DD1CT10N
 guide-entry-skillchip-kommand = Kommand
 guide-entry-skillchip-detective-taste = DET.ekt
 guide-entry-skillchip-cleanbot-whisperer = CL34NM4ST.R
+guide-entry-skillchip-musical = MUSS13CAL

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/musical.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/musical.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipMusical
+  name: MUSS13CAL skillchip
+  description: An old copy of "Space Station 13, The Musical", ran on the station's 200th anniversary, or maybe it was the 400th. Allows you to hit that high note, like those that came a century before us.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipMusicalData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -15,6 +15,7 @@
     - SkillchipIdAppraisal
     - SkillchipKommand
     - SkillchipLightbulb
+    - SkillchipMusical
 
 - type: guideEntry
   id: SkillchipStation
@@ -70,3 +71,8 @@
   id: SkillchipCleanbotWhisperer
   name: guide-entry-skillchip-cleanbot-whisperer
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipCleanbotWhisperer.xml"
+
+- type: guideEntry
+  id: SkillchipMusical
+  name: guide-entry-skillchip-musical
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipMusical.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/musical.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/musical.yml
@@ -1,0 +1,6 @@
+- type: skillchip
+  id: SkillchipMusicalData
+  name: Memory of a Musical
+  capacityCost: 1
+  grants:
+  - !type:SingAccentGrant

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipMusical.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipMusical.xml
@@ -1,0 +1,11 @@
+<Document>
+# MUSS13CAL
+
+An old copy of "Space Station 13, The Musical", ran on the station's 200th anniversary, or maybe it was the 400th. Allows you to hit that high note, like those that came a century before us.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipMusical"/>
+</Box>
+
+Speak normally and the chip will stretch the last [color=#a4885c]vowel[/color] of every line for you, then stamp an exclamation mark on the end. There is no opt-out short of removing the chip.
+</Document>


### PR DESCRIPTION
## About the PR

Adds the SS13 Musical skillchip, a generic-tier consumer chip. When implanted, every line the holder speaks has the last vowel of the final word stretched four times and the trailing punctuation forced to an exclamation. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Generic tier, capacity cost 1. The chip is silly flavor; the SS13 source's `make_music` proc does exactly this vowel-stretch reshape on `COMSIG_MOB_SAY`. Porting the mechanic gives a player a self-imposed gimmick they can swap out by popping the chip.

## Technical details

- `SingAccentComponent` (Content.Shared): marker component, networked.
- `SingAccentGrant` (Content.Shared): `SkillchipGrant` subclass. `Apply` ensures the component on the mob via `SharedSkillchipSystem.EnsureMobComponent`, `Revert` removes it. The helper pair on `SharedSkillchipSystem` already exists, this PR just adds the grant.
- `SingAccentSystem` (Content.Server): subscribes `SingAccentComponent` to `AccentGetEvent` and rewrites the message via `Singify` plus `ReshapeWord` (find the last vowel, repeat it four times, fix the trailing punctuation).
- Per-chip prototypes at `Resources/Prototypes/@RussStation/Skillchips/musical.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/musical.yml`. Capacity cost 1, no category. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.
- Guidebook entry under the Skillchips index.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: SS13 Musical skillchip. Implanting it makes you sing every sentence, holding the last vowel and ending in an exclamation.