### PR TITLE
honksquad: feat: cybernetic heart + heartless system (Phase 1 split 8/16)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/CyberneticHeartEffectsTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/CyberneticHeartEffectsTest.cs
@@ -1,0 +1,202 @@
+using Content.Server.RussStation.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(CyberneticOrganEffectsSystem))]
+public sealed class CyberneticHeartEffectsTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CyberHeartTestBody
+  components:
+  - type: Body
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Critical
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      200: Dead
+  - type: Damageable
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 0.5
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: SolutionContainerManager
+  - type: Hunger
+
+- type: entity
+  id: CyberHeartTestHeart
+  components:
+  - type: Organ
+    category: Heart
+  - type: CyberneticHeart
+
+- type: entity
+  id: CyberHeartTestBodyWithHeart
+  components:
+  - type: Body
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Critical
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      200: Dead
+  - type: Damageable
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 0.5
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: SolutionContainerManager
+  - type: Hunger
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: CyberHeartTestHeart
+";
+
+    [Test]
+    public async Task HeartInjectsEpinephrineOnCritTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var mobStateSystem = entMan.System<MobStateSystem>();
+            var solutionSys = entMan.System<SharedSolutionContainerSystem>();
+            var body = entMan.SpawnEntity("CyberHeartTestBodyWithHeart", mapData.GridCoords);
+
+            var bloodstream = entMan.GetComponent<BloodstreamComponent>(body);
+            Assert.That(solutionSys.TryGetSolution(body, bloodstream.BloodSolutionName,
+                out _, out var bloodBefore), Is.True);
+            var epiBefore = bloodBefore.GetTotalPrototypeQuantity("Epinephrine");
+            Assert.That(epiBefore, Is.EqualTo(FixedPoint2.Zero), "No epinephrine before crit");
+
+            mobStateSystem.ChangeMobState(body, MobState.Critical);
+
+            Assert.That(solutionSys.TryGetSolution(body, bloodstream.BloodSolutionName,
+                out _, out var bloodAfter), Is.True);
+            var epiAfter = bloodAfter.GetTotalPrototypeQuantity("Epinephrine");
+            Assert.That(epiAfter, Is.GreaterThan(FixedPoint2.Zero),
+                "Epinephrine should be injected on crit");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task HeartCooldownPreventsRepeatedInjectionTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var mobStateSystem = entMan.System<MobStateSystem>();
+            var solutionSys = entMan.System<SharedSolutionContainerSystem>();
+            var body = entMan.SpawnEntity("CyberHeartTestBodyWithHeart", mapData.GridCoords);
+            var bloodstream = entMan.GetComponent<BloodstreamComponent>(body);
+
+            // First crit
+            mobStateSystem.ChangeMobState(body, MobState.Critical);
+            solutionSys.TryGetSolution(body, bloodstream.BloodSolutionName, out _, out var blood1);
+            var afterFirst = blood1.GetTotalPrototypeQuantity("Epinephrine");
+            Assert.That(afterFirst, Is.GreaterThan(FixedPoint2.Zero), "First crit should inject");
+
+            // Reset to alive, then crit again immediately
+            mobStateSystem.ChangeMobState(body, MobState.Alive);
+            mobStateSystem.ChangeMobState(body, MobState.Critical);
+            solutionSys.TryGetSolution(body, bloodstream.BloodSolutionName, out _, out var blood2);
+            var afterSecond = blood2.GetTotalPrototypeQuantity("Epinephrine");
+            Assert.That(afterSecond, Is.EqualTo(afterFirst),
+                "Second crit within cooldown should not inject again");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task HeartNoEffectWithoutOrganTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var mobStateSystem = entMan.System<MobStateSystem>();
+            var solutionSys = entMan.System<SharedSolutionContainerSystem>();
+            var body = entMan.SpawnEntity("CyberHeartTestBody", mapData.GridCoords);
+            var bloodstream = entMan.GetComponent<BloodstreamComponent>(body);
+
+            mobStateSystem.ChangeMobState(body, MobState.Critical);
+
+            solutionSys.TryGetSolution(body, bloodstream.BloodSolutionName, out _, out var blood);
+            var epi = blood.GetTotalPrototypeQuantity("Epinephrine");
+            Assert.That(epi, Is.EqualTo(FixedPoint2.Zero),
+                "No epinephrine without cybernetic heart");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task HeartDoesNotInjectOnNonCritStateChangeTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var containerSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedSolutionContainerSystem>();
+        var mobStateSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberHeartTestBodyWithHeart", mapData.GridCoords);
+
+            // Transition to Dead (not Critical) -- should not inject
+            mobStateSys.ChangeMobState(body, MobState.Dead);
+
+            var bloodstream = entMan.GetComponent<BloodstreamComponent>(body);
+            Assert.That(containerSys.TryGetSolution(body, bloodstream.BloodSolutionName, out _, out var solution),
+                Is.True);
+            Assert.That(solution.GetTotalPrototypeQuantity("Epinephrine"), Is.EqualTo(FixedPoint2.Zero),
+                "Heart should not inject on state changes other than Critical");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticEmpSystem.cs
@@ -1,0 +1,66 @@
+using Content.Shared.Body;
+using Content.Shared.Emp;
+using Content.Shared.RussStation.Body;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Applies EMP effects to bodies that contain cybernetic organs.
+/// </summary>
+public sealed class CyberneticEmpSystem : EntitySystem
+{
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+
+    private static readonly EntProtoId CardiacArrestEffect = "StatusEffectCardiacArrest";
+    private static readonly EntProtoId BreathingSuppressedEffect = "StatusEffectBreathingSuppressed";
+    private static readonly EntProtoId BlindnessEffect = "StatusEffectTemporaryBlindness";
+    private static readonly EntProtoId DeafnessEffect = "StatusEffectTemporaryDeafness";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BodyComponent, EmpPulseEvent>(OnBodyEmpPulse);
+    }
+
+    private void OnBodyEmpPulse(EntityUid uid, BodyComponent body, ref EmpPulseEvent args)
+    {
+        if (body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!TryComp<CyberneticOrganComponent>(organ, out var cyber))
+                continue;
+
+            args.Affected = true;
+            ApplyEmpEffect(uid, cyber, args.Duration, args.EnergyConsumption);
+        }
+    }
+
+    private void ApplyEmpEffect(
+        EntityUid body,
+        CyberneticOrganComponent cyber,
+        TimeSpan baseDuration,
+        float energy)
+    {
+        var duration = baseDuration * cyber.EmpVulnerability;
+
+        var effectId = cyber.EmpEffect switch
+        {
+            CyberneticEmpEffect.CardiacArrest => (EntProtoId?) CardiacArrestEffect,
+            CyberneticEmpEffect.BreathingFailure => BreathingSuppressedEffect,
+            CyberneticEmpEffect.Flicker => BlindnessEffect,
+            CyberneticEmpEffect.Deafen => DeafnessEffect,
+            _ => null,
+        };
+
+        if (effectId == null)
+            return;
+
+        if (!_statusEffects.TryAddStatusEffectDuration(body, effectId.Value, duration))
+            Log.Debug($"Failed to apply EMP effect {cyber.EmpEffect} to {ToPrettyString(body)}");
+    }
+}

