### PR TITLE
honksquad: feat: cybernetic ears + earless deafness (Phase 1 split 11/16)

### DIFF
--- a/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
+++ b/Content.Client/RussStation/Hearing/DeafAudioSystem.cs
@@ -12,10 +12,9 @@ using Robust.Shared.Player;
 namespace Content.Client.RussStation.Hearing;
 
 /// <summary>
-/// Applies audio occlusion to muffle sounds for the local player while their
-/// <see cref="DeafableComponent.IsDeaf"/> is set. Partial-occlusion sources like
-/// hearing impairment from cybernetic ears live in their own systems and stack on
-/// top via the same <see cref="AudioSystem.GetOcclusionOverride"/> delegate hook.
+/// Applies audio occlusion effects based on the local player's hearing state:
+/// - Fully deaf: high occlusion (8f) via DeafableComponent.IsDeaf
+/// - Impaired (basic cybernetic ears): partial occlusion (3.5f) via HearingImpairmentComponent
 /// </summary>
 public sealed class DeafAudioSystem : EntitySystem
 {
@@ -27,6 +26,8 @@ public sealed class DeafAudioSystem : EntitySystem
     private const float DeafOcclusion = 8f;
 
     private bool _isDeaf;
+    private bool _isImpaired;
+    private float _impairedOcclusion;
     private float _maxRayLength;
 
     public override void Initialize()
@@ -39,8 +40,15 @@ public sealed class DeafAudioSystem : EntitySystem
         SubscribeLocalEvent<DeafableComponent, ComponentRemove>(OnDeafRemove);
         SubscribeLocalEvent<DeafableComponent, DeafnessChangedEvent>(OnDeafnessChanged);
 
+        SubscribeLocalEvent<HearingImpairmentComponent, ComponentStartup>(OnImpairmentStartup);
+        SubscribeLocalEvent<HearingImpairmentComponent, LocalPlayerAttachedEvent>(OnImpairmentAttached);
+        SubscribeLocalEvent<HearingImpairmentComponent, LocalPlayerDetachedEvent>(OnImpairmentDetached);
+        SubscribeLocalEvent<HearingImpairmentComponent, ComponentRemove>(OnImpairmentRemove);
+
         Subs.CVar(_cfg, Robust.Shared.CVars.AudioRaycastLength, v => _maxRayLength = v, true);
     }
+
+    // ── Deafness handlers ────────────────────────────────────────────────────
 
     private void OnDeafStartup(EntityUid uid, DeafableComponent comp, ComponentStartup args)
     {
@@ -70,22 +78,68 @@ public sealed class DeafAudioSystem : EntitySystem
             SetDeaf(args.Deaf);
     }
 
+    // ── Impairment handlers ───────────────────────────────────────────────────
+
+    private void OnImpairmentStartup(EntityUid uid, HearingImpairmentComponent comp, ComponentStartup args)
+    {
+        if (uid == _player.LocalEntity)
+            SetImpaired(true, comp.OcclusionBonus);
+    }
+
+    private void OnImpairmentAttached(EntityUid uid, HearingImpairmentComponent comp, LocalPlayerAttachedEvent args)
+    {
+        SetImpaired(true, comp.OcclusionBonus);
+    }
+
+    private void OnImpairmentDetached(EntityUid uid, HearingImpairmentComponent comp, LocalPlayerDetachedEvent args)
+    {
+        SetImpaired(false, 0f);
+    }
+
+    private void OnImpairmentRemove(EntityUid uid, HearingImpairmentComponent comp, ComponentRemove args)
+    {
+        if (uid == _player.LocalEntity)
+            SetImpaired(false, 0f);
+    }
+
+    // ── State management ──────────────────────────────────────────────────────
+
     private void SetDeaf(bool deaf)
     {
         if (_isDeaf == deaf)
             return;
 
+        var wasActive = _isDeaf || _isImpaired;
         _isDeaf = deaf;
+        var isActive = _isDeaf || _isImpaired;
 
-        if (_isDeaf)
+        UpdateOcclusionDelegate(wasActive, isActive);
+    }
+
+    private void SetImpaired(bool impaired, float occlusion)
+    {
+        if (_isImpaired == impaired)
+            return;
+
+        var wasActive = _isDeaf || _isImpaired;
+        _isImpaired = impaired;
+        _impairedOcclusion = occlusion;
+        var isActive = _isDeaf || _isImpaired;
+
+        UpdateOcclusionDelegate(wasActive, isActive);
+    }
+
+    private void UpdateOcclusionDelegate(bool wasActive, bool isActive)
+    {
+        if (isActive && !wasActive)
             _audio.GetOcclusionOverride += OcclusionOverride;
-        else
+        else if (!isActive && wasActive)
             _audio.GetOcclusionOverride -= OcclusionOverride;
     }
 
