### PR TITLE
honksquad: feat: BULLET_DODGER skillchip

### DIFF
--- a/Content.Server/RussStation/Emotes/ForkEmoteSystem.cs
+++ b/Content.Server/RussStation/Emotes/ForkEmoteSystem.cs
@@ -22,9 +22,7 @@ public sealed class ForkEmoteSystem : EntitySystem
     private const string SpinEmoteId = "Spin";
 
     private const float MolesAmmoniaPerFart = 2.5f;
-    private static readonly TimeSpan FlipDuration = TimeSpan.FromSeconds(0.5);
     private const float FlipTurns = 1f;
-    private static readonly TimeSpan SpinDuration = TimeSpan.FromSeconds(0.5);
     /// One full S→E→N→W cycle in SpinDuration. Bump if you want it spinnier.
     private const float SpinSteps = 4f;
 
@@ -51,12 +49,12 @@ public sealed class ForkEmoteSystem : EntitySystem
                 break;
 
             case FlipEmoteId:
-                BroadcastSpriteEmote(ent.Owner, SpriteEmoteKind.Flip, FlipDuration, FlipTurns);
+                BroadcastSpriteEmote(ent.Owner, SpriteEmoteKind.Flip, ForkEmoteDurations.Flip, FlipTurns);
                 args.Handled = true;
                 break;
 
             case SpinEmoteId:
-                BroadcastSpriteEmote(ent.Owner, SpriteEmoteKind.Spin, SpinDuration, SpinSteps);
+                BroadcastSpriteEmote(ent.Owner, SpriteEmoteKind.Spin, ForkEmoteDurations.Spin, SpinSteps);
                 args.Handled = true;
                 break;
         }

--- a/Content.Server/RussStation/Skillchips/BulletDodgeSystem.cs
+++ b/Content.Server/RussStation/Skillchips/BulletDodgeSystem.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Chat;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Projectiles;
+using Content.Shared.RussStation.Emotes;
+using Content.Shared.RussStation.Skillchips;
+using Robust.Shared.Timing;
+
+namespace Content.Server.RussStation.Skillchips;
+
+/// <summary>
+/// Opens a brief projectile-deflect window when the mob performs a trigger emote.
+/// The window length matches the firing emote's animation duration, so a Flip
+/// covers exactly as long as the flip animation is visible. Consumes stamina on
+/// each successful deflect and closes the window immediately after.
+/// </summary>
+public sealed class BulletDodgeSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BulletDodgeComponent, EmoteEvent>(OnEmote);
+        SubscribeLocalEvent<BulletDodgeComponent, ProjectileReflectAttemptEvent>(OnReflectAttempt);
+    }
+
+    private void OnEmote(Entity<BulletDodgeComponent> ent, ref EmoteEvent args)
+    {
+        if (!ent.Comp.ActivateEmoteIds.Contains(args.Emote.ID))
+            return;
+
+        if (GetWindowFor(args.Emote.ID) is not { } window)
+            return;
+
+        ent.Comp.ActiveUntil = _timing.CurTime + window;
+    }
+
+    private void OnReflectAttempt(Entity<BulletDodgeComponent> ent, ref ProjectileReflectAttemptEvent args)
+    {
+        if (ent.Comp.ActiveUntil == null || _timing.CurTime > ent.Comp.ActiveUntil)
+        {
+            ent.Comp.ActiveUntil = null;
+            return;
+        }
+
+        args.Cancelled = true;
+        ent.Comp.ActiveUntil = null;
+        _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCost);
+    }
+
+    private static TimeSpan? GetWindowFor(string emoteId) => emoteId switch
+    {
+        "Flip" => ForkEmoteDurations.Flip,
+        "Spin" => ForkEmoteDurations.Spin,
+        _ => null,
+    };
+}

--- a/Content.Shared/RussStation/Emotes/ForkEmoteDurations.cs
+++ b/Content.Shared/RussStation/Emotes/ForkEmoteDurations.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared.RussStation.Emotes;
+
+/// <summary>
+/// Animation durations for the fork-added physical emotes. Single source of truth
+/// for both the emote system that drives the visual and any consumer (e.g. the
+/// BULLET_DODGER skillchip) that needs to align its window with the animation.
+/// </summary>
+public static class ForkEmoteDurations
+{
+    public static readonly TimeSpan Flip = TimeSpan.FromSeconds(0.5);
+    public static readonly TimeSpan Spin = TimeSpan.FromSeconds(0.5);
+}

--- a/Content.Shared/RussStation/Skillchips/BulletDodgeComponent.cs
+++ b/Content.Shared/RussStation/Skillchips/BulletDodgeComponent.cs
@@ -1,0 +1,29 @@
+namespace Content.Shared.RussStation.Skillchips;
+
+/// <summary>
+/// Grants the mob a brief bullet-deflect window when they perform the trigger emote.
+/// The window stays open for the duration of the triggering emote's animation, so
+/// the visual matches the mechanical effect. Added by the BULLET_DODGER skillchip.
+/// Server-only logic; not networked.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BulletDodgeComponent : Component
+{
+    /// <summary>
+    /// Emotes that activate the dodge window. Any of these opens the window.
+    /// </summary>
+    [DataField]
+    public HashSet<string> ActivateEmoteIds = new(BulletDodgeConstants.ActivateEmoteIds);
+
+    /// <summary>
+    /// Stamina drained on each successful deflect.
+    /// </summary>
+    [DataField]
+    public float StaminaCost = BulletDodgeConstants.StaminaCost;
+
+    /// <summary>
+    /// Server-only: when the active dodge window expires.
+    /// </summary>
+    [DataField]
+    public TimeSpan? ActiveUntil;
+}

