### PR TITLE
honksquad: fix: name the Honksquad changelog tab

### DIFF
--- a/Resources/Locale/en-US/@RussStation/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/@RussStation/changelog/changelog-window.ftl
@@ -1,0 +1,1 @@
+changelog-tab-title-HonksquadChangelog = Honksquad


### PR DESCRIPTION
## About the PR

The Honksquad changelog tab in the in-game Changelog window shows the raw localization key (`changelog-tab-title-HonksquadChangelog`) instead of a friendly name.

## Why / Balance

`HonksquadChangelog.yml` has no `Name:` field, so `ChangelogManager` defaults the Name to the filename. The window then looks up `changelog-tab-title-HonksquadChangelog`, which doesn't exist. Players see the missing-key fallback.

## Technical details

Add the missing FTL entry in a fork-side file (`Resources/Locale/en-US/@RussStation/changelog/changelog-window.ftl`) so the upstream `changelog-window.ftl` stays untouched. Tab title becomes "Honksquad".

## Media

n/a, single locale string.

## Requirements

- [x] Fork-only file, no upstream touch.
- [x] No new dependencies.

## Breaking changes

None.

## Changelog

No `:cl:` entry. Cosmetic fix to the changelog UI itself.