-    // Mirrors the engine's baseline occlusion raycast, then adds the deaf bonus on top so
-    // wall muffling still stacks. Keep in sync with
-    // RobustToolbox/Robust.Client/Audio/AudioSystem.cs GetOcclusion during rebases.
+    // Mirrors the engine's baseline occlusion raycast, then adds the appropriate
+    // bonus on top so wall muffling still stacks.
+    // Keep in sync with RobustToolbox/Robust.Client/Audio/AudioSystem.cs GetOcclusion during rebases.
     private float OcclusionOverride(MapCoordinates listener, Vector2 delta, float distance, EntityUid? ignoredEnt)
     {
         float occlusion = 0;
@@ -97,6 +151,8 @@ public sealed class DeafAudioSystem : EntitySystem
             occlusion = _physics.IntersectRayPenetration(listener.MapId, ray, rayLength, ignoredEnt);
         }
 
-        return occlusion + DeafOcclusion;
+        // Full deafness takes priority over impairment
+        var bonus = _isDeaf ? DeafOcclusion : _impairedOcclusion;
+        return occlusion + bonus;
     }
 }

--- a/Content.IntegrationTests/Tests/RussStation/Body/CyberneticEarsEffectsTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/CyberneticEarsEffectsTest.cs
@@ -1,0 +1,197 @@
+using System.Linq;
+using Content.Server.RussStation.Body;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Body;
+using Content.Shared.RussStation.Hearing;
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(CyberneticOrganEffectsSystem))]
+public sealed class CyberneticEarsEffectsTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CyberEarsTestBody
+  components:
+  - type: Body
+
+- type: entity
+  id: CyberEarsTestEars
+  components:
+  - type: Organ
+    category: Ears
+  - type: CyberneticEars
+
+- type: entity
+  id: CyberEarsTestBodyWithEars
+  components:
+  - type: Body
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: CyberEarsTestEars
+
+- type: entity
+  id: CyberEarsTestDeafBodyWithEars
+  components:
+  - type: Body
+  - type: Deafable
+  - type: TemporaryDeafness
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: CyberEarsTestEars
+
+- type: entity
+  id: CyberEarsTestDeafBody
+  components:
+  - type: Body
+  - type: Deafable
+  - type: TemporaryDeafness
+";
+
+    [Test]
+    public async Task EarsResistDeafnessTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberEarsTestBodyWithEars", mapData.GridCoords);
+
+            var ev = new CanHearAttemptEvent();
+            ev.Cancel();
+
+            entMan.EventBus.RaiseLocalEvent(body, ev);
+
+            Assert.That(ev.Cancelled, Is.False,
+                "Cybernetic ears should uncancel deafness");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EarsNoResistanceWithoutOrganTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberEarsTestBody", mapData.GridCoords);
+
+            var ev = new CanHearAttemptEvent();
+            ev.Cancel();
+
+            entMan.EventBus.RaiseLocalEvent(body, ev);
+
+            Assert.That(ev.Cancelled, Is.True,
+                "Deafness should persist without cybernetic ears");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EarsOverrideTemporaryDeafnessTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // Entity has DeafableComponent + TemporaryDeafness + CyberneticEars
+            var body = entMan.SpawnEntity("CyberEarsTestDeafBodyWithEars", mapData.GridCoords);
+
+            var ev = new CanHearAttemptEvent();
+            ev.Cancel(); // Simulate something trying to deafen
+            entMan.EventBus.RaiseLocalEvent(body, ev);
+
+            Assert.That(ev.Deaf, Is.False,
+                "Cybernetic ears should override temporary deafness (uncancel the event)");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DeafBodyWithoutEarsRemainsDeafTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // Entity has DeafableComponent + TemporaryDeafness but NO ears
+            var body = entMan.SpawnEntity("CyberEarsTestDeafBody", mapData.GridCoords);
+
+            var ev = new CanHearAttemptEvent();
+            entMan.EventBus.RaiseLocalEvent(body, ev);
+
+            Assert.That(ev.Deaf, Is.True,
+                "Deaf entity without cybernetic ears should remain deaf");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EarsRemovalRestoresDeafnessVulnerabilityTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var containerSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberEarsTestDeafBodyWithEars", mapData.GridCoords);
+
+            // Verify ears override deafness
+            var evBefore = new CanHearAttemptEvent();
+            evBefore.Cancel();
+            entMan.EventBus.RaiseLocalEvent(body, evBefore);
+            Assert.That(evBefore.Cancelled, Is.False, "Precondition: ears should uncancel deafness");
+
+            // Remove the ears organ
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            foreach (var ent in organContainer.ContainedEntities.ToList())
+            {
+                if (entMan.HasComponent<CyberneticEarsComponent>(ent))
+                    containerSys.Remove(ent, organContainer);
+            }
+
+            var evAfter = new CanHearAttemptEvent();
+            evAfter.Cancel();
+            entMan.EventBus.RaiseLocalEvent(body, evAfter);
+            Assert.That(evAfter.Cancelled, Is.True,
+                "Deafness should persist after removing cybernetic ears");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Body/EarlessTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/EarlessTest.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using Content.Server.RussStation.Body;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Hearing;
+using Content.Shared.RussStation.Hearing.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(OrganLossSystem))]
+[TestOf(typeof(DeafableSystem))]
+public sealed class EarlessTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: EarlessTestEars
+  components:
+  - type: Organ
+    category: Ears
+
+- type: entity
+  id: EarlessTestBodyWithEars
+  components:
+  - type: Body
+  - type: Deafable
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: EarlessTestEars
+";
+
+    [Test]
+    public async Task EarsPresentLeavesPatientHearingTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var deafableSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<DeafableSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("EarlessTestBodyWithEars", mapData.GridCoords);
+
+            // Force a recompute -- nothing else has triggered one yet, IsDeaf default is false.
+            deafableSys.UpdateIsDeaf(body);
+
+            var deafable = entMan.GetComponent<DeafableComponent>(body);
+            Assert.That(deafable.IsDeaf, Is.False,
+                "Body with at least one ears organ should not be deaf");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EarRemovalDeafensPatientTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var containerSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("EarlessTestBodyWithEars", mapData.GridCoords);
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            var ears = organContainer.ContainedEntities
+                .First(o => entMan.TryGetComponent<OrganComponent>(o, out var c) && c.Category == "Ears");
+
+            containerSys.Remove(ears, organContainer);
+
+            var deafable = entMan.GetComponent<DeafableComponent>(body);
+            Assert.That(deafable.IsDeaf, Is.True,
+                "Body with no ears should be deaf");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EarReinsertionRestoresHearingTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var containerSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("EarlessTestBodyWithEars", mapData.GridCoords);
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            var ears = organContainer.ContainedEntities
+                .First(o => entMan.TryGetComponent<OrganComponent>(o, out var c) && c.Category == "Ears");
+
+            containerSys.Remove(ears, organContainer);
+            Assert.That(entMan.GetComponent<DeafableComponent>(body).IsDeaf, Is.True,
+                "Precondition: deaf without ears");
+
+            containerSys.Insert(ears, organContainer, force: true);
+
+            Assert.That(entMan.GetComponent<DeafableComponent>(body).IsDeaf, Is.False,
+                "Reinserting ears should restore hearing");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Body;
+using Content.Shared.RussStation.Hearing;
 using Robust.Shared.Timing;
 
 namespace Content.Server.RussStation.Body;
