### PR TITLE
honksquad: feat: HONK0023 analyzer for NetworkedComponent namespace import

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkNetworkedComponentNamespaceAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkNetworkedComponentNamespaceAnalyzerTest.cs
@@ -1,0 +1,107 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkNetworkedComponentNamespaceAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkNetworkedComponentNamespaceAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameStates
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            // Re-exported so the typo resolves without the correct using.
+            public sealed class NetworkedComponentAttribute : System.Attribute { }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task NetworkedComponent_MissingGameStatesUsing_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            [NetworkedComponent]
+            public sealed partial class FooComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs",
+            new DiagnosticResult("HONK0023", DiagnosticSeverity.Info)
+                .WithSpan("Content.Shared/RussStation/Foo/FooComponent.cs", 3, 2, 3, 20)
+                .WithArguments("FooComponent"));
+    }
+
+    [Test]
+    public async Task NetworkedComponent_WithGameStatesUsing_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameStates;
+
+            [NetworkedComponent]
+            public sealed partial class FooComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task NoNetworkedComponentAttribute_DoesNotReport()
+    {
+        const string code = """
+            public sealed partial class FooComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            [NetworkedComponent]
+            public sealed partial class FooComponent { }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task UsingInsideNamespace_DoesNotReport()
+    {
+        const string code = """
+            namespace Content.Shared.RussStation.Foo
+            {
+                using Robust.Shared.GameStates;
+
+                [NetworkedComponent]
+                public sealed partial class FooComponent { }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs");
+    }
+}

--- a/Content.Analyzers.Honk/HonkNetworkedComponentNamespaceAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkNetworkedComponentNamespaceAnalyzer.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0023: <c>NetworkedComponentAttribute</c> lives in
+/// <c>Robust.Shared.GameStates</c>. The closely named
+/// <c>Robust.Shared.GameObjects</c> is a frequent typo that compiles when
+/// the attribute happens to resolve via another <c>using</c>, and the
+/// wrong import tends to travel with other namespace mistakes. Flagged at
+/// the attribute site as a confusion signal, not a hard error.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkNetworkedComponentNamespaceAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0023",
+        title: "[NetworkedComponent] without using Robust.Shared.GameStates",
+        messageFormat: "Class '{0}' is decorated with [NetworkedComponent] but the file does not import Robust.Shared.GameStates; add 'using Robust.Shared.GameStates;'",
+        category: "Honk.Networking",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "NetworkedComponentAttribute lives in Robust.Shared.GameStates. Missing that using often travels with other Robust.Shared.GameObjects-vs-GameStates namespace mistakes.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var classDecl = (ClassDeclarationSyntax)context.Node;
+
+        var path = classDecl.SyntaxTree.FilePath;
+        if (!IsForkFile(path))
+            return;
+
+        var attribute = FindNetworkedComponentAttribute(classDecl, context);
+        if (attribute is null)
+            return;
+
+        if (HasGameStatesUsing(classDecl.SyntaxTree))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, attribute.GetLocation(), classDecl.Identifier.ValueText));
+    }
+
+    private static AttributeSyntax? FindNetworkedComponentAttribute(ClassDeclarationSyntax classDecl, SyntaxNodeAnalysisContext context)
+    {
+        foreach (var list in classDecl.AttributeLists)
+        {
+            foreach (var attr in list.Attributes)
+            {
+                var symbol = context.SemanticModel.GetSymbolInfo(attr, context.CancellationToken).Symbol;
+                var attrType = (symbol as IMethodSymbol)?.ContainingType;
+                if (attrType?.Name == "NetworkedComponentAttribute")
+                    return attr;
+            }
+        }
+        return null;
+    }
+
+    private static bool HasGameStatesUsing(SyntaxTree tree)
+    {
+        var root = tree.GetCompilationUnitRoot();
+        return UsingsContain(root.Usings, "Robust.Shared.GameStates")
+            || root.Members.OfType<BaseNamespaceDeclarationSyntax>().Any(ns => UsingsContain(ns.Usings, "Robust.Shared.GameStates"));
+    }
+
+    private static bool UsingsContain(SyntaxList<UsingDirectiveSyntax> usings, string namespaceName)
+    {
+        foreach (var u in usings)
+        {
+            if (u.Name?.ToString() == namespaceName)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a fork-side Roslyn analyzer (HONK0023) that flags fork source files declaring a `[NetworkedComponent]` class without a `using Robust.Shared.GameStates;` directive. Scoped to fork files only.

## Why / Balance

Closes #806.

`NetworkedComponentAttribute` lives in `Robust.Shared.GameStates`. The closely named `Robust.Shared.GameObjects` is a frequent typo and shows up in confused fork code. The build can still succeed when the attribute resolves via another `using` path, but the wrong import tends to travel with other namespace mistakes (`SharedPopupSystem`, `KnockedDownComponent`, friends). Catching it at the declaration site keeps the namespace gotcha visible.

## Technical details

- `Content.Analyzers.Honk/HonkNetworkedComponentNamespaceAnalyzer.cs`: walks `ClassDeclarationSyntax`, finds `[NetworkedComponent]` via the semantic model (so renamed or aliased usages still match), and reports if the compilation unit (or any containing namespace) does not have a `Robust.Shared.GameStates` using.
- `Content.Analyzers.Honk.Tests/HonkNetworkedComponentNamespaceAnalyzerTest.cs`: five cases covering the missing-using positive, the present-using negative, a non-networked class negative, an upstream-file negative, and a using-placed-inside-the-namespace negative.

Severity is Info: the code may still compile, this is a confusion signal rather than a hard error. Suggested fix in the message: add `using Robust.Shared.GameStates;`.

## Media

Code-only.

## Breaking changes

None.