### PR TITLE
honksquad: feat: cybernetic stomach (Phase 1 split 12/16)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/CyberneticStomachEffectsTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/CyberneticStomachEffectsTest.cs
@@ -1,0 +1,169 @@
+using System.Linq;
+using Content.Server.RussStation.Body;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(CyberneticOrganEffectsSystem))]
+public sealed class CyberneticStomachEffectsTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CyberStomachTestStomach
+  components:
+  - type: Organ
+    category: Stomach
+  - type: CyberneticStomach
+
+- type: entity
+  id: CyberStomachTestBodyNoHunger
+  components:
+  - type: Body
+
+- type: entity
+  id: CyberStomachTestBodyWithStomach
+  components:
+  - type: Body
+  - type: Hunger
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: CyberStomachTestStomach
+";
+
+    [Test]
+    public async Task StomachReducesHungerDecayTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberStomachTestBodyWithStomach", mapData.GridCoords);
+            var hunger = entMan.GetComponent<HungerComponent>(body);
+
+            // CyberneticStomachComponent.DecayMultiplier is 0.5
+            var defaultRate = 0.01666666666f;
+            var expected = defaultRate * 0.5f;
+            Assert.That(hunger.BaseDecayRate, Is.EqualTo(expected).Within(0.0001f),
+                "Hunger decay should be halved with cybernetic stomach");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task StomachRestoresDecayOnRemovalTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var containerSys = entMan.System<SharedContainerSystem>();
+            var body = entMan.SpawnEntity("CyberStomachTestBodyWithStomach", mapData.GridCoords);
+            var hunger = entMan.GetComponent<HungerComponent>(body);
+
+            var reducedRate = hunger.BaseDecayRate;
+            var defaultRate = 0.01666666666f;
+            Assert.That(reducedRate, Is.LessThan(defaultRate),
+                "Rate should be reduced with stomach");
+
+            // Remove stomach
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            foreach (var ent in organContainer.ContainedEntities.ToList())
+            {
+                if (entMan.HasComponent<CyberneticStomachComponent>(ent))
+                    containerSys.Remove(ent, organContainer);
+            }
+
+            Assert.That(hunger.BaseDecayRate, Is.EqualTo(defaultRate).Within(0.0001f),
+                "Hunger decay should be restored to default after stomach removal");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task StomachDecayRateRestoredAfterRemoveAndReinsertTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var containerSys = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberStomachTestBodyWithStomach", mapData.GridCoords);
+            var hunger = entMan.GetComponent<HungerComponent>(body);
+            var reducedRate = hunger.BaseDecayRate;
+
+            // Remove the stomach organ
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            EntityUid stomachOrgan = default;
+            foreach (var ent in organContainer.ContainedEntities.ToList())
+            {
+                if (entMan.HasComponent<CyberneticStomachComponent>(ent))
+                {
+                    stomachOrgan = ent;
+                    containerSys.Remove(ent, organContainer);
+                    break;
+                }
+            }
+
+            var restoredRate = hunger.BaseDecayRate;
+            Assert.That(restoredRate, Is.GreaterThan(reducedRate),
+                "Removing stomach should restore the original higher decay rate");
+
+            // Re-insert the same stomach organ
+            containerSys.Insert(stomachOrgan, organContainer);
+
+            Assert.That(hunger.BaseDecayRate, Is.EqualTo(reducedRate).Within(0.0001f),
+                "Re-inserting stomach should re-apply the reduced decay rate");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task StomachNoEffectWithoutHungerComponentTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberStomachTestBodyNoHunger", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<HungerComponent>(body), Is.False,
+                "Precondition: body should not have HungerComponent");
+
+            // Insert stomach into body without Hunger - should not throw
+            entMan.SpawnInContainerOrDrop("CyberStomachTestStomach", body, BodyComponent.ContainerID);
+
+            Assert.That(entMan.HasComponent<HungerComponent>(body), Is.False,
+                "Stomach insertion should not add HungerComponent to body that lacks one");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -2,6 +2,8 @@ using Content.Server.Body.Systems;
 using Content.Shared.Body;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Mobs;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Body;
 using Content.Shared.RussStation.Hearing;
