### PR TITLE
honksquad: fix: repair organ manipulation surgery flow

### DIFF
--- a/Content.Client/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Client/RussStation/Surgery/SurgerySystem.cs
@@ -97,13 +97,12 @@ public sealed class SurgerySystem : SharedSurgerySystem
                 _ => OnOrganSelected(target, id),
                 id)
             {
-                ToolTip = protoId != null ? $"{name} ({protoId})" : name,
+                ToolTip = name,
             };
 
             if (protoId != null)
             {
-                option.IconSpecifier = RadialMenuIconSpecifier.With(
-                    new SpriteSpecifier.EntityPrototype(protoId));
+                option.IconSpecifier = RadialMenuIconSpecifier.With(new EntProtoId(protoId));
             }
 
             buttons.Add(option);

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared.Body;
+using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Components;
@@ -27,22 +28,30 @@ public sealed partial class SurgerySystem
             return;
         }
 
-        // Block if the patient already has an organ of the same category,
-        // or the same prototype if category is null.
         var organProtoId = MetaData(organ).EntityPrototype?.ID;
+
+        // Block if the patient already has an equivalent organ.
+        // Categorized organs deduplicate by category; null-category organs deduplicate by prototype ID.
         foreach (var existing in body.Organs.ContainedEntities)
         {
             if (!TryComp<OrganComponent>(existing, out var existingOrgan))
                 continue;
 
-            if (organComp.Category != null && existingOrgan.Category == organComp.Category
-                || organComp.Category == null && MetaData(existing).EntityPrototype?.ID == organProtoId)
-            {
-                _popup.PopupEntity(
-                    Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(organ).EntityName)),
-                    patient, surgeon);
-                return;
-            }
+            bool isDuplicate;
+            if (organComp.Category != null && existingOrgan.Category != null)
+                isDuplicate = existingOrgan.Category == organComp.Category;
+            else if (organComp.Category == null && existingOrgan.Category == null)
+                isDuplicate = organProtoId != null && organProtoId == MetaData(existing).EntityPrototype?.ID;
+            else
+                isDuplicate = false;
+
+            if (!isDuplicate)
+                continue;
+
+            _popup.PopupEntity(
+                Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
+                patient, surgeon);
+            return;
         }
 
         _container.Insert(organ, body.Organs, force: true);
@@ -84,21 +93,18 @@ public sealed partial class SurgerySystem
 
     private void OnOrganSelected(SelectOrganEvent ev, EntitySessionEventArgs args)
     {
-        // Validate sender
         if (args.SenderSession.AttachedEntity is not { } surgeon)
             return;
 
         if (!TryGetEntity(ev.Target, out var patient) || !TryGetEntity(ev.OrganId, out var organ))
             return;
 
-        // Validate: surgeon must be in range and have active surgery on this patient
         if (!_interaction.InRangeUnobstructed(surgeon, patient.Value))
             return;
 
         if (!TryComp<ActiveSurgeryComponent>(patient.Value, out var active) || active.Surgeon != surgeon)
             return;
 
-        // Validate the procedure is at an organ removal step
         if (active.ProcedureId == null ||
             !ProtoManager.TryIndex<SurgeryProcedurePrototype>(active.ProcedureId.Value, out var proto))
             return;
@@ -107,7 +113,8 @@ public sealed partial class SurgerySystem
             return;
 
         var step = proto.Steps[active.CurrentStep];
-        if (step.Effect is not RemoveOrganEffect)
+        // step.Effect is null for preset-supplied effects; GetEffect() resolves the preset fallback
+        if (step.GetEffect() is not RemoveOrganEffect)
             return;
 
         if (!TryComp<BodyComponent>(patient.Value, out var body) || body.Organs == null)
@@ -116,17 +123,82 @@ public sealed partial class SurgerySystem
         if (!body.Organs.ContainedEntities.Contains(organ.Value))
             return;
 
-        if (!_container.Remove(organ.Value, body.Organs))
+        if (!_pendingOrganRemovalTools.TryGetValue(patient.Value, out var tool) || !Exists(tool))
         {
             _popup.PopupEntity(Loc.GetString("surgery-organ-remove-failed"), patient.Value, surgeon);
             return;
         }
 
-        _xform.DropNextTo(organ.Value, patient.Value);
+        StartOrganRemovalDoAfter(surgeon, patient.Value, tool, organ.Value, step, proto.Difficulty);
+    }
 
