### PR TITLE
honksquad: fix: fold fork changelog into the main tab

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -127,6 +127,22 @@ namespace Content.Client.Changelog
                     changelogs.Add(changelog);
                 }
 
+                // HONK START - merge same-Name changelogs (e.g. fork's HonksquadChangelog with Name: Changelog)
+                // into one tab so fork entries render under the upstream tab instead of in a separate tab.
+                changelogs = changelogs
+                    .GroupBy(c => c.Name)
+                    .Select(g => g.Count() == 1
+                        ? g.First()
+                        : new Changelog
+                        {
+                            Name = g.Key,
+                            AdminOnly = g.Any(c => c.AdminOnly),
+                            Order = g.Min(c => c.Order),
+                            Entries = g.SelectMany(c => c.Entries).OrderBy(e => e.Time).ToList(),
+                        })
+                    .ToList();
+                // HONK END
+
                 changelogs.Sort((a, b) => a.Order.CompareTo(b.Order));
                 return changelogs;
             });

--- a/Resources/Changelog/HonksquadChangelog.yml
+++ b/Resources/Changelog/HonksquadChangelog.yml
@@ -1,3 +1,4 @@
+Name: Changelog
 Entries:
 - author: HellWatcher
   changes:

--- a/Resources/Locale/en-US/@RussStation/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/@RussStation/changelog/changelog-window.ftl
@@ -1,0 +1,1 @@
+changelog-tab-title-HonksquadChangelog = Honksquad


### PR DESCRIPTION
## About the PR

Stops the fork's changelog from rendering as a separate tab whose title is the unresolved localization key. Fork entries now appear in the main Changelog tab, interleaved with upstream entries by time.

## Why / Balance

`HonksquadChangelog.yml` had no `Name:` field, so `ChangelogManager` defaulted Name to the filename and the window asked for `changelog-tab-title-HonksquadChangelog`, which doesn't exist. Players saw the raw key on screen, and the fork tab sat next to upstream's instead of merging in.

## Technical details

- Add `Name: Changelog` at the top of `HonksquadChangelog.yml` so the fork file declares itself part of the main changelog.
- In `ChangelogManager.LoadChangelog`, group loaded changelogs by Name (HONK-marked block). Single-Name groups pass through unchanged. Multiple-Name groups merge into one Changelog with combined entries sorted by time, the lowest Order, and AdminOnly OR-ed across the inputs.

## Media

n/a, single tab now reads 'Changelog' and contains both upstream and fork entries.

## Requirements

- [x] Upstream-file touch limited to a HONK-marked block in `ChangelogManager.LoadChangelog`.
- [x] No new dependencies.

## Breaking changes

None for players. The 'Honksquad' tab no longer appears (its entries moved into the main Changelog tab).

## Changelog

No `:cl:` entry. Cosmetic fix to the changelog UI itself.