### PR TITLE
honksquad: feat: cybernetic lungs (Phase 1 split 9/16)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/CyberneticLungBreathingTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/CyberneticLungBreathingTest.cs
@@ -1,0 +1,220 @@
+using System.Linq;
+using Content.Server.Body.Systems;
+using Content.Shared.Atmos;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Metabolism;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+/// <summary>
+/// Locks in the SharedCyberneticLungsSystem behavior: when a cybernetic lung organ
+/// is inserted into a body whose other organs carry MetabolizerTypes (e.g. [Human]),
+/// the lung's MetabolizerComponent should inherit the same set so the Oxygenate
+/// effect's MetabolizerTypeCondition resolves and the patient actually breathes.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SharedCyberneticLungsSystem))]
+public sealed class CyberneticLungBreathingTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CyberLungBreathTestHeart
+  components:
+  - type: Organ
+    category: Heart
+  - type: Metabolizer
+    metabolizerTypes: [ Human ]
+
+- type: entity
+  id: CyberLungBreathTestLung
+  components:
+  - type: Organ
+    category: Lungs
+  - type: Lung
+  - type: SolutionContainerManager
+    solutions:
+      Lung:
+        maxVol: 100.0
+        canReact: false
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: BreathingFailure
+    empVulnerability: 1.0
+  - type: Metabolizer
+    stages: [ Respiration ]
+
+- type: entity
+  id: CyberLungBreathTestBody
+  components:
+  - type: Body
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: CyberLungBreathTestHeart
+        - id: CyberLungBreathTestLung
+";
+
+    [Test]
+    public async Task RealCyberneticLungPrototypeHasLungSolutionTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var solSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedSolutionContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // Spawn each tier of the actual fork prototype standalone and check the
+            // 'Lung' solution actually exists on it -- if the YAML re-declaration of
+            // SolutionContainerManager wiped the parent's, this asserts will fail.
+            foreach (var protoId in new[]
+            {
+                "OrganCyberneticLungsBasic",
+                "OrganCyberneticLungsStandard",
+                "OrganCyberneticLungsAdvanced",
+            })
+            {
+                var lung = entMan.SpawnEntity(protoId, mapData.GridCoords);
+
+                Assert.That(entMan.HasComponent<LungComponent>(lung), Is.True,
+                    $"{protoId} should carry LungComponent (inherited from OrganBaseLungs)");
+                Assert.That(entMan.HasComponent<MetabolizerComponent>(lung), Is.True,
+                    $"{protoId} should carry MetabolizerComponent");
+
+                var lungComp = entMan.GetComponent<LungComponent>(lung);
+                Assert.That(solSys.TryGetSolution(lung, lungComp.SolutionName, out _, out _), Is.True,
+                    $"{protoId} should have its '{lungComp.SolutionName}' solution wired up");
+
+                var metabolizer = entMan.GetComponent<MetabolizerComponent>(lung);
+                Assert.That(metabolizer.Stages, Does.Contain(new Robust.Shared.Prototypes.ProtoId<MetabolismStagePrototype>("Respiration")),
+                    $"{protoId} should have the Respiration stage on its Metabolizer");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CyberneticLungFillsWithOxygenOnInhaleTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var solSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedSolutionContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberLungBreathTestBody", mapData.GridCoords);
+            var bodyComp = entMan.GetComponent<BodyComponent>(body);
+            var lung = bodyComp.Organs!.ContainedEntities
+                .First(o => entMan.HasComponent<CyberneticOrganComponent>(o));
+
+            var lungComp = entMan.GetComponent<LungComponent>(lung);
+            Assert.That(solSys.TryGetSolution(lung, lungComp.SolutionName, out _, out var solBefore), Is.True);
+            Assert.That(solBefore!.Volume, Is.EqualTo(FixedPoint2.Zero),
+                "Precondition: lung solution starts empty");
+
+            // Synthesize an inhale -- this is exactly what RespiratorSystem.Inhale does internally.
+            var gas = new GasMixture(6f);
+            gas.SetMoles(Gas.Oxygen, 5f);
+            var inhale = new InhaledGasEvent(gas);
+            entMan.EventBus.RaiseLocalEvent(body, ref inhale);
+
+            Assert.That(inhale.Succeeded, Is.True,
+                "InhaledGasEvent should land on the cybernetic lung's RespiratorSystem handler");
+
+            Assert.That(solSys.TryGetSolution(lung, lungComp.SolutionName, out _, out var solAfter), Is.True);
+            Assert.That(solAfter!.Volume, Is.GreaterThan(FixedPoint2.Zero),
+                "Lung solution should contain reagents after the inhale relay reaches the lung");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DynamicallyInsertedCyberneticLungBreathesTest()
+    {
+        // Mirrors the surgery flow: bio lungs out, cybernetic lungs in. We simulate by
+        // spawning the body without lungs (just the heart) and then inserting a bare
+        // cybernetic lung entity into the body_organs container.
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var solSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedSolutionContainerSystem>();
+        var containerSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<Robust.Shared.Containers.SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // Body that only has a heart at spawn (so the heart's MetabolizerTypes seeds
+            // the dynamic inheritance), no lungs yet.
+            var heartOnly = entMan.SpawnEntity("CyberLungBreathTestBody", mapData.GridCoords);
+            var bodyComp = entMan.GetComponent<BodyComponent>(heartOnly);
+            // remove the auto-spawned lung so we're testing the dynamic insert below
+            var existingLung = bodyComp.Organs!.ContainedEntities
+                .First(o => entMan.HasComponent<CyberneticOrganComponent>(o));
+            containerSys.Remove(existingLung, bodyComp.Organs);
+            entMan.DeleteEntity(existingLung);
+
+            // Spawn a fresh cybernetic lung and insert it the way surgery does
+            var lung = entMan.SpawnEntity("CyberLungBreathTestLung", mapData.GridCoords);
+            var inserted = containerSys.Insert(lung, bodyComp.Organs);
+            Assert.That(inserted, Is.True, "Cybernetic lung should insert into body_organs");
+
+            var metabolizer = entMan.GetComponent<MetabolizerComponent>(lung);
+            Assert.That(metabolizer.MetabolizerTypes, Is.Not.Null,
+                "MetabolizerTypes should be populated after dynamic insertion");
+            Assert.That(metabolizer.MetabolizerTypes!.Any(t => t.Id == "Human"), Is.True);
+
+            var lungComp = entMan.GetComponent<LungComponent>(lung);
+            var gas = new GasMixture(6f);
+            gas.SetMoles(Gas.Oxygen, 5f);
+            var inhale = new InhaledGasEvent(gas);
+            entMan.EventBus.RaiseLocalEvent(heartOnly, ref inhale);
+
+            Assert.That(solSys.TryGetSolution(lung, lungComp.SolutionName, out _, out var sol), Is.True);
+            Assert.That(sol!.Volume, Is.GreaterThan(FixedPoint2.Zero),
+                "Dynamically-inserted cybernetic lung should fill its solution on inhale");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CyberneticLungInheritsHostMetabolizerTypesTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberLungBreathTestBody", mapData.GridCoords);
+            var bodyComp = entMan.GetComponent<BodyComponent>(body);
+            Assert.That(bodyComp.Organs, Is.Not.Null);
+
+            var lung = bodyComp.Organs!.ContainedEntities
+                .First(o => entMan.HasComponent<CyberneticOrganComponent>(o));
+
+            var metabolizer = entMan.GetComponent<MetabolizerComponent>(lung);
+            Assert.That(metabolizer.MetabolizerTypes, Is.Not.Null,
+                "Cybernetic lung should have MetabolizerTypes copied from the host body's other organs");
+            Assert.That(metabolizer.MetabolizerTypes!, Has.Count.GreaterThan(0),
+                "Inherited MetabolizerTypes should not be empty");
+            Assert.That(metabolizer.MetabolizerTypes!.Any(t => t.Id == "Human"), Is.True,
+                "Inherited MetabolizerTypes should contain 'Human' from the other host organs");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -22,7 +22,9 @@ using Robust.Shared.Timing;
 namespace Content.Shared.Metabolism;
 
 /// <inheritdoc/>
-public sealed class MetabolizerSystem : EntitySystem
+//HONK START - partial so a fork-side .Honk.cs can expose the MetabolizerTypes setter to SharedCyberneticLungsSystem
+public sealed partial class MetabolizerSystem : EntitySystem
+//HONK END
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;

--- a/Content.Shared/RussStation/Body/CyberneticLungsComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticLungsComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker component for advanced cybernetic lungs. Currently no extra effect beyond the
+/// shared CyberneticOrgan EMP behavior; toxic-gas filtering is deferred to a follow-up PR.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CyberneticLungsComponent : Component;

--- a/Content.Shared/RussStation/Body/MetabolizerSystem.Honk.cs
+++ b/Content.Shared/RussStation/Body/MetabolizerSystem.Honk.cs
@@ -1,0 +1,22 @@
+// HONK Fork-side partial extension on the upstream MetabolizerSystem so fork code can write
+// to MetabolizerComponent.MetabolizerTypes without tripping HONK0003. The field is already in
+// MetabolizerComponent's [Access] friend list (HONK-marked); this just keeps the write inside
+// the owning system rather than scattering it across RussStation files.
+
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Metabolism;
+
+public sealed partial class MetabolizerSystem
+{
+    /// <summary>
+    /// HONK Replaces the metabolizer's type set in-place. Used by SharedCyberneticLungsSystem to
+    /// inherit host-body metabolizer types onto a freshly-inserted cybernetic lung so the
+    /// Oxygenate condition resolves for any species.
+    /// </summary>
+    public void SetMetabolizerTypes(Entity<MetabolizerComponent> metabolizer, HashSet<ProtoId<MetabolizerTypePrototype>> types)
+    {
+        metabolizer.Comp.MetabolizerTypes = types;
+        Dirty(metabolizer);
+    }
+}

--- a/Content.Shared/RussStation/Body/SharedCyberneticLungsSystem.cs
+++ b/Content.Shared/RussStation/Body/SharedCyberneticLungsSystem.cs
@@ -1,0 +1,52 @@
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Metabolism;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Copies the host body's metabolizer types onto cybernetic lung entities at insertion time,
+/// so the Oxygenate MetabolizerTypeCondition resolves correctly for any species.
+/// </summary>
+public sealed class SharedCyberneticLungsSystem : EntitySystem
+{
+    [Dependency] private readonly MetabolizerSystem _metabolizer = default!;
+
+    private EntityQuery<MetabolizerComponent> _metabolizerQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _metabolizerQuery = GetEntityQuery<MetabolizerComponent>();
+
+        SubscribeLocalEvent<LungComponent, OrganGotInsertedEvent>(OnLungInserted);
+    }
+
+    private void OnLungInserted(EntityUid uid, LungComponent _, ref OrganGotInsertedEvent args)
+    {
+        if (!HasComp<CyberneticOrganComponent>(uid))
+            return;
+
+        if (!_metabolizerQuery.TryComp(uid, out var metabolizer))
+            return;
+
+        if (!TryComp<BodyComponent>(args.Target, out var body) || body.Organs == null)
+            return;
+
+        var types = new HashSet<ProtoId<MetabolizerTypePrototype>>();
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!_metabolizerQuery.TryComp(organ, out var otherMet) || otherMet.MetabolizerTypes == null)
+                continue;
+
+            types.UnionWith(otherMet.MetabolizerTypes);
+        }
+
+        if (types.Count == 0)
+            return;
+
+        _metabolizer.SetMetabolizerTypes((uid, metabolizer), types);
+    }
+}

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -64,3 +64,73 @@
     empEffect: CardiacArrest
     empVulnerability: 0.5
   - type: CyberneticHeart