-        _popup.PopupEntity(
-            Loc.GetString("surgery-organ-removed", ("organ", MetaData(organ.Value).EntityName)),
-            patient.Value, surgeon);
+    private void StartOrganRemovalDoAfter(
+        EntityUid surgeon,
+        EntityUid patient,
+        EntityUid tool,
+        EntityUid organ,
+        SurgeryStep step,
+        SurgeryDifficulty difficulty)
+    {
+        var duration = TimeSpan.FromSeconds(
+            (float) GetStepDuration(step, patient, difficulty, surgeon).TotalSeconds
+            * GetToolTierModifier(tool));
+
+        var ev = new OrganRemovalDoAfterEvent { SelectedOrgan = GetNetEntity(organ) };
+        var doAfterArgs = new DoAfterArgs(
+            EntityManager, surgeon, duration, ev, patient,
+            target: patient,
+            used: tool)
+        {
+            NeedHand = true,
+            BreakOnMove = true,
+            BreakOnHandChange = true,
+        };
+
+        if (!_doAfter.TryStartDoAfter(doAfterArgs))
+            _popup.PopupEntity(Loc.GetString("surgery-busy"), patient, surgeon);
+    }
+
+    private void OnOrganRemovalDoAfter(Entity<ActiveSurgeryComponent> ent, ref OrganRemovalDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        args.Handled = true;
+        var patient = ent.Owner;
+
+        if (!TryGetEntity(args.SelectedOrgan, out var organ))
+            return;
+
+        if (!TryComp<BodyComponent>(patient, out var body) || body.Organs == null)
+            return;
+
+        if (!body.Organs.ContainedEntities.Contains(organ.Value))
+        {
+            if (args.User is { } u1)
+                _popup.PopupEntity(Loc.GetString("surgery-organ-remove-failed"), patient, u1);
+            return;
+        }
+
+        if (!_container.Remove(organ.Value, body.Organs))
+        {
+            if (args.User is { } u2)
+                _popup.PopupEntity(Loc.GetString("surgery-organ-remove-failed"), patient, u2);
+            return;
+        }
+
+        _pendingOrganRemovalTools.Remove(patient);
+        _xform.DropNextTo(organ.Value, patient);
+
+        if (args.User is { } surgeon)
+        {
+            _popup.PopupEntity(
+                Loc.GetString("surgery-step-remove-organ", ("user", surgeon), ("target", patient)),
+                patient, surgeon);
+            _popup.PopupEntity(
+                Loc.GetString("surgery-organ-removed", ("organ", MetaData(organ.Value).EntityName)),
+                patient, surgeon);
+        }
     }
 
     private static bool IsLimbCategory(ProtoId<OrganCategoryPrototype>? category)

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
@@ -188,7 +188,9 @@ public sealed partial class SurgerySystem
         }
 
         _pendingOrganRemovalTools.Remove(patient);
