### PR TITLE
honksquad: feat: deafness framework (Phase 1 split 3/16)

### DIFF
--- a/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
+++ b/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
@@ -1,0 +1,102 @@
+using System.Numerics;
+using Content.Shared.RussStation.Hearing;
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Client.Audio;
+using Robust.Client.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Client.RussStation.Hearing;
+
+/// <summary>
+/// Applies audio occlusion to muffle sounds for the local player while their
+/// <see cref="DeafableComponent.IsDeaf"/> is set. Partial-occlusion sources like
+/// hearing impairment from cybernetic ears live in their own systems and stack on
+/// top via the same <see cref="AudioSystem.GetOcclusionOverride"/> delegate hook.
+/// </summary>
+public sealed class DeafAudioSystem : EntitySystem
+{
+    [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    private const float DeafOcclusion = 8f;
+
+    private bool _isDeaf;
+    private float _maxRayLength;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DeafableComponent, ComponentStartup>(OnDeafStartup);
+        SubscribeLocalEvent<DeafableComponent, LocalPlayerAttachedEvent>(OnDeafAttached);
+        SubscribeLocalEvent<DeafableComponent, LocalPlayerDetachedEvent>(OnDeafDetached);
+        SubscribeLocalEvent<DeafableComponent, ComponentRemove>(OnDeafRemove);
+        SubscribeLocalEvent<DeafableComponent, DeafnessChangedEvent>(OnDeafnessChanged);
+
+        Subs.CVar(_cfg, Robust.Shared.CVars.AudioRaycastLength, v => _maxRayLength = v, true);
+    }
+
+    private void OnDeafStartup(EntityUid uid, DeafableComponent comp, ComponentStartup args)
+    {
+        if (uid == _player.LocalEntity)
+            SetDeaf(comp.IsDeaf);
+    }
+
+    private void OnDeafAttached(EntityUid uid, DeafableComponent comp, LocalPlayerAttachedEvent args)
+    {
+        SetDeaf(comp.IsDeaf);
+    }
+
+    private void OnDeafDetached(EntityUid uid, DeafableComponent comp, LocalPlayerDetachedEvent args)
+    {
+        SetDeaf(false);
+    }
+
+    private void OnDeafRemove(EntityUid uid, DeafableComponent comp, ComponentRemove args)
+    {
+        if (uid == _player.LocalEntity)
+            SetDeaf(false);
+    }
+
+    private void OnDeafnessChanged(EntityUid uid, DeafableComponent comp, ref DeafnessChangedEvent args)
+    {
+        if (uid == _player.LocalEntity)
+            SetDeaf(args.Deaf);
+    }
+
+    private void SetDeaf(bool deaf)
+    {
+        if (_isDeaf == deaf)
+            return;
+
+        _isDeaf = deaf;
+
+        if (_isDeaf)
+            _audio.GetOcclusionOverride += OcclusionOverride;
+        else
+            _audio.GetOcclusionOverride -= OcclusionOverride;
+    }
+
+    // Mirrors the engine's baseline occlusion raycast, then adds the deaf bonus on top so
+    // wall muffling still stacks. Keep in sync with
+    // RobustToolbox/Robust.Client/Audio/AudioSystem.cs GetOcclusion during rebases.
+    private float OcclusionOverride(MapCoordinates listener, Vector2 delta, float distance, EntityUid? ignoredEnt)
+    {
+        float occlusion = 0;
+
+        if (distance > 0.1f)
+        {
+            var rayLength = MathF.Min(distance, _maxRayLength);
+            var ray = new CollisionRay(listener.Position, delta / distance, _audio.OcclusionCollisionMask);
+            occlusion = _physics.IntersectRayPenetration(listener.MapId, ray, rayLength, ignoredEnt);
+        }
+
+        return occlusion + DeafOcclusion;
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Hearing/DeafableSystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Hearing/DeafableSystemTest.cs
@@ -1,0 +1,226 @@
+using Content.Shared.RussStation.Hearing;
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Hearing;
+
+[TestFixture]
+[TestOf(typeof(DeafableSystem))]
+public sealed class DeafableSystemTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: DeafTestEntity
+  components:
+  - type: Deafable
+
+- type: entity
+  id: DeafTestEntityWithTempDeafness
+  components:
+  - type: Deafable
+  - type: TemporaryDeafness
+";
+
+    // ================================================================
+    // DeafableSystem — CanHearAttemptEvent / IsDeaf state
+    // ================================================================
+
+    [Test]
+    public async Task EntityWithoutDeafnessCanHearTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntity", mapData.GridCoords);
+            var deafable = entMan.GetComponent<DeafableComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.False,
+                "Entity with DeafableComponent but no deafness source should not be deaf");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TemporaryDeafnessMakesEntityDeafTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntityWithTempDeafness", mapData.GridCoords);
+            var deafable = entMan.GetComponent<DeafableComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.True,
+                "Entity with TemporaryDeafnessComponent should be deaf");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RemovingTemporaryDeafnessRestoresHearingTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntityWithTempDeafness", mapData.GridCoords);
+            var deafable = entMan.GetComponent<DeafableComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.True, "Precondition: entity should be deaf");
+
+            entMan.RemoveComponent<TemporaryDeafnessComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.False,
+                "Removing TemporaryDeafnessComponent should restore hearing");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task AddingTemporaryDeafnessDynamicallyMakesDeafTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntity", mapData.GridCoords);
+            var deafable = entMan.GetComponent<DeafableComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.False, "Precondition: entity should hear");
+
+            entMan.AddComponent<TemporaryDeafnessComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.True,
+                "Dynamically adding TemporaryDeafnessComponent should make entity deaf");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CanHearAttemptEventCancelledByDeafnessTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntityWithTempDeafness", mapData.GridCoords);
+
+            var ev = new CanHearAttemptEvent();
+            entMan.EventBus.RaiseLocalEvent(ent, ev);
+
+            Assert.That(ev.Deaf, Is.True,
+                "CanHearAttemptEvent should be cancelled (Deaf=true) for a deaf entity");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CanHearAttemptEventNotCancelledForHearingEntityTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntity", mapData.GridCoords);
+
+            var ev = new CanHearAttemptEvent();
+            entMan.EventBus.RaiseLocalEvent(ent, ev);
+
+            Assert.That(ev.Deaf, Is.False,
+                "CanHearAttemptEvent should not be cancelled for a hearing entity");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RejuvenateUpdatesDeafnessStateTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var deafSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<DeafableSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntityWithTempDeafness", mapData.GridCoords);
+            var deafable = entMan.GetComponent<DeafableComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.True, "Precondition: entity should be deaf");
+
+            // Remove the deafness source, then call UpdateIsDeaf (simulates what Rejuvenate triggers)
+            entMan.RemoveComponent<TemporaryDeafnessComponent>(ent);
+            deafSys.UpdateIsDeaf(ent);
+
+            Assert.That(deafable.IsDeaf, Is.False,
+                "UpdateIsDeaf should detect deafness source is gone");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task IsDeafStateTracksDeafnessSourcesTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var ent = entMan.SpawnEntity("DeafTestEntity", mapData.GridCoords);
+            var deafable = entMan.GetComponent<DeafableComponent>(ent);
+
+            Assert.That(deafable.IsDeaf, Is.False, "Should start hearing");
+
+            // Add deafness source
+            entMan.AddComponent<TemporaryDeafnessComponent>(ent);
+            Assert.That(deafable.IsDeaf, Is.True, "Should be deaf after adding source");
+
+            // Remove deafness source
+            entMan.RemoveComponent<TemporaryDeafnessComponent>(ent);
+            Assert.That(deafable.IsDeaf, Is.False, "Should hear again after removing source");
+
+            // Add again to verify re-application
+            entMan.AddComponent<TemporaryDeafnessComponent>(ent);
+            Assert.That(deafable.IsDeaf, Is.True, "Should be deaf again after re-adding source");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -20,6 +20,9 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Players;
 using Content.Shared.Players.RateLimiting;
 using Content.Shared.Radio;