+
+# ============================================================
+# LUNGS - EmpEffect: BreathingFailure
+# ============================================================
+
+- type: entity
+  parent: [OrganBaseLungs, OrganCyberneticInternal]
+  id: OrganCyberneticLungsBasic
+  name: basic cybernetic lungs
+  description: Budget cybernetic lungs. You'll breathe, but don't push it.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: lung-plastic-l
+    - state: lung-plastic-r
+  - type: SolutionContainerManager
+    solutions:
+      Lung:
+        maxVol: 75.0
+        canReact: false
+  - type: Metabolizer
+    stages: [Respiration]
+    maxReagents: 2
+  - type: CyberneticOrgan
+    tier: Basic
+    empEffect: BreathingFailure
+    empVulnerability: 1.5
+
+- type: entity
+  parent: [OrganBaseLungs, OrganCyberneticInternal]
+  id: OrganCyberneticLungsStandard
+  name: cybernetic lungs
+  description: Reliable cybernetic lungs. Breathe easy.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: lung-plasma-l
+    - state: lung-plasma-r
+  - type: Metabolizer
+    stages: [Respiration]
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: BreathingFailure
+    empVulnerability: 1.0
+
+- type: entity
+  parent: [OrganBaseLungs, OrganCyberneticInternal]
+  id: OrganCyberneticLungsAdvanced
+  name: advanced cybernetic lungs
+  description: High-end cybernetic lungs with extended oxygen reserves.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: lung-bluespace-l
+    - state: lung-bluespace-r
+  - type: SolutionContainerManager
+    solutions:
+      Lung:
+        maxVol: 130.0
+        canReact: false
+  - type: Metabolizer
+    stages: [Respiration]
+  - type: CyberneticOrgan
+    tier: Advanced
+    empEffect: BreathingFailure
+    empVulnerability: 0.5
+  - type: CyberneticLungs

