### PR TITLE
honksquad: feat: wine_tasting skillchip consumer

### DIFF
--- a/Content.Shared/RussStation/Skillchips/Consumers/WineTastingSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Consumers/WineTastingSystem.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Nutrition;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Popups;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Skillchips.Consumers;
+
+/// <summary>
+/// Consumer for the <c>wine_tasting</c> capability (WINE / Wine.Is.Not.Equal chip).
+/// SS13's TRAIT_WINE_TASTER overrides a wine reagent's taste description to reveal
+/// its vintage. SS14 has no vintage data, so the faithful analog is: a holder
+/// identifies exactly what they just drank, by reagent name, instead of the
+/// generic flavour profile everyone else gets.
+/// </summary>
+public sealed class WineTastingSystem : EntitySystem
+{
+    public const string WineTastingTag = "wine_tasting";
+
+    [Dependency] private readonly SharedSkillchipSystem _skillchip = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EdibleComponent, IngestedEvent>(OnIngested);
+    }
+
+    private void OnIngested(Entity<EdibleComponent> ent, ref IngestedEvent args)
+    {
+        if (!_skillchip.HasCapability(args.Target, WineTastingTag))
+            return;
+
+        var names = new List<string>();
+        foreach (var quantity in args.Split.Contents)
+        {
+            if (_proto.TryIndex<ReagentPrototype>(quantity.Reagent.Prototype, out var reagent))
+                names.Add(reagent.LocalizedName);
+        }
+
+        if (names.Count == 0)
+            return;
+
+        _popup.PopupEntity(
+            Loc.GetString("skillchip-wine-tasting-identify", ("drink", string.Join(", ", names.Distinct()))),
+            args.Target,
+            args.Target);
+    }
+}

--- a/Resources/Locale/en-US/@RussStation/skillchips/wine-tasting.ftl
+++ b/Resources/Locale/en-US/@RussStation/skillchips/wine-tasting.ftl
@@ -1,0 +1,1 @@
+skillchip-wine-tasting-identify = Your trained palate identifies it: {$drink}.


### PR DESCRIPTION
## About the PR

Held. Ports the SS13 wine vintage system so the WINE skillchip (`wine_tasting`) has something to read. SS14 wine is a single generic reagent with no vintage data, so the chip cannot do anything until that substrate exists. This PR adds the vintage system plus the taster reveal.

## Why / Balance

#704 shipped the WINE chip registering a `wine_tasting` tag that nothing read. Per #703, a catalog chip is done when it reproduces its SS13 behavior. SS13's wine taster (`code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm`, `get_taste_description`) reveals a wine's procedurally generated vintage: a year plus a style (`"2567 Nanotrasen Light Red"`; unlabeled bottles roll a random year up to 50 back and a style from a fixed list), `"mixed wine"` once blended, `"synthetic wine"` when machine made. SS14 has none of that substrate. The chip needs the vintage system built before a consumer means anything. Pure flavour, no mechanical effect, same as SS13.

## Technical details

Planned, not yet implemented:

- A fork vintage carrier (year plus style string) on the Wine reagent or its container, generated when a wine bottle spawns. Labeled and unlabeled bottle variants matching SS13's two generators (`code/modules/reagents/reagent_containers/cups/glassbottle.dm`). Blended wine collapses to a `mixed wine` marker.
- A server consumer that surfaces the vintage to a `wine_tasting` holder instead of the generic taste.
- Hook is open. The `EdibleComponent` / `IngestedEvent` route is unusable fork-side: it is an upstream-owned by-ref directed subscription and a second subscriber on that component is rejected at boot. A class or broadcast event, or a fork-owned component, is required. Server-side, since the skillchip framework is server only.

## Media

No visuals.

## Breaking changes

None.