### PR TITLE
honksquad: feat: cybernetic liver + overdose resistance (Phase 1 split 13/16)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/CyberneticLiverEffectsTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/CyberneticLiverEffectsTest.cs
@@ -1,0 +1,197 @@
+using System.Linq;
+using Content.Server.RussStation.Body;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(CyberneticOrganEffectsSystem))]
+public sealed class CyberneticLiverEffectsTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CyberLiverTestBody
+  components:
+  - type: Body
+
+- type: entity
+  id: CyberLiverTestLiver
+  components:
+  - type: Organ
+    category: Liver
+  - type: CyberneticLiver
+
+- type: entity
+  id: CyberLiverTestBodyWithLiver
+  components:
+  - type: Body
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: CyberLiverTestLiver
+";
+
+    [Test]
+    public async Task LiverAppliesOverdoseResistanceOnInsertTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberLiverTestBodyWithLiver", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.True,
+                "Body should have OverdoseResistanceComponent after liver insertion");
+
+            var resistance = entMan.GetComponent<OverdoseResistanceComponent>(body);
+            Assert.That(resistance.ThresholdMultiplier, Is.EqualTo(1.5f),
+                "Threshold multiplier should match liver's configured value");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task LiverRemovesOverdoseResistanceOnRemovalTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var containerSys = entMan.System<SharedContainerSystem>();
+            var body = entMan.SpawnEntity("CyberLiverTestBodyWithLiver", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.True,
+                "Precondition: resistance should be present");
+
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            foreach (var ent in organContainer.ContainedEntities.ToList())
+            {
+                if (entMan.HasComponent<CyberneticLiverComponent>(ent))
+                    containerSys.Remove(ent, organContainer);
+            }
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.False,
+                "OverdoseResistanceComponent should be removed with liver");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task LiverNoResistanceWithoutOrganTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberLiverTestBody", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.False,
+                "Body without cybernetic liver should not have overdose resistance");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DynamicOrganInsertionTriggersEffectTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberLiverTestBody", mapData.GridCoords);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.False);
+
+            entMan.SpawnInContainerOrDrop("CyberLiverTestLiver", body, BodyComponent.ContainerID);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.True,
+                "Dynamic organ insertion should trigger liver effect");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task LiverOverdoseThresholdMultiplierMatchesComponentTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("CyberLiverTestBodyWithLiver", mapData.GridCoords);
+            var resistance = entMan.GetComponent<OverdoseResistanceComponent>(body);
+
+            Assert.That(resistance.ThresholdMultiplier, Is.EqualTo(1.5f),
+                "OverdoseResistanceComponent multiplier should match CyberneticLiverComponent default (1.5)");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RemovingOneOfTwoLiversKeepsResistanceTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var containerSys = entMan.System<SharedContainerSystem>();
+            var body = entMan.SpawnEntity("CyberLiverTestBody", mapData.GridCoords);
+
+            // Insert two cybernetic livers
+            var liver1 = entMan.SpawnInContainerOrDrop("CyberLiverTestLiver", body, BodyComponent.ContainerID);
+            var liver2 = entMan.SpawnInContainerOrDrop("CyberLiverTestLiver", body, BodyComponent.ContainerID);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.True,
+                "Precondition: resistance should be present with two livers");
+
+            // Remove one liver
+            var organContainer = containerSys.GetContainer(body, BodyComponent.ContainerID);
+            containerSys.Remove(liver1, organContainer);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.True,
+                "OverdoseResistanceComponent should remain when a second liver is still present");
+
+            // Remove the second liver
+            containerSys.Remove(liver2, organContainer);
+
+            Assert.That(entMan.HasComponent<OverdoseResistanceComponent>(body), Is.False,
+                "OverdoseResistanceComponent should be removed when all livers are gone");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
+++ b/Content.Server/RussStation/Body/CyberneticOrganEffectsSystem.cs
@@ -37,6 +37,10 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
         // Stomach: nutrient efficiency (reduced hunger decay)
         SubscribeLocalEvent<CyberneticStomachComponent, OrganGotInsertedEvent>(OnStomachInserted);
         SubscribeLocalEvent<CyberneticStomachComponent, OrganGotRemovedEvent>(OnStomachRemoved);
+
+        // Liver: overdose resistance (applied to body on insert/remove)
+        SubscribeLocalEvent<CyberneticLiverComponent, OrganGotInsertedEvent>(OnLiverInserted);
+        SubscribeLocalEvent<CyberneticLiverComponent, OrganGotRemovedEvent>(OnLiverRemoved);
     }
 
     // ================================================================
@@ -123,5 +127,31 @@ public sealed class CyberneticOrganEffectsSystem : EntitySystem
 
         _hunger.SetBaseDecayRate(args.Target, stomach.OriginalDecayRate.Value, hunger);
         stomach.OriginalDecayRate = null;