+//HONK START - deafness system
+using Content.Shared.RussStation.Hearing;
+//HONK END
 using Content.Shared.Station.Components;
 using Content.Shared.Whitelist;
 using Robust.Server.Player;
@@ -496,6 +499,14 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
+            //HONK START - Deafness: deaf listeners can't make out whispers at all
+            if (TryComp<DeafableComponent>(listener, out var whisperDeafable) && whisperDeafable.IsDeaf)
+            {
+                _chatManager.ChatMessageToOne(ChatChannel.Whisper, obfuscatedMessage, wrappedUnknownMessage, source, false, session.Channel);
+                continue;
+            }
+            //HONK END
+
             if (data.Range <= WhisperClearRange || data.Observer)
                 _chatManager.ChatMessageToOne(ChatChannel.Whisper, message, wrappedMessage, source, false, session.Channel);
             //If listener is too far, they only hear fragments of the message
@@ -672,6 +683,11 @@ public sealed partial class ChatSystem : SharedChatSystem
         RaiseLocalEvent(source, ref voiceRangeEv);
         //HONK END
 
+        //HONK START - Deafness: obfuscate messages for deaf recipients
+        string? deafMessage = null;
+        string? deafWrapped = null;
+        //HONK END
+
         //HONK START - use voiceRangeEv.Range (was VoiceRange)
         foreach (var (session, data) in GetRecipients(source, voiceRangeEv.Range))
         //HONK END