@@ -25,6 +26,10 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
         // Heart: auto-inject epinephrine on crit
         SubscribeLocalEvent<BodyComponent, MobStateChangedEvent>(OnMobStateChanged);
+
+        // Basic ears: hearing impairment (muffled audio)
+        SubscribeLocalEvent<CyberneticEarsBasicComponent, OrganGotInsertedEvent>(OnBasicEarsInserted);
+        SubscribeLocalEvent<CyberneticEarsBasicComponent, OrganGotRemovedEvent>(OnBasicEarsRemoved);
     }
 
     // ================================================================
@@ -66,5 +71,28 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         _popup.PopupEntity(
             Loc.GetString("cybernetic-heart-inject"),
             body, body, PopupType.MediumCaution);
+    }
+
+    // ================================================================
+    // Basic ears — hearing impairment (muffled audio)
+    // ================================================================
+
+    private void OnBasicEarsInserted(EntityUid uid, CyberneticEarsBasicComponent comp, ref OrganGotInsertedEvent args)
+    {
+        EnsureComp<HearingImpairmentComponent>(args.Target);
+    }
+
+    private void OnBasicEarsRemoved(EntityUid uid, CyberneticEarsBasicComponent comp, ref OrganGotRemovedEvent args)
+    {
+        if (TryComp<BodyComponent>(args.Target, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                if (organ != uid && HasComp<CyberneticEarsBasicComponent>(organ))
+                    return;
+            }
+        }
+
+        RemComp<HearingImpairmentComponent>(args.Target);
     }
 }

