### PR TITLE
honksquad: chore: re-register changelog workflow with GitHub

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -1,10 +1,10 @@
 name: "Weekly Changelog Update"
 
 on:
+  workflow_dispatch:
   schedule:
     # Saturdays 22:00 UTC = 6pm EDT (UTC-4). Shifts to 5pm during EST (UTC-5).
     - cron: '0 22 * * 6'
-  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## About the PR

Fixes the registration glitch tracked in #763. GitHub registered \`changelog-update.yml\` on 2026-04-30 with a parse error: the workflow shows up under its file path rather than its \`name:\` field, and both the \`schedule\` and \`workflow_dispatch\` triggers were dropped. As a result the weekly cron has never fired and \`gh workflow run\` returns 422 "Workflow does not have 'workflow_dispatch' trigger".

## Why / Balance

The weekly changelog is supposed to land Saturdays at 22:00 UTC. It hasn't run once since the workflow was added in #735.

## Technical details

Reorder the entries inside \`on:\` (workflow_dispatch first, schedule second). Pure no-op for the workflow's behavior, but any edit to the file makes GitHub re-parse and re-register the triggers.

## Media

n/a, infra change.

## Requirements

- [x] Fork-only file, no upstream touch.
- [x] No new dependencies.

## Breaking changes

None.

## Changelog

No \`:cl:\` entry. Internal CI plumbing.