+    }
+
+    // ================================================================
+    // Liver — overdose resistance
+    // ================================================================
+
+    private void OnLiverInserted(EntityUid uid, CyberneticLiverComponent liver, ref OrganGotInsertedEvent args)
+    {
+        var resistance = EnsureComp<OverdoseResistanceComponent>(args.Target);
+        resistance.ThresholdMultiplier = liver.OverdoseThresholdMultiplier;
+        Dirty(args.Target, resistance);
+    }
+
+    private void OnLiverRemoved(EntityUid uid, CyberneticLiverComponent liver, ref OrganGotRemovedEvent args)
+    {
+        // Check if any other cybernetic liver remains in the body
+        if (TryComp<BodyComponent>(args.Target, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                if (organ != uid && HasComp<CyberneticLiverComponent>(organ))
+                    return;
+            }
+        }
+
+        RemComp<OverdoseResistanceComponent>(args.Target);
     }
 }

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -9,6 +9,9 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.EntityConditions;
 using Content.Shared.EntityConditions.Conditions;
 using Content.Shared.EntityConditions.Conditions.Body;
+//HONK START - cybernetic liver overdose threshold
+using Content.Shared.RussStation.Body;
+//HONK END
 using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.Effects.Body;
 using Content.Shared.EntityEffects.Effects.Solution;
@@ -308,7 +311,23 @@ public sealed partial class MetabolizerSystem : EntitySystem
                     if (_entityConditions.TryCondition(organ, condition))
                         continue;
                     break;
-                case ReagentCondition:
+                //HONK START - cybernetic liver overdose threshold
+                case ReagentCondition reagentCondition:
+                    if (TryComp<OverdoseResistanceComponent>(body, out var overdoseResist)
+                        && reagentCondition.Min > FixedPoint2.Zero)
+                    {
+                        var soln = solution.Comp.Solution;
+                        var quant = soln.GetTotalPrototypeQuantity(reagentCondition.Reagent);
+                        var scaledMin = reagentCondition.Min * overdoseResist.ThresholdMultiplier;
+                        var scaledMax = reagentCondition.Max > FixedPoint2.Zero
+                            ? reagentCondition.Max * overdoseResist.ThresholdMultiplier
+                            : reagentCondition.Max;
+                        var result = quant >= scaledMin && quant <= scaledMax;
+                        if (reagentCondition.Inverted != result)
+                            continue;
+                        break;
+                    }
+                //HONK END
                     if (_entityConditions.TryCondition(solution, condition))
                         continue;
                     break;

--- a/Content.Shared/RussStation/Body/CyberneticLiverComponent.cs
+++ b/Content.Shared/RussStation/Body/CyberneticLiverComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Marker component for advanced cybernetic liver. The multiplier is read on the server during
+/// metabolism; the component is networked so the engine's lifecycle hooks (EnsureComp/Dirty
+/// during entity init) don't trip on a non-networked add. The corresponding effect on the host
+/// body lives in <see cref="OverdoseResistanceComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CyberneticLiverComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to ReagentCondition minimum thresholds during metabolism.
+    /// Values above 1.0 raise the overdose threshold (e.g., 1.5 = 50% higher tolerance).
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public float OverdoseThresholdMultiplier = CyberneticOrganConstants.DefaultOverdoseThresholdMultiplier;
+}

--- a/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
+++ b/Content.Shared/RussStation/Body/CyberneticOrganConstants.cs
@@ -15,4 +15,8 @@ public static class CyberneticOrganConstants
 
     /// <summary>Default hunger-decay multiplier on <see cref="CyberneticStomachComponent"/>.</summary>
     public const float DefaultStomachDecayMultiplier = 0.5f;
+
+    /// <summary>Default overdose-threshold multiplier on the cybernetic liver and the
+    /// derived <see cref="OverdoseResistanceComponent"/> applied to its host body.</summary>
+    public const float DefaultOverdoseThresholdMultiplier = 1.5f;
 }

--- a/Content.Shared/RussStation/Body/OverdoseResistanceComponent.cs
+++ b/Content.Shared/RussStation/Body/OverdoseResistanceComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Applied to a body entity when a cybernetic liver with overdose resistance is installed.
+/// Networked so EnsureComp/Dirty during entity init doesn't trip; the multiplier is read in
+/// MetabolizerSystem.CanMetabolizeEffect (server-only) so we don't need to actively replicate
+/// the field, but the component presence itself is part of the body's networked state.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class OverdoseResistanceComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to ReagentCondition minimum thresholds.
+    /// Values above 1.0 raise overdose thresholds (e.g., 1.5 = 50% more tolerance).
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public float ThresholdMultiplier = CyberneticOrganConstants.DefaultOverdoseThresholdMultiplier;
+}

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -316,3 +316,56 @@
     empEffect: None
     empVulnerability: 0.5
   - type: CyberneticStomach