@@ -680,6 +696,20 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (entRange == MessageRangeCheckResult.Disallowed)
                 continue;
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
+
+            //HONK START - Deafness: send obfuscated message to deaf recipients
+            if (session.AttachedEntity is { Valid: true } listener
+                && TryComp<DeafableComponent>(listener, out var deafable)
+                && deafable.IsDeaf)
+            {
+                deafMessage ??= ObfuscateMessageReadability(message, 0.2f);
+                deafWrapped ??= Loc.GetString("chat-manager-entity-deaf-wrap-message",
+                    ("message", FormattedMessage.EscapeText(deafMessage)));
+                _chatManager.ChatMessageToOne(channel, deafMessage, deafWrapped, source, entHideChat, session.Channel, author: author);
+                continue;
+            }
+            //HONK END
+
             _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author);
         }
 

--- a/Content.Shared/RussStation/Hearing/ActiveTemporaryDeafnessComponent.cs
+++ b/Content.Shared/RussStation/Hearing/ActiveTemporaryDeafnessComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Marker placed on a body while it has the TemporaryDeafness status effect active.
+/// Cancels CanHearAttemptEvent. Mirrors the
+/// <see cref="Content.Shared.RussStation.Body.ActiveBreathingSuppressedComponent"/> pattern.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActiveTemporaryDeafnessComponent : Component;

--- a/Content.Shared/RussStation/Hearing/DeafableComponent.cs
+++ b/Content.Shared/RussStation/Hearing/DeafableComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Component for entities that can be deafened.
+/// Analogous to <see cref="Content.Shared.Eye.Blinding.Components.BlindableComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(DeafableSystem))]
+public sealed partial class DeafableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool IsDeaf;
+}

--- a/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Inventory;
+using Content.Shared.Rejuvenate;
+
+namespace Content.Shared.RussStation.Hearing.Systems;
+
+/// <summary>
+/// Manages the IsDeaf state on <see cref="DeafableComponent"/> by raising
+/// <see cref="CanHearAttemptEvent"/>. Sources of deafness (cybernetic ears, missing ears,
+/// flashbangs, etc.) live in their own systems and subscribe to the attempt event.
+/// </summary>
+public sealed class DeafableSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<DeafableComponent, RejuvenateEvent>(OnRejuvenate);
+    }
+
+    private void OnRejuvenate(Entity<DeafableComponent> ent, ref RejuvenateEvent args)
+    {
+        UpdateIsDeaf((ent.Owner, (DeafableComponent?) ent.Comp));
+    }
+
+    public void UpdateIsDeaf(Entity<DeafableComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp, false))
+            return;
+
+        if (TerminatingOrDeleted(entity.Owner))
+            return;
+
+        var old = entity.Comp.IsDeaf;
+
+        var ev = new CanHearAttemptEvent();
+        RaiseLocalEvent(entity.Owner, ev);
+        entity.Comp.IsDeaf = ev.Deaf;
+
+        if (old == entity.Comp.IsDeaf)
+            return;
+
+        var changeEv = new DeafnessChangedEvent(entity.Comp.IsDeaf);
+        RaiseLocalEvent(entity.Owner, ref changeEv);
+        Dirty(entity);
+    }
+}
+
+[ByRefEvent]
+public record struct DeafnessChangedEvent(bool Deaf);
+
+/// <summary>
+/// Raised directed at an entity to check whether it can currently hear.
+/// Cancel to make the entity deaf.
+/// </summary>
+public sealed class CanHearAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
+{
+    public bool Deaf => Cancelled;
+    public SlotFlags TargetSlots => SlotFlags.EARS | SlotFlags.HEAD | SlotFlags.MASK;
+}