--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -1,0 +1,70 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Timing;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Handles all passive effects for cybernetic organs installed in a body. Each organ type
+/// has a marker component that enables its effect; per-organ PRs add more handlers in this
+/// file as their PRs land.
+/// </summary>
+public sealed class CyberneticOrganEffectsSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // Heart: auto-inject epinephrine on crit
+        SubscribeLocalEvent<BodyComponent, MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    // ================================================================
+    // Heart — epinephrine auto-injection on entering crit
+    // ================================================================
+
+    private void OnMobStateChanged(EntityUid uid, BodyComponent body, MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Critical || body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!TryComp<CyberneticHeartComponent>(organ, out var heart))
+                continue;
+
+            TryInjectEpinephrine(uid, organ, heart);
+            break;
+        }
+    }
+
+    private void TryInjectEpinephrine(EntityUid body, EntityUid organ, CyberneticHeartComponent heart)
+    {
+        var now = _timing.CurTime;
+
+        if (heart.LastInjection != null && now - heart.LastInjection.Value < heart.Cooldown)
+            return;
+
+        var solution = new Solution(heart.Reagent, heart.InjectAmount);
+        if (!_bloodstream.TryAddToBloodstream(body, solution))
+        {
+            Log.Warning($"Cybernetic heart failed to inject into {ToPrettyString(body)}");
+            return;
+        }
+
+        heart.LastInjection = now;
+        Dirty(organ, heart);
+
+        _popup.PopupEntity(
+            Loc.GetString("cybernetic-heart-inject"),
+            body, body, PopupType.MediumCaution);
+    }
+}

