### PR TITLE
honksquad: feat: skillchip category restriction (one per category)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipGrantTest.cs
@@ -35,6 +35,24 @@ public sealed class SkillchipGrantTest
   - !type:CapabilityTagGrant
     tag: test_capability_2
 
+- type: skillchip
+  id: TestChipCatA1
+  name: Test Chip Cat A 1
+  capacityCost: 1
+  category: test_cat_a
+
+- type: skillchip
+  id: TestChipCatA2
+  name: Test Chip Cat A 2
+  capacityCost: 1
+  category: test_cat_a
+
+- type: skillchip
+  id: TestChipCatB
+  name: Test Chip Cat B
+  capacityCost: 1
+  category: test_cat_b
+
 - type: entity
   id: TestBrain
   components:
@@ -321,6 +339,38 @@ public sealed class SkillchipGrantTest
                 "First chip should install within capacity");
             Assert.That(skillchips.TryInstall((brain, holder), "TestChipData2"), Is.False,
                 "Second chip should be rejected when at capacity");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Installing two chips that share a non-null category should reject the second.
+    /// A chip in a different category still installs. A chip with no category coexists
+    /// with anything.
+    /// </summary>
+    [Test]
+    public async Task Install_SameCategory_ReturnsFalse()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = server.System<SharedSkillchipSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("TestBrain", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipCatA1"), Is.True,
+                "First chip in category A should install");
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipCatA2"), Is.False,
+                "Second chip in category A should be rejected");
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipCatB"), Is.True,
+                "Chip in a different category should still install");
+            Assert.That(skillchips.TryInstall((brain, holder), "TestChipData"), Is.True,
+                "Chip with no category should coexist freely");
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/RussStation/Skillchips/SkillchipPrototype.cs
+++ b/Content.Shared/RussStation/Skillchips/SkillchipPrototype.cs
@@ -25,4 +25,12 @@ public sealed partial class SkillchipPrototype : IPrototype
     /// </summary>
     [DataField]
     public List<SkillchipGrant> Grants = new();
+
+    /// <summary>
+    /// Optional mutual-exclusion key. A brain can hold at most one chip per non-null
+    /// category, so SS13-style job chips (chef, janitor, etc.) sharing a category
+    /// reject install attempts past the first. Null means no restriction.
+    /// </summary>
+    [DataField]
+    public string? Category;
 }

--- a/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
+++ b/Content.Shared/RussStation/Skillchips/Systems/SharedSkillchipSystem.cs
@@ -46,6 +46,9 @@ public abstract class SharedSkillchipSystem : EntitySystem
         if (UsedCapacity(brain.Comp) + prototype.CapacityCost > brain.Comp.MaxCapacity)
             return false;
 
+        if (prototype.Category != null && HasCategoryInstalled(brain.Comp, prototype.Category))
+            return false;
+
         // Apply grants first so a thrown grant leaves the holder untouched. Recording the chip
         // last keeps capacity accounting consistent with what is actually active on the mob.
         if (GetBody(brain) is { } body)
@@ -238,6 +241,20 @@ public abstract class SharedSkillchipSystem : EntitySystem
         foreach (var chipProto in holder.ImplantedChips)
             total += _proto.Index(chipProto).CapacityCost;
         return total;
+    }
+
+    /// <summary>
+    /// True if any already-implanted chip declares the given category. Used to enforce
+    /// the one-per-category rule for job chips.
+    /// </summary>
+    private bool HasCategoryInstalled(SkillchipHolderComponent holder, string category)
+    {
+        foreach (var chipProto in holder.ImplantedChips)
+        {
+            if (_proto.Index(chipProto).Category == category)
+                return true;
+        }
+        return false;
     }
 
     private EntityUid? GetBody(Entity<SkillchipHolderComponent> brain)


### PR DESCRIPTION
## About the PR

Adds a `Category` field to `SkillchipPrototype`. `TryInstall` rejects a chip if another chip of the same category is already implanted. Foundation for job chips, which are limited to one per job category.

Closes #717.

## Why / Balance

Job chips in the SS13 roster use a mutual-exclusion rule: at most one chef chip, one janitor chip, etc. The category field implements that restriction without any per-chip logic. Existing chips have no category and behave exactly as before.

## Technical details

- `SkillchipPrototype.Category` is a nullable string `[DataField]`. Null means no restriction.
- `SharedSkillchipSystem.TryInstall` calls a new `HasCategoryInstalled` helper after the duplicate and capacity gates; the helper scans implanted chips and compares categories.
- Integration test `Install_SameCategory_ReturnsFalse` covers same-category rejection, different-category install still succeeding, and a null-category chip coexisting with everything.

## Breaking changes

None. Every current chip prototype has a null category, so the new gate is a no-op for them.

:cl:
- add: Skillchips can declare a category; only one chip per category can be implanted at a time.