### PR TITLE
honksquad: feat: add skillchip guidebook entry (#788)

### DIFF
--- a/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
+++ b/Resources/Locale/en-US/@RussStation/guidebook/skillchips.ftl
@@ -1,0 +1,1 @@
+guide-entry-skillchips = Skillchips

--- a/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
+++ b/Resources/Prototypes/@RussStation/Guidebook/skillchips.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: Skillchips
+  name: guide-entry-skillchips
+  text: "/ServerInfo/Guidebook/Service/Skillchips.xml"

--- a/Resources/Prototypes/Guidebook/service.yml
+++ b/Resources/Prototypes/Guidebook/service.yml
@@ -8,6 +8,9 @@
   - Botany
   - Chef
   - Janitorial
+  # HONK START - Skillchips guidebook entry (#788), curator-domain
+  - Skillchips
+  # HONK END
   
 - type: guideEntry
   id: Bartender

--- a/Resources/ServerInfo/Guidebook/Service/Skillchips.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Skillchips.xml
@@ -1,0 +1,12 @@
+<Document>
+# Skillchips
+
+A skillchip is a small implantable chip that grants its holder a single capability for as long as it stays installed. Pop the chip out and the capability goes with it.
+
+## How they work
+- A chip occupies your brain's limited skillchip [color=#a4885c]capacity[/color]. Bigger or fancier chips cost more capacity, so you can only run so many at once.
+- The capability is active only while the chip is installed. Removing it (or losing the brain it sits in) ends the effect immediately.
+- Chips are commercial hardware, not a permanent upgrade. They are meant to be swapped as the job demands.
+
+Specific chips and what each one does are covered in their own entries as they come online.
+</Document>


### PR DESCRIPTION
## About the PR

Adds a guidebook entry explaining what a skillchip is. The page is deliberately thin: it covers the concept (an implantable chip that grants one capability while it stays installed and costs brain capacity) without per-chip detail. It sits under the Service guide tree.

## Why / Balance

Closes #788. Skillchips exist in the game but a player who picks one up has nowhere in the guide that says what it is. Filed under Service rather than Science because skillchips are the librarian's area (the old SS13 curator role, with the librarian being the closest fit in our setup); #788 originally suggested Science but predates that call.

## Technical details

- New page `Resources/ServerInfo/Guidebook/Service/Skillchips.xml`.
- New `@RussStation` `guideEntry` (`Resources/Prototypes/@RussStation/Guidebook/skillchips.yml`) and its locale string `guide-entry-skillchips`.
- Three-line HONK-marked child entry adding `Skillchips` to the upstream Service guide tree in `Resources/Prototypes/Guidebook/service.yml`.

No C#, prototypes and content text only.

## Media

<!-- screenshots attached -->

## Breaking changes

None.

:cl:
- add: Guidebook entry explaining what skillchips are.