--- a/Content.Server/RussStation/Body/HeartlessSystem.cs
+++ b/Content.Server/RussStation/Body/HeartlessSystem.cs
@@ -1,0 +1,78 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Body;
+
+/// <summary>
+/// Tracks heart presence on bodies. While a body has no Heart-category organ installed,
+/// <see cref="NoHeartComponent"/> is present and the body bleeds saturation each tick so
+/// the patient suffocates fatally. Defibrillation does not clear this -- a heart has to
+/// physically be reinserted.
+/// </summary>
+public sealed class HeartlessSystem : EntitySystem
+{
+    [Dependency] private readonly RespiratorSystem _respirator = default!;
+
+    private static readonly ProtoId<OrganCategoryPrototype> HeartCategory = "Heart";
+
+    /// <summary>Saturation drained per second while the body has no heart.</summary>
+    private const float HeartlessDrainPerSecond = 3f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BodyComponent, OrganInsertedIntoEvent>(OnOrganInserted);
+        SubscribeLocalEvent<BodyComponent, OrganRemovedFromEvent>(OnOrganRemoved);
+    }
+
+    private void OnOrganRemoved(Entity<BodyComponent> body, ref OrganRemovedFromEvent args)
+    {
+        // Body cleanup removes organs as it terminates; don't ensure markers in that window.
+        if (TerminatingOrDeleted(body.Owner))
+            return;
+
+        if (!TryComp<OrganComponent>(args.Organ, out var organ))
+            return;
+
+        if (organ.Category == HeartCategory && !HasAnyHeart(body.Comp))
+            EnsureComp<NoHeartComponent>(body);
+    }
+
+    private void OnOrganInserted(Entity<BodyComponent> body, ref OrganInsertedIntoEvent args)
+    {
+        if (!TryComp<OrganComponent>(args.Organ, out var organ))
+            return;
+
+        if (organ.Category == HeartCategory)
+            RemComp<NoHeartComponent>(body);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var drain = -HeartlessDrainPerSecond * frameTime;
+        var query = EntityQueryEnumerator<NoHeartComponent>();
+
+        while (query.MoveNext(out var uid, out _))
+            _respirator.UpdateSaturation(uid, drain);
+    }
+
+    private bool HasAnyHeart(BodyComponent body)
+    {
+        if (body.Organs == null)
+            return false;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (TryComp<OrganComponent>(organ, out var organComp) && organComp.Category == HeartCategory)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Shared/Body/GibbableOrganSystem.cs
+++ b/Content.Shared/Body/GibbableOrganSystem.cs
@@ -1,4 +1,7 @@
 using Content.Shared.Gibbing;
+//HONK START
+using Content.Shared.RussStation.Body;
+//HONK END
 
 namespace Content.Shared.Body;
 
@@ -13,6 +16,11 @@ public sealed class GibbableOrganSystem : EntitySystem
 
     private void OnBeingGibbed(Entity<GibbableOrganComponent> ent, ref BodyRelayedEvent<BeingGibbedEvent> args)
     {
+        //HONK START - Cybernetic organs inherit GibbableOrgan from base but shouldn't gib
+        if (HasComp<CyberneticOrganComponent>(ent))
+            return;
+        //HONK END
+
         args.Args.Giblets.Add(ent);
     }
 }

--- a/Content.Shared/RussStation/Body/CyberneticHeartComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticHeartComponent.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// When attached to an organ inside a body, auto-injects epinephrine
+/// into the host's bloodstream when they enter crit.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CyberneticHeartComponent : Component
+{
+    [DataField]
+    public ProtoId<ReagentPrototype> Reagent = "Epinephrine";
+
+    [DataField]
+    public FixedPoint2 InjectAmount = FixedPoint2.New(10);
+
+    /// <summary>
+    /// Minimum time between auto-injections.
+    /// </summary>
+    [DataField]
+    public TimeSpan Cooldown = CyberneticOrganConstants.HeartEpinephrineCooldown;
+
+    /// <summary>
+    /// When the last injection occurred. Tracked on the component so it
+    /// survives across system updates.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan? LastInjection;
+}