--- a/Content.Shared/RussStation/Skillchips/BulletDodgeConstants.cs
+++ b/Content.Shared/RussStation/Skillchips/BulletDodgeConstants.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.RussStation.Skillchips;
+
+public static class BulletDodgeConstants
+{
+    /// <summary>Emote IDs that open the dodge window. Matches the in-engine Flip and Spin emotes.</summary>
+    public static readonly string[] ActivateEmoteIds = ["Flip", "Spin"];
+
+    /// <summary>Stamina cost charged on each successful deflect.</summary>
+    public const float StaminaCost = 30f;
+}

--- a/Content.Shared/RussStation/Skillchips/Grants/BulletDodgeGrant.cs
+++ b/Content.Shared/RussStation/Skillchips/Grants/BulletDodgeGrant.cs
@@ -1,0 +1,16 @@
+using Content.Shared.RussStation.Skillchips.Systems;
+
+namespace Content.Shared.RussStation.Skillchips.Grants;
+
+/// <summary>
+/// Adds BulletDodgeComponent to the mob, granting a brief projectile-deflect window on trigger emote.
+/// </summary>
+[Serializable]
+public sealed partial class BulletDodgeGrant : SkillchipGrant
+{
+    public override void Apply(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.EnsureMobComponent<BulletDodgeComponent>(mob);
+
+    public override void Revert(EntityUid mob, EntityUid brain, SharedSkillchipSystem system)
+        => system.RemoveMobComponent<BulletDodgeComponent>(mob);
+}

--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -11,3 +11,4 @@ guide-entry-skillchip-kommand = Kommand
 guide-entry-skillchip-detective-taste = DET.ekt
 guide-entry-skillchip-cleanbot-whisperer = CL34NM4ST.R
 guide-entry-skillchip-musical = MUSS13CAL
+guide-entry-skillchip-bullet-dodger = BULLET_DODGER

--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/bullet_dodger.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/bullet_dodger.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipBulletDodger
+  name: BULLET_DODGER skillchip
+  description: A small neural interface chip. At the cost of stamina, your taunts can also be used to dodge incoming projectiles.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipBulletDodgerData

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -5,6 +5,7 @@
   filterEnabled: True
   children:
     - SkillchipStation
+    - SkillchipBulletDodger
     - SkillchipCleanbotWhisperer
     - SkillchipDetectiveTaste
     - SkillchipDiskVerifier
@@ -76,3 +77,8 @@
   id: SkillchipMusical
   name: guide-entry-skillchip-musical
   text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipMusical.xml"
+
+- type: guideEntry
+  id: SkillchipBulletDodger
+  name: guide-entry-skillchip-bullet-dodger
+  text: "/ServerInfo/Guidebook/@RussStation/References/SkillchipBulletDodger.xml"

--- a/Resources/Prototypes/@RussStation/Skillchips/bullet_dodger.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/bullet_dodger.yml
@@ -1,0 +1,6 @@
+- type: skillchip
+  id: SkillchipBulletDodgerData
+  name: Taunt 2 Dodge
+  capacityCost: 1
+  grants:
+  - !type:BulletDodgeGrant

--- a/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipBulletDodger.xml
+++ b/Resources/ServerInfo/Guidebook/@RussStation/References/SkillchipBulletDodger.xml
@@ -1,0 +1,11 @@
+<Document>
+# BULLET_DODGER
+
+At the cost of stamina, your taunts can also be used to dodge incoming projectiles.
+
+<Box>
+<GuideEntityEmbed Entity="SkillchipBulletDodger"/>
+</Box>
+
+Perform the [color=#a4885c]Flip[/color] or [color=#a4885c]Spin[/color] emote to open a brief deflect window. The next projectile that would hit you in that window is bounced off, but costs stamina, so spamming it puts you on the floor.
+</Document>


### PR DESCRIPTION
## About the PR

Adds the BULLET_DODGER skillchip, a generic-tier consumer. Performing the Flip or Spin emote opens a deflect window that lasts as long as that emote's animation. The next projectile that would hit the holder in that window is reflected and 30 stamina is consumed. Part of the SS13 chip catalog port tracked in #703.

## Why / Balance

Commercial tier, capacity cost 1. The window length is tied to the visible emote animation, so the dodge frame is exactly what the player and the shooter can both see. The 30 stamina drain is what keeps this from being a free I-win button against ranged combat: a holder has to commit to the flip and a sustained pistol burst will floor them.

## Technical details

- `BulletDodgeComponent` (Content.Shared): holds the trigger emote set, stamina cost, and a server-only `ActiveUntil` timestamp. Constants live in `BulletDodgeConstants.cs` so no raw numeric literals sit on the data fields.
- `BulletDodgeGrant` (Content.Shared): `SkillchipGrant` subclass. `Apply` ensures the component on the mob via `SharedSkillchipSystem.EnsureMobComponent`, `Revert` removes it.
- `BulletDodgeSystem` (Content.Server): subscribes `EmoteEvent` to open the window for the matched emote's duration, and `ProjectileReflectAttemptEvent` to cancel the hit, drain stamina, and close the window.
- `ForkEmoteDurations` (Content.Shared): new constants file. `ForkEmoteSystem` and `BulletDodgeSystem` both read from it so the emote animation and the dodge window can't drift apart by accident.
- Per-chip prototypes at `Resources/Prototypes/@RussStation/Skillchips/bullet_dodger.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/bullet_dodger.yml`. Capacity cost 1, no category. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.
- Guidebook entry under the Skillchips index.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: BULLET_DODGER skillchip. Flip or Spin to open a deflect window as long as the emote runs. The next projectile that would hit you is reflected, at the cost of stamina.