### PR TITLE
honksquad: HONK0025 — raw EntityUid in a network-serialized type

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkRawEntityUidInNetworkedTypeAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkRawEntityUidInNetworkedTypeAnalyzerTest.cs
@@ -26,6 +26,7 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         namespace Robust.Shared.GameObjects
         {
             public abstract class EntityEventArgs { }
+            public abstract class BoundUserInterfaceState { }
         }
         namespace Robust.Shared.Analyzers
         {
@@ -68,8 +69,10 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
     }
 
     [Test]
-    public async Task EntityEventArgs_EntityUidField_ForkFile_Reports()
+    public async Task LocalEntityEventArgs_DoesNotReport()
     {
+        // A bare EntityEventArgs is a local event (RaiseLocalEvent); a raw
+        // EntityUid is correct there and must NOT be flagged.
         const string code = """
             using Robust.Shared.GameObjects;
 
@@ -79,10 +82,7 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
             }
             """;
 
-        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
-            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
-                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 22, 5, 28)
-                .WithArguments("Target"));
+        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs");
     }
 
     [Test]
@@ -91,15 +91,15 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         const string code = """
             using Robust.Shared.GameObjects;
 
-            public sealed class FooEvent : EntityEventArgs
+            public sealed class FooState : BoundUserInterfaceState
             {
                 public EntityUid? Target;
             }
             """;
 
-        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs",
             new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
-                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 23, 5, 29)
+                .WithSpan("Content.Shared/RussStation/Foo/FooState.cs", 5, 23, 5, 29)
                 .WithArguments("Target"));
     }
 
@@ -110,15 +110,15 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
             using System.Collections.Generic;
             using Robust.Shared.GameObjects;
 
-            public sealed class FooEvent : EntityEventArgs
+            public sealed class FooState : BoundUserInterfaceState
             {
                 public List<EntityUid> Targets;
             }
             """;
 
-        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs",
             new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
-                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 6, 28, 6, 35)
+                .WithSpan("Content.Shared/RussStation/Foo/FooState.cs", 6, 28, 6, 35)
                 .WithArguments("Targets"));
     }
 
@@ -128,15 +128,15 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         const string code = """
             using Robust.Shared.GameObjects;
 
-            public sealed class FooEvent : EntityEventArgs
+            public sealed class FooState : BoundUserInterfaceState
             {
                 public EntityUid[] Targets;
             }
             """;
 
-        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs",
             new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
-                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 24, 5, 31)
+                .WithSpan("Content.Shared/RussStation/Foo/FooState.cs", 5, 24, 5, 31)
                 .WithArguments("Targets"));
     }
 
@@ -146,15 +146,15 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         const string code = """
             using Robust.Shared.GameObjects;
 
-            public sealed class FooEvent : EntityEventArgs
+            public sealed class FooState : BoundUserInterfaceState
             {
                 public EntityUid Target { get; set; }
             }
             """;
 
-        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs",
             new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
-                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 22, 5, 28)
+                .WithSpan("Content.Shared/RussStation/Foo/FooState.cs", 5, 22, 5, 28)
                 .WithArguments("Target"));
     }
 
@@ -214,13 +214,13 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         const string code = """
             using Robust.Shared.GameObjects;
 
-            public sealed class FooEvent : EntityEventArgs
+            public sealed class FooState : BoundUserInterfaceState
             {
                 public EntityUid Target;
             }
             """;
 
-        await Verify(code, "Content.Shared/Foo/FooEvent.cs");
+        await Verify(code, "Content.Shared/Foo/FooState.cs");
     }
 
     [Test]
@@ -229,15 +229,15 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         const string code = """
             using Robust.Shared.GameObjects;
 
