### PR TITLE
test: integration tests for fork systems (batch 2)

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/LogWindowTest.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/LogWindowTest.cs
@@ -37,11 +37,30 @@ public sealed class LogWindowTest : InteractionTest
         var refresh = logWindow.Logs.RefreshButton;
         var cont = logWindow.Logs.LogsContainer;
 
+        //HONK START - deflake: log requests are serviced asynchronously (Task.Run) and replied
+        // over the network, so a fixed RunTicks(5) wasn't always enough for the reply to arrive
+        // and populate the container. Poll until the expected log shows up instead.
+        async Task<AdminLogLabel[]> WaitForLog(string expected)
+        {
+            AdminLogLabel[] result = [];
+            for (var i = 0; i < 30; i++)
+            {
+                await RunTicks(5);
+                result = cont.Children.Where(x => x.Visible && x is AdminLogLabel).Cast<AdminLogLabel>().ToArray();
+                if (result.Length == 1 && result[0].Log.Message.Contains(expected))
+                    break;
+            }
+
+            return result;
+        }
+        //HONK END
+
         // Search for the log we added earlier.
         await Client.WaitPost(() => search.Text = guid.ToString());
         await ClickControl(refresh);
-        await RunTicks(5);
-        var searchResult = cont.Children.Where(x => x.Visible && x is AdminLogLabel).Cast<AdminLogLabel>().ToArray();
+        //HONK START - deflake: poll for the async reply instead of a single fixed wait
+        var searchResult = await WaitForLog(guid.ToString());
+        //HONK END
         Assert.That(searchResult.Length, Is.EqualTo(1));
         Assert.That(searchResult[0].Log.Message, Contains.Substring($" test log 1: {guid}"));
 
@@ -52,8 +71,9 @@ public sealed class LogWindowTest : InteractionTest
         // Update the search and refresh
         await Client.WaitPost(() => search.Text = guid.ToString());
         await ClickControl(refresh);
-        await RunTicks(5);
-        searchResult = cont.Children.Where(x => x.Visible && x is AdminLogLabel).Cast<AdminLogLabel>().ToArray();
+        //HONK START - deflake: poll for the async reply instead of a single fixed wait
+        searchResult = await WaitForLog(guid.ToString());
+        //HONK END
         Assert.That(searchResult.Length, Is.EqualTo(1));
         Assert.That(searchResult[0].Log.Message, Contains.Substring($" test log 2: {guid}"));
     }

