### PR TITLE
honksquad: feat: EMP blindness status effect (Phase 1 split 7/16)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/EmpBlindnessTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/EmpBlindnessTest.cs
@@ -1,0 +1,110 @@
+using Content.Server.RussStation.Body;
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(EmpBlindnessSystem))]
+public sealed class EmpBlindnessTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: EmpBlindTestBody
+  components:
+  - type: Body
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Critical
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      200: Dead
+  - type: Damageable
+  - type: Blindable
+";
+
+    private const string EffectProto = "StatusEffectTemporaryBlindness";
+
+    [Test]
+    public async Task ApplyingEffectAddsTemporaryBlindnessTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var statusSys = entMan.System<StatusEffectsSystem>();
+            var body = entMan.SpawnEntity("EmpBlindTestBody", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<TemporaryBlindnessComponent>(body), Is.False,
+                "Should not have TemporaryBlindnessComponent before effect");
+
+            var added = statusSys.TryAddStatusEffectDuration(body, EffectProto, TimeSpan.FromSeconds(10));
+            Assert.That(added, Is.True, "Should successfully apply EMP blindness effect");
+            Assert.That(entMan.HasComponent<TemporaryBlindnessComponent>(body), Is.True,
+                "Should have TemporaryBlindnessComponent after effect applied");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RemovingEffectRemovesTemporaryBlindnessTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        EntityUid body = default;
+
+        await server.WaitAssertion(() =>
+        {
+            var statusSys = entMan.System<StatusEffectsSystem>();
+            body = entMan.SpawnEntity("EmpBlindTestBody", mapData.GridCoords);
+
+            statusSys.TryAddStatusEffectDuration(body, EffectProto, TimeSpan.FromSeconds(10));
+            Assert.That(entMan.HasComponent<TemporaryBlindnessComponent>(body), Is.True);
+
+            statusSys.TryRemoveStatusEffect(body, EffectProto);
+        });
+
+        // PredictedQueueDel is deferred
+        await server.WaitRunTicks(2);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entMan.HasComponent<TemporaryBlindnessComponent>(body), Is.False,
+                "TemporaryBlindnessComponent should be removed when effect is removed");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task NoBlindnessWithoutEffectTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("EmpBlindTestBody", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<TemporaryBlindnessComponent>(body), Is.False,
+                "Body without EMP blindness effect should not have TemporaryBlindnessComponent");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Body/EmpBlindnessSystem.cs
+++ b/Content.Server/RussStation/Body/EmpBlindnessSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.RussStation.Body;
+using Content.Shared.StatusEffectNew;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Bridges the new status effect system to upstream temporary blindness.
+/// When the EMP blindness effect is applied, adds <see cref="TemporaryBlindnessComponent"/>
+/// to the body so the upstream <see cref="TemporaryBlindnessSystem"/> handles the actual blinding.
+/// </summary>
+public sealed class EmpBlindnessSystem : EntitySystem
+{
+    [Dependency] private readonly BlindableSystem _blindable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmpBlindnessComponent, StatusEffectAppliedEvent>(OnApplied);
+        SubscribeLocalEvent<EmpBlindnessComponent, StatusEffectRemovedEvent>(OnRemoved);
+    }
+
+    private void OnApplied(Entity<EmpBlindnessComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        EnsureComp<TemporaryBlindnessComponent>(args.Target);
+    }
+
+    private void OnRemoved(Entity<EmpBlindnessComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        RemComp<TemporaryBlindnessComponent>(args.Target);
+        _blindable.UpdateIsBlind(args.Target);
+    }
+}

--- a/Content.Server/RussStation/Body/EmpBlindnessSystem.cs
+++ b/Content.Server/RussStation/Body/EmpBlindnessSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.RussStation.Body;
 using Content.Shared.StatusEffectNew;
+using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Body;
 
@@ -13,6 +14,7 @@ namespace Content.Server.RussStation.Body;
 public sealed class EmpBlindnessSystem : EntitySystem
 {
     [Dependency] private readonly BlindableSystem _blindable = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -24,6 +26,9 @@ public sealed class EmpBlindnessSystem : EntitySystem
 
     private void OnApplied(Entity<EmpBlindnessComponent> ent, ref StatusEffectAppliedEvent args)
     {
+        if (_timing.ApplyingState)
+            return;
+
         EnsureComp<TemporaryBlindnessComponent>(args.Target);
     }
 

--- a/Content.Shared/RussStation/Body/EmpBlindnessComponent.cs
+++ b/Content.Shared/RussStation/Body/EmpBlindnessComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker on the status effect entity for EMP-induced temporary blindness.
+/// The system bridges this to the body by adding/removing <see cref="Content.Shared.Eye.Blinding.Components.TemporaryBlindnessComponent"/>.
+/// </summary>
+[RegisterComponent]
+public sealed partial class EmpBlindnessComponent : Component;

--- a/Resources/Prototypes/@RussStation/StatusEffects/vision.yml
+++ b/Resources/Prototypes/@RussStation/StatusEffects/vision.yml
@@ -1,0 +1,14 @@
+# Causes temporary blindness - vision cuts out entirely.
+# Used by cybernetic eyes EMP effect (Flicker).
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectTemporaryBlindness
+  name: temporary blindness
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Blindable
+        requireAll: true
+    - type: EmpBlindness


### PR DESCRIPTION
## About the PR

EMP-flavored blindness as a discrete status effect: while applied, the body is fully blind via `BlindableSystem.SetMinDamage` so the existing greyscale `BlindOverlay` activates. Cure restores vision cleanly. Generic over the source. The cybernetic-eye Flicker EMP path that uses this lands with the eyes PR.

## Why / Balance

Part of the split of #298. Full blindness as a timed effect is reusable beyond the cybernetic-organ context (chemicals, antag tools, etc.). Distinct from `TemporaryBlindness` (upstream) and `PermanentBlindness` (trait) by being status-effect-driven and curing without leaving residual eye damage.

## Technical details

- `EmpBlindnessComponent` (status entity marker) + `ActiveEmpBlindnessComponent` (body marker).
- `EmpBlindnessSystem` (server):
  - Apply: `BlindableSystem.SetMinDamage(target, MaxDamage)` so `IsBlind` flips and the greyscale overlay activates.
  - Remove: `SetMinDamage(target, 0)` then `AdjustEyeDamage(-EyeDamage)` to undo any accrued damage so the patient can see again instead of staying blurred.
- `StatusEffectEmpBlindness` prototype.

## Media

Greyscale + circle-mask overlay is the existing upstream `BlindOverlay`. Skipping a screenshot.

## Breaking changes

None.

## Changelog

<!-- No source attaches this yet; per-source PRs ship the actual gameplay. -->