-            public sealed class FooEvent : EntityEventArgs
+            public sealed class FooState : BoundUserInterfaceState
             {
                 public EntityUid Target;
             }
             """;
 
-        await Verify(code, "Content.Shared/Foo/FooEvent.Honk.cs",
+        await Verify(code, "Content.Shared/Foo/FooState.Honk.cs",
             new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
-                .WithSpan("Content.Shared/Foo/FooEvent.Honk.cs", 5, 22, 5, 28)
+                .WithSpan("Content.Shared/Foo/FooState.Honk.cs", 5, 22, 5, 28)
                 .WithArguments("Target"));
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkRawEntityUidInNetworkedTypeAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkRawEntityUidInNetworkedTypeAnalyzerTest.cs
@@ -25,6 +25,9 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
         }
         namespace Robust.Shared.GameObjects
         {
+            // EntityEventArgs is itself [NetSerializable] in Robust, so a local
+            // event whose own type is NOT marked must still go unflagged.
+            [Robust.Shared.Serialization.NetSerializable]
             public abstract class EntityEventArgs { }
             public abstract class BoundUserInterfaceState { }
         }

--- a/Content.Analyzers.Honk.Tests/HonkRawEntityUidInNetworkedTypeAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkRawEntityUidInNetworkedTypeAnalyzerTest.cs
@@ -1,0 +1,243 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkRawEntityUidInNetworkedTypeAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkRawEntityUidInNetworkedTypeAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public readonly struct EntityUid { }
+        }
+        namespace Robust.Shared.Serialization
+        {
+            public readonly struct NetEntity { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum)]
+            public sealed class NetSerializableAttribute : System.Attribute { }
+        }
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class EntityEventArgs { }
+        }
+        namespace Robust.Shared.Analyzers
+        {
+            [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+            public sealed class AutoNetworkedFieldAttribute : System.Attribute { }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task NetSerializableStruct_EntityUidField_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization;
+
+            [NetSerializable]
+            public struct FooState
+            {
+                public EntityUid Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooState.cs", 7, 22, 7, 28)
+                .WithArguments("Target"));
+    }
+
+    [Test]
+    public async Task EntityEventArgs_EntityUidField_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public EntityUid Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 22, 5, 28)
+                .WithArguments("Target"));
+    }
+
+    [Test]
+    public async Task NullableEntityUid_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public EntityUid? Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 23, 5, 29)
+                .WithArguments("Target"));
+    }
+
+    [Test]
+    public async Task ListOfEntityUid_ForkFile_Reports()
+    {
+        const string code = """
+            using System.Collections.Generic;
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public List<EntityUid> Targets;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 6, 28, 6, 35)
+                .WithArguments("Targets"));
+    }
+
+    [Test]
+    public async Task EntityUidArray_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public EntityUid[] Targets;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 24, 5, 31)
+                .WithArguments("Targets"));
+    }
+
+    [Test]
+    public async Task EntityUidProperty_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public EntityUid Target { get; set; }
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooEvent.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/RussStation/Foo/FooEvent.cs", 5, 22, 5, 28)
+                .WithArguments("Target"));
+    }
+
+    [Test]
+    public async Task NetEntityField_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Serialization;
+
+            [NetSerializable]
+            public struct FooState
+            {
+                public NetEntity Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs");
+    }
+
+    [Test]
+    public async Task AutoNetworkedField_Excluded_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+            using Robust.Shared.Serialization;
+            using Robust.Shared.Analyzers;
+
+            [NetSerializable]
+            public struct FooState
+            {
+                [AutoNetworkedField]
+                public EntityUid Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooState.cs");
+    }
+
+    [Test]
+    public async Task PlainClass_EntityUidField_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooComponent
+            {
+                public EntityUid Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/RussStation/Foo/FooComponent.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public EntityUid Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooEvent.cs");
+    }
+
+    [Test]
+    public async Task HonkPartialFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class FooEvent : EntityEventArgs
+            {
+                public EntityUid Target;
+            }
+            """;
+
+        await Verify(code, "Content.Shared/Foo/FooEvent.Honk.cs",
+            new DiagnosticResult("HONK0025", DiagnosticSeverity.Warning)
+                .WithSpan("Content.Shared/Foo/FooEvent.Honk.cs", 5, 22, 5, 28)
+                .WithArguments("Target"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkRawEntityUidInNetworkedTypeAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkRawEntityUidInNetworkedTypeAnalyzer.cs
@@ -77,19 +77,22 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzer : DiagnosticAnalyzer
         if (type is null)
             return false;
 
+        // [NetSerializable] must be declared on the type ITSELF; it is not
+        // inherited for serialization. Walking base types for the attribute
+        // would wrongly flag every local event, because Robust's EntityEventArgs
+        // base is itself [NetSerializable] — yet a raw EntityUid in a local
+        // (RaiseLocalEvent) event is correct and must not be reported.
+        foreach (var attr in type.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == "NetSerializableAttribute")
+                return true;
+        }
+
+        // Otherwise it only counts if it derives a base that is inherently
+        // networked (BUI messages/states and DoAfter events always cross the
+        // wire). A bare EntityEventArgs does not qualify.
         for (var current = type; current is not null; current = current.BaseType)
         {
-            foreach (var attr in current.GetAttributes())
-            {
-                if (attr.AttributeClass?.Name == "NetSerializableAttribute")
-                    return true;
-            }
-
-            // Note: a bare EntityEventArgs base is deliberately NOT treated as
-            // network-serialized. Most events are local (RaiseLocalEvent) and an
-            // EntityUid in those is correct. Only events explicitly marked
-            // [NetSerializable] (handled above), BUI messages/states, and DoAfter
-            // events actually cross the wire.
             switch (current.Name)
             {
                 case "BoundUserInterfaceMessage":

--- a/Content.Analyzers.Honk/HonkRawEntityUidInNetworkedTypeAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkRawEntityUidInNetworkedTypeAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Content.Analyzers.Honk;
 
 /// <summary>
 /// HONK0025: A raw <c>EntityUid</c> stored in a network-serialized type (a
-/// <c>[NetSerializable]</c> type, or an event/BUI message/DoAfter event) is the
+/// <c>[NetSerializable]</c> type, a BUI message/state, or a DoAfter event) is the
 /// sender's local entity id. It does not survive the client/server boundary and
 /// resolves to the wrong or an invalid entity on the receiving side; the portable
 /// form is <c>NetEntity</c>. Component-state auto-networking is exempt because the
@@ -85,9 +85,13 @@ public sealed class HonkRawEntityUidInNetworkedTypeAnalyzer : DiagnosticAnalyzer
                     return true;
             }
 
+            // Note: a bare EntityEventArgs base is deliberately NOT treated as
+            // network-serialized. Most events are local (RaiseLocalEvent) and an
+            // EntityUid in those is correct. Only events explicitly marked
+            // [NetSerializable] (handled above), BUI messages/states, and DoAfter
+            // events actually cross the wire.
             switch (current.Name)
             {
-                case "EntityEventArgs":
                 case "BoundUserInterfaceMessage":
                 case "BoundUserInterfaceState":
                 case "DoAfterEvent":

--- a/Content.Analyzers.Honk/HonkRawEntityUidInNetworkedTypeAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkRawEntityUidInNetworkedTypeAnalyzer.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0025: A raw <c>EntityUid</c> stored in a network-serialized type (a
+/// <c>[NetSerializable]</c> type, or an event/BUI message/DoAfter event) is the
+/// sender's local entity id. It does not survive the client/server boundary and
+/// resolves to the wrong or an invalid entity on the receiving side; the portable
+/// form is <c>NetEntity</c>. Component-state auto-networking is exempt because the
+/// <c>[AutoNetworkedField]</c> source generator translates EntityUid correctly.
+/// Scoped to fork files so upstream drift is not this rule's problem.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkRawEntityUidInNetworkedTypeAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0025",
+        title: "Raw EntityUid in a network-serialized type",
+        messageFormat: "Member '{0}' is EntityUid-typed in a network-serialized type; use NetEntity to avoid client/server desync",
+        category: "Honk.Networking",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A serialized EntityUid is the sender's local id and resolves to the wrong/invalid entity across the network boundary; NetEntity is the portable form.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Field, SymbolKind.Property);
+    }
+
+    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    {
+        var symbol = context.Symbol;
+
+        var path = symbol.Locations.Length > 0 ? symbol.Locations[0].SourceTree?.FilePath : null;
+        if (!IsForkFile(path))
+            return;
+
+        // Component-state auto-networking translates EntityUid correctly; flagging it is wrong.
+        if (HasAttribute(symbol, "AutoNetworkedFieldAttribute"))
+            return;
+
+        if (!IsNetworkSerializedType(symbol.ContainingType))
+            return;
+
+        var type = symbol switch
+        {
+            IFieldSymbol f => f.Type,
+            IPropertySymbol p => p.Type,
+            _ => null,
+        };
+        if (type is null)
+            return;
+
+        if (!IsEntityUidTyped(type))
+            return;
+
+        foreach (var location in symbol.Locations)
+        {
+            if (location.IsInSource)
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, symbol.Name));
+        }
+    }
+
+    private static bool IsNetworkSerializedType(INamedTypeSymbol? type)
+    {
+        if (type is null)
+            return false;
+
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            foreach (var attr in current.GetAttributes())
+            {
+                if (attr.AttributeClass?.Name == "NetSerializableAttribute")
+                    return true;
+            }
+
+            switch (current.Name)
+            {
+                case "EntityEventArgs":
+                case "BoundUserInterfaceMessage":
+                case "BoundUserInterfaceState":
+                case "DoAfterEvent":
+                case "SimpleDoAfterEvent":
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEntityUidTyped(ITypeSymbol type)
+    {
+        // Unwrap Nullable<T>.
+        if (type is INamedTypeSymbol nullable && nullable.IsGenericType && nullable.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T)
+            type = nullable.TypeArguments[0];
+
+        if (type.Name == "EntityUid")
+            return true;
+
+        // EntityUid[].
+        if (type is IArrayTypeSymbol array && array.ElementType.Name == "EntityUid")
+            return true;
+
+        // List<EntityUid>, HashSet<EntityUid>, etc.
+        if (type is INamedTypeSymbol named && named.IsGenericType)
+        {
+            foreach (var arg in named.TypeArguments)
+            {
+                if (arg.Name == "EntityUid")
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string attributeName)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == attributeName)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## About the PR

New analyzer **HONK0025** (`Honk.Networking`, `Warning`). Flags `EntityUid`-typed members (incl. `EntityUid?`, `List<EntityUid>`, `EntityUid[]`) in a **network-serialized** type and steers them to `NetEntity`. "Network-serialized" = the type carries `[NetSerializable]`, or derives `BoundUserInterfaceMessage` / `BoundUserInterfaceState` / `DoAfterEvent` / `SimpleDoAfterEvent`. Members marked `[AutoNetworkedField]` are excluded (the component-state generator translates `EntityUid` correctly).

A bare `EntityEventArgs` base is **deliberately not** treated as networked — most events are local (`RaiseLocalEvent`) where `EntityUid` is correct.

## Why / Balance

A serialized `EntityUid` is the sender's local id and resolves to the wrong/invalid entity across the client/server boundary — a classic silent desync. The fork already uses `NetEntity` correctly (40+ sites), so this locks in that convention.

**0 current hits** → green Release build; pure regression guard.

Note: an earlier draft also triggered on `EntityEventArgs` and false-positived on correct local events (`BalanceChangedEvent`, `CategorizedPopupRaisedEvent`, `LightReplacerBulbReplacedEvent`); the scope was narrowed and the test updated before this PR.

⚠️ Couldn't compile locally (no SDK/submodule); CI is the first real build. No code-fix yet (future work).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZuoozgagZu4MWn1FcNo6)_