### PR TITLE
honksquad: feat: cybernetic kidneys (stub) + metabolism stage scaffolding

### DIFF
--- a/Resources/Locale/en-US/@RussStation/metabolism/stages.ftl
+++ b/Resources/Locale/en-US/@RussStation/metabolism/stages.ftl
@@ -1,0 +1,2 @@
+metabolism-stage-detoxification = Detoxification
+metabolism-stage-excretion = Excretion

--- a/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
+++ b/Resources/Prototypes/@RussStation/Body/cybernetic_organs.yml
@@ -369,3 +369,60 @@
     empEffect: None
     empVulnerability: 0.5
   - type: CyberneticLiver
+
+# ============================================================
+# KIDNEYS - EmpEffect: None (non-critical organ)
+# TODO (#679): wire Excretion stage effects per tier once the kidney
+# metabolizer chain is implemented:
+#   Basic: no sub-tolerance filter, reduced drain rate
+#   Standard: normal Excretion stage behavior
+#   Advanced: enhanced drain rate, lower tolerance threshold
+# ============================================================
+
+- type: entity
+  parent: [OrganBaseKidneys, OrganCyberneticInternal]
+  id: OrganCyberneticKidneysBasic
+  name: basic cybernetic kidneys
+  description: Cheap cybernetic kidneys. They filter blood, slowly.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: kidney-plastic-l
+    - state: kidney-plastic-r
+  - type: CyberneticOrgan
+    tier: Basic
+    empEffect: None
+    empVulnerability: 1.5
+
+- type: entity
+  parent: [OrganBaseKidneys, OrganCyberneticInternal]
+  id: OrganCyberneticKidneysStandard
+  name: cybernetic kidneys
+  description: Reliable cybernetic kidneys. A clean biological replacement.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: kidney-plasma-l
+    - state: kidney-plasma-r
+  - type: CyberneticOrgan
+    tier: Standard
+    empEffect: None
+    empVulnerability: 1.0
+
+- type: entity
+  parent: [OrganBaseKidneys, OrganCyberneticInternal]
+  id: OrganCyberneticKidneysAdvanced
+  name: advanced cybernetic kidneys
+  description: High-efficiency cybernetic kidneys. Chems clear faster and trace doses are filtered before they can accumulate.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Cybernetics/cybernetic_organs.rsi"
+    layers:
+    - state: kidney-bluespace-l
+    - state: kidney-bluespace-r
+  - type: CyberneticOrgan
+    tier: Advanced
+    empEffect: None
+    empVulnerability: 0.5

--- a/Resources/Prototypes/@RussStation/Metabolism/stages.yml
+++ b/Resources/Prototypes/@RussStation/Metabolism/stages.yml
@@ -1,0 +1,13 @@
+# Fork metabolism stages for the #679 organ chain refactor.
+# Detoxification: liver toxin scrubbing stage (Metabolites -> Waste).
+# Excretion: kidney sub-tolerance filter + slow blood drain stage.
+# Neither stage has backing systems yet; prototypes are prewired so
+# organ YAML can reference them once #679 implementation lands.
+
+- type: metabolismStage
+  id: Detoxification
+  name: metabolism-stage-detoxification
+
+- type: metabolismStage
+  id: Excretion
+  name: metabolism-stage-excretion


### PR DESCRIPTION
## About the PR

Adds three tiers of cybernetic kidney entity prototypes (Basic, Standard, Advanced) and registers two metabolism stages (Detoxification, Excretion) that future kidney/liver work will hang behavior off of.

## Why / Balance

Kidneys round out the cybernetic organ set so a fully cyborg body is buildable from the autosurgeon catalog. Behavior is intentionally stubbed for now, the entities exist, can be transplanted, and take the EmpEffect: None path the rest of the non-critical organs use. Excretion stage prewiring lands here so the next pass on filter-rate / sub-tolerance work in #679 has somewhere to subscribe.

## Technical details

- Three new entity prototypes parented on `OrganBaseKidneys` + `OrganCyberneticInternal`, sprite layers point at the existing kidney states (`kidney-plastic-l/r`, `kidney-plasma-l/r`, `kidney-bluespace-l/r`) already shipped in the cybernetic_organs RSI.
- `Resources/Prototypes/@RussStation/Metabolism/stages.yml` registers `Detoxification` and `Excretion` `metabolismStage` prototypes with locale-backed names. No system reads them yet.
- EMP vulnerability scales 1.5 / 1.0 / 0.5 across tiers, matching the rest of the cybernetic organ family.

## Media

<!-- screenshots attached -->

## Breaking changes

None.

## Changelog

:cl:
- add: Cybernetic kidneys are available in three tiers from the autosurgeon catalog.