--- a/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
+++ b/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
@@ -56,3 +56,22 @@
   parent: BaseCyberneticRecipeAdvanced
   id: CyberneticHeartAdvanced
   result: OrganCyberneticHeartAdvanced
+
+# ============================================================
+# Lungs
+# ============================================================
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeBasic
+  id: CyberneticLungsBasic
+  result: OrganCyberneticLungsBasic
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeStandard
+  id: CyberneticLungsStandard
+  result: OrganCyberneticLungsStandard
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeAdvanced
+  id: CyberneticLungsAdvanced
+  result: OrganCyberneticLungsAdvanced


### PR DESCRIPTION
## About the PR

Cybernetic lungs (3 tiers) plus the dynamic metabolizer-type inheritance that makes them work for any species. Without that inheritance, the lung's `MetabolizerTypeCondition` would never match and the patient would suffocate regardless of which gas they breathe. EMP wiring routes through the dispatcher in #750.

## Why / Balance

Tier curve: Basic has reduced solution volume (75 vs the base 100) and `maxReagents: 2` (slower processing); Standard mirrors biological lungs; Advanced gets a 130-volume Lung solution so it can buffer more oxygen between inhales. EMP vulnerability tracks the same 1.5 / 1.0 / 0.5 ladder as the heart and routes to the BreathingSuppressed status effect (#748).

## Technical details

- `CyberneticLungsComponent`: empty marker on the Advanced tier. The toxic-gas filter feature lands in a follow-up issue (#739 from the original PR).
- `SharedCyberneticLungsSystem`: on `OrganGotInsertedEvent` for any organ that has both `LungComponent` and `CyberneticOrganComponent`, walks the host body's other organs, unions their `MetabolizerTypes`, writes the result onto the cybernetic lung's `MetabolizerComponent` via the partial setter below. Skips the write if no source organ has any types (so a body that's lost everything else doesn't accidentally null out the lung).
- `MetabolizerSystem` (HONK-marked): adds the `partial` keyword so the fork-side `.Honk.cs` partial compiles. Otherwise unchanged.
- `MetabolizerSystem.Honk.cs`: `SetMetabolizerTypes(Entity<MetabolizerComponent>, HashSet<ProtoId<MetabolizerTypePrototype>>)`. The setter lives inside `MetabolizerSystem` so the write to `MetabolizerTypes` doesn't trip `HONK0003`.
- Three lung entity prototypes (`OrganCyberneticLungsBasic` / `Standard` / `Advanced`) parenting `OrganBaseLungs` + `OrganCyberneticInternal`. Basic re-declares `SolutionContainerManager` (Lung 75 maxVol) + `Metabolizer { stages: [Respiration], maxReagents: 2 }`. Advanced re-declares `SolutionContainerManager` (Lung 130) and adds the `CyberneticLungs` marker.
- Three lathe recipes under `Robotics` parenting the abstract base recipes from #750.

## Media

In-game: rip out a Vox's biological lungs, slot in a Standard cybernetic lung, watch them keep breathing nitrogen normally because the system inherited `[Vox]` metabolizer types from their other organs.

## Breaking changes

`MetabolizerSystem` is now `partial`. No public API change.

## Changelog

:cl:
- add: Cybernetic lungs are now manufacturable at the exosuit fabricator. Three tiers (Basic / Standard / Advanced) work on any species -- the lung inherits the host's metabolic profile from their remaining organs on installation. EMPs put the host into breathing suppression for the duration.

## Depends on

- #744 cybernetic organ framework
- #748 breathing suppressed status effect (for EMP wiring)
- #750 cybernetic heart (provides the abstract lathe recipes)