@@ -18,6 +20,7 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+    [Dependency] private readonly HungerSystem _hunger = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
@@ -30,6 +33,10 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         // Basic ears: hearing impairment (muffled audio)
         SubscribeLocalEvent<CyberneticEarsBasicComponent, OrganGotInsertedEvent>(OnBasicEarsInserted);
         SubscribeLocalEvent<CyberneticEarsBasicComponent, OrganGotRemovedEvent>(OnBasicEarsRemoved);
+
+        // Stomach: nutrient efficiency (reduced hunger decay)
+        SubscribeLocalEvent<CyberneticStomachComponent, OrganGotInsertedEvent>(OnStomachInserted);
+        SubscribeLocalEvent<CyberneticStomachComponent, OrganGotRemovedEvent>(OnStomachRemoved);
     }
 
     // ================================================================
@@ -94,5 +101,27 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         }
 
         RemComp<HearingImpairmentComponent>(args.Target);
+    }
+
+    // ================================================================
+    // Stomach — nutrient efficiency (reduced hunger decay)
+    // ================================================================
+
+    private void OnStomachInserted(EntityUid uid, CyberneticStomachComponent stomach, ref OrganGotInsertedEvent args)
+    {
+        if (!TryComp<HungerComponent>(args.Target, out var hunger))
+            return;
+
+        stomach.OriginalDecayRate = hunger.BaseDecayRate;
+        _hunger.SetBaseDecayRate(args.Target, hunger.BaseDecayRate * stomach.DecayMultiplier, hunger);
+    }
+
+    private void OnStomachRemoved(EntityUid uid, CyberneticStomachComponent stomach, ref OrganGotRemovedEvent args)
+    {
+        if (stomach.OriginalDecayRate == null || !TryComp<HungerComponent>(args.Target, out var hunger))
+            return;
+
+        _hunger.SetBaseDecayRate(args.Target, stomach.OriginalDecayRate.Value, hunger);
+        stomach.OriginalDecayRate = null;
     }
 }

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -104,6 +104,19 @@ public sealed class HungerSystem : EntitySystem
         UpdateCurrentThreshold(uid, component);
     }
 
+    //HONK START - Cybernetic stomach nutrient efficiency
+    public void SetBaseDecayRate(EntityUid uid, float rate, HungerComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        var currentHunger = GetHunger(component);
+        component.BaseDecayRate = rate;
+        SetAuthoritativeHungerValue((uid, component), currentHunger);
+        UpdateCurrentThreshold(uid, component);
+    }
+    //HONK END
+
     /// <summary>
     /// Sets <see cref="HungerComponent.LastAuthoritativeHungerValue"/> and
     /// <see cref="HungerComponent.LastAuthoritativeHungerChangeTime"/>, and dirties this entity. This "resets" the

--- a/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
@@ -12,4 +12,7 @@ public static class CyberneticOrganConstants
 
     /// <summary>Cooldown between auto-injections for <see cref="CyberneticHeartComponent"/>.</summary>
     public static readonly TimeSpan HeartEpinephrineCooldown = TimeSpan.FromSeconds(120);
+
+    /// <summary>Default hunger-decay multiplier on <see cref="CyberneticStomachComponent"/>.</summary>
+    public const float DefaultStomachDecayMultiplier = 0.5f;
 }

--- a/Content.Shared/RussStation/Body/CyberneticStomachComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticStomachComponent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker component for advanced cybernetic stomach that reduces hunger decay rate.
+/// Networked so EnsureComp/Dirty during entity init doesn't trip; the multiplier itself is
+/// only read on the server.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CyberneticStomachComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to <see cref="Content.Shared.Nutrition.Components.HungerComponent.BaseDecayRate"/>.
+    /// 0.5 = half the normal hunger drain.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DecayMultiplier = CyberneticOrganConstants.DefaultStomachDecayMultiplier;
+
+    /// <summary>
+    /// Original BaseDecayRate stored on insert, restored on remove.
+    /// Avoids float drift from multiply/divide roundtrips.
+    /// </summary>
+    [ViewVariables]
+    public float? OriginalDecayRate;
+}

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -254,3 +254,65 @@
     empEffect: Deafen
     empVulnerability: 0.5
   - type: CyberneticEars
