### PR TITLE
test: integration tests for fork systems (batch 1)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/GibbableCyberneticOrganTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/GibbableCyberneticOrganTest.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Content.Shared.Body;
+using Content.Shared.Gibbing;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+/// <summary>
+/// Verifies the fork's change to <see cref="GibbableOrganSystem"/>: a plain gibbable organ is
+/// added to the giblet set when its body is gibbed, but an organ that is also a
+/// <see cref="CyberneticOrganComponent"/> is excluded so cybernetics don't turn into gibs.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(GibbableOrganSystem))]
+public sealed class GibbableCyberneticOrganTest
+{
+    [Test]
+    public async Task OrganicOrganIsGibbedButCyberneticIsNotTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var bodyComp = entMan.EnsureComponent<BodyComponent>(body);
+
+            var organicOrgan = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<GibbableOrganComponent>(organicOrgan);
+
+            var cyberneticOrgan = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<GibbableOrganComponent>(cyberneticOrgan);
+            entMan.AddComponent<CyberneticOrganComponent>(cyberneticOrgan);
+
+            // Organic organ: should be collected into the giblet set.
+            var organicGiblets = new HashSet<EntityUid>();
+            var organicEv = new BodyRelayedEvent<BeingGibbedEvent>((body, bodyComp), new BeingGibbedEvent(organicGiblets));
+            entMan.EventBus.RaiseLocalEvent(organicOrgan, ref organicEv);
+            Assert.That(organicGiblets, Does.Contain(organicOrgan),
+                "A plain gibbable organ should be added to the giblets.");
+
+            // Cybernetic organ: should be skipped.
+            var cyberneticGiblets = new HashSet<EntityUid>();
+            var cyberneticEv = new BodyRelayedEvent<BeingGibbedEvent>((body, bodyComp), new BeingGibbedEvent(cyberneticGiblets));
+            entMan.EventBus.RaiseLocalEvent(cyberneticOrgan, ref cyberneticEv);
+            Assert.That(cyberneticGiblets, Does.Not.Contain(cyberneticOrgan),
+                "A cybernetic organ should be excluded from the giblets.");
+
+            entMan.DeleteEntity(body);
+            entMan.DeleteEntity(organicOrgan);
+            entMan.DeleteEntity(cyberneticOrgan);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/DoAfterCancel/DoAfterCancelTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/DoAfterCancel/DoAfterCancelTest.cs
@@ -1,0 +1,86 @@
+using Content.IntegrationTests.Fixtures;
+using Content.Server.RussStation.DoAfterCancel;
+using Content.Shared.DoAfter;
+using Content.Shared.RussStation.DoAfterCancel;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests.RussStation.DoAfterCancel;
+
+/// <summary>
+/// Verifies <see cref="DoAfterCancelSystem"/>: when the player sends
+/// <see cref="CancelAllDoAftersEvent"/> (their Escape press), only DoAfters the player
+/// started themselves are cancelled. Hostile DoAfters where the player is merely the
+/// target live on the attacker's component and keep running.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(DoAfterCancelSystem))]
+public sealed partial class DoAfterCancelTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: DoAfterCancelDummy
+  components:
+  - type: DoAfter
+";
+
+    [Serializable, NetSerializable]
+    private sealed partial class TestDoAfterEvent : DoAfterEvent
+    {
+        public override DoAfterEvent Clone() => this;
+    }
+
+    [Test]
+    public async Task CancelsOwnDoAfterButNotHostileTest()
+    {
+        var server = Server;
+        var entMan = server.EntMan;
+        var timing = server.ResolveDependency<IGameTiming>();
+        var doAfterSys = entMan.System<SharedDoAfterSystem>();
+
+        var ownEvent = new TestDoAfterEvent();
+        var hostileEvent = new TestDoAfterEvent();
+
+        // Long enough that neither DoAfter completes on its own during the test.
+        var longDelay = timing.TickPeriod * 1000;
+
+        await server.WaitPost(() =>
+        {
+            var player = entMan.SpawnEntity("DoAfterCancelDummy", MapCoordinates.Nullspace);
+            var attacker = entMan.SpawnEntity("DoAfterCancelDummy", MapCoordinates.Nullspace);
+
+            // Make the player session control the player entity, so the server sees it as
+            // the sender of the cancel event.
+            server.PlayerMan.SetAttachedEntity(ServerSession, player, force: true);
+
+            // A DoAfter the player started themselves.
+            var ownArgs = new DoAfterArgs(entMan, player, longDelay, ownEvent, null) { Broadcast = true };
+            Assert.That(doAfterSys.TryStartDoAfter(ownArgs), Is.True);
+
+            // A hostile DoAfter run by the attacker, targeting the player. It is stored on the
+            // attacker's DoAfterComponent, not the player's.
+            var hostileArgs = new DoAfterArgs(entMan, attacker, longDelay, hostileEvent, null, player) { Broadcast = true };
+            Assert.That(doAfterSys.TryStartDoAfter(hostileArgs), Is.True);
+
+            Assert.That(ownEvent.Cancelled, Is.False);
+            Assert.That(hostileEvent.Cancelled, Is.False);
+        });
+
+        // The client presses Escape: send the cancel event from the client to the server.
+        await Client.WaitPost(() =>
+            Client.EntMan.EntityNetManager.SendSystemNetworkMessage(new CancelAllDoAftersEvent()));
+
+        await Pair.RunTicksSync(15);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ownEvent.Cancelled, Is.True,
+                "The player's own DoAfter should be cancelled by the Escape key.");
+            Assert.That(hostileEvent.Cancelled, Is.False,
+                "A hostile DoAfter targeting the player should keep running.");
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Economy/SkavenPaydayTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/SkavenPaydayTest.cs
@@ -1,0 +1,70 @@
+using Content.Server.RussStation.Economy;
+using Content.Shared.RussStation.Economy;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+// EconomyConstants exists in both the server and shared economy namespaces; the
+// SkavenPaydayMultiplier this test asserts against lives on the server one.
+using EconomyConstants = Content.Server.RussStation.Economy.EconomyConstants;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+/// <summary>
+/// Verifies that <see cref="SkavenPaydaySystem"/> scales a Skaven's wage down to the
+/// configured fraction (<see cref="EconomyConstants.SkavenPaydayMultiplier"/> = 0.25)
+/// when <see cref="PayrollSystem"/> raises <see cref="GetWageEvent"/> before depositing.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SkavenPaydaySystem))]
+public sealed class SkavenPaydayTest
+{
+    [Test]
+    public async Task SkavenWageIsQuarteredTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var skaven = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<SkavenPaydayComponent>(skaven);
+
+            var ev = new GetWageEvent(100);
+            entMan.EventBus.RaiseLocalEvent(skaven, ref ev);
+
+            Assert.That(ev.Wage, Is.EqualTo((int)(100 * EconomyConstants.SkavenPaydayMultiplier)),
+                "Skaven payday should scale the wage by the SkavenPaydayMultiplier.");
+            Assert.That(ev.Wage, Is.EqualTo(25), "0.25 * 100 should deposit 25.");
+
+            entMan.DeleteEntity(skaven);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// An entity without the component should be untouched by the wage hook.
+    /// </summary>
+    [Test]
+    public async Task NonSkavenWageUnchangedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var crew = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+
+            var ev = new GetWageEvent(100);
+            entMan.EventBus.RaiseLocalEvent(crew, ref ev);
+
+            Assert.That(ev.Wage, Is.EqualTo(100), "A non-Skaven entity's wage should be unchanged.");
+
+            entMan.DeleteEntity(crew);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Messenger/MessengerServerTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Messenger/MessengerServerTest.cs
@@ -1,0 +1,285 @@
+using System.Linq;
+using Content.Server.RussStation.Messenger;
+using Content.Shared.PDA;
+using Content.Shared.RussStation.Messenger;
+using Content.Shared.StationRecords;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Messenger;
+
+/// <summary>
+/// Exercises the round-scoped message store in <see cref="MessengerServerSystem"/>: sending and
+/// retrieving messages (with per-viewer "from self" framing), the ID-card write gate, unread
+/// tracking, the per-conversation FIFO cap, message-length truncation, and the read-only
+/// classification of antag / non-roster cartridges.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(MessengerServerSystem))]
+public sealed class MessengerServerTest
+{
+    /// <summary>
+    /// Build a cartridge wired into a PDA the way the loader does at runtime: the cartridge's
+    /// transform parent is a PDA, and that PDA optionally holds an ID card.
+    /// </summary>
+    private static EntityUid MakeWiredCartridge(
+        IEntityManager entMan,
+        SharedTransformSystem xformSys,
+        MapCoordinates coords,
+        string address,
+        bool withId = true,
+        bool stationCrewId = false)
+    {
+        var pda = entMan.SpawnEntity(null, coords);
+        var pdaComp = entMan.AddComponent<PdaComponent>(pda);
+
+        if (withId)
+        {
+            var id = entMan.SpawnEntity(null, coords);
+            if (stationCrewId)
+            {
+                var keyStorage = entMan.AddComponent<StationRecordKeyStorageComponent>(id);
+                keyStorage.Key = new StationRecordKey(1, pda);
+            }
+
+            pdaComp.ContainedId = id;
+        }
+
+        var cart = entMan.SpawnEntity(null, coords);
+        var cartComp = entMan.AddComponent<MessengerCartridgeComponent>(cart);
+        cartComp.Address = address;
+        xformSys.SetParent(cart, pda);
+
+        return cart;
+    }
+
+    [Test]
+    public async Task SendStoresMessageWithViewerPerspectiveTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var sender = MakeWiredCartridge(entMan, xformSys, coords, "NT0001");
+            var recipient = MakeWiredCartridge(entMan, xformSys, coords, "NT0002");
+
+            Assert.That(messenger.SendMessage(sender, recipient, "hello there"), Is.True);
+
+            var fromSender = messenger.GetConversation(sender, recipient);
+            Assert.That(fromSender, Has.Count.EqualTo(1));
+            Assert.That(fromSender[0].Text, Is.EqualTo("hello there"));
+            Assert.That(fromSender[0].SenderName, Is.EqualTo("NT0001"));
+            Assert.That(fromSender[0].FromSelf, Is.True, "Sender should see their own message as from-self.");
+
+            var fromRecipient = messenger.GetConversation(recipient, sender);
+            Assert.That(fromRecipient, Has.Count.EqualTo(1));
+            Assert.That(fromRecipient[0].FromSelf, Is.False, "Recipient should not see the message as from-self.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SendRequiresIdCardTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var sender = MakeWiredCartridge(entMan, xformSys, coords, "NT0001", withId: false);
+            var recipient = MakeWiredCartridge(entMan, xformSys, coords, "NT0002");
+
+            Assert.That(messenger.SendMessage(sender, recipient, "hello"), Is.False,
+                "Sending without an ID card in the PDA should be rejected.");
+            Assert.That(messenger.GetConversation(sender, recipient), Is.Empty);
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SendRejectsEmptyTextTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var sender = MakeWiredCartridge(entMan, xformSys, coords, "NT0001");
+            var recipient = entMan.SpawnEntity(null, coords);
+
+            Assert.That(messenger.SendMessage(sender, recipient, ""), Is.False);
+            Assert.That(messenger.SendMessage(sender, recipient, "   "), Is.False);
+            Assert.That(messenger.GetConversation(sender, recipient), Is.Empty);
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task UnreadTrackingTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var sender = MakeWiredCartridge(entMan, xformSys, coords, "NT0001");
+            var recipient = entMan.SpawnEntity(null, coords);
+
+            Assert.That(messenger.HasUnread(recipient, sender), Is.False, "No messages yet, nothing unread.");
+
+            messenger.SendMessage(sender, recipient, "ping");
+            Assert.That(messenger.HasUnread(recipient, sender), Is.True, "A new message should be unread.");
+
+            messenger.MarkRead(recipient, sender);
+            Assert.That(messenger.HasUnread(recipient, sender), Is.False, "Marking read should clear unread.");
+
+            messenger.SendMessage(sender, recipient, "ping again");
+            Assert.That(messenger.HasUnread(recipient, sender), Is.True, "A later message should be unread again.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ConversationCapTrimsOldestTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var sender = MakeWiredCartridge(entMan, xformSys, coords, "NT0001");
+            var recipient = entMan.SpawnEntity(null, coords);
+
+            var overflow = MessengerServerSystem.MaxMessagesPerConversation + 5;
+            for (var i = 0; i < overflow; i++)
+                messenger.SendMessage(sender, recipient, $"msg{i}");
+
+            var conversation = messenger.GetConversation(sender, recipient);
+            Assert.That(conversation, Has.Count.EqualTo(MessengerServerSystem.MaxMessagesPerConversation),
+                "Conversation should be capped at MaxMessagesPerConversation.");
+            Assert.That(conversation[0].Text, Is.EqualTo("msg5"),
+                "The five oldest messages should have been trimmed off the front.");
+            Assert.That(conversation.Last().Text, Is.EqualTo($"msg{overflow - 1}"),
+                "The newest message should be retained.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task LongMessageTruncatedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var sender = MakeWiredCartridge(entMan, xformSys, coords, "NT0001");
+            var recipient = entMan.SpawnEntity(null, coords);
+
+            var longText = new string('a', MessengerServerSystem.MaxMessageLength + 50);
+            Assert.That(messenger.SendMessage(sender, recipient, longText), Is.True);
+
+            var conversation = messenger.GetConversation(sender, recipient);
+            Assert.That(conversation, Has.Count.EqualTo(1));
+            Assert.That(conversation[0].Text, Has.Length.EqualTo(MessengerServerSystem.MaxMessageLength),
+                "Over-length messages should be truncated to MaxMessageLength.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ContactReadOnlyClassificationTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            // Antag address: read-only regardless of ID.
+            var antag = MakeWiredCartridge(entMan, xformSys, coords, "SY1234");
+            Assert.That(messenger.IsContactReadOnly(antag), Is.True, "Antag-prefixed cartridges are read-only.");
+
+            // Crew address but the ID is not on the station roster: still read-only.
+            var unregistered = MakeWiredCartridge(entMan, xformSys, coords, "NT5678");
+            Assert.That(messenger.IsContactReadOnly(unregistered), Is.True,
+                "A crew address with no station record key is read-only (e.g. CentComm/ERT).");
+
+            // Crew address with a station-record-keyed ID: writable.
+            var crew = MakeWiredCartridge(entMan, xformSys, coords, "NT9012", stationCrewId: true);
+            Assert.That(messenger.IsContactReadOnly(crew), Is.False,
+                "A station-roster crew cartridge should be writable.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/BulletDodgeTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/BulletDodgeTest.cs
@@ -1,0 +1,138 @@
+using Content.Server.RussStation.Skillchips;
+using Content.Shared.Chat;
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.Damage.Components;
+using Content.Shared.Projectiles;
+using Content.Shared.RussStation.Skillchips;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests.RussStation.Skillchips;
+
+/// <summary>
+/// Verifies <see cref="BulletDodgeSystem"/>: a trigger emote (Flip) opens a deflect window,
+/// an incoming projectile-reflect attempt during the window is cancelled and drains stamina,
+/// and reflect attempts outside the window do nothing.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(BulletDodgeSystem))]
+public sealed class BulletDodgeTest
+{
+    private const string FlipEmote = "Flip";
+
+    [Test]
+    public async Task TriggerEmoteOpensWindowTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var comp = entMan.AddComponent<BulletDodgeComponent>(mob);
+
+            Assert.That(comp.ActiveUntil, Is.Null, "Window should start closed.");
+
+            var ev = new EmoteEvent(protoMan.Index<EmotePrototype>(FlipEmote));
+            entMan.EventBus.RaiseLocalEvent(mob, ref ev);
+
+            Assert.That(comp.ActiveUntil, Is.Not.Null, "A trigger emote should open the deflect window.");
+
+            entMan.DeleteEntity(mob);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ReflectCancelledWhileWindowActiveTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var comp = entMan.AddComponent<BulletDodgeComponent>(mob);
+            comp.ActiveUntil = timing.CurTime + TimeSpan.FromSeconds(1);
+
+            var proj = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var projComp = entMan.AddComponent<ProjectileComponent>(proj);
+
+            var ev = new ProjectileReflectAttemptEvent(proj, projComp, false);
+            entMan.EventBus.RaiseLocalEvent(mob, ref ev);
+
+            Assert.That(ev.Cancelled, Is.True, "Projectile should be deflected while the window is open.");
+            Assert.That(comp.ActiveUntil, Is.Null, "The window should close immediately after a deflect.");
+
+            entMan.DeleteEntity(mob);
+            entMan.DeleteEntity(proj);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DeflectConsumesStaminaTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var comp = entMan.AddComponent<BulletDodgeComponent>(mob);
+            var stamina = entMan.AddComponent<StaminaComponent>(mob);
+            comp.ActiveUntil = timing.CurTime + TimeSpan.FromSeconds(1);
+
+            var proj = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var projComp = entMan.AddComponent<ProjectileComponent>(proj);
+
+            var ev = new ProjectileReflectAttemptEvent(proj, projComp, false);
+            entMan.EventBus.RaiseLocalEvent(mob, ref ev);
+
+            Assert.That(stamina.StaminaDamage, Is.GreaterThan(0f),
+                "A successful deflect should drain the dodger's stamina.");
+
+            entMan.DeleteEntity(mob);
+            entMan.DeleteEntity(proj);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ReflectIgnoredWhenWindowClosedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<BulletDodgeComponent>(mob); // ActiveUntil stays null
+
+            var proj = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var projComp = entMan.AddComponent<ProjectileComponent>(proj);
+
+            var ev = new ProjectileReflectAttemptEvent(proj, projComp, false);
+            entMan.EventBus.RaiseLocalEvent(mob, ref ev);
+
+            Assert.That(ev.Cancelled, Is.False, "No deflect should happen when the window is closed.");
+
+            entMan.DeleteEntity(mob);
+            entMan.DeleteEntity(proj);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Traits/PapyrophobiaTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Traits/PapyrophobiaTest.cs
@@ -1,0 +1,82 @@
+using Content.Shared.Interaction.Events;
+using Content.Shared.Paper;
+using Content.Shared.RussStation.Traits;
+using Content.Shared.UserInterface;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Traits;
+
+/// <summary>
+/// Verifies <see cref="PapyrophobiaSystem"/> blocks all three paper-interaction paths
+/// for an afflicted user: opening the paper UI, writing on paper, and using paper in hand.
+/// Non-paper targets and non-afflicted users are left alone.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(PapyrophobiaSystem))]
+public sealed class PapyrophobiaTest
+{
+    [Test]
+    public async Task BlocksPaperInteractionsTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var user = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<PapyrophobiaComponent>(user);
+
+            var paper = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<PaperComponent>(paper);
+
+            // Opening the paper's activatable UI should be cancelled.
+            var openEv = new UserOpenActivatableUIAttemptEvent(user, paper, silent: true);
+            entMan.EventBus.RaiseLocalEvent(user, openEv);
+            Assert.That(openEv.Cancelled, Is.True, "Papyrophobe should not be able to open a paper UI.");
+
+            // Writing on paper should be cancelled with the trait's fail reason.
+            var writeEv = new PaperWriteAttemptEvent(paper);
+            entMan.EventBus.RaiseLocalEvent(user, ref writeEv);
+            Assert.That(writeEv.Cancelled, Is.True, "Papyrophobe should not be able to write on paper.");
+            Assert.That(writeEv.FailReason, Is.EqualTo("papyrophobia-popup"));
+
+            // Using paper in hand should be short-circuited (Handled) before ingestion eats it.
+            var useEv = new UseInHandEvent(user);
+            entMan.EventBus.RaiseLocalEvent(paper, useEv);
+            Assert.That(useEv.Handled, Is.True, "Papyrophobe using paper in hand should be intercepted.");
+
+            entMan.DeleteEntity(user);
+            entMan.DeleteEntity(paper);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task NonPaperUiNotBlockedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var user = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<PapyrophobiaComponent>(user);
+
+            // A non-paper target (no PaperComponent) must not be blocked by the phobia.
+            var nonPaper = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+
+            var openEv = new UserOpenActivatableUIAttemptEvent(user, nonPaper, silent: true);
+            entMan.EventBus.RaiseLocalEvent(user, openEv);
+            Assert.That(openEv.Cancelled, Is.False, "Papyrophobia should only block paper, not arbitrary UIs.");
+
+            entMan.DeleteEntity(user);
+            entMan.DeleteEntity(nonPaper);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Traits/WageModifierTraitTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Traits/WageModifierTraitTest.cs
@@ -1,0 +1,68 @@
+using Content.Server.RussStation.Traits;
+using Content.Shared.RussStation.Economy;
+using Content.Shared.RussStation.Traits;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Traits;
+
+/// <summary>
+/// Verifies the wage-modifying traits hook <see cref="GetWageEvent"/> and scale the
+/// payroll wage by their configured multipliers: Indebted halves it,
+/// Negotiator increases it by 50%.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(IndebtedSystem))]
+[TestOf(typeof(NegotiatorSystem))]
+public sealed class WageModifierTraitTest
+{
+    [Test]
+    public async Task IndebtedHalvesWageTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var comp = entMan.AddComponent<IndebtedComponent>(mob);
+
+            var ev = new GetWageEvent(100);
+            entMan.EventBus.RaiseLocalEvent(mob, ref ev);
+
+            Assert.That(ev.Wage, Is.EqualTo((int)(100 * comp.WageMultiplier)),
+                "Indebted should scale the wage by its WageMultiplier.");
+            Assert.That(ev.Wage, Is.EqualTo(50), "Default Indebted multiplier of 0.5 should halve a 100 wage.");
+
+            entMan.DeleteEntity(mob);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task NegotiatorRaisesWageTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var comp = entMan.AddComponent<NegotiatorComponent>(mob);
+
+            var ev = new GetWageEvent(100);
+            entMan.EventBus.RaiseLocalEvent(mob, ref ev);
+
+            Assert.That(ev.Wage, Is.EqualTo((int)(100 * comp.WageMultiplier)),
+                "Negotiator should scale the wage by its WageMultiplier.");
+            Assert.That(ev.Wage, Is.EqualTo(150), "Default Negotiator multiplier of 1.5 should raise a 100 wage to 150.");
+
+            entMan.DeleteEntity(mob);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
## About the PR

First batch of integration tests covering fork-specific (`RussStation`) systems that previously had **zero** integration coverage. Came out of a full audit of the release branch for deterministic, server-observable behavior worth guarding in CI.

| System | What's asserted |
|---|---|
| `SkavenPaydaySystem` | `GetWageEvent` scales a Skaven's wage to 25%; non-Skaven unchanged |
| `IndebtedSystem` / `NegotiatorSystem` | Wage multipliers (0.5× / 1.5×) |
| `PapyrophobiaSystem` | Blocks paper UI-open, paper write, and paper use-in-hand; leaves non-paper UIs alone |
| `GibbableOrganSystem` | Plain organs go to giblets; cybernetic organs are excluded |
| `DoAfterCancelSystem` | Player's own DoAfters cancel on the Escape event; a hostile DoAfter targeting them keeps running |
| `BulletDodgeSystem` | Trigger emote opens the deflect window; reflect during the window cancels + drains stamina; no effect when closed |
| `MessengerServerSystem` | Send/retrieve with per-viewer framing, ID-card write gate, unread tracking, conversation FIFO cap, length truncation, read-only contact classification |

`DoAfterCancelSystem` uses a connected pair to exercise the real client→server network event; the rest run server-side against the standard `PoolManager` harness.

## Why / Balance

These fork systems carry real gameplay/balance logic (wage multipliers, the bullet-deflect window, paper phobia, organ gibbing, DoAfter cancellation, messenger write-gating) that until now was only protected by the compiler. Regressions here would be silent. No production code changes — tests only, so there is no balance impact.

Part of a 3-PR audit series (batch 1 of 3).

https://claude.ai/code/session_01DsUH3U8WKJe6qsCkzeH5Xb