### PR TITLE
Botany overhaul: CVar-gated growth + full mutation replacement

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -1,6 +1,9 @@
+using Content.Server.RussStation.Botany.Systems;
 using Content.Shared.Atmos;
+using Content.Shared.CCVar;
 using Content.Shared.EntityEffects;
 using Content.Shared.Random;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
@@ -14,6 +17,10 @@ public sealed class MutationSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedEntityEffectsSystem _entityEffects = default!;
+    //HONK START - mutation overhaul: replacement algorithm + toggle.
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly BotanyMutationOverhaulSystem _overhaul = default!;
+    //HONK END
     private RandomPlantMutationListPrototype _randomMutations = default!;
 
     public override void Initialize()
@@ -47,6 +54,14 @@ public sealed class MutationSystem : EntitySystem
     /// </summary>
     public void MutateSeed(EntityUid plantHolder, ref SeedData seed, float severity)
     {
+        //HONK START - mutation overhaul: hand off to the replacement algorithm when enabled.
+        if (_cfg.GetCVar(CCVars.BotanyMutationOverhaulEnabled))
+        {
+            _overhaul.MutateSeed(plantHolder, ref seed, severity);
+            return;
+        }
+        //HONK END
+
         if (!seed.Unique)
         {
             Log.Error($"Attempted to mutate a shared seed");
@@ -58,6 +73,11 @@ public sealed class MutationSystem : EntitySystem
 
     public SeedData Cross(SeedData a, SeedData b)
     {
+        //HONK START - mutation overhaul: hand off to the replacement algorithm when enabled.
+        if (_cfg.GetCVar(CCVars.BotanyMutationOverhaulEnabled))
+            return _overhaul.Cross(a, b);
+        //HONK END
+
         SeedData result = b.Clone();
 
         CrossChemicals(ref result.Chemicals, a.Chemicals);

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -55,7 +55,7 @@ public sealed class MutationSystem : EntitySystem
     public void MutateSeed(EntityUid plantHolder, ref SeedData seed, float severity)
     {
         //HONK START - mutation overhaul: hand off to the replacement algorithm when enabled.
-        if (_cfg.GetCVar(CCVars.BotanyMutationOverhaulEnabled))
+        if (_cfg.GetCVar(CCVars.BotanyOverhaulEnabled))
         {
             _overhaul.MutateSeed(plantHolder, ref seed, severity);
             return;
@@ -74,7 +74,7 @@ public sealed class MutationSystem : EntitySystem
     public SeedData Cross(SeedData a, SeedData b)
     {
         //HONK START - mutation overhaul: hand off to the replacement algorithm when enabled.
-        if (_cfg.GetCVar(CCVars.BotanyMutationOverhaulEnabled))
+        if (_cfg.GetCVar(CCVars.BotanyOverhaulEnabled))
             return _overhaul.Cross(a, b);
         //HONK END
 

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -59,7 +59,7 @@ public sealed class MutationSystem : EntitySystem
         //HONK START - mutation overhaul: hand off to the replacement algorithm when enabled.
         if (_cfg.GetCVar(CCVars.BotanyOverhaulEnabled))
         {
-            _overhaul.MutateSeed(plantHolder, ref seed, severity);
+            _overhaul.MutateSeed(plantHolder, ref seed, severity, seed.Potency);
             return;
         }
         //HONK END

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -1,12 +1,14 @@
-using Content.Server.RussStation.Botany.Systems;
 using Content.Shared.Atmos;
-using Content.Shared.CCVar;
 using Content.Shared.EntityEffects;
 using Content.Shared.Random;
-using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
+//HONK START - mutation overhaul: usings for the replacement system, CVar + config access.
+using Content.Server.RussStation.Botany.Systems;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+//HONK END
 
 namespace Content.Server.Botany;
 

--- a/Content.Server/RussStation/Botany/Components/BotanyOverhaulComponent.cs
+++ b/Content.Server/RussStation/Botany/Components/BotanyOverhaulComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.RussStation.Botany.Components;
+
+/// <summary>
+///     Marker added to plant holders at map init when <c>botany.overhaul_enabled</c> is true.
+///     This is the proof-of-concept hook point for the botany overhaul: it lets overhaul
+///     behavior attach to trays without editing any upstream botany system, so the toggle
+///     can be flipped per-server with zero merge surface against upstream.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BotanyOverhaulComponent : Component
+{
+}

--- a/Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs
+++ b/Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs
@@ -40,13 +40,16 @@ public sealed class BotanyMutationOverhaulSystem : EntitySystem
     ///     Overhauled random mutation: rolls prototype effects with a severity-curved probability
     ///     and additionally drifts a couple of numeric stats so every mutation tick nudges the genome.
     /// </summary>
-    public void MutateSeed(EntityUid plantHolder, ref SeedData seed, float severity)
+    public void MutateSeed(EntityUid plantHolder, ref SeedData seed, float severity, float plantyness)
     {
         if (!seed.Unique)
         {
             Log.Error("Attempted to mutate a shared seed");
             return;
         }
+
+        // Threaded in from the delegation guard; wired up but not yet driving behavior.
+        _ = plantyness;
 
         // Severity curve: low severity barely mutates, high severity ramps up fast.
         var chanceScale = MathF.Pow(Math.Clamp(severity / 25f, 0f, 1f), 0.5f);

--- a/Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs
+++ b/Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs
@@ -10,7 +10,7 @@ namespace Content.Server.RussStation.Botany.Systems;
 
 /// <summary>
 ///     Full replacement for the vanilla mutation algorithm, gated behind
-///     <c>botany.mutation_overhaul_enabled</c>. When the CVar is on, the stock
+///     <c>botany.overhaul_enabled</c>. When the CVar is on, the stock
 ///     <see cref="MutationSystem"/> delegates <c>MutateSeed</c> and <c>Cross</c> to the methods
 ///     here; when off, vanilla runs unchanged.
 ///

--- a/Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs
+++ b/Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs
@@ -1,0 +1,173 @@
+using Content.Server.Botany;
+using Content.Shared.Atmos;
+using Content.Shared.EntityEffects;
+using Content.Shared.Random;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using System.Linq;
+
+namespace Content.Server.RussStation.Botany.Systems;
+
+/// <summary>
+///     Full replacement for the vanilla mutation algorithm, gated behind
+///     <c>botany.mutation_overhaul_enabled</c>. When the CVar is on, the stock
+///     <see cref="MutationSystem"/> delegates <c>MutateSeed</c> and <c>Cross</c> to the methods
+///     here; when off, vanilla runs unchanged.
+///
+///     The overhaul swaps vanilla's "coin-flip each stat from one parent" genetics for a
+///     continuous blend model: offspring stats interpolate between both parents with random
+///     variance and occasional hybrid vigor, hybrids inherit the union of both parents' chemicals,
+///     gasses and mutations, and random mutation rolls additionally apply severity-scaled numeric
+///     drift so every mutation tick nudges the genome.
+/// </summary>
+public sealed class BotanyMutationOverhaulSystem : EntitySystem
+{
+    private static readonly ProtoId<RandomPlantMutationListPrototype> RandomPlantMutations = "RandomPlantMutations";
+
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedEntityEffectsSystem _entityEffects = default!;
+
+    private RandomPlantMutationListPrototype _mutations = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _mutations = _prototype.Index(RandomPlantMutations);
+    }
+
+    /// <summary>
+    ///     Overhauled random mutation: rolls prototype effects with a severity-curved probability
+    ///     and additionally drifts a couple of numeric stats so every mutation tick nudges the genome.
+    /// </summary>
+    public void MutateSeed(EntityUid plantHolder, ref SeedData seed, float severity)
+    {
+        if (!seed.Unique)
+        {
+            Log.Error("Attempted to mutate a shared seed");
+            return;
+        }
+
+        // Severity curve: low severity barely mutates, high severity ramps up fast.
+        var chanceScale = MathF.Pow(Math.Clamp(severity / 25f, 0f, 1f), 0.5f);
+
+        foreach (var mutation in _mutations.mutations)
+        {
+            if (!_random.Prob(Math.Min(mutation.BaseOdds * chanceScale, 1.0f)))
+                continue;
+
+            if (mutation.AppliesToPlant)
+                _entityEffects.TryApplyEffect(plantHolder, mutation.Effect);
+
+            // Stat-adjusting effects don't persist; only flagged mutations stick to the genome.
+            if (mutation.Persists && seed.Mutations.All(m => m.Name != mutation.Name))
+                seed.Mutations.Add(mutation);
+        }
+
+        // Continuous genetic drift unique to the overhaul.
+        var drift = Math.Clamp(severity / 25f, 0f, 1f);
+        seed.Potency = Math.Clamp(seed.Potency + RandomDrift(drift) * 5f, 0f, 100f);
+        seed.Yield = Math.Max(0, seed.Yield + (int)MathF.Round(RandomDrift(drift)));
+    }
+
+    /// <summary>
+    ///     Overhauled crossbreeding: offspring blend continuously between both parents rather than
+    ///     inheriting whole stats from one. Chemicals, gasses and mutations from both parents are
+    ///     inherited, making hybrids richer than vanilla.
+    /// </summary>
+    public SeedData Cross(SeedData a, SeedData b)
+    {
+        var result = b.Clone();
+
+        BlendFloat(ref result.NutrientConsumption, a.NutrientConsumption);
+        BlendFloat(ref result.WaterConsumption, a.WaterConsumption);
+        BlendFloat(ref result.IdealHeat, a.IdealHeat);
+        BlendFloat(ref result.HeatTolerance, a.HeatTolerance);
+        BlendFloat(ref result.IdealLight, a.IdealLight);
+        BlendFloat(ref result.LightTolerance, a.LightTolerance);
+        BlendFloat(ref result.ToxinsTolerance, a.ToxinsTolerance);
+        BlendFloat(ref result.LowPressureTolerance, a.LowPressureTolerance);
+        BlendFloat(ref result.HighPressureTolerance, a.HighPressureTolerance);
+        BlendFloat(ref result.PestTolerance, a.PestTolerance);
+        BlendFloat(ref result.WeedTolerance, a.WeedTolerance);
+
+        BlendFloat(ref result.Endurance, a.Endurance);
+        BlendInt(ref result.Yield, a.Yield);
+        BlendFloat(ref result.Lifespan, a.Lifespan);
+        BlendFloat(ref result.Maturation, a.Maturation);
+        BlendFloat(ref result.Production, a.Production);
+        BlendFloat(ref result.Potency, a.Potency);
+
+        // Bools can't be blended; keep the vanilla coin-flip for these.
+        CrossBool(ref result.Seedless, a.Seedless);
+        CrossBool(ref result.Ligneous, a.Ligneous);
+        CrossBool(ref result.TurnIntoKudzu, a.TurnIntoKudzu);
+        CrossBool(ref result.CanScream, a.CanScream);
+
+        // Hybrids inherit the union of both parents' chemicals and gasses.
+        UnionChemicals(result.Chemicals, a.Chemicals);
+        UnionGasses(result.ExudeGasses, a.ExudeGasses);
+        UnionGasses(result.ConsumeGasses, a.ConsumeGasses);
+
+        // Carry every mutation from both parents forward, deduped by name.
+        result.Mutations = result.Mutations
+            .UnionBy(a.Mutations, m => m.Name)
+            .ToList();
+
+        return result;
+    }
+
+    /// <summary>
+    ///     Interpolate between the current value and the other parent's value by a random factor,
+    ///     with a small chance of hybrid vigor / regression that nudges the result past the blend.
+    /// </summary>
+    private void BlendFloat(ref float val, float other)
+    {
+        var t = _random.NextFloat();
+        var blended = val + (other - val) * t;
+
+        if (_random.Prob(0.15f))
+            blended *= 1f + (_random.NextFloat() - 0.5f) * 0.2f;
+
+        val = blended;
+    }
+
+    private void BlendInt(ref int val, int other)
+    {
+        var t = _random.NextFloat();
+        val = (int)MathF.Round(val + (other - val) * t);
+    }
+
+    private void CrossBool(ref bool val, bool other)
+    {
+        val = _random.Prob(0.5f) ? val : other;
+    }
+
+    private void UnionChemicals(Dictionary<string, SeedChemQuantity> target, Dictionary<string, SeedChemQuantity> other)
+    {
+        foreach (var (key, value) in other)
+        {
+            if (target.ContainsKey(key))
+                continue;
+
+            // Inherited (non-inherent) chemicals are stripped on species mutation, matching vanilla.
+            var chem = value;
+            chem.Inherent = false;
+            target[key] = chem;
+        }
+    }
+
+    private void UnionGasses(Dictionary<Gas, float> target, Dictionary<Gas, float> other)
+    {
+        foreach (var (key, value) in other)
+            target.TryAdd(key, value);
+    }
+
+    /// <summary>
+    ///     Returns a value in [-scale, scale].
+    /// </summary>
+    private float RandomDrift(float scale)
+    {
+        return (_random.NextFloat() - 0.5f) * 2f * scale;
+    }
+}

--- a/Content.Server/RussStation/Botany/Systems/BotanyOverhaulSystem.cs
+++ b/Content.Server/RussStation/Botany/Systems/BotanyOverhaulSystem.cs
@@ -1,0 +1,56 @@
+using Content.Server.Botany.Components;
+using Content.Server.RussStation.Botany.Components;
+using Content.Shared.CCVar;
+using Content.Shared.Examine;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.RussStation.Botany.Systems;
+
+/// <summary>
+///     Proof-of-concept for gating a botany overhaul behind a CVar with zero edits to any
+///     upstream botany system.
+///
+///     On map init, if <c>botany.overhaul_enabled</c> is set, every plant holder gets a
+///     <see cref="BotanyOverhaulComponent"/> marker and the tweaks below take over. Flip the
+///     CVar off (the default) and vanilla botany is completely untouched.
+///
+///     This deliberately reuses the stock <see cref="PlantHolderComponent"/> and only nudges
+///     one field so the swap is observable and tiny. The full overhaul would instead replace
+///     the component with an overhaul-owned one and run its own growth loop here.
+/// </summary>
+public sealed class BotanyOverhaulSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private bool _enabled;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_cfg, CCVars.BotanyOverhaulEnabled, value => _enabled = value, invokeImmediately: true);
+
+        SubscribeLocalEvent<PlantHolderComponent, MapInitEvent>(OnPlantHolderMapInit);
+        SubscribeLocalEvent<BotanyOverhaulComponent, ExaminedEvent>(OnOverhaulExamine);
+    }
+
+    private void OnPlantHolderMapInit(Entity<PlantHolderComponent> ent, ref MapInitEvent args)
+    {
+        if (!_enabled)
+            return;
+
+        // Mark the tray as overhauled so other overhaul code (and examine) can find it.
+        EnsureComp<BotanyOverhaulComponent>(ent);
+
+        // Observable proof the swap took effect: overhauled trays cycle growth twice as fast.
+        ent.Comp.CycleDelay /= 2;
+    }
+
+    private void OnOverhaulExamine(Entity<BotanyOverhaulComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        args.PushMarkup(Loc.GetString("botany-overhaul-poc-examine"));
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Botany.cs
+++ b/Content.Shared/CCVar/CCVars.Botany.cs
@@ -5,21 +5,11 @@ namespace Content.Shared.CCVar;
 public sealed partial class CCVars
 {
     /// <summary>
-    ///     Proof-of-concept master toggle for the botany overhaul.
-    ///     When enabled, hydroponics trays receive overhaul behavior at map init
-    ///     (see <c>BotanyOverhaulSystem</c>) instead of running vanilla growth unchanged.
-    ///     Defaults to off so the fork ships with stock botany until the overhaul is ready.
+    ///     Master toggle for the botany overhaul. When enabled, hydroponics trays receive overhaul
+    ///     growth behavior at map init (see <c>BotanyOverhaulSystem</c>) and the mutation algorithm
+    ///     is fully replaced by <c>BotanyMutationOverhaulSystem</c> (random mutation rolls and
+    ///     crossbreeding). Off (the default) runs vanilla botany unchanged.
     /// </summary>
     public static readonly CVarDef<bool> BotanyOverhaulEnabled =
         CVarDef.Create("botany.overhaul_enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
-
-    /// <summary>
-    ///     Fully replaces the vanilla mutation algorithm (random mutation rolls and crossbreeding)
-    ///     with <c>BotanyMutationOverhaulSystem</c> when enabled. The stock <c>MutationSystem</c>
-    ///     delegates to the overhaul behind this flag; off (the default) runs vanilla unchanged.
-    ///     Independent from <see cref="BotanyOverhaulEnabled"/> so the growth and genetics overhauls
-    ///     can be toggled separately.
-    /// </summary>
-    public static readonly CVarDef<bool> BotanyMutationOverhaulEnabled =
-        CVarDef.Create("botany.mutation_overhaul_enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/CCVar/CCVars.Botany.cs
+++ b/Content.Shared/CCVar/CCVars.Botany.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     Proof-of-concept master toggle for the botany overhaul.
+    ///     When enabled, hydroponics trays receive overhaul behavior at map init
+    ///     (see <c>BotanyOverhaulSystem</c>) instead of running vanilla growth unchanged.
+    ///     Defaults to off so the fork ships with stock botany until the overhaul is ready.
+    /// </summary>
+    public static readonly CVarDef<bool> BotanyOverhaulEnabled =
+        CVarDef.Create("botany.overhaul_enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/CCVar/CCVars.Botany.cs
+++ b/Content.Shared/CCVar/CCVars.Botany.cs
@@ -12,4 +12,14 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> BotanyOverhaulEnabled =
         CVarDef.Create("botany.overhaul_enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    ///     Fully replaces the vanilla mutation algorithm (random mutation rolls and crossbreeding)
+    ///     with <c>BotanyMutationOverhaulSystem</c> when enabled. The stock <c>MutationSystem</c>
+    ///     delegates to the overhaul behind this flag; off (the default) runs vanilla unchanged.
+    ///     Independent from <see cref="BotanyOverhaulEnabled"/> so the growth and genetics overhauls
+    ///     can be toggled separately.
+    /// </summary>
+    public static readonly CVarDef<bool> BotanyMutationOverhaulEnabled =
+        CVarDef.Create("botany.mutation_overhaul_enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/@RussStation/botany/overhaul.ftl
+++ b/Resources/Locale/en-US/@RussStation/botany/overhaul.ftl
@@ -1,0 +1,1 @@
+botany-overhaul-poc-examine = [color=#7cc576]This tray is running the botany overhaul.[/color]


### PR DESCRIPTION
## Summary

A low-conflict scaffold for overhauling botany, gated behind a single CVar `botany.overhaul_enabled` (default **off** → vanilla behavior is byte-for-byte unchanged). The goal is to let an overhaul live alongside upstream with a minimal merge surface: nearly all new logic sits in fork-owned `RussStation` directories, and the only edits to upstream files are tiny delegation guards.

Flip `botany.overhaul_enabled true` to enable both pieces below.

### 1. Growth swap (proof-of-concept)
- On `MapInitEvent`, plant holders get a `BotanyOverhaulComponent` marker and an observable behavior change (growth cycle halved + an examine line).
- Subscribes **alongside** the stock `PlantHolderSystem` via the marker component — **zero edits** to any upstream growth code.
- This is intentionally tiny; it proves the map-init seam where a full growth rewrite would later swap in an overhaul-owned component.

### 2. Full mutation-system replacement
- `MutationSystem.MutateSeed` and `MutationSystem.Cross` delegate to a new fork-owned `BotanyMutationOverhaulSystem` when the CVar is on.
- The replacement algorithm:
  - **Crossbreeding** blends stats continuously between both parents (with a ~15% hybrid-vigor/regression kick) instead of vanilla's per-stat coin flip.
  - Hybrids inherit the **union** of both parents' chemicals, gasses, and mutations.
  - **Random mutation** uses severity-curved odds plus genetic drift on potency/yield, while still reusing the `RandomPlantMutations` prototype + `EntityEffect` infrastructure.

## Upstream surface
Only one upstream file is touched — `Content.Server/Botany/Systems/MutationSystem.cs` — with two small `//HONK`-marked delegation guards plus two injected dependencies. Everything else is new files:

- `Content.Shared/CCVar/CCVars.Botany.cs` (new CVar)
- `Content.Server/RussStation/Botany/Components/BotanyOverhaulComponent.cs`
- `Content.Server/RussStation/Botany/Systems/BotanyOverhaulSystem.cs`
- `Content.Server/RussStation/Botany/Systems/BotanyMutationOverhaulSystem.cs`
- `Resources/Locale/en-US/@RussStation/botany/overhaul.ftl`

## Testing / status
- **Not yet compiled** — the development environment has no .NET toolchain, so this PR is opened specifically to run CI and review the diff. Static-checked against existing field types and APIs (`SeedData` reference-type fields, `IRobustRandom`, `SharedEntityEffectsSystem`, LINQ `UnionBy`), but a real build is needed.
- Default-off means no behavioral change to existing gameplay unless the CVar is set.

https://claude.ai/code/session_019zVy2SXySMfgHggNrH3Nst

---
_Generated by [Claude Code](https://claude.ai/code/session_019zVy2SXySMfgHggNrH3Nst)_