### PR TITLE
honksquad: feat: breathing suppressed status effect (Phase 1 split 6/16)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/BreathingSuppressedTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/BreathingSuppressedTest.cs
@@ -1,0 +1,163 @@
+using Content.Server.Body.Systems;
+using Content.Server.RussStation.Body;
+using Content.Shared.Atmos;
+using Content.Shared.Body;
+using Content.Shared.RussStation.Body;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(BreathingSuppressedSystem))]
+public sealed class BreathingSuppressedTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: BreathSuppTestBody
+  components:
+  - type: Body
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Critical
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      200: Dead
+  - type: Damageable
+  - type: Respirator
+    damage:
+      types:
+        Asphyxiation: 0.5
+    damageRecovery:
+      types:
+        Asphyxiation: -0.5
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 0.5
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: SolutionContainerManager
+";
+
+    private const string EffectProto = "StatusEffectBreathingSuppressed";
+
+    [Test]
+    public async Task ApplyingEffectAddsActiveComponentTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var statusSys = entMan.System<StatusEffectsSystem>();
+            var body = entMan.SpawnEntity("BreathSuppTestBody", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<ActiveBreathingSuppressedComponent>(body), Is.False,
+                "Should not have active component before effect");
+
+            var added = statusSys.TryAddStatusEffectDuration(body, EffectProto, TimeSpan.FromSeconds(10));
+            Assert.That(added, Is.True, "Should successfully apply breathing suppressed effect");
+            Assert.That(entMan.HasComponent<ActiveBreathingSuppressedComponent>(body), Is.True,
+                "Should have active component after effect applied");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RemovingEffectRemovesActiveComponentTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        EntityUid body = default;
+
+        await server.WaitAssertion(() =>
+        {
+            var statusSys = entMan.System<StatusEffectsSystem>();
+            body = entMan.SpawnEntity("BreathSuppTestBody", mapData.GridCoords);
+
+            statusSys.TryAddStatusEffectDuration(body, EffectProto, TimeSpan.FromSeconds(10));
+            Assert.That(entMan.HasComponent<ActiveBreathingSuppressedComponent>(body), Is.True);
+
+            statusSys.TryRemoveStatusEffect(body, EffectProto);
+        });
+
+        // PredictedQueueDel is deferred
+        await server.WaitRunTicks(2);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entMan.HasComponent<ActiveBreathingSuppressedComponent>(body), Is.False,
+                "Active component should be removed when effect is removed");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task InhaledGasIsHandledWhenActiveTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var statusSys = entMan.System<StatusEffectsSystem>();
+            var body = entMan.SpawnEntity("BreathSuppTestBody", mapData.GridCoords);
+
+            statusSys.TryAddStatusEffectDuration(body, EffectProto, TimeSpan.FromSeconds(10));
+            Assert.That(entMan.HasComponent<ActiveBreathingSuppressedComponent>(body), Is.True);
+
+            // Raise InhaledGasEvent on the body - breathing suppressed should mark it handled
+            var gasMix = new GasMixture(10f);
+            gasMix.SetMoles(Gas.Oxygen, 10f);
+            var ev = new InhaledGasEvent(gasMix);
+            entMan.EventBus.RaiseLocalEvent(body, ref ev);
+
+            Assert.That(ev.Handled, Is.True,
+                "InhaledGasEvent should be handled when breathing is suppressed");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task InhaledGasNotHandledWithoutEffectTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("BreathSuppTestBody", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<ActiveBreathingSuppressedComponent>(body), Is.False);
+
+            var gasMix = new GasMixture(10f);
+            gasMix.SetMoles(Gas.Oxygen, 10f);
+            var ev = new InhaledGasEvent(gasMix);
+            entMan.EventBus.RaiseLocalEvent(body, ref ev);
+
+            Assert.That(ev.Handled, Is.False,
+                "InhaledGasEvent should not be handled without breathing suppression");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Body/BreathingSuppressedSystem.cs
+++ b/Content.Server/RussStation/Body/BreathingSuppressedSystem.cs
@@ -1,0 +1,41 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Body;
+using Content.Shared.StatusEffectNew;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Handles the BreathingSuppressed status effect.
+/// When active, intercepts inhaled gas events before lungs can process them,
+/// causing the gas to be returned to the atmosphere and the body to suffocate naturally.
+/// </summary>
+public sealed class BreathingSuppressedSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BreathingSuppressedComponent, StatusEffectAppliedEvent>(OnApplied);
+        SubscribeLocalEvent<BreathingSuppressedComponent, StatusEffectRemovedEvent>(OnRemoved);
+        SubscribeLocalEvent<ActiveBreathingSuppressedComponent, InhaledGasEvent>(OnInhaled,
+            before: [typeof(RespiratorSystem)]);
+    }
+
+    private void OnApplied(Entity<BreathingSuppressedComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        EnsureComp<ActiveBreathingSuppressedComponent>(args.Target);
+    }
+
+    private void OnRemoved(Entity<BreathingSuppressedComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        RemComp<ActiveBreathingSuppressedComponent>(args.Target);
+    }
+
+    private void OnInhaled(Entity<ActiveBreathingSuppressedComponent> ent, ref InhaledGasEvent args)
+    {
+        // Mark as handled so the gas is returned to atmosphere by RespiratorSystem.
+        // Lungs will see Handled=true and skip processing, causing natural suffocation.
+        args.Handled = true;
+    }
+}