--- a/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
@@ -1,0 +1,69 @@
+using Content.Shared.StatusEffectNew;
+
+namespace Content.Shared.RussStation.Hearing.Systems;
+
+/// <summary>
+/// Bridges the TemporaryDeafness component to the actual body's deafness state. Supports two
+/// usage paths:
+///
+/// 1. Status effect: <see cref="StatusEffectsSystem"/> spawns a child status effect entity
+///    carrying <see cref="TemporaryDeafnessComponent"/>; the per-applied event hook adds
+///    <see cref="ActiveTemporaryDeafnessComponent"/> to the body. Same shape as
+///    <c>BreathingSuppressedSystem</c>.
+///
+/// 2. Direct attach: tests / one-off cases put <see cref="TemporaryDeafnessComponent"/> right
+///    on a body that has <see cref="DeafableComponent"/>; ComponentStartup falls back to
+///    treating the host entity as the target.
+/// </summary>
+public sealed class TemporaryDeafnessSystem : EntitySystem
+{
+    [Dependency] private readonly DeafableSystem _deafable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TemporaryDeafnessComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<TemporaryDeafnessComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<TemporaryDeafnessComponent, StatusEffectAppliedEvent>(OnApplied);
+        SubscribeLocalEvent<TemporaryDeafnessComponent, StatusEffectRemovedEvent>(OnRemoved);
+        SubscribeLocalEvent<ActiveTemporaryDeafnessComponent, CanHearAttemptEvent>(OnTryHear);
+    }
+
+    private void OnStartup(EntityUid uid, TemporaryDeafnessComponent component, ComponentStartup args)
+    {
+        // Direct-attach path: only meaningful when the host carries DeafableComponent (a body).
+        // The status-effect path goes through OnApplied and uses args.Target instead.
+        if (!HasComp<DeafableComponent>(uid))
+            return;
+
+        EnsureComp<ActiveTemporaryDeafnessComponent>(uid);
+        _deafable.UpdateIsDeaf(uid);
+    }
+
+    private void OnShutdown(EntityUid uid, TemporaryDeafnessComponent component, ComponentShutdown args)
+    {
+        if (!HasComp<DeafableComponent>(uid))
+            return;
+
+        RemComp<ActiveTemporaryDeafnessComponent>(uid);
+        _deafable.UpdateIsDeaf(uid);
+    }
+
+    private void OnApplied(Entity<TemporaryDeafnessComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        EnsureComp<ActiveTemporaryDeafnessComponent>(args.Target);
+        _deafable.UpdateIsDeaf(args.Target);
+    }
+
+    private void OnRemoved(Entity<TemporaryDeafnessComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        RemComp<ActiveTemporaryDeafnessComponent>(args.Target);
+        _deafable.UpdateIsDeaf(args.Target);
+    }
+
+    private void OnTryHear(EntityUid uid, ActiveTemporaryDeafnessComponent component, CanHearAttemptEvent args)
+    {
+        args.Cancel();
+    }
+}

--- a/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/TemporaryDeafnessSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.StatusEffectNew;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.RussStation.Hearing.Systems;
 