-        _xform.DropNextTo(organ.Value, patient);
+
+        if (!_hands.TryPickupAnyHand(args.User, organ.Value, checkActionBlocker: false))
+            _xform.DropNextTo(organ.Value, patient);
 
         if (args.User is { } surgeon)
         {

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Components;
+using Content.Shared.RussStation.Surgery.Effects;
 using Content.Shared.RussStation.Surgery.Systems;
 using Content.Shared.RussStation.Wounds.Systems;
 using Content.Shared.Standing;
@@ -49,6 +50,9 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
     private List<string> _cachedProcedureIds = new();
 
+    // Tracks the tool held when the organ removal menu was opened, keyed by patient.
+    private readonly Dictionary<EntityUid, EntityUid> _pendingOrganRemovalTools = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -56,6 +60,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         SubscribeLocalEvent<BodyComponent, AfterInteractUsingEvent>(OnAfterInteract);
         SubscribeLocalEvent<ActiveSurgeryComponent, SurgeryStepDoAfterEvent>(OnStepDoAfter);
         SubscribeLocalEvent<ActiveSurgeryComponent, SurgeryCauteryDoAfterEvent>(OnCauteryDoAfter);
+        SubscribeLocalEvent<ActiveSurgeryComponent, OrganRemovalDoAfterEvent>(OnOrganRemovalDoAfter);
         SubscribeLocalEvent<SurgeryDrapedComponent, ComponentStartup>(OnDrapedStartup);
 
         SubscribeNetworkEvent<SelectSurgeryProcedureEvent>(OnProcedureSelected);
@@ -268,6 +273,14 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         // Tool matches current step
         if (ToolMatchesStep(tool, currentStep))
         {
+            // RemoveOrgan steps show the organ menu immediately; DoAfter runs after the surgeon picks an organ.
+            if (currentStep.GetEffect() is RemoveOrganEffect)
+            {
+                _pendingOrganRemovalTools[patient] = tool;
+                OpenOrganRemovalMenu(surgeon, patient);
+                return;
+            }
+
             StartStepDoAfter(surgeon, patient, tool, currentStep, proto.Difficulty);
             return;
         }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.RussStation.Surgery.Effects;
 using Content.Shared.RussStation.Surgery.Systems;
 using Content.Shared.RussStation.Wounds.Systems;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Standing;
 using Content.Shared.Tag;
 using Content.Shared.Tools;
@@ -44,6 +45,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedWoundSystem _wounds = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
 
     [Dependency] private readonly EntityQuery<SurgeryDrapedComponent> _drapedQuery = default!;
     [Dependency] private readonly EntityQuery<ActiveSurgeryComponent> _activeSurgeryQuery = default!;

--- a/Content.Shared/RussStation/Surgery/SurgeryDoAfterEvent.cs
+++ b/Content.Shared/RussStation/Surgery/SurgeryDoAfterEvent.cs
@@ -8,3 +8,9 @@ public sealed partial class SurgeryStepDoAfterEvent : SimpleDoAfterEvent;
 
 [Serializable, NetSerializable]
 public sealed partial class SurgeryCauteryDoAfterEvent : SimpleDoAfterEvent;
+
+[Serializable, NetSerializable]
+public sealed partial class OrganRemovalDoAfterEvent : SimpleDoAfterEvent
+{
+    public NetEntity SelectedOrgan;
+}

--- a/Content.Shared/RussStation/Surgery/Systems/SharedSurgerySystem.cs
+++ b/Content.Shared/RussStation/Surgery/Systems/SharedSurgerySystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Examine;
 using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.Tools;
 using Content.Shared.Tools.Systems;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.RussStation.Surgery.Systems;
@@ -53,6 +54,10 @@ public abstract partial class SharedSurgerySystem : EntitySystem
 
         // Drop bedsheet/drape when draping is removed
         if (ent.Comp.Bedsheet is not { } bedsheet || !Exists(bedsheet))
+            return;
+
+        // Skip during entity termination — the whole entity tree is going away.
+        if (MetaData(ent.Owner).EntityLifeStage >= EntityLifeStage.Terminating)
             return;
 
         var xformSys = EntityManager.System<SharedTransformSystem>();

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -35,7 +35,7 @@ surgery-step-repeat-done = The treatment has done all it can.
 ## Organ Operations
 surgery-organ-removed = {CAPITALIZE(THE($organ))} has been removed.
 surgery-organ-inserted = {CAPITALIZE(THE($organ))} has been inserted.
-surgery-organ-already-exists = {CAPITALIZE(THE($organ))} is already installed.
+surgery-organ-already-exists = This patient already has {THE($organ)}.
 surgery-organ-insert-failed = The organ cannot be inserted.
 surgery-organ-remove-failed = The organ could not be removed.
 surgery-no-organs-to-remove = There are no removable organs.

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -35,7 +35,7 @@ surgery-step-repeat-done = The treatment has done all it can.
 ## Organ Operations
 surgery-organ-removed = {CAPITALIZE(THE($organ))} has been removed.
 surgery-organ-inserted = {CAPITALIZE(THE($organ))} has been inserted.
-surgery-organ-already-exists = The patient already has {THE($organ)}.
+surgery-organ-already-exists = {CAPITALIZE(THE($organ))} is already installed.
 surgery-organ-insert-failed = The organ cannot be inserted.
 surgery-organ-remove-failed = The organ could not be removed.
 surgery-no-organs-to-remove = There are no removable organs.

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -35,7 +35,7 @@ surgery-step-repeat-done = The treatment has done all it can.
 ## Organ Operations
 surgery-organ-removed = {CAPITALIZE(THE($organ))} has been removed.
 surgery-organ-inserted = {CAPITALIZE(THE($organ))} has been inserted.
-surgery-organ-already-exists = This patient already has {THE($organ)}.
+surgery-organ-already-exists = { CAPITALIZE($organ) } already installed.
 surgery-organ-insert-failed = The organ cannot be inserted.
 surgery-organ-remove-failed = The organ could not be removed.
 surgery-no-organs-to-remove = There are no removable organs.

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -35,7 +35,7 @@ surgery-step-repeat-done = The treatment has done all it can.
 ## Organ Operations
 surgery-organ-removed = {CAPITALIZE(THE($organ))} has been removed.
 surgery-organ-inserted = {CAPITALIZE(THE($organ))} has been inserted.
-surgery-organ-already-exists = { CAPITALIZE($organ) } already installed.
+surgery-organ-already-exists = { CAPITALIZE($organ) } already present.
 surgery-organ-insert-failed = The organ cannot be inserted.
 surgery-organ-remove-failed = The organ could not be removed.
 surgery-no-organs-to-remove = There are no removable organs.


### PR DESCRIPTION
## About the PR

Organ manipulation surgery had several bugs making organ removal completely non-functional, plus a few quality-of-life gaps. This also closes a server shutdown error triggered by surgeries left active when the map unloads.

## Why / Balance

The root cause: `OnOrganSelected` checked `step.Effect`, which is always null for preset-defined steps. `RemoveOrganEffect` lives on the preset, so the removal guard always rejected and nothing happened. The other issues were on top of that.

## Technical details

- `SurgerySystem.Organs.cs`: `OnOrganSelected` now calls `step.GetEffect()` to resolve the preset fallback. Organ removal is restructured so the hemostat opens the organ menu immediately; the DoAfter progress bar runs after the surgeon picks which organ to pull. Removed organs go to the surgeon's free hand if one is available, floor otherwise. `TryInsertOrgan` names the existing organ in the duplicate popup, not the one being inserted. Null-category organs deduplicate by prototype ID instead of failing silently.
- `SurgerySystem.cs`: Adds `_pendingOrganRemovalTools` to track the tool held when the organ menu opens. `TryAdvanceStep` short-circuits for `RemoveOrganEffect` steps to open the menu immediately. Subscribes to the new `OrganRemovalDoAfterEvent`.
- `SurgeryDoAfterEvent.cs`: New `OrganRemovalDoAfterEvent` carries the selected organ's `NetEntity` through the DoAfter to the removal handler.
- `Content.Client/.../SurgerySystem.cs`: Organ removal radial menu uses `EntityPrototypeView` (all sprite layers) instead of `TextureRect` (first layer only). Paired organs like lungs and kidneys now show both sides in the picker.
- `SharedSurgerySystem.cs`: Guards the bedsheet drop in `OnDrapedShutdown` against entity termination. When the operating table terminates on server shutdown, the unbuckle cascade fires `StoodEvent` on the patient, triggering a transform-attach-to-terminating error. The fix skips the drop if the patient's `EntityLifeStage` is `Terminating` or later.
- `surgery.ftl`: Duplicate organ popup uses "already present" to avoid article and verb-agreement issues across singular and plural organ names.

## Media

<!-- screenshots attached -->

## Breaking changes

None.

## Changelog

:cl:
- fix: Organ removal surgery now actually removes organs.
- fix: Selecting an organ from the surgery menu starts a progress bar before removal.
- fix: Removed organs go to the surgeon's free hand when one is available.
- fix: The "patient already has that organ" popup now names the existing organ, not the one being inserted.
- fix: Paired organ icons (lungs, kidneys) now show both sides in the organ removal menu.