--- a/Content.Server/RussStation/Body/OrganLossSystem.cs
+++ b/Content.Server/RussStation/Body/OrganLossSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Body.Components;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.RussStation.Body;
+using Content.Shared.RussStation.Hearing.Systems;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.RussStation.Body;
@@ -19,9 +20,11 @@ public sealed class OrganLossSystem : EntitySystem
 {
     [Dependency] private readonly RespiratorSystem _respirator = default!;
     [Dependency] private readonly BlindableSystem _blinding = default!;
+    [Dependency] private readonly DeafableSystem _deafable = default!;
 
     private static readonly ProtoId<OrganCategoryPrototype> HeartCategory = "Heart";
     private static readonly ProtoId<OrganCategoryPrototype> EyesCategory = "Eyes";
+    private static readonly ProtoId<OrganCategoryPrototype> EarsCategory = "Ears";
 
     /// <summary>Saturation drained per second while the body has no heart.</summary>
     private const float NoHeartDrainPerSecond = 3f;
@@ -50,6 +53,8 @@ public sealed class OrganLossSystem : EntitySystem
             EnsureComp<NoHeartComponent>(body);
         else if (organ.Category == EyesCategory && !HasAnyOrganOfCategory(body.Comp, EyesCategory))
             EnsureComp<NoEyesComponent>(body);
+        else if (organ.Category == EarsCategory)
+            _deafable.UpdateIsDeaf(body.Owner);
     }
 
     private void OnOrganInserted(Entity<BodyComponent> body, ref OrganInsertedIntoEvent args)
@@ -61,6 +66,8 @@ public sealed class OrganLossSystem : EntitySystem
             RemComp<NoHeartComponent>(body);
         else if (organ.Category == EyesCategory)
             RemComp<NoEyesComponent>(body);
+        else if (organ.Category == EarsCategory)
+            _deafable.UpdateIsDeaf(body.Owner);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/RussStation/Body/CyberneticEarsBasicComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticEarsBasicComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker for basic cybernetic ears. While installed in a body, applies
+/// HearingImpairmentComponent to the host, muffling all audio.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CyberneticEarsBasicComponent : Component;

--- a/Content.Shared/RussStation/Body/CyberneticEarsComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticEarsComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker component for advanced cybernetic ears.
+/// While the organ is implanted, cancels deafness attempts (deafness resistance).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CyberneticEarsComponent : Component
+{
+}

--- a/Content.Shared/RussStation/Hearing/HearingImpairmentComponent.cs
+++ b/Content.Shared/RussStation/Hearing/HearingImpairmentComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Applied to a mob when basic cybernetic ears are installed. Causes partial
+/// audio muffling (weaker than full deafness) via DeafAudioSystem on the client,
+/// so the value has to network.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class HearingImpairmentComponent : Component
+{
+    /// <summary>
+    /// Extra occlusion added to all audio sources. Lower than the full deaf
+    /// value of 8 — audible but noticeably muffled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float OcclusionBonus = HearingImpairmentConstants.DefaultOcclusionBonus;
+}

