### PR TITLE
honksquad: fix: quote :cl: step name in changelog workflow

### DIFF
--- a/.github/workflows/changelog-weekly.yml
+++ b/.github/workflows/changelog-weekly.yml
@@ -59,7 +59,7 @@ jobs:
             --json number,mergedAt,author,body \
             > /tmp/prs.json
 
-      - name: Scan for new :cl: entries
+      - name: "Scan for new :cl: entries"
         run: |
           python3 scripts/changelog-update.py \
             Resources/Changelog/HonksquadChangelog.yml \


### PR DESCRIPTION
Root cause of #763. The unquoted `:cl:` in the step name 'Scan for new :cl: entries' is a YAML mapping value indicator, breaking the parser at line 62. GitHub couldn't read the file's `name` field or `on:` triggers, so the weekly cron never fired and `workflow_dispatch` returned 422. Quoting the step name fixes it. Closes #763.