--- a/Content.IntegrationTests/Tests/RussStation/Pulling/VirtualItemPullReleaseTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Pulling/VirtualItemPullReleaseTest.cs
@@ -1,0 +1,106 @@
+using Content.Shared.Interaction.Events;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.RussStation.Pulling;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.IntegrationTests.Tests.RussStation.Pulling;
+
+/// <summary>
+/// Verifies <see cref="VirtualItemPullReleaseSystem"/>: dropping the virtual item that
+/// represents a pulled entity stops the pull. A virtual item whose blocking entity is not the
+/// thing being pulled leaves the pull alone.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(VirtualItemPullReleaseSystem))]
+public sealed class VirtualItemPullReleaseTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: VirtualPullBody
+  components:
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.25
+  - type: Puller
+    needsHands: false
+  - type: Pullable
+";
+
+    [Test]
+    public async Task DroppingVirtualItemStopsPullTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var pulling = entMan.System<PullingSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var puller = entMan.SpawnEntity("VirtualPullBody", new MapCoordinates(0, 0, mapId));
+            var pullable = entMan.SpawnEntity("VirtualPullBody", new MapCoordinates(0.5f, 0, mapId));
+
+            Assert.That(pulling.TryStartPull(puller, pullable), Is.True);
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.EqualTo(pullable));
+
+            // The virtual item stands in for the pulled entity in the puller's hand.
+            var virtualItem = entMan.SpawnEntity(null, new MapCoordinates(0, 0, mapId));
+            var virtualComp = entMan.AddComponent<VirtualItemComponent>(virtualItem);
+            virtualComp.BlockingEntity = pullable;
+
+            entMan.EventBus.RaiseLocalEvent(virtualItem, new DroppedEvent(puller));
+
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.Null,
+                "Dropping the virtual item should stop the pull.");
+            Assert.That(entMan.GetComponent<PullableComponent>(pullable).Puller, Is.Null);
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DroppingUnrelatedVirtualItemKeepsPullTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var pulling = entMan.System<PullingSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var puller = entMan.SpawnEntity("VirtualPullBody", new MapCoordinates(0, 0, mapId));
+            var pullable = entMan.SpawnEntity("VirtualPullBody", new MapCoordinates(0.5f, 0, mapId));
+            var unrelated = entMan.SpawnEntity("VirtualPullBody", new MapCoordinates(1f, 0, mapId));
+
+            Assert.That(pulling.TryStartPull(puller, pullable), Is.True);
+
+            // A virtual item blocking some other entity must not tear down this pull.
+            var virtualItem = entMan.SpawnEntity(null, new MapCoordinates(0, 0, mapId));
+            var virtualComp = entMan.AddComponent<VirtualItemComponent>(virtualItem);
+            virtualComp.BlockingEntity = unrelated;
+
+            entMan.EventBus.RaiseLocalEvent(virtualItem, new DroppedEvent(puller));
+
+            Assert.That(entMan.GetComponent<PullerComponent>(puller).Pulling, Is.EqualTo(pullable),
+                "An unrelated virtual item drop should leave the pull intact.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/DrunkenBrawlerTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/DrunkenBrawlerTest.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using Content.Shared.Body;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Drunk;
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Skillchips;
+using Content.Shared.RussStation.Skillchips.Consumers;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Content.Shared.StatusEffectNew;
+using Content.Shared.Weapons.Melee.Components;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.RussStation.Skillchips;
+
+/// <summary>
+/// Verifies <see cref="SharedDrunkenBrawlerSystem"/>'s offense branch: while a chip holder is
+/// intoxicated, their unarmed swings hit harder. A sober holder (capability present but not drunk)
+/// deals baseline damage.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SharedDrunkenBrawlerSystem))]
+public sealed class DrunkenBrawlerTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: skillchip
+  id: DrunkenBrawlerTestChip
+  name: Drunken Brawler Test Chip
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: drunken_brawler
+
+- type: entity
+  id: DrunkenBrawlerTestBrain
+  components:
+  - type: Brain
+  - type: Organ
+    category: Brain
+  - type: SkillchipHolder
+
+- type: entity
+  id: DrunkenBrawlerTestBody
+  components:
+  - type: Body
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Critical
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      200: Dead
+  - type: Damageable
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 5
+";
+
+    // Referenced via a named constant rather than an inline literal: RA0033 forbids string
+    // literals in IPrototypeManager.Index.
+    private const string BluntDamageType = "Blunt";
+
+    [Test]
+    public async Task DrunkBrawlerHitsHarderThanSoberTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var skillchips = em.System<SharedSkillchipSystem>();
+        var containers = em.System<SharedContainerSystem>();
+        var status = em.System<StatusEffectsSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        var blunt = protoMan.Index<DamageTypePrototype>(BluntDamageType);
+
+        await server.WaitAssertion(() =>
+        {
+            var brain = em.SpawnEntity("DrunkenBrawlerTestBrain", mapData.GridCoords);
+            var mob = em.SpawnEntity("DrunkenBrawlerTestBody", mapData.GridCoords);
+            var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+            skillchips.TryInstall((brain, holder), "DrunkenBrawlerTestChip");
+            var container = containers.EnsureContainer<Container>(mob, BodyComponent.ContainerID);
+            containers.Insert(brain, container);
+
+            Assert.That(skillchips.HasCapability(mob, SharedDrunkenBrawlerSystem.DrunkenBrawlerTag), Is.True);
+
+            // Sober: an unarmed swing (User == Weapon == mob) deals baseline damage.
+            var soberDamage = new DamageSpecifier(blunt, FixedPoint2.New(10));
+            var soberEv = new GetMeleeDamageEvent(mob, soberDamage, new List<DamageModifierSet>(), mob);
+            em.EventBus.RaiseLocalEvent(mob, ref soberEv);
+            Assert.That(soberEv.Damage.GetTotal(), Is.EqualTo(FixedPoint2.New(10)),
+                "A sober brawler should deal unmodified unarmed damage.");
+
+            // Drunk: the same swing should hit harder.
+            Assert.That(status.TryAddStatusEffectDuration(mob, SharedDrunkSystem.Drunk, TimeSpan.FromSeconds(60)), Is.True);
+
+            var drunkDamage = new DamageSpecifier(blunt, FixedPoint2.New(10));
+            var drunkEv = new GetMeleeDamageEvent(mob, drunkDamage, new List<DamageModifierSet>(), mob);
+            em.EventBus.RaiseLocalEvent(mob, ref drunkEv);
+            Assert.That(drunkEv.Damage.GetTotal(), Is.GreaterThan(FixedPoint2.New(10)),
+                "A drunken brawler's unarmed swing should be boosted.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SingAccentTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SingAccentTest.cs
@@ -1,0 +1,67 @@
+using Content.Server.RussStation.Skillchips;
+using Content.Shared.RussStation.Skillchips;
+using Content.Shared.Speech;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Skillchips;
+
+/// <summary>
+/// Verifies <see cref="SingAccentSystem"/> reshapes the final word of a message into a "sung"
+/// form: the last vowel is held (repeated) and the line ends on emphatic punctuation.
+/// Granted by the SS13 Musical skillchip via <see cref="SingAccentComponent"/>.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SingAccentSystem))]
+public sealed class SingAccentTest
+{
+    [Test]
+    public async Task SingifiesFinalWordTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var singer = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<SingAccentComponent>(singer);
+
+            var ev = new AccentGetEvent(singer, "hello world.");
+            entMan.EventBus.RaiseLocalEvent(singer, ev);
+
+            // "world." -> hold the 'o' -> "woooorld" and the trailing period becomes "!".
+            Assert.That(ev.Message, Does.StartWith("hello "), "Only the final word should be reshaped.");
+            Assert.That(ev.Message, Does.Contain("oooo"), "The last vowel of the final word should be held.");
+            Assert.That(ev.Message, Does.EndWith("!"), "A trailing period should become an exclamation mark.");
+
+            entMan.DeleteEntity(singer);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task AddsExclamationWhenNoPunctuationTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var singer = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<SingAccentComponent>(singer);
+
+            var ev = new AccentGetEvent(singer, "do re mi");
+            entMan.EventBus.RaiseLocalEvent(singer, ev);
+
+            Assert.That(ev.Message, Does.EndWith("!"), "Final word without punctuation should gain an exclamation mark.");
+            Assert.That(ev.Message, Does.Contain("miii"), "The vowel 'i' in the final word should be held.");
+
+            entMan.DeleteEntity(singer);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipExamineConsumerTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipExamineConsumerTest.cs
@@ -1,0 +1,168 @@
+using Content.Shared.Body;
+using Content.Shared.Examine;
+using Content.Shared.RussStation.Skillchips;
+using Content.Shared.RussStation.Skillchips.Consumers;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Map;
+using Robust.Shared.Utility;
+
+namespace Content.IntegrationTests.Tests.RussStation.Skillchips;
+
+/// <summary>
+/// Verifies the examine-hook skillchip consumers: <see cref="SharedIdAppraiserSystem"/> appends
+/// an origin line (CentCom / Syndicate / station) when a capable examiner inspects an appraisable
+/// ID, and <see cref="SharedDiskVerifierSystem"/> appends a forgery warning when a capable examiner
+/// inspects a forged nuke disk. Both are gated on capability and details range.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SharedIdAppraiserSystem))]
+[TestOf(typeof(SharedDiskVerifierSystem))]
+public sealed class SkillchipExamineConsumerTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: skillchip
+  id: ExamineConsumerTestChip
+  name: Examine Consumer Test Chip
+  capacityCost: 1
+  grants:
+  - !type:CapabilityTagGrant
+    tag: id_appraisal
+  - !type:CapabilityTagGrant
+    tag: disk_verifier
+
+- type: entity
+  id: ExamineConsumerTestBrain
+  components:
+  - type: Brain
+  - type: Organ
+    category: Brain
+  - type: SkillchipHolder
+
+- type: entity
+  id: ExamineConsumerTestBody
+  components:
+  - type: Body
+";
+
+    private static EntityUid MakeCapableExaminer(
+        IEntityManager em,
+        SharedSkillchipSystem skillchips,
+        SharedContainerSystem containers,
+        EntityCoordinates coords)
+    {
+        var brain = em.SpawnEntity("ExamineConsumerTestBrain", coords);
+        var body = em.SpawnEntity("ExamineConsumerTestBody", coords);
+        var holder = em.GetComponent<SkillchipHolderComponent>(brain);
+
+        skillchips.TryInstall((brain, holder), "ExamineConsumerTestChip");
+        var container = containers.EnsureContainer<Container>(body, BodyComponent.ContainerID);
+        containers.Insert(brain, container);
+
+        return body;
+    }
+
+    private static string Examine(IEntityManager em, EntityUid examined, EntityUid examiner, bool details = true)
+    {
+        var ev = new ExaminedEvent(new FormattedMessage(), examined, examiner, details, hasDescription: false);
+        em.EventBus.RaiseLocalEvent(examined, ev);
+        return ev.GetTotalMessage().ToString();
+    }
+
+    [Test]
+    public async Task IdAppraiserReportsOriginTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var loc = server.ResolveDependency<ILocalizationManager>();
+        var skillchips = em.System<SharedSkillchipSystem>();
+        var containers = em.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var examiner = MakeCapableExaminer(em, skillchips, containers, mapData.GridCoords);
+
+            var stationId = em.SpawnEntity(null, mapData.GridCoords);
+            em.AddComponent<IdAppraisableComponent>(stationId);
+            Assert.That(Examine(em, stationId, examiner),
+                Does.Contain(loc.GetString("skillchip-id-appraisal-examine-station")),
+                "A plain appraisable ID should read as station-issued.");
+
+            var centcomId = em.SpawnEntity(null, mapData.GridCoords);
+            em.AddComponent<IdAppraisableComponent>(centcomId);
+            em.AddComponent<CentcomIssuedComponent>(centcomId);
+            Assert.That(Examine(em, centcomId, examiner),
+                Does.Contain(loc.GetString("skillchip-id-appraisal-examine-centcom")),
+                "A CentCom-flagged ID should read as CentCom-issued.");
+
+            var syndieId = em.SpawnEntity(null, mapData.GridCoords);
+            em.AddComponent<IdAppraisableComponent>(syndieId);
+            em.AddComponent<SyndicateIssuedComponent>(syndieId);
+            Assert.That(Examine(em, syndieId, examiner),
+                Does.Contain(loc.GetString("skillchip-id-appraisal-examine-syndicate")),
+                "A Syndicate-flagged ID should read as off-console.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task IdAppraiserSilentWithoutCapabilityTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // A plain examiner with no skillchip capability.
+            var examiner = em.SpawnEntity(null, mapData.GridCoords);
+            var id = em.SpawnEntity(null, mapData.GridCoords);
+            em.AddComponent<IdAppraisableComponent>(id);
+
+            Assert.That(Examine(em, id, examiner), Is.Empty,
+                "Without the id_appraisal capability nothing should be appended.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DiskVerifierFlagsForgeryOnlyTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var skillchips = em.System<SharedSkillchipSystem>();
+        var containers = em.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var examiner = MakeCapableExaminer(em, skillchips, containers, mapData.GridCoords);
+
+            var forgedDisk = em.SpawnEntity(null, mapData.GridCoords);
+            var forgedComp = em.AddComponent<NukeDiskVerifiableComponent>(forgedDisk);
+            forgedComp.IsForgery = true;
+            Assert.That(Examine(em, forgedDisk, examiner), Is.Not.Empty,
+                "A capable examiner should get a warning on a forged disk.");
+
+            var genuineDisk = em.SpawnEntity(null, mapData.GridCoords);
+            em.AddComponent<NukeDiskVerifiableComponent>(genuineDisk); // IsForgery stays false
+            Assert.That(Examine(em, genuineDisk, examiner), Is.Empty,
+                "A genuine disk should produce no warning (silence = all good).");
+
+            // Out of details range: no warning even on a forgery.
+            Assert.That(Examine(em, forgedDisk, examiner, details: false), Is.Empty,
+                "The warning should only appear within details range.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Speech/QueekishThirdPersonTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Speech/QueekishThirdPersonTest.cs
@@ -1,0 +1,85 @@
+using Content.Server.RussStation.Speech.EntitySystems;
+using Content.Shared.Speech;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Speech;
+
+/// <summary>
+/// Verifies <see cref="QueekishThirdPersonSystem"/> rewrites first-person pronouns to the
+/// speaker's first name for a Skaven (e.g. "I am leaving" -> "Thanquol am leaving"), and that
+/// the marker is inert on non-Skaven speakers.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(QueekishThirdPersonSystem))]
+public sealed class QueekishThirdPersonTest
+{
+    // HumanoidProfileComponent.Species is write-restricted to HumanoidProfileSystem, so the
+    // species is baked into the prototypes rather than assigned from the test.
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: QueekishSkavenDummy
+  components:
+  - type: HumanoidProfile
+    species: Skaven
+  - type: QueekishThirdPerson
+
+- type: entity
+  id: QueekishHumanDummy
+  components:
+  - type: HumanoidProfile
+    species: Human
+  - type: QueekishThirdPerson
+";
+
+    [Test]
+    public async Task SkavenPronounsBecomeFirstNameTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var metaData = entMan.System<MetaDataSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var speaker = entMan.SpawnEntity("QueekishSkavenDummy", MapCoordinates.Nullspace);
+            metaData.SetEntityName(speaker, "Thanquol-Boneripper");
+
+            var ev = new AccentGetEvent(speaker, "I am leaving");
+            entMan.EventBus.RaiseLocalEvent(speaker, ev);
+
+            Assert.That(ev.Message, Is.EqualTo("Thanquol am leaving"),
+                "First-person pronouns should be replaced with the Skaven's first name.");
+
+            entMan.DeleteEntity(speaker);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task NonSkavenSpeakerUnchangedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var metaData = entMan.System<MetaDataSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var speaker = entMan.SpawnEntity("QueekishHumanDummy", MapCoordinates.Nullspace);
+            metaData.SetEntityName(speaker, "John Smith");
+
+            var ev = new AccentGetEvent(speaker, "I am leaving");
+            entMan.EventBus.RaiseLocalEvent(speaker, ev);
+
+            Assert.That(ev.Message, Is.EqualTo("I am leaving"),
+                "The pronoun rewrite should only apply to Skaven speakers.");
+
+            entMan.DeleteEntity(speaker);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
## About the PR

Second batch of integration tests for fork-specific (`RussStation`) systems, continuing the release-branch audit. Tier 2 = deterministic, server-observable behavior that needs a bit more fixture setup than batch 1.

| System | What's asserted |
|---|---|
| `SingAccentSystem` | Final word's last vowel is held; trailing period → `!`; bare word gains `!` |
| `QueekishThirdPersonSystem` | Skaven "I/me/my…" → first name (`"I am leaving"` → `"Thanquol am leaving"`); non-Skaven untouched |
| `VirtualItemPullReleaseSystem` | Dropping the pulled entity's virtual item stops the pull; an unrelated virtual item leaves it intact |
| `SharedIdAppraiserSystem` | Examine appends CentCom / Syndicate / station origin line; silent without the `id_appraisal` capability |
| `SharedDiskVerifierSystem` | Forged disk warns a capable examiner; genuine disk and out-of-range stay silent |
| `SharedDrunkenBrawlerSystem` | Intoxicated chip holder's unarmed swing is boosted; sober holder deals baseline |

The examine and combat consumers reuse the brain→chip→body capability setup from the existing `SkillchipGrantTest`. Examine assertions read the accumulated `ExaminedEvent.GetTotalMessage()`.

## Why / Balance

Covers fork accents, the pull-release cleanup path, the capability-gated examine/combat skillchip consumers — behavior that's easy to regress on rebases and currently untested. No production code changes — tests only, so no balance impact.

Batch 2 of the 3-PR audit series (#840 is batch 1). A few heavier Tier-2 candidates (BluespaceBlink teleport, ManualResuscitator / Wound damage-spike DoAfters, ItemSlotEjectMenu / LightReplacerRecycler UI flows) are intentionally left for a follow-up since they need grid/UI/DoAfter fixtures.

https://claude.ai/code/session_01DsUH3U8WKJe6qsCkzeH5Xb