### PR TITLE
honksquad: feat: HONK0021 analyzer for YamlMappingNode.Children in sandboxed code

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkYamlMappingChildrenSandboxAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkYamlMappingChildrenSandboxAnalyzerTest.cs
@@ -1,0 +1,119 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkYamlMappingChildrenSandboxAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkYamlMappingChildrenSandboxAnalyzerTest
+{
+    private const string Stubs = """
+        namespace YamlDotNet.RepresentationModel
+        {
+            public class YamlNode { }
+            public sealed class YamlMappingNode : YamlNode
+            {
+                public System.Collections.Generic.IDictionary<YamlNode, YamlNode> Children
+                    => new System.Collections.Generic.Dictionary<YamlNode, YamlNode>();
+            }
+        }
+        public sealed class OtherChildren
+        {
+            public int Children => 0;
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task ChildrenAccess_InSharedForkFile_Reports()
+    {
+        const string code = """
+            using YamlDotNet.RepresentationModel;
+
+            public static class T
+            {
+                public static int Run(YamlMappingNode node) => node.Children.Count;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs",
+            new DiagnosticResult("HONK0021", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooSystem.cs", 5, 57, 5, 65));
+    }
+
+    [Test]
+    public async Task ChildrenAccess_InServer_DoesNotReport()
+    {
+        const string code = """
+            using YamlDotNet.RepresentationModel;
+
+            public static class T
+            {
+                public static int Run(YamlMappingNode node) => node.Children.Count;
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task ChildrenAccess_OnUnrelatedType_DoesNotReport()
+    {
+        const string code = """
+            public static class T
+            {
+                public static int Run(OtherChildren x) => x.Children;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task ChildrenAccess_InUpstreamShared_DoesNotReport()
+    {
+        const string code = """
+            using YamlDotNet.RepresentationModel;
+
+            public static class T
+            {
+                public static int Run(YamlMappingNode node) => node.Children.Count;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task ChildrenAccess_InHonkPartialShared_Reports()
+    {
+        const string code = """
+            using YamlDotNet.RepresentationModel;
+
+            public static class T
+            {
+                public static int Run(YamlMappingNode node) => node.Children.Count;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooSystem.Honk.cs",
+            new DiagnosticResult("HONK0021", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/Foo/FooSystem.Honk.cs", 5, 57, 5, 65));
+    }
+}

--- a/Content.Analyzers.Honk/HonkYamlMappingChildrenSandboxAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkYamlMappingChildrenSandboxAnalyzer.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0021: <c>YamlMappingNode.Children</c> resolves to
+/// <c>IDictionary&lt;YamlNode, YamlNode&gt;</c>, which fails the engine
+/// sandbox typecheck on Shared and Client. Code compiles, then the
+/// assembly fails to load. The mechanical fix is to iterate the node
+/// directly with <c>foreach</c>, which goes through the allowed
+/// enumerator. Scoped to fork files in sandboxed assemblies.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkYamlMappingChildrenSandboxAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0021",
+        title: "YamlMappingNode.Children access in sandboxed code",
+        messageFormat: "YamlMappingNode.Children is sandbox-banned in Shared/Client; iterate the node directly with foreach instead",
+        category: "Honk.Sandbox",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "YamlMappingNode.Children returns IDictionary<YamlNode, YamlNode>, which is not on the sandbox allowlist. The assembly loads fine on the developer's box and is rejected by the engine.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.SimpleMemberAccessExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var member = (MemberAccessExpressionSyntax)context.Node;
+
+        if (member.Name.Identifier.ValueText != "Children")
+            return;
+
+        var path = member.SyntaxTree.FilePath;
+        if (!IsForkFile(path) || !IsSandboxedAssemblyPath(path))
+            return;
+
+        var receiverType = context.SemanticModel.GetTypeInfo(member.Expression, context.CancellationToken).Type;
+        if (receiverType is null || !IsYamlMappingNode(receiverType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, member.Name.GetLocation()));
+    }
+
+    private static bool IsYamlMappingNode(ITypeSymbol type)
+    {
+        if (type.Name != "YamlMappingNode")
+            return false;
+
+        var ns = type.ContainingNamespace;
+        return ns is { Name: "RepresentationModel" }
+            && ns.ContainingNamespace is { Name: "YamlDotNet" };
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool IsSandboxedAssemblyPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/Content.Shared/")
+            || normalized.Contains("/Content.Client/")
+            || normalized.StartsWith("Content.Shared/", StringComparison.Ordinal)
+            || normalized.StartsWith("Content.Client/", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a fork-side Roslyn analyzer (HONK0021) that flags `YamlMappingNode.Children` member access in sandboxed assemblies (`Content.Shared` and `Content.Client`). Scoped to fork files only.

## Why / Balance

Closes #804.

`YamlMappingNode.Children` returns `IDictionary<YamlNode, YamlNode>`, which is not on the engine sandbox allowlist. The build succeeds locally, then the assembly fails to load. The fix is mechanical: iterate the node directly with `foreach`, which goes through the allowed enumerator.

## Technical details

- `Content.Analyzers.Honk/HonkYamlMappingChildrenSandboxAnalyzer.cs`: matches `MemberAccessExpressionSyntax` named `Children` where the receiver type is `YamlDotNet.RepresentationModel.YamlMappingNode`. Path gate requires both a fork marker and a sandboxed assembly path.
- `Content.Analyzers.Honk.Tests/HonkYamlMappingChildrenSandboxAnalyzerTest.cs`: five cases covering the Shared fork positive, the Server negative, the unrelated-`Children`-property negative, the upstream-Shared negative, and a `.Honk.cs` partial in Shared positive.

Severity is Warning. Suggested fix in the message: `foreach (var entry in node)` enumerates entries directly without going through `Children`.

## Media

Code-only.

## Breaking changes

None.