--- a/Content.Server/RussStation/Body/BreathingSuppressedSystem.cs
+++ b/Content.Server/RussStation/Body/BreathingSuppressedSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Body.Systems;
 using Content.Shared.Body.Components;
 using Content.Shared.RussStation.Body;
 using Content.Shared.StatusEffectNew;
+using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Body;
 
@@ -12,6 +13,8 @@ namespace Content.Server.RussStation.Body;
 /// </summary>
 public sealed class BreathingSuppressedSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -24,6 +27,9 @@ public sealed class BreathingSuppressedSystem : EntitySystem
 
     private void OnApplied(Entity<BreathingSuppressedComponent> ent, ref StatusEffectAppliedEvent args)
     {
+        if (_timing.ApplyingState)
+            return;
+
         EnsureComp<ActiveBreathingSuppressedComponent>(args.Target);
     }
 

--- a/Content.Shared/RussStation/Body/BreathingSuppressedComponent.cs
+++ b/Content.Shared/RussStation/Body/BreathingSuppressedComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker placed on a status effect entity to indicate breathing suppression.
+/// When applied, adds <see cref="ActiveBreathingSuppressedComponent"/> to the target body,
+/// preventing lungs from processing inhaled gas and causing natural suffocation.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BreathingSuppressedComponent : Component;
+
+/// <summary>
+/// Marker placed on a body entity whose breathing is currently suppressed.
+/// Managed by <see cref="BreathingSuppressedComponent"/> status effect lifecycle.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ActiveBreathingSuppressedComponent : Component;

--- a/Resources/Prototypes/@RussStation/StatusEffects/breathing.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/breathing.yml
@@ -1,0 +1,14 @@
+# Suppresses breathing - lungs cannot process inhaled gas, causing suffocation.
+# Used by cybernetic lungs EMP effect (BreathingFailure).
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectBreathingSuppressed
+  name: breathing suppressed
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Body
+        requireAll: true
+    - type: BreathingSuppressed


### PR DESCRIPTION
## About the PR

Breathing suppression as a discrete status effect: while applied, the body's `InhaledGasEvent` short-circuits before reaching any lungs, so gas returns to atmosphere and the patient suffocates as if they'd stopped breathing. Generic over the source. The cybernetic-lung EMP path that uses this lands with the lungs PR.

## Why / Balance

Part of the split of #298. Breathing suppression is its own self-contained mechanism that's also useful for chemicals, abilities, antag tools, etc. Without a healthy respirator response, the patient runs out of oxygen at the normal saturation drain rate (~10s before suffocation damage starts).

## Technical details

- `BreathingSuppressedComponent` (status entity marker) + `ActiveBreathingSuppressedComponent` (body marker).
- `BreathingSuppressedSystem` (server):
  - `StatusEffectAppliedEvent` → add the active marker.
  - `StatusEffectRemovedEvent` → remove it.
  - Subscribes to `InhaledGasEvent` on the active marker with `before: [typeof(RespiratorSystem)]` and sets `Handled = true`. `RespiratorSystem` sees the handled event and returns the gas to atmosphere; lungs never get the relayed `BodyRelayedEvent<InhaledGasEvent>`.
- `StatusEffectBreathingSuppressed` proto.

## Media

No visible UI surface; effect manifests as the body suffocating without external explanation. Per-source PRs (cybernetic lung EMP, chems, etc.) attach the visible cause.

## Breaking changes

None.

## Changelog

<!-- Effect not surfaced to players from any source yet; per-source PRs ship the actual gameplay. -->