### PR TITLE
honksquad: HONK0011 — generalize unguarded Comp&lt;T&gt;() to any receiver

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkUnguardedCompAnalyzerTest.cs
@@ -16,9 +16,19 @@ public sealed class HonkUnguardedCompAnalyzerTest
             public interface IComponent { }
             public readonly struct EntityUid { }
 
+            public sealed class MetaDataComponent : IComponent { }
+            public sealed class TransformComponent : IComponent { }
+
+            public interface IEntityManager
+            {
+                T GetComponent<T>(EntityUid uid) where T : IComponent;
+            }
+
             public abstract class EntitySystem
             {
+                protected IEntityManager EntityManager => default!;
                 protected T Comp<T>(EntityUid uid) where T : IComponent => default!;
+                protected T GetComponent<T>(EntityUid uid) where T : IComponent => default!;
                 protected bool HasComp<T>(EntityUid uid) where T : IComponent => false;
                 protected bool TryComp<T>(EntityUid uid, out T? comp) where T : IComponent
                 { comp = default; return false; }
@@ -29,6 +39,7 @@ public sealed class HonkUnguardedCompAnalyzerTest
             using Robust.Shared.GameObjects;
             public sealed class TargetComp : IComponent { }
             public sealed class OtherComp : IComponent { }
+            public sealed class FooComponent : IComponent { }
             public sealed class SomeEvent
             {
                 public EntityUid Target;
@@ -114,7 +125,7 @@ public sealed class HonkUnguardedCompAnalyzerTest
     }
 
     [Test]
-    public async Task CompOnLocalUid_DoesNotReport()
+    public async Task CompOnLocalUid_Reports()
     {
         const string code = """
             using Robust.Shared.GameObjects;
@@ -125,7 +136,76 @@ public sealed class HonkUnguardedCompAnalyzerTest
                 public void OnIt(SomeEvent args)
                 {
                     var local = args.Target;
-                    var c = Comp<TargetComp>(local);
+                    var c = Comp<FooComponent>(local);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 9, 17, 9, 42)
+                .WithArguments("FooComponent", "local"));
+    }
+
+    [Test]
+    public async Task CompOnGuardedLocalUid_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var local = args.Target;
+                    if (!HasComp<FooComponent>(local))
+                        return;
+                    var c = Comp<FooComponent>(local);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task GetComponentOnLocalUid_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var local = args.Target;
+                    var c = EntityManager.GetComponent<FooComponent>(local);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0011", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 9, 17, 9, 64)
+                .WithArguments("FooComponent", "local"));
+    }
+
+    [Test]
+    public async Task CompOnWhitelistedType_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Fork.Stubs;
+
+            public sealed class Sys : EntitySystem
+            {
+                public void OnIt(SomeEvent args)
+                {
+                    var local = args.Target;
+                    var meta = Comp<MetaDataComponent>(local);
+                    var xform = Comp<TransformComponent>(local);
                 }
             }
             """;

--- a/Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkUnguardedCompAnalyzer.cs
@@ -9,11 +9,13 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Content.Analyzers.Honk;
 
 /// <summary>
-/// HONK0011: <c>Comp&lt;T&gt;(args.Target)</c> / <c>Comp&lt;T&gt;(args.User)</c>
-/// / <c>Comp&lt;T&gt;(args.OtherEntity)</c> in an <see cref="EntitySystem"/>
-/// handler with no preceding <c>HasComp&lt;T&gt;</c> / <c>TryComp&lt;T&gt;</c>
-/// guard in the same method body. <c>Comp&lt;T&gt;</c> throws on miss;
-/// server-side that kills the handler for the rest of the tick.
+/// HONK0011: <c>Comp&lt;T&gt;(receiver)</c> / <c>GetComponent&lt;T&gt;(receiver)</c>
+/// for any receiver expression in an <see cref="EntitySystem"/> handler with no
+/// preceding <c>HasComp&lt;T&gt;</c> / <c>TryComp&lt;T&gt;</c> guard in the same
+/// method body. <c>Comp&lt;T&gt;</c> / <c>GetComponent&lt;T&gt;</c> throws on
+/// miss; server-side that kills the handler for the rest of the tick.
+/// Type arguments that always exist (<c>MetaDataComponent</c>,
+/// <c>TransformComponent</c>) are whitelisted and never reported.
 /// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
 /// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
 /// </summary>
@@ -22,12 +24,12 @@ public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
 {
     private static readonly DiagnosticDescriptor Descriptor = new(
         id: "HONK0011",
-        title: "Unguarded Comp<T>() on args.*",
+        title: "Unguarded Comp<T>()/GetComponent<T>()",
         messageFormat: "Comp<{0}>({1}) has no HasComp<{0}>/TryComp<{0}> guard in the enclosing method; a missing component throws mid-tick",
         category: "Honk.EntitySystem",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Comp<T> throws when the component is absent. On args.Target / args.User / args.OtherEntity the absence is routine, and the throw wipes out the rest of the handler. Pair with HasComp<T> or TryComp<T> first.");
+        description: "Comp<T> / GetComponent<T> throw when the component is absent, and the throw wipes out the rest of the handler. For any receiver whose component is not guaranteed present, pair with HasComp<T> or TryComp<T> first. MetaDataComponent and TransformComponent always exist and are whitelisted.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Descriptor);
@@ -47,15 +49,21 @@ public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
             return;
 
         var invokedName = GetGenericName(invocation);
-        if (invokedName is null || invokedName.Identifier.ValueText != "Comp")
+        if (invokedName is null)
+            return;
+
+        var name = invokedName.Identifier.ValueText;
+        if (name != "Comp" && name != "GetComponent")
             return;
 
         if (invocation.ArgumentList.Arguments.Count < 1)
             return;
 
-        var uidArg = invocation.ArgumentList.Arguments[0].Expression;
-        if (!IsArgsMemberAccess(uidArg, out var uidText))
+        if (invokedName.TypeArgumentList.Arguments.Count == 0)
             return;
+
+        var uidArg = invocation.ArgumentList.Arguments[0].Expression;
+        var uidText = GetReceiverText(uidArg);
 
         var containingType = context.ContainingSymbol?.ContainingType;
         if (containingType is null || !InheritsEntitySystem(containingType))
@@ -66,6 +74,9 @@ public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
             return;
 
         var typeArgText = invokedName.TypeArgumentList.Arguments[0].ToString();
+        if (typeArgText is "MetaDataComponent" or "TransformComponent")
+            return;
+
         if (HasGuardCall(methodBody, typeArgText))
             return;
 
@@ -91,21 +102,21 @@ public sealed class HonkUnguardedCompAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    private static bool IsArgsMemberAccess(ExpressionSyntax expr, out string text)
+    private static string GetReceiverText(ExpressionSyntax expr)
     {
-        text = string.Empty;
-        if (expr is not MemberAccessExpressionSyntax member)
-            return false;
+        // Keep the args.Target / args.User / args.OtherEntity wording verbatim so
+        // existing messages still read naturally; otherwise fall back to a short
+        // textual form of whatever the receiver expression is.
+        if (expr is MemberAccessExpressionSyntax member &&
+            member.Expression is IdentifierNameSyntax root &&
+            root.Identifier.ValueText == "args")
+        {
+            var memberName = member.Name.Identifier.ValueText;
+            if (memberName is "Target" or "User" or "OtherEntity")
+                return $"args.{memberName}";
+        }
 
-        if (member.Expression is not IdentifierNameSyntax root || root.Identifier.ValueText != "args")
-            return false;
-
-        var name = member.Name.Identifier.ValueText;
-        if (name != "Target" && name != "User" && name != "OtherEntity")
-            return false;
-
-        text = $"args.{name}";
-        return true;
+        return expr.ToString().Trim();
     }
 
     private static bool InheritsEntitySystem(INamedTypeSymbol type)


### PR DESCRIPTION
## About the PR

Generalizes the existing **HONK0011** analyzer. Previously it only flagged `Comp<T>(args.Target/User/OtherEntity)` without a guard. Now it flags `Comp<T>(receiver)` **and** `GetComponent<T>(receiver)` for *any* receiver (locals, fields, loop vars) in an `EntitySystem`, since `Comp<T>`/`GetComponent<T>` throw on a missing component and kill the rest of the tick.

- Keeps the existing `args.*` wording/behavior and all prior tests.
- Whitelists `MetaDataComponent` and `TransformComponent` (always present) so they never report.
- Same guard logic (a `HasComp<T>`/`TryComp<T>` for the same type in the method suppresses it), same fork-file scoping, same `EntitySystem`-only scoping. Severity stays `Warning`.

## Why / Balance

Closes a real gap: the throw is identical regardless of receiver. **0 current hits** in fork code (the only two `Comp<>`/`GetComponent<>` sites target `MetaDataComponent`, which is whitelisted), so this is a regression guard with no cleanup required.

⚠️ Authoring note: the analyzer/test couldn't be compiled locally (no .NET SDK + uninitialized RobustToolbox submodule in the authoring env), so CI is the first real build. Test spans were hand-counted against the existing harness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZuoozgagZu4MWn1FcNo6)_