### PR TITLE
honksquad: feat: B0RK-X3 skillchip (Close Quarters Cooking, job tier)

### DIFF
--- a/Resources/Prototypes/@RussStation/Entities/Skillchips/borkx3.yml
+++ b/Resources/Prototypes/@RussStation/Entities/Skillchips/borkx3.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: SkillchipBorkX3
+  name: B0RK-X3 skillchip
+  description: A small neural interface chip. This biochip faintly smells of garlic, which is odd for something normally wedged inside a user's brain. Consult a dietician before use.
+  components:
+  - type: Sprite
+    sprite: "@RussStation/Objects/Misc/skillchip.rsi"
+    state: skillchip
+  - type: Skillchip
+    chipProto: SkillchipBorkX3Data

--- a/Resources/Prototypes/@RussStation/Skillchips/borkx3.yml
+++ b/Resources/Prototypes/@RussStation/Skillchips/borkx3.yml
@@ -1,0 +1,8 @@
+- type: skillchip
+  id: SkillchipBorkX3Data
+  name: Close Quarters Cooking
+  capacityCost: 2
+  category: job
+  grants:
+  - !type:CapabilityTagGrant
+    tag: chef_cqc


### PR DESCRIPTION
## About the PR

Adds the B0RK-X3 skillchip as a capability-tag-only placeholder. Grants `chef_cqc`. Part of the SS13 chip catalog port tracked in #703. Supersedes the closed #736.

## Why / Balance

Chef job chip. The SS13 consumer is a full Chef CQC martial-arts style (`/datum/martial_art/cqc/under_siege` in `code/modules/library/skill_learning/job_skillchips/chef.dm`) that grants kick / slam / restraint moves only while standing in a kitchen-tagged area. SS14 has no martial-arts framework, so the consumer cannot be written. The chip lands now with the right tag; the work is tracked in two follow-ups: the martial-arts framework + CQC style, and the kitchen-zone restriction layer.

## Technical details

- Chip prototype and entity at `Resources/Prototypes/@RussStation/Skillchips/borkx3.yml` and `Resources/Prototypes/@RussStation/Entities/Skillchips/borkx3.yml`. `capacityCost: 2`, `category: job`, `CapabilityTagGrant` with tag `chef_cqc`. Uses the shared `@RussStation/Objects/Misc/skillchip.rsi` sprite.

## Media

No new visuals; the chip uses the shared skillchip sprite.

## Breaking changes

None.

## Changelog

:cl:
- add: B0RK-X3 skillchip. Implant to register as a chef who knows Close Quarters Cooking.