--- a/Content.Shared/RussStation/Body/CyberneticOrganComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganComponent.cs
@@ -1,0 +1,44 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.RussStation.Body;
+
+[NetSerializable, Serializable]
+public enum CyberneticTier : byte
+{
+    Basic,
+    Standard,
+    Advanced,
+}
+
+[NetSerializable, Serializable]
+public enum CyberneticEmpEffect : byte
+{
+    None,
+    CardiacArrest,
+    BreathingFailure,
+    Flicker,
+    Deafen,
+}
+
+/// <summary>
+/// Marker + data component for cybernetic organ replacements.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CyberneticOrganComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public CyberneticTier Tier = CyberneticTier.Basic;
+
+    /// <summary>
+    /// What happens to this organ's host when hit by an EMP.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public CyberneticEmpEffect EmpEffect = CyberneticEmpEffect.None;
+
+    /// <summary>
+    /// Multiplier for EMP duration/severity. Higher = more vulnerable.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float EmpVulnerability = CyberneticOrganConstants.DefaultEmpVulnerability;
+}

--- a/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
@@ -9,4 +9,7 @@ public static class CyberneticOrganConstants
 {
     /// <summary>Default EMP vulnerability multiplier on <see cref="CyberneticOrganComponent"/>.</summary>
     public const float DefaultEmpVulnerability = 1.0f;
+
+    /// <summary>Cooldown between auto-injections for <see cref="CyberneticHeartComponent"/>.</summary>
+    public static readonly TimeSpan HeartEpinephrineCooldown = TimeSpan.FromSeconds(120);
 }

--- a/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Tunable defaults for cybernetic organ components. Per the magic-number audit, every numeric
+/// default referenced from a [DataField] in this folder lives here so reviewers can re-tune
+/// values centrally without grepping through every component file.
+/// </summary>
+public static class CyberneticOrganConstants
+{
+    /// <summary>Default EMP vulnerability multiplier on <see cref="CyberneticOrganComponent"/>.</summary>
+    public const float DefaultEmpVulnerability = 1.0f;
+}

--- a/Content.Shared/RussStation/Body/NoHeartComponent.cs
+++ b/Content.Shared/RussStation/Body/NoHeartComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Added to a body that has no Heart-category organ installed.
+/// Drives saturation drain in HeartlessSystem -- not removable by defibrillation.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NoHeartComponent : Component;

--- a/Resources/Locale/en-US/@RussStation/medical/cybernetic-heart.ftl
+++ b/Resources/Locale/en-US/@RussStation/medical/cybernetic-heart.ftl
@@ -1,0 +1,1 @@
+cybernetic-heart-inject = You feel a sharp jolt as your cybernetic heart injects emergency epinephrine!

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -10,3 +10,57 @@
   components:
   - type: Sprite
     sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+
+# ============================================================
+# HEART - EmpEffect: CardiacArrest
+# ============================================================
+
+- type: entity
+  parent: [OrganBaseHeart, OrganCyberneticInternal]
+  id: OrganCyberneticHeartBasic
+  name: basic cybernetic heart
+  description: A cheap cybernetic heart replacement. Keeps you alive, barely.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: heart-plastic-on
+  - type: Metabolizer
+    maxReagents: 1
+  - type: CyberneticOrgan
+    tier: Basic
+    empEffect: CardiacArrest
+    empVulnerability: 1.5
+
+- type: entity
+  parent: [OrganBaseHeart, OrganCyberneticInternal]
+  id: OrganCyberneticHeartStandard
+  name: cybernetic heart
+  description: A reliable cybernetic heart. Performs identically to a biological one.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: heart-plasma-on
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: CardiacArrest
+    empVulnerability: 1.0
+
+- type: entity
+  parent: [OrganBaseHeart, OrganCyberneticInternal]
+  id: OrganCyberneticHeartAdvanced
+  name: advanced cybernetic heart
+  description: A state-of-the-art cybernetic heart with enhanced circulatory efficiency.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: heart-bluespace-on
+  - type: Metabolizer
+    maxReagents: 3
+  - type: CyberneticOrgan
+    tier: Advanced
+    empEffect: CardiacArrest
+    empVulnerability: 0.5
+  - type: CyberneticHeart

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -1,0 +1,12 @@
+# Cybernetic organ replacements - shared base. Specific organ prototypes (Heart/Lungs/Eyes/etc.)
+# land alongside their per-organ feature PRs and inherit OrganCyberneticInternal for the shared
+# RSI path. GibbableOrgan is inherited but suppressed in C# (GibbableOrganSystem skips
+# CyberneticOrgan entities).
+# Sprites: @RussStation/Objects/Cybernetics/cybernetic_organs.rsi (Katyes, CC-BY-SA-4.0)
+
+- type: entity
+  id: OrganCyberneticInternal
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"

