### PR TITLE
honksquad: feat: cybernetic organ framework (Phase 1 split 2/16)

### DIFF
--- a/Content.Shared/Body/GibbableOrganSystem.cs
+++ b/Content.Shared/Body/GibbableOrganSystem.cs
@@ -1,4 +1,7 @@
 using Content.Shared.Gibbing;
+//HONK START
+using Content.Shared.RussStation.Body;
+//HONK END
 
 namespace Content.Shared.Body;
 
@@ -13,6 +16,11 @@ public sealed class GibbableOrganSystem : EntitySystem
 
     private void OnBeingGibbed(Entity<GibbableOrganComponent> ent, ref BodyRelayedEvent<BeingGibbedEvent> args)
     {
+        //HONK START - Cybernetic organs inherit GibbableOrgan from base but shouldn't gib
+        if (HasComp<CyberneticOrganComponent>(ent))
+            return;
+        //HONK END
+
         args.Args.Giblets.Add(ent);
     }
 }

--- a/Content.Shared/RussStation/Body/CyberneticOrganComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganComponent.cs
@@ -1,0 +1,44 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.Body;
+
+[NetSerializable, Serializable]
+public enum CyberneticTier : byte
+{
+    Basic,
+    Standard,
+    Advanced,
+}
+
+[NetSerializable, Serializable]
+public enum CyberneticEmpEffect : byte
+{
+    None,
+    CardiacArrest,
+    BreathingFailure,
+    Flicker,
+    Deafen,
+}
+
+/// <summary>
+/// Marker + data component for cybernetic organ replacements.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CyberneticOrganComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public CyberneticTier Tier = CyberneticTier.Basic;
+
+    /// <summary>
+    /// What happens to this organ's host when hit by an EMP.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public CyberneticEmpEffect EmpEffect = CyberneticEmpEffect.None;
+
+    /// <summary>
+    /// Multiplier for EMP duration/severity. Higher = more vulnerable.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float EmpVulnerability = CyberneticOrganConstants.DefaultEmpVulnerability;
+}

--- a/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Tunable defaults for cybernetic organ components. Per the magic-number audit, every numeric
+/// default referenced from a [DataField] in this folder lives here so reviewers can re-tune
+/// values centrally without grepping through every component file.
+/// </summary>
+public static class CyberneticOrganConstants
+{
+    /// <summary>Default EMP vulnerability multiplier on <see cref="CyberneticOrganComponent"/>.</summary>
+    public const float DefaultEmpVulnerability = 1.0f;
+}

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -1,0 +1,12 @@
+# Cybernetic organ replacements - shared base. Specific organ prototypes (Heart/Lungs/Eyes/etc.)
+# land alongside their per-organ feature PRs and inherit OrganCyberneticInternal for the shared
+# RSI path. GibbableOrgan is inherited but suppressed in C# (GibbableOrganSystem skips
+# CyberneticOrgan entities).
+# Sprites: @RussStation/Objects/Cybernetics/cybernetic_organs.rsi (Katyes, CC-BY-SA-4.0)
+
+- type: entity
+  id: OrganCyberneticInternal
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"


### PR DESCRIPTION
## About the PR

Load-bearing scaffolding for the cybernetic organ feature: shared component, EMP-effect/tier enums, the abstract entity prototype that shares the cybernetic RSI path, and a HONK guard so cybernetic organs inherit `GibbableOrgan` without actually gibbing. No specific organs (heart, lungs, eyes, etc.) ship in this PR; each lands separately on top of this one.

## Why / Balance

This is part of the split of the original cybernetic-organs PR (#298) into reviewable chunks. PR #298 was 57 commits / ~96 files; reviewers can't reasonably read it. This PR is the foundation every per-organ PR depends on, with no balance impact on its own (the components don't get added to anything yet).

## Technical details

- `Content.Shared/RussStation/Body/CyberneticOrganComponent.cs`: networked component carrying `Tier` (Basic/Standard/Advanced), `EmpEffect` (None/CardiacArrest/BreathingFailure/Flicker/Deafen), and `EmpVulnerability` multiplier. The EMP enum values point at status effects that ship in their own follow-up PRs; nothing reacts to the values yet.
- `Content.Shared/RussStation/Body/CyberneticOrganConstants.cs`: just `DefaultEmpVulnerability` for now. Per-organ default values will append to this file as their PRs land, keeping every cybernetic-organ magic number in one auditable place.
- `Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml`: contains only the abstract `OrganCyberneticInternal` entity that wires the shared `cybernetic_organs.rsi` sprite path. Per-organ prototypes (`OrganCyberneticHeartBasic` etc.) land in their own PRs and parent into this abstract.
- `Content.Shared/Body/GibbableOrganSystem.cs`: HONK-marked `BodyRelayedEvent<BeingGibbedEvent>` handler now early-returns when the organ has `CyberneticOrganComponent`. Without this, cybernetic organs that inherit `GibbableOrgan` from the base organ prototypes would gib when the host is dismembered.

The cybernetic organ sprite sheet (74 PNGs in `cybernetic_organs.rsi/`) already shipped in #7b133b71cc ("art: add cybernetic organ sprites") and is not part of this diff.

## Media

No in-game effect; cybernetic organs aren't spawnable yet.

## Breaking changes

None.

## Changelog

<!-- No player-facing change yet; per-organ PRs ship the actual gameplay. -->