+
+# ============================================================
+# LIVER - EmpEffect: None (non-critical organ)
+# ============================================================
+
+- type: entity
+  parent: [OrganBaseLiver, OrganCyberneticInternal]
+  id: OrganCyberneticLiverBasic
+  name: basic cybernetic liver
+  description: A cheap cybernetic liver. Filters toxins, eventually.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: liver-plastic
+  - type: CyberneticOrgan
+    tier: Basic
+    empEffect: None
+    empVulnerability: 1.5
+
+- type: entity
+  parent: [OrganBaseLiver, OrganCyberneticInternal]
+  id: OrganCyberneticLiverStandard
+  name: cybernetic liver
+  description: A reliable cybernetic liver.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: liver-plasma
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: None
+    empVulnerability: 1.0
+
+- type: entity
+  parent: [OrganBaseLiver, OrganCyberneticInternal]
+  id: OrganCyberneticLiverAdvanced
+  name: advanced cybernetic liver
+  description: A high-performance cybernetic liver with enhanced toxin processing.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: liver-bluespace
+  - type: Metabolizer
+    maxReagents: 2
+    updateIntervalMultiplier: 0.75
+  - type: CyberneticOrgan
+    tier: Advanced
+    empEffect: None
+    empVulnerability: 0.5
+  - type: CyberneticLiver

--- a/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
+++ b/Resources/Prototypes/@RussStation/Recipes/Lathes/cybernetics.yml
@@ -132,3 +132,22 @@
   parent: BaseCyberneticRecipeAdvanced
   id: CyberneticStomachAdvanced
   result: OrganCyberneticStomachAdvanced
+
+# ============================================================
+# Liver
+# ============================================================
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeBasic
+  id: CyberneticLiverBasic
+  result: OrganCyberneticLiverBasic
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeStandard
+  id: CyberneticLiverStandard
+  result: OrganCyberneticLiverStandard
+
+- type: latheRecipe
+  parent: BaseCyberneticRecipeAdvanced
+  id: CyberneticLiverAdvanced
+  result: OrganCyberneticLiverAdvanced


### PR DESCRIPTION
## About the PR

Three tiers of cybernetic liver. Advanced-tier passive raises overdose thresholds 50% so the patient can take heavier doses before chems start biting back. Touches `MetabolizerSystem.CanMetabolizeEffect` (HONK-marked) so the existing `ReagentCondition` branch scales by the host's resistance multiplier.

## Why / Balance

Tier curve: Basic and Standard are clean replacements with no overdose passive (Basic is just slower-firing stock metabolizer; Standard is biological-equivalent). Advanced gets `Metabolizer { maxReagents: 2, updateIntervalMultiplier: 0.75 }` (faster cycle, more reagents per pass) AND the `OverdoseResistanceComponent` applied to the host body.

`OverdoseResistanceComponent.ThresholdMultiplier = 1.5` means a chem with overdose threshold 30 needs 45 units to actually overdose. That's still a real ceiling -- chems don't become risk-free, just need bigger stacks before the body reacts.

## Technical details

- `CyberneticLiverComponent` (Advanced marker): carries `OverdoseThresholdMultiplier`.
- `OverdoseResistanceComponent`: applied to the host body. Networked (the `EnsureComp` lifecycle requires it; the field itself is server-read-only via `MetabolizerSystem`).
- `CyberneticOrganEffectsSystem` extension: insert ensures the body's `OverdoseResistanceComponent` and pushes the multiplier from the liver onto it. Remove scans for any other cybernetic liver still in the body before removing the resistance -- so two livers tolerate one being yanked without losing the effect.
- `MetabolizerSystem` extension (HONK-marked): the `ReagentCondition` branch in `CanMetabolizeEffect` now scales `reagentCondition.Min` / `Max` by the host body's `OverdoseResistanceComponent.ThresholdMultiplier` before computing `quant >= scaledMin && quant <= scaledMax`. Falls back to the upstream behavior when the body has no resistance comp.
- `CyberneticOrganConstants`: append `DefaultOverdoseThresholdMultiplier = 1.5f`.
- Three liver entity prototypes; three lathe recipes.

## Media

In-game: install advanced cybernetic liver -> drink past the normal overdose threshold of any reagent without taking overdose damage. Drink past 1.5x and the OD damage kicks in normally.

## Breaking changes

None. `MetabolizerSystem.CanMetabolizeEffect`'s ReagentCondition path now consults `OverdoseResistanceComponent` if present; behavior is unchanged for bodies without the comp.

## Changelog

:cl:
- add: Cybernetic livers are manufacturable at the exosuit fabricator. Three tiers: Basic (slow stock liver), Standard (clean biological equivalent), Advanced (50% higher overdose tolerance + faster metabolism cycle).

## Depends on

- #744 cybernetic organ framework
- #754 cybernetic stomach (chained base; provides the prior recipe + organ context)