+
+# ============================================================
+# STOMACH - EmpEffect: None (non-critical organ)
+# ============================================================
+
+- type: entity
+  parent: [OrganBaseStomach, OrganCyberneticInternal]
+  id: OrganCyberneticStomachBasic
+  name: basic cybernetic stomach
+  description: A bare-bones cybernetic stomach. Digests slowly.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: stomach-plastic
+  - type: SolutionContainerManager
+    solutions:
+      stomach:
+        maxVol: 35
+  - type: Metabolizer
+    maxReagents: 2
+  - type: CyberneticOrgan
+    tier: Basic
+    empEffect: None
+    empVulnerability: 1.5
+
+- type: entity
+  parent: [OrganBaseStomach, OrganCyberneticInternal]
+  id: OrganCyberneticStomachStandard
+  name: cybernetic stomach
+  description: A dependable cybernetic stomach.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: stomach-plasma
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: None
+    empVulnerability: 1.0
+
+- type: entity
+  parent: [OrganBaseStomach, OrganCyberneticInternal]
+  id: OrganCyberneticStomachAdvanced
+  name: advanced cybernetic stomach
+  description: A high-efficiency cybernetic stomach that extracts more nutrients from food.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: stomach-bluespace
+  - type: SolutionContainerManager
+    solutions:
+      stomach:
+        maxVol: 70
+  - type: Metabolizer
+    maxReagents: 4
+  - type: CyberneticOrgan
+    tier: Advanced
+    empEffect: None
+    empVulnerability: 0.5
+  - type: CyberneticStomach

--- a/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
+++ b/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
@@ -113,3 +113,22 @@
   parent: BaseCyberneticRecipeAdvanced
   id: CyberneticEarsAdvanced
   result: OrganCyberneticEarsAdvanced
+
+# ============================================================
+# Stomach
+# ============================================================
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeBasic
+  id: CyberneticStomachBasic
+  result: OrganCyberneticStomachBasic
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeStandard
+  id: CyberneticStomachStandard
+  result: OrganCyberneticStomachStandard
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeAdvanced
+  id: CyberneticStomachAdvanced
+  result: OrganCyberneticStomachAdvanced


### PR DESCRIPTION
## About the PR

Three tiers of cybernetic stomach. Advanced-tier passive halves hunger decay so the patient gets more mileage out of every meal. EMP effect is `None` -- stomach is non-critical for EMP impact. Adds `HungerSystem.SetBaseDecayRate` upstream so the rate change preserves current hunger.

## Why / Balance

Tier curve: Basic gets a smaller stomach solution (35 maxVol vs the upstream baseline) and `maxReagents: 2` -- digests slower. Standard is a clean replacement. Advanced gets a larger solution (70 maxVol), `maxReagents: 4`, and the half-hunger-decay marker. EMP vulnerability still tracks 1.5 / 1.0 / 0.5 even though no EMP effect fires (the multiplier is reserved for future tier variants).

## Technical details

- `CyberneticStomachComponent` (Advanced marker): networked. `DecayMultiplier` default 0.5 (from `CyberneticOrganConstants`); `OriginalDecayRate` (server-only state) stores the host's `HungerComponent.BaseDecayRate` at insertion time so we restore it cleanly on removal instead of multiplying it back up and accumulating float drift.
- `CyberneticOrganEffectsSystem` extension: insert handler caches `hunger.BaseDecayRate`, then `_hunger.SetBaseDecayRate(target, baseRate * multiplier)`. Remove handler restores the cached rate.
- `HungerSystem` extension (HONK-marked): new public `SetBaseDecayRate(uid, rate, comp?)` API preserves the current hunger value across the rate change (it gets `LastAuthoritativeHungerValue` first, sets the field, then re-asserts the value so the new rate doesn't retroactively rewind hunger).
- `CyberneticOrganConstants`: append `DefaultStomachDecayMultiplier = 0.5f`.
- Three stomach entity prototypes parenting `OrganBaseStomach` + `OrganCyberneticInternal`. Basic re-declares the stomach solution at 35 maxVol; Advanced at 70 maxVol with `maxReagents: 4`.
- Three lathe recipes.

## Media

In-game: install advanced cybernetic stomach -> hunger meter drops noticeably slower than baseline. Remove -> rate returns to normal.

## Breaking changes

`HungerSystem` gains a public `SetBaseDecayRate` method. No existing API change.

## Changelog

:cl:
- add: Cybernetic stomachs are manufacturable at the exosuit fabricator. Three tiers: Basic (smaller capacity, slow digestion), Standard (clean replacement), Advanced (extra-large solution, halved hunger decay).

## Depends on

- #744 cybernetic organ framework
- #753 cybernetic ears (chained base; provides the prior recipe + organ context)