### PR TITLE
honksquad: feat: HONK0020 analyzer for Convert.ToInt32(object) in sandboxed code

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkSandboxConvertToInt32AnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkSandboxConvertToInt32AnalyzerTest.cs
@@ -1,0 +1,122 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkSandboxConvertToInt32Analyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkSandboxConvertToInt32AnalyzerTest
+{
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task ConvertToInt32_Object_InSharedForkFile_Reports()
+    {
+        const string code = """
+            public enum Mode { A, B }
+
+            public static class T
+            {
+                public static int Run()
+                {
+                    Mode m = Mode.A;
+                    return System.Convert.ToInt32((object)m);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs",
+            new DiagnosticResult("HONK0020", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooSystem.cs", 8, 16, 8, 49));
+    }
+
+    [Test]
+    public async Task ConvertToInt32_Object_InServer_DoesNotReport()
+    {
+        const string code = """
+            public enum Mode { A, B }
+
+            public static class T
+            {
+                public static int Run()
+                {
+                    Mode m = Mode.A;
+                    return System.Convert.ToInt32((object)m);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task ConvertToInt32_String_DoesNotReport()
+    {
+        const string code = """
+            public static class T
+            {
+                public static int Run()
+                {
+                    return System.Convert.ToInt32("42");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task ConvertToInt32_Object_InUpstreamShared_DoesNotReport()
+    {
+        const string code = """
+            public enum Mode { A, B }
+
+            public static class T
+            {
+                public static int Run()
+                {
+                    Mode m = Mode.A;
+                    return System.Convert.ToInt32((object)m);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task ConvertToInt32_Object_InHonkPartialShared_Reports()
+    {
+        const string code = """
+            public enum Mode { A, B }
+
+            public static class T
+            {
+                public static int Run()
+                {
+                    Mode m = Mode.A;
+                    return System.Convert.ToInt32((object)m);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooSystem.Honk.cs",
+            new DiagnosticResult("HONK0020", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/Foo/FooSystem.Honk.cs", 8, 16, 8, 49));
+    }
+}

--- a/Content.Analyzers.Honk/HonkSandboxConvertToInt32Analyzer.cs
+++ b/Content.Analyzers.Honk/HonkSandboxConvertToInt32Analyzer.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0020: the engine sandbox bans <c>System.Convert.ToInt32(object)</c>.
+/// Code compiles on a developer machine, then fails the sandbox typecheck
+/// on CI or at runtime. The common trigger is the generic enum-to-int
+/// idiom; the replacement is the one-liner <c>(int)(object)value</c>.
+/// Scoped to fork files under <c>Content.Shared/</c> or
+/// <c>Content.Client/</c> (the two sandboxed assemblies).
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkSandboxConvertToInt32Analyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0020",
+        title: "Convert.ToInt32(object) in sandboxed code",
+        messageFormat: "System.Convert.ToInt32(object) is sandbox-banned in Shared/Client; use (int)(object)value for the enum-to-int case",
+        category: "Honk.Sandbox",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Convert.ToInt32(object) is not on the sandbox allowlist. The build succeeds locally but the assembly is rejected on load.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        var path = invocation.SyntaxTree.FilePath;
+        if (!IsForkFile(path) || !IsSandboxedAssemblyPath(path))
+            return;
+
+        var symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol as IMethodSymbol;
+        if (symbol is null)
+            return;
+
+        if (symbol.Name != "ToInt32")
+            return;
+
+        var containing = symbol.ContainingType;
+        if (containing is null || containing.Name != "Convert" || containing.ContainingNamespace is not { Name: "System" })
+            return;
+
+        if (symbol.Parameters.Length != 1 || symbol.Parameters[0].Type.SpecialType != SpecialType.System_Object)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation()));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool IsSandboxedAssemblyPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/Content.Shared/")
+            || normalized.Contains("/Content.Client/")
+            || normalized.StartsWith("Content.Shared/", StringComparison.Ordinal)
+            || normalized.StartsWith("Content.Client/", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a fork-side Roslyn analyzer (HONK0020) that flags `System.Convert.ToInt32(object)` invocations in sandboxed assemblies (`Content.Shared` and `Content.Client`). Scoped to fork files only.

## Why / Balance

Closes #803.

`Convert.ToInt32(object)` is not on the engine sandbox allowlist. Code that calls it compiles cleanly on a developer machine, then fails sandbox typecheck on CI or at runtime. The usual trigger is the generic enum-to-int idiom; the replacement is the one-liner `(int)(object)value`.

## Technical details

- `Content.Analyzers.Honk/HonkSandboxConvertToInt32Analyzer.cs`: matches `InvocationExpressionSyntax` where the resolved method symbol is `System.Convert.ToInt32` with a single `object`-typed parameter. Path gate requires both a fork marker (`/RussStation/` or `.Honk.cs`) and a sandboxed assembly path (`Content.Shared/` or `Content.Client/`).
- `Content.Analyzers.Honk.Tests/HonkSandboxConvertToInt32AnalyzerTest.cs`: five cases covering the Shared fork positive, the Server negative (not sandboxed), the string-overload negative, the upstream-Shared negative, and a `.Honk.cs` partial in Shared positive.

Severity is Warning. Suggested fix in the message: `(int)(object)value` for the enum-to-int case.

## Media

Code-only.

## Breaking changes

None.