### PR TITLE
honksquad: fix: drop duplicate organ-removal surgery popup

### DIFF
--- a/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
@@ -195,9 +195,6 @@ public sealed partial class SurgerySystem
         if (args.User is { } surgeon)
         {
             _popup.PopupEntity(
-                Loc.GetString("surgery-step-remove-organ", ("user", surgeon), ("target", patient)),
-                patient, surgeon);
-            _popup.PopupEntity(
                 Loc.GetString("surgery-organ-removed", ("organ", MetaData(organ.Value).EntityName)),
                 patient, surgeon);
         }

--- a/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
+++ b/Resources/Locale/en-US/@RussStation/surgery/surgery.ftl
@@ -16,7 +16,6 @@ surgery-step-saw = {CAPITALIZE(THE($user))} saws through dense tissue on {THE($t
 surgery-step-cauterize = {CAPITALIZE(THE($user))} sears the wound on {THE($target)} shut with a sizzle.
 surgery-step-treat-brute = {CAPITALIZE(THE($user))} stitches torn muscle on {THE($target)} back together.
 surgery-step-treat-burn = {CAPITALIZE(THE($user))} scrapes away charred flesh on {THE($target)} and dresses what's left.
-surgery-step-remove-organ = {CAPITALIZE(THE($user))} plunges a hand into {THE($target)} and pulls out an organ.
 surgery-step-set-bones = {CAPITALIZE(THE($user))} wrenches {POSS-ADJ($target)} shattered bones back into line.
 surgery-step-treat-burn-wounds = {CAPITALIZE(THE($user))} cauterizes and dresses {POSS-ADJ($target)} weeping burns.
 


### PR DESCRIPTION
## About the PR

Surgery currently shows two popups in a row when an organ is removed: a generic "plunges a hand in" line followed by the more useful "organ has been removed" line that names the organ. Drop the first; keep the second.

## Why / Balance

The duplicate is noise. The first popup doesn't tell the surgeon which organ came out, the second does. Spotted while playtesting cybernetic organ surgery flow on a different branch.

## Technical details

- `Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs`: remove one of the two `PopupEntity` calls in `OnOrganRemovalDoAfter`.
- `Resources/Locale/en-US/@RussStation/surgery/surgery.ftl`: remove the now-unreferenced `surgery-step-remove-organ` locale key.

## Media

Popup-only change; nothing to screenshot beyond "one message instead of two".

## Breaking changes

None.

## Changelog

:cl:
- tweak: Surgical organ removal now shows a single popup naming the organ that was extracted, rather than two consecutive messages.