--- a/Content.Shared/RussStation/Hearing/HearingImpairmentConstants.cs
+++ b/Content.Shared/RussStation/Hearing/HearingImpairmentConstants.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared.RussStation.Hearing;
+
+/// <summary>
+/// Tunable defaults for hearing-impairment audio occlusion.
+/// </summary>
+public static class HearingImpairmentConstants
+{
+    /// <summary>Default extra audio occlusion applied while
+    /// <see cref="HearingImpairmentComponent"/> is on a mob. Lower than the full deaf
+    /// value of 8 -- audible but noticeably muffled.</summary>
+    public const float DefaultOcclusionBonus = 3.5f;
+}

--- a/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
+++ b/Content.Shared/RussStation/Hearing/Systems/DeafableSystem.cs
@@ -1,5 +1,9 @@
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Rejuvenate;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.RussStation.Hearing.Systems;
 
@@ -7,13 +11,20 @@ namespace Content.Shared.RussStation.Hearing.Systems;
 /// Manages the IsDeaf state on <see cref="DeafableComponent"/> by raising
 /// <see cref="CanHearAttemptEvent"/>. Sources of deafness (cybernetic ears, missing ears,
 /// flashbangs, etc.) live in their own systems and subscribe to the attempt event.
+///
+/// Also handles the body-organ ear-tracking path: a body with an Advanced
+/// <see cref="CyberneticEarsComponent"/> trumps every other deafness source (Uncancel),
+/// while a body with no Ears-category organ at all is unconditionally deaf (Cancel).
 /// </summary>
 public sealed class DeafableSystem : EntitySystem
 {
+    private static readonly ProtoId<OrganCategoryPrototype> EarsCategory = "Ears";
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<DeafableComponent, RejuvenateEvent>(OnRejuvenate);
+        SubscribeLocalEvent<BodyComponent, CanHearAttemptEvent>(OnCanHearAttempt);
     }
 
     private void OnRejuvenate(Entity<DeafableComponent> ent, ref RejuvenateEvent args)
@@ -41,6 +52,29 @@ public sealed class DeafableSystem : EntitySystem
         var changeEv = new DeafnessChangedEvent(entity.Comp.IsDeaf);
         RaiseLocalEvent(entity.Owner, ref changeEv);
         Dirty(entity);
+    }
+
+    private void OnCanHearAttempt(EntityUid uid, BodyComponent body, CanHearAttemptEvent args)
+    {
+        if (body.Organs == null)
+            return;
+
+        var hasEars = false;
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            // Advanced cybernetic ears trump any other deafness source (earmuffs, flashbangs, etc).
+            if (HasComp<CyberneticEarsComponent>(organ))
+            {
+                args.Uncancel();
+                return;
+            }
+
+            if (TryComp<OrganComponent>(organ, out var organComp) && organComp.Category == EarsCategory)
+                hasEars = true;
+        }
+
+        if (!hasEars)
+            args.Cancel();
     }
 }
 

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -203,3 +203,54 @@
     autoRot: true
     radius: 6
   - type: UnpoweredFlashlight
+
+# ============================================================
+# EARS - EmpEffect: Deafen
+# ============================================================
+
+- type: entity
+  parent: [OrganBaseEars, OrganCyberneticInternal]
+  id: OrganCyberneticEarsBasic
+  name: basic cybernetic ears
+  description: Budget cybernetic ears. They pick up sound, but the analog-to-digital conversion leaves something to be desired. Everything sounds slightly muffled.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: ears-plastic
+  - type: CyberneticOrgan
+    tier: Basic
+    empEffect: Deafen
+    empVulnerability: 1.5
+  - type: CyberneticEarsBasic
+
+- type: entity
+  parent: [OrganBaseEars, OrganCyberneticInternal]
+  id: OrganCyberneticEarsStandard
+  name: cybernetic ears
+  description: Reliable cybernetic ears with normal hearing. A clean replacement for biological ones.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: ears-plasma
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: Deafen
+    empVulnerability: 1.0
+
+- type: entity
+  parent: [OrganBaseEars, OrganCyberneticInternal]
+  id: OrganCyberneticEarsAdvanced
+  name: advanced cybernetic ears
+  description: High-end cybernetic ears with active deafness suppression. Flashbangs and explosions won't silence you.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: ears-bluespace
+  - type: CyberneticOrgan
+    tier: Advanced
+    empEffect: Deafen
+    empVulnerability: 0.5
+  - type: CyberneticEars

