### PR TITLE
honksquad: feat: HONK0022 analyzer for EnumerateHands().Count()/.Any()

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkEnumerateHandsCountAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkEnumerateHandsCountAnalyzerTest.cs
@@ -1,0 +1,119 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkEnumerateHandsCountAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkEnumerateHandsCountAnalyzerTest
+{
+    private const string Stubs = """
+        using System.Collections.Generic;
+
+        public class SharedHandsSystem
+        {
+            public IEnumerable<string> EnumerateHands(int uid) => System.Array.Empty<string>();
+        }
+        public sealed class HandsSystem : SharedHandsSystem { }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task EnumerateHandsCount_ForkFile_Reports()
+    {
+        const string code = """
+            using System.Linq;
+
+            public static class T
+            {
+                public static int Run(HandsSystem hands) => hands.EnumerateHands(0).Count();
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs",
+            new DiagnosticResult("HONK0022", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooSystem.cs", 5, 73, 5, 78)
+                .WithArguments("Count"));
+    }
+
+    [Test]
+    public async Task EnumerateHandsAny_ForkFile_Reports()
+    {
+        const string code = """
+            using System.Linq;
+
+            public static class T
+            {
+                public static bool Run(HandsSystem hands) => hands.EnumerateHands(0).Any();
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs",
+            new DiagnosticResult("HONK0022", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooSystem.cs", 5, 74, 5, 77)
+                .WithArguments("Any"));
+    }
+
+    [Test]
+    public async Task EnumerateHandsForeach_DoesNotReport()
+    {
+        const string code = """
+            public static class T
+            {
+                public static void Run(HandsSystem hands)
+                {
+                    foreach (var h in hands.EnumerateHands(0)) { }
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using System.Linq;
+
+            public static class T
+            {
+                public static int Run(HandsSystem hands) => hands.EnumerateHands(0).Count();
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task UnrelatedEnumerableCount_DoesNotReport()
+    {
+        const string code = """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public static class T
+            {
+                public static int Run() => new List<string> { "a", "b" }.Count();
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooSystem.cs");
+    }
+}

--- a/Content.Analyzers.Honk/HonkEnumerateHandsCountAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkEnumerateHandsCountAnalyzer.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0022: <c>HandsSystem.EnumerateHands()</c> returns the names of every
+/// hand on the entity, not the unoccupied ones. Counting the sequence
+/// (with <c>.Count()</c> or <c>.Any()</c>) almost always means the author
+/// wanted "do I have a free hand," which is what <c>CountFreeHands()</c>
+/// answers. The bug is silent: an entity holding an item still passes
+/// "has any hand" gates. Scoped to fork files.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkEnumerateHandsCountAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0022",
+        title: "EnumerateHands().Count()/.Any() counts every hand, including occupied",
+        messageFormat: "EnumerateHands().{0}() counts every hand on the entity; use CountFreeHands() for free-hand checks, or add an explicit comment if total-hand count is intended",
+        category: "Honk.Hands",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "HandsSystem.EnumerateHands returns hand names. The common .Count()/.Any() pattern conflates total hands with free hands and silently breaks gating logic.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var outer = (InvocationExpressionSyntax)context.Node;
+
+        if (outer.Expression is not MemberAccessExpressionSyntax outerMember)
+            return;
+
+        var outerName = outerMember.Name.Identifier.ValueText;
+        if (outerName != "Count" && outerName != "Any")
+            return;
+
+        if (outerMember.Expression is not InvocationExpressionSyntax inner)
+            return;
+
+        var path = outer.SyntaxTree.FilePath;
+        if (!IsForkFile(path))
+            return;
+
+        var innerSymbol = context.SemanticModel.GetSymbolInfo(inner, context.CancellationToken).Symbol as IMethodSymbol;
+        if (innerSymbol is null)
+            return;
+
+        if (innerSymbol.Name != "EnumerateHands")
+            return;
+
+        if (!IsHandsSystem(innerSymbol.ContainingType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, outerMember.Name.GetLocation(), outerName));
+    }
+
+    private static bool IsHandsSystem(INamedTypeSymbol? type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name is "SharedHandsSystem" or "HandsSystem")
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a fork-side Roslyn analyzer (HONK0022) that flags `EnumerateHands().Count()` and `EnumerateHands().Any()` usages. Scoped to fork files only.

## Why / Balance

Closes #805.

`SharedHandsSystem.EnumerateHands()` returns `IEnumerable<string>` (hand names), not hand objects. Counting it gives the total number of hands on the entity, not the number of free hands, which is almost always the intent. `CountFreeHands()` exists for the common case. The bug is silent: an entity holding an item still passes "do you have a hand free" gates and the balance breakage only shows up in playtests.

## Technical details

- `Content.Analyzers.Honk/HonkEnumerateHandsCountAnalyzer.cs`: matches `InvocationExpressionSyntax` where the outer call is `Count` or `Any` and the receiver invocation resolves to a method named `EnumerateHands` on `SharedHandsSystem` or one of its subclasses (`HandsSystem` server/client). Fork-scoped via the standard `/RussStation/` and `.Honk.cs` path test.
- `Content.Analyzers.Honk.Tests/HonkEnumerateHandsCountAnalyzerTest.cs`: five cases covering `.Count()` positive, `.Any()` positive, plain `foreach` negative, upstream-file negative, and an unrelated `List<T>.Count()` negative.

Severity is Warning. Suggested fix in the message: use `CountFreeHands()` for free-hand checks, or add an explicit comment if the total-hand count really is intended.

## Media

Code-only.

## Breaking changes

None.