--- a/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
+++ b/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
@@ -1,0 +1,58 @@
+# Cybernetic organ lathe recipes. Per-organ recipes are added by their respective PRs.
+# Printed at the exosuit fabricator (Robotics category).
+
+# ============================================================
+# Abstract bases per tier
+# ============================================================
+
+- type: latheRecipe
+  abstract: true
+  id: BaseCyberneticRecipeBasic
+  categories:
+    - Robotics
+  completetime: 4
+  materials:
+    Steel: 500
+    Plastic: 300
+
+- type: latheRecipe
+  abstract: true
+  id: BaseCyberneticRecipeStandard
+  categories:
+    - Robotics
+  completetime: 6
+  materials:
+    Steel: 500
+    Plastic: 300
+    Gold: 200
+
+- type: latheRecipe
+  abstract: true
+  id: BaseCyberneticRecipeAdvanced
+  categories:
+    - Robotics
+  completetime: 8
+  materials:
+    Steel: 500
+    Plasma: 300
+    Gold: 300
+    Silver: 200
+
+# ============================================================
+# Heart
+# ============================================================
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeBasic
+  id: CyberneticHeartBasic
+  result: OrganCyberneticHeartBasic
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeStandard
+  id: CyberneticHeartStandard
+  result: OrganCyberneticHeartStandard
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeAdvanced
+  id: CyberneticHeartAdvanced
+  result: OrganCyberneticHeartAdvanced


### PR DESCRIPTION
## About the PR

First per-organ PR. Adds cybernetic heart (3 tiers), the heartless system (no-heart bodies suffocate fatally), and the central `CyberneticEmpSystem` dispatcher that applies the right status effect when a body with cybernetic organs takes an EMP pulse. Builds on top of the cybernetic-organ framework PR (#744) and the cardiac-arrest framework PR (#747).

## Why / Balance

Heart is the highest-impact organ to ship first because losing it is fatal and the cybernetic-heart vulnerability adds an EMP angle to combat. Tier curve: Basic is barely-functional (Metabolizer maxReagents 1, EMP vulnerability 1.5), Standard mirrors a biological heart, Advanced gets the epinephrine auto-inject and the lowest EMP vulnerability (0.5).

## Technical details

- `CyberneticHeartComponent`: reagent proto (default `Epinephrine`), inject amount, cooldown (default 120s). Lives only on the Advanced tier prototype.
- `NoHeartComponent`: marker on the body, applied by `HeartlessSystem` whenever no Heart-category organ remains in the body container.
- `HeartlessSystem`: subscribes `OrganInsertedIntoEvent` / `OrganRemovedFromEvent` on `BodyComponent`, applies/removes the marker, and runs an `Update` loop that drains 3/s saturation from every body carrying the marker. Defibrillation doesn't undo it.
- `CyberneticOrganEffectsSystem`: heart-only today (`MobStateChangedEvent` → epinephrine inject via `BloodstreamSystem`). Per-organ PRs add their handlers next to this.
- `CyberneticEmpSystem`: `EmpPulseEvent` on `BodyComponent`, walks the body's organs, applies `StatusEffectCardiacArrest` / `StatusEffectBreathingSuppressed` / `StatusEffectTemporaryBlindness` / `StatusEffectTemporaryDeafness` based on each organ's `EmpEffect`, scaled by `EmpVulnerability`. Heart is the first user; later organ PRs reuse the dispatcher.
- Three heart prototypes parenting `OrganBaseHeart` + `OrganCyberneticInternal`.
- Lathe recipe abstracts (`BaseCyberneticRecipeBasic/Standard/Advanced`) + the three heart recipes. The abstracts are reused by every later per-organ PR.

## Media

In-game: rip out a captain's heart, watch saturation cap at MinSaturation as they suffocate. Defib does nothing. Implant a Standard cybernetic heart, saturation recovers normally. EMP a body with the cybernetic heart, watch the cardiac arrest alert pop on the health analyzer.

## Breaking changes

None. New components and prototypes only.

## Changelog

:cl:
- add: Cybernetic heart implants are now manufacturable at the exosuit fabricator. Three tiers: Basic (cheap), Standard (mirrors biological), Advanced (auto-injects epinephrine on crit). All three are vulnerable to EMP, which puts the host into cardiac arrest -- defibrillator clears it.
- add: Patients with no heart organ now suffocate fatally regardless of working lungs or defibrillation. Reinserting a heart restores breathing.

## Depends on

- #744 cybernetic organ framework
- #747 cardiac arrest status effect (for EMP wiring)