--- a/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
+++ b/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
@@ -94,3 +94,22 @@
   parent: BaseCyberneticRecipeAdvanced
   id: CyberneticEyesAdvanced
   result: OrganCyberneticEyesAdvanced
+
+# ============================================================
+# Ears
+# ============================================================
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeBasic
+  id: CyberneticEarsBasic
+  result: OrganCyberneticEarsBasic
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeStandard
+  id: CyberneticEarsStandard
+  result: OrganCyberneticEarsStandard
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeAdvanced
+  id: CyberneticEarsAdvanced
+  result: OrganCyberneticEarsAdvanced


### PR DESCRIPTION
## About the PR

Three tiers of cybernetic ears (Basic / Standard / Advanced) and the earless system that makes "lost both ears" actually deaf the patient. Basic-tier passive is constant audio muffling; Advanced-tier passive is total deafness immunity. EMP routes to `StatusEffectTemporaryDeafness` from #745 via the dispatcher in #750.

## Why / Balance

Tier curve is the standard 1.5 / 1.0 / 0.5 EMP vulnerability ladder. Basic ears trade hearing fidelity (everything sounds occluded) for surviving cheap. Standard is a clean replacement. Advanced shrugs off flashbangs, explosions, and any other deafness source.

Removing both ears now drops the patient into full deafness in real time -- chat obfuscation, audio muffling, radio block (the radio piece lives in PR #15).

## Technical details

- `CyberneticEarsBasicComponent` (Basic marker): `CyberneticOrganEffectsSystem` adds `HearingImpairmentComponent` to the host body on insert, removes on the last basic ears organ leaving.
- `CyberneticEarsComponent` (Advanced marker): `DeafableSystem` checks for it on `CanHearAttemptEvent` and Uncancels, trumping any other source.
- `HearingImpairmentComponent` (+ Constants): networked, carries `OcclusionBonus` (default 3.5). Client-side `DeafAudioSystem` raises engine `GetOcclusionOverride` while it's present on the local player.
- `DeafableSystem` extension: subscribes to `BodyComponent + CanHearAttemptEvent`. Iterates `body.Organs`; cybernetic ears -> Uncancel + return; biological ears -> mark `hasEars = true`; if no ears at all -> Cancel.
- `OrganLossSystem` extension: Ears category in the organ-insert/remove handlers now calls `DeafableSystem.UpdateIsDeaf(body)` to recompute `IsDeaf` in real time.
- `CyberneticOrganEffectsSystem` extension: `CyberneticEarsBasicComponent` insert/remove handlers manage the host-body `HearingImpairmentComponent`.
- `DeafAudioSystem` extension (client): `HearingImpairment` handlers stack on top of the full-deafness path through the same `GetOcclusionOverride` callback.
- Three ear entity prototypes parenting `OrganBaseEars` + `OrganCyberneticInternal`. Basic and Advanced carry their respective markers; Standard is just a clean biological replacement.
- Three lathe recipes parenting the abstract base recipes.

## Media

In-game: install Basic ears -> everything sounds slightly muffled. Install Advanced ears -> get hit with a flashbang, no deafness. Remove both ears (any tier) -> full deafness, chat obfuscates, audio muffles. Reinsert -> hearing returns.

## Breaking changes

None.

## Changelog

:cl:
- add: Cybernetic ears are manufacturable at the exosuit fabricator. Three tiers: Basic (hearing impairment), Standard (clean replacement), Advanced (immune to deafness sources like flashbangs).
- add: Patients with no ear organs are now deaf -- chat obfuscates, ambient audio muffles. Reinserting any ear restores hearing.

## Depends on

- #744 cybernetic organ framework
- #745 deafness framework (DeafableComponent, DeafableSystem, audio muffling, status effect proto)
- #752 cybernetic eyes (chained base; provides OrganLossSystem and the prior recipe + organ context)

## Note on base

This PR's base is `honksquad/per-organ-deafness-merge`, a merge branch that combines #745 and #752 so the diff against this PR's base shows only the ear-specific additions (modifying DeafableSystem and DeafAudioSystem rather than re-adding them).