### PR TITLE
honksquad: feat: HONK0019 analyzer for [AutoNetworkedField] on DoAfterId

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkAutoNetworkedDoAfterIdAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkAutoNetworkedDoAfterIdAnalyzerTest.cs
@@ -1,0 +1,146 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkAutoNetworkedDoAfterIdAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkAutoNetworkedDoAfterIdAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class AutoNetworkedFieldAttribute : System.Attribute { }
+        }
+        namespace Content.Shared.DoAfter
+        {
+            public readonly struct DoAfterId { }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task DoAfterIdField_WithAttribute_ForkFile_Reports()
+    {
+        const string code = """
+            using Content.Shared.DoAfter;
+            using Robust.Shared.Analyzers;
+
+            public sealed class FooComponent
+            {
+                [AutoNetworkedField]
+                public DoAfterId? Active;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs",
+            new DiagnosticResult("HONK0019", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooComponent.cs", 7, 23, 7, 29)
+                .WithArguments("Active"));
+    }
+
+    [Test]
+    public async Task DoAfterIdProperty_WithAttribute_ForkFile_Reports()
+    {
+        const string code = """
+            using Content.Shared.DoAfter;
+            using Robust.Shared.Analyzers;
+
+            public sealed class FooComponent
+            {
+                [AutoNetworkedField]
+                public DoAfterId Active { get; set; }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs",
+            new DiagnosticResult("HONK0019", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooComponent.cs", 7, 22, 7, 28)
+                .WithArguments("Active"));
+    }
+
+    [Test]
+    public async Task AttributeOnUnrelatedType_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            public sealed class FooComponent
+            {
+                [AutoNetworkedField]
+                public int Count;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task DoAfterIdWithoutAttribute_DoesNotReport()
+    {
+        const string code = """
+            using Content.Shared.DoAfter;
+
+            public sealed class FooComponent
+            {
+                public DoAfterId? Active;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Content.Shared.DoAfter;
+            using Robust.Shared.Analyzers;
+
+            public sealed class FooComponent
+            {
+                [AutoNetworkedField]
+                public DoAfterId? Active;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task HonkPartialFile_Reports()
+    {
+        const string code = """
+            using Content.Shared.DoAfter;
+            using Robust.Shared.Analyzers;
+
+            public sealed class FooComponent
+            {
+                [AutoNetworkedField]
+                public DoAfterId? Active;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooComponent.Honk.cs",
+            new DiagnosticResult("HONK0019", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/Foo/FooComponent.Honk.cs", 7, 23, 7, 29)
+                .WithArguments("Active"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkAutoNetworkedDoAfterIdAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkAutoNetworkedDoAfterIdAnalyzer.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0019: <c>DoAfterId</c> is not <c>NetSerializable</c>, so wrapping a
+/// field of that type in <c>[AutoNetworkedField]</c> compiles fine but
+/// crashes the source-generated component state serializer at runtime
+/// (and trips the YAML linter on the affected prototype). Scoped to fork
+/// files so upstream drift is not this rule's problem.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkAutoNetworkedDoAfterIdAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0019",
+        title: "[AutoNetworkedField] on DoAfterId-typed member",
+        messageFormat: "Member '{0}' is DoAfterId-typed and cannot be auto-networked; drop [AutoNetworkedField] and call Dirty() manually",
+        category: "Honk.Networking",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "DoAfterId is not NetSerializable. The auto-state source generator emits a serializer that throws at runtime, so the prototype fails to load.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Field, SymbolKind.Property);
+    }
+
+    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    {
+        var symbol = context.Symbol;
+
+        var path = symbol.Locations.Length > 0 ? symbol.Locations[0].SourceTree?.FilePath : null;
+        if (!IsForkFile(path))
+            return;
+
+        if (!HasAttribute(symbol, "AutoNetworkedFieldAttribute"))
+            return;
+
+        var type = symbol switch
+        {
+            IFieldSymbol f => f.Type,
+            IPropertySymbol p => p.Type,
+            _ => null,
+        };
+        if (type is null)
+            return;
+
+        if (!IsDoAfterId(type))
+            return;
+
+        foreach (var location in symbol.Locations)
+        {
+            if (location.IsInSource)
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, symbol.Name));
+        }
+    }
+
+    private static bool IsDoAfterId(ITypeSymbol type)
+    {
+        // Unwrap Nullable<T>.
+        if (type is INamedTypeSymbol named && named.IsGenericType && named.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T)
+            type = named.TypeArguments[0];
+
+        if (type.Name != "DoAfterId")
+            return false;
+
+        var ns = type.ContainingNamespace;
+        return ns is { Name: "DoAfter" }
+            && ns.ContainingNamespace is { Name: "Shared" }
+            && ns.ContainingNamespace.ContainingNamespace is { Name: "Content" };
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string attributeName)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == attributeName)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a fork-side Roslyn analyzer (HONK0019) that flags `DoAfterId`-typed fields or properties carrying `[AutoNetworkedField]`. Scoped to fork files only (`/RussStation/` paths or `.Honk.cs` partials).

## Why / Balance

Closes #802.

`DoAfterId` is not `NetSerializable`. Wrapping it in `[AutoNetworkedField]` compiles cleanly, then the source-generated component state serializer throws at runtime and the YAML linter trips on the affected prototype. The fork hit this once already, so the rule pays off on the first catch.

## Technical details

- `Content.Analyzers.Honk/HonkAutoNetworkedDoAfterIdAnalyzer.cs`: walks field and property symbols, checks for `[AutoNetworkedField]`, and confirms the declared type is `Content.Shared.DoAfter.DoAfterId` (also unwraps `Nullable<DoAfterId>`). Fork-scoped via the same `/RussStation/` and `.Honk.cs` path test the other HONK analyzers use.
- `Content.Analyzers.Honk.Tests/HonkAutoNetworkedDoAfterIdAnalyzerTest.cs`: six cases covering the field positive, the property positive, attribute on an unrelated type, `DoAfterId` without the attribute, an upstream-file negative, and a `.Honk.cs` partial positive.

Severity is Warning. Suggested fix in the message: drop the attribute and call `Dirty()` manually.

## Media

Code-only.

## Breaking changes

None.