@@ -18,6 +19,7 @@ namespace Content.Shared.RussStation.Hearing.Systems;
 public sealed class TemporaryDeafnessSystem : EntitySystem
 {
     [Dependency] private readonly DeafableSystem _deafable = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -52,6 +54,9 @@ public sealed class TemporaryDeafnessSystem : EntitySystem
 
     private void OnApplied(Entity<TemporaryDeafnessComponent> ent, ref StatusEffectAppliedEvent args)
     {
+        if (_timing.ApplyingState)
+            return;
+
         EnsureComp<ActiveTemporaryDeafnessComponent>(args.Target);
         _deafable.UpdateIsDeaf(args.Target);
     }

--- a/Content.Shared/RussStation/Hearing/TemporaryDeafnessComponent.cs
+++ b/Content.Shared/RussStation/Hearing/TemporaryDeafnessComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Component applied by the TemporaryDeafness status effect.
+/// While present, the entity cannot hear.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TemporaryDeafnessComponent : Component
+{
+}

--- a/Resources/Locale/en-US/@RussStation/hearing/deafness.ftl
+++ b/Resources/Locale/en-US/@RussStation/hearing/deafness.ftl
@@ -1,0 +1,1 @@
+chat-manager-entity-deaf-wrap-message = [italic][font size=10]You can barely make out: "[BubbleContent]{$message}[/BubbleContent]"[/font][/italic]

--- a/Resources/Prototypes/@RussStation/StatusEffects/hearing.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/hearing.yml
@@ -1,0 +1,13 @@
+# Causes temporary deafness - muffles/obfuscates incoming chat messages.
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectTemporaryDeafness
+  name: temporary deafness
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Deafable
+        requireAll: true
+    - type: TemporaryDeafness

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -195,6 +195,9 @@
   - type: Wound
   # HONK END
   - type: Blindable
+  # HONK START - Deafness system
+  - type: Deafable
+  # HONK END
   - type: Temperature
     currentTemperature: 310.15
     specificHeat: 42


### PR DESCRIPTION
## About the PR

A generic deafness framework. Adds `DeafableComponent` plus the system that re-evaluates `IsDeaf` by raising `CanHearAttemptEvent`, the `TemporaryDeafness` status effect, the client-side audio muffling, and chat-side obfuscation for whispers and voice messages received by deaf listeners. Deafness *sources* (missing ears, cybernetic ears shielding, flashbangs, etc.) live in follow-up PRs and subscribe to the attempt event.

## Why / Balance

Part of the split of #298. The deafness framework was sprawling across cybernetic-organ work but is independent enough to merit its own foundation PR. With this in, the per-source PRs (no-ears, flashbang deafen, explosion deafen, deaf-radio-block, cybernetic ears) each become small additive changes rather than re-introducing the whole stack.

Player-facing impact alone is minimal: humanoids gain `DeafableComponent` so they're *eligible* to be deafened, but no source actually deafens them yet. The `TemporaryDeafness` status effect can be applied via admin commands or the new status-effect API.

## Technical details

- `DeafableComponent` (shared, networked): `IsDeaf` flag.
- `DeafableSystem` (shared): exposes `UpdateIsDeaf(entity)`. Raises `CanHearAttemptEvent` (a cancellable, inventory-relayed event); deafness sources cancel to mark the entity deaf. Subscribes to `RejuvenateEvent` to clear deafness on revive.
- `TemporaryDeafness` status effect (new StatusEffectNew flow): `TemporaryDeafnessComponent` lives on the status entity. On `StatusEffectAppliedEvent`, `ActiveTemporaryDeafnessComponent` is placed on the target body; that marker cancels `CanHearAttemptEvent`. Same shape as `BreathingSuppressedSystem`. Legacy direct-attach is supported via a `ComponentStartup` fallback so test prototypes can attach the component straight to a body.
- `DeafAudioSystem` (client): hooks `AudioSystem.GetOcclusionOverride` while the local player is `IsDeaf`, replicating the engine's baseline raycast and stacking +8 occlusion on top so wall muffling still functions. Cleanly removes itself when deafness clears.
- `ChatSystem` deaf paths (HONK-marked): whispers are fully obfuscated for deaf listeners; voice-range messages run the existing `ObfuscateMessageReadability(0.2)` then dispatch via the `chat-manager-entity-deaf-wrap-message` locale wrap so the recipient sees *something* in chat.
- `StatusEffectTemporaryDeafness` prototype with whitelist `MobState + Deafable`.
- `species_base.yml`: humanoid base now carries `Deafable` (HONK-marked).

## Media

No standalone in-game test surface yet — admin commands can apply the `StatusEffectTemporaryDeafness` to verify the chat obfuscation + audio muffling, but per-source PRs (e.g. flashbang deafening) are the visible gameplay.

## Breaking changes

None. New components only.

## Changelog

<!-- No player-facing change yet; per-source PRs ship the actual gameplay. -->