### PR TITLE
honksquad: fix: Skaven survival kit in remaining Survival* loadout groups

### DIFF
--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -571,6 +571,9 @@
   - EmergencyNitrogenClown
   - EmergencyOxygenClown
   - LoadoutSpeciesVoxNitrogen
+  # HONK START - Skaven (#787): species-gated entry so Skaven clowns get an ammonia kit.
+  - EmergencySkavenAmmonia
+  # HONK END
 
 - type: loadoutGroup
   id: ClownJobTrinkets
@@ -635,6 +638,9 @@
   - EmergencyOxygenMime
   - EmergencySpeciesMothMime
   - LoadoutSpeciesVoxNitrogen
+  # HONK START - Skaven (#787): species-gated entry so Skaven mimes get an ammonia kit.
+  - EmergencySkavenAmmonia
+  # HONK END
 
 #- type: loadoutGroup
 #  id: MimeJobTrinkets
@@ -981,6 +987,9 @@
   - EmergencyNitrogenExtended
   - EmergencyOxygenExtended
   - LoadoutSpeciesVoxNitrogen
+  # HONK START - Skaven (#787): species-gated entry so Skaven engineers/atmos get an ammonia kit.
+  - EmergencySkavenAmmonia
+  # HONK END
 
 # Science
 - type: loadoutGroup
@@ -1314,6 +1323,9 @@
   - EmergencyNitrogenSecurity
   - EmergencyOxygenSecurity
   - LoadoutSpeciesVoxNitrogen
+  # HONK START - Skaven (#787): species-gated entry so Skaven sec gets an ammonia kit.
+  - EmergencySkavenAmmonia
+  # HONK END
 
 # Wildcards
 - type: loadoutGroup
@@ -1366,6 +1378,9 @@
   - EmergencyNitrogenSyndicate
   - EmergencyOxygenSyndicate
   - LoadoutSpeciesVoxNitrogen
+  # HONK START - Skaven (#787): species-gated entry so Skaven syndies get an ammonia kit.
+  - EmergencySkavenAmmonia
+  # HONK END
 
 - type: loadoutGroup
   id: SurvivalMilitaryDouble
@@ -1375,6 +1390,9 @@
   loadouts:
   - EmergencyNitrogenMilitaryDouble
   - EmergencyOxygenMilitaryDouble
+  # HONK START - Skaven (#787): species-gated entry so Skaven ERT/military get an ammonia kit.
+  - EmergencySkavenAmmonia
+  # HONK END
 
 - type: loadoutGroup
   id: GroupSpeciesBreathTool


### PR DESCRIPTION
## About the PR

Adds the species-gated `EmergencySkavenAmmonia` entry to the remaining `Survival*` loadout groups (`SurvivalExtended`, `SurvivalClown`, `SurvivalMime`, `SurvivalSecurity`, `SurvivalSyndicate`, `SurvivalMilitaryDouble`). Skaven taking any job that uses one of these groups now spawns with the ammonia survival box and pocket tank.

## Why / Balance

Fixes #787. The original Skaven port (#481) only wired the species entry into the basic `Survival` group. Every other survival variant fell through the default-fill loop with zero valid entries for Skaven, so Skaven engineers, clowns, mimes, security, and syndies were spawning with the gas mask but no breathable tank or survival box.

## Technical details

Six HONK blocks added to `Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml`, each mirroring the existing block on the basic `Survival` group. One YAML file, 18 lines added, no upstream lines modified.

## Media

Not applicable, fix only affects inventory contents on spawn.

## Breaking changes

None.

## Changelog

:cl:
- fix: Skaven engineers, clowns, mimes, security, and syndicate roles now spawn with their ammonia survival kit instead of an empty backpack.