### PR TITLE
honksquad: HONK0026 — duplicated ProtoId&lt;T&gt; constant across fork files

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkDuplicateProtoIdConstantAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkDuplicateProtoIdConstantAnalyzerTest.cs
@@ -71,10 +71,10 @@ public sealed class HonkDuplicateProtoIdConstantAnalyzerTest
 
         await Verify(
             new[] { (pathA, fileA), (pathB, fileB) },
-            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Warning)
                 .WithSpan(pathA, 6, 52, 6, 58)
                 .WithArguments("StackPrototype", "Credit", "2"),
-            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Warning)
                 .WithSpan(pathB, 6, 52, 6, 58)
                 .WithArguments("StackPrototype", "Credit", "2"));
     }
@@ -183,10 +183,10 @@ public sealed class HonkDuplicateProtoIdConstantAnalyzerTest
 
         await Verify(
             new[] { (pathA, fileA), (pathB, fileB) },
-            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Warning)
                 .WithSpan(pathA, 6, 52, 6, 63)
                 .WithArguments("StackPrototype", "Credit", "2"),
-            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Warning)
                 .WithSpan(pathB, 6, 52, 6, 63)
                 .WithArguments("StackPrototype", "Credit", "2"));
     }

--- a/Content.Analyzers.Honk.Tests/HonkDuplicateProtoIdConstantAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkDuplicateProtoIdConstantAnalyzerTest.cs
@@ -1,0 +1,193 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkDuplicateProtoIdConstantAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkDuplicateProtoIdConstantAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.Prototypes
+        {
+            public readonly struct ProtoId<T>
+            {
+                public ProtoId(string id) { }
+                public static implicit operator ProtoId<T>(string s) => default;
+            }
+        }
+        namespace Content.Shared.Stacks
+        {
+            public sealed class StackPrototype { }
+        }
+        """;
+
+    private static Task Verify(
+        (string FilePath, string Code)[] sources,
+        params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs },
+            },
+        };
+        foreach (var (filePath, code) in sources)
+            test.TestState.Sources.Add((filePath, code));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task SameProtoIdLiteral_TwoForkFiles_BothReport()
+    {
+        const string fileA = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class IdCardAccountSystem
+            {
+                public static readonly ProtoId<StackPrototype> Credit = "Credit";
+            }
+            """;
+
+        const string fileB = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class VendingPaymentSystem
+            {
+                public static readonly ProtoId<StackPrototype> Credit = "Credit";
+            }
+            """;
+
+        const string pathA = "Content.Server/RussStation/Economy/IdCardAccountSystem.cs";
+        const string pathB = "Content.Server/RussStation/Economy/VendingPaymentSystem.cs";
+
+        await Verify(
+            new[] { (pathA, fileA), (pathB, fileB) },
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+                .WithSpan(pathA, 6, 52, 6, 58)
+                .WithArguments("StackPrototype", "Credit", "2"),
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+                .WithSpan(pathB, 6, 52, 6, 58)
+                .WithArguments("StackPrototype", "Credit", "2"));
+    }
+
+    [Test]
+    public async Task SingleDeclaration_DoesNotReport()
+    {
+        const string code = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class IdCardAccountSystem
+            {
+                public static readonly ProtoId<StackPrototype> Credit = "Credit";
+            }
+            """;
+
+        await Verify(new[] { ("Content.Server/RussStation/Economy/IdCardAccountSystem.cs", code) });
+    }
+
+    [Test]
+    public async Task DifferentLiterals_DoNotReport()
+    {
+        const string fileA = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class IdCardAccountSystem
+            {
+                public static readonly ProtoId<StackPrototype> Credit = "Credit";
+            }
+            """;
+
+        const string fileB = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class VendingPaymentSystem
+            {
+                public static readonly ProtoId<StackPrototype> Plasma = "Plasma";
+            }
+            """;
+
+        await Verify(new[]
+        {
+            ("Content.Server/RussStation/Economy/IdCardAccountSystem.cs", fileA),
+            ("Content.Server/RussStation/Economy/VendingPaymentSystem.cs", fileB),
+        });
+    }
+
+    [Test]
+    public async Task OneForkOneUpstream_DoesNotReport()
+    {
+        const string forkFile = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class IdCardAccountSystem
+            {
+                public static readonly ProtoId<StackPrototype> Credit = "Credit";
+            }
+            """;
+
+        const string upstreamFile = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class CargoSystem
+            {
+                public static readonly ProtoId<StackPrototype> Credit = "Credit";
+            }
+            """;
+
+        await Verify(new[]
+        {
+            ("Content.Server/RussStation/Economy/IdCardAccountSystem.cs", forkFile),
+            ("Content.Server/Cargo/Systems/CargoSystem.cs", upstreamFile),
+        });
+    }
+
+    [Test]
+    public async Task HonkPartialFiles_BothReport()
+    {
+        const string fileA = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class IdCardAccountSystem
+            {
+                public static readonly ProtoId<StackPrototype> CreditStack = "Credit";
+            }
+            """;
+
+        const string fileB = """
+            using Content.Shared.Stacks;
+            using Robust.Shared.Prototypes;
+
+            public sealed class VendingPaymentSystem
+            {
+                public static readonly ProtoId<StackPrototype> CreditStack = "Credit";
+            }
+            """;
+
+        const string pathA = "Content.Shared/Economy/IdCardAccountSystem.Honk.cs";
+        const string pathB = "Content.Shared/Economy/VendingPaymentSystem.Honk.cs";
+
+        await Verify(
+            new[] { (pathA, fileA), (pathB, fileB) },
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+                .WithSpan(pathA, 6, 52, 6, 63)
+                .WithArguments("StackPrototype", "Credit", "2"),
+            new DiagnosticResult("HONK0026", DiagnosticSeverity.Info)
+                .WithSpan(pathB, 6, 52, 6, 63)
+                .WithArguments("StackPrototype", "Credit", "2"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkDuplicateProtoIdConstantAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkDuplicateProtoIdConstantAnalyzer.cs
@@ -26,7 +26,7 @@ public sealed class HonkDuplicateProtoIdConstantAnalyzer : DiagnosticAnalyzer
         title: "Duplicated ProtoId<T> constant across fork files",
         messageFormat: "ProtoId<{0}> = \"{1}\" is declared in {2} fork files; extract one shared constant to avoid drift",
         category: "Honk.Drift",
-        defaultSeverity: DiagnosticSeverity.Info,
+        defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "When the same typed prototype id literal is redeclared in multiple fork files, an upstream id change updates only some copies and the rest drift to a dangling reference. Extract a single shared constant.",
         customTags: new[] { WellKnownDiagnosticTags.CompilationEnd });

--- a/Content.Analyzers.Honk/HonkDuplicateProtoIdConstantAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkDuplicateProtoIdConstantAnalyzer.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0026: fires when the same typed prototype id literal -- a
+/// <c>ProtoId&lt;T&gt;</c> initialised from a string literal -- is declared in
+/// two or more fork files. Each copy is an independent magic string, so when
+/// the upstream prototype id is renamed only the copies someone happens to
+/// remember get updated and the rest silently drift to a dangling reference.
+/// The fix is to extract one shared constant (e.g. a fork-owned
+/// <c>EconomyConstants</c> field) and reference it everywhere. Scoped to fork
+/// files; an upstream copy of the same literal is not counted because rebases
+/// own that surface.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkDuplicateProtoIdConstantAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0026",
+        title: "Duplicated ProtoId<T> constant across fork files",
+        messageFormat: "ProtoId<{0}> = \"{1}\" is declared in {2} fork files; extract one shared constant to avoid drift",
+        category: "Honk.Drift",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "When the same typed prototype id literal is redeclared in multiple fork files, an upstream id change updates only some copies and the rest drift to a dangling reference. Extract a single shared constant.",
+        customTags: new[] { WellKnownDiagnosticTags.CompilationEnd });
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var groups = new ConcurrentDictionary<(string TypeArg, string Literal), ConcurrentBag<Location>>();
+
+        context.RegisterSymbolAction(symCtx =>
+        {
+            var field = (IFieldSymbol)symCtx.Symbol;
+
+            var location = field.Locations.Length > 0 ? field.Locations[0] : null;
+            var path = location?.SourceTree?.FilePath;
+            if (!IsForkFile(path))
+                return;
+
+            if (field.Type is not INamedTypeSymbol named
+                || !named.IsGenericType
+                || named.Name != "ProtoId"
+                || named.TypeArguments.Length != 1)
+            {
+                return;
+            }
+
+            var typeArg = named.TypeArguments[0].Name;
+            if (string.IsNullOrEmpty(typeArg))
+                return;
+
+            var literal = GetStringLiteral(field, symCtx.CancellationToken);
+            if (literal is null)
+                return;
+
+            groups
+                .GetOrAdd((typeArg, literal), _ => new ConcurrentBag<Location>())
+                .Add(location!);
+        }, SymbolKind.Field);
+
+        context.RegisterCompilationEndAction(endCtx =>
+        {
+            foreach (var pair in groups)
+            {
+                var locations = pair.Value;
+                var count = locations.Count;
+                if (count < 2)
+                    continue;
+
+                foreach (var location in locations)
+                {
+                    endCtx.ReportDiagnostic(Diagnostic.Create(
+                        Descriptor,
+                        location,
+                        pair.Key.TypeArg,
+                        pair.Key.Literal,
+                        count));
+                }
+            }
+        });
+    }
+
+    private static string? GetStringLiteral(IFieldSymbol field, System.Threading.CancellationToken cancellationToken)
+    {
+        // Prefer the resolved constant value for `const` fields.
+        if (field.IsConst && field.ConstantValue is string constValue)
+            return constValue;
+
+        // Otherwise inspect the declaring syntax's initializer for a string literal.
+        foreach (var reference in field.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax(cancellationToken) is not VariableDeclaratorSyntax declarator)
+                continue;
+
+            if (declarator.Initializer?.Value is LiteralExpressionSyntax literal
+                && literal.Token.Value is string value)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var normalized = path!.Replace('\\', '/');
+        return normalized.Contains("/RussStation/")
+            || normalized.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Verbs;
 using Content.Server.RussStation.UI;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using SharedEconomyConstants = Content.Shared.RussStation.Economy.EconomyConstants;
 
 namespace Content.Server.RussStation.Economy;
 
@@ -30,7 +31,6 @@ public sealed class IdCardAccountSystem : EntitySystem
     [Dependency] private readonly PlayerBalanceSystem _balance = default!;
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    private static readonly ProtoId<StackPrototype> CreditStack = "Credit";
 
     public override void Initialize()
     {
@@ -158,7 +158,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (!TryComp<StackComponent>(args.Used, out var stack) || stack.StackTypeId != CreditStack)
+        if (!TryComp<StackComponent>(args.Used, out var stack) || stack.StackTypeId != SharedEconomyConstants.CreditStack)
             return;
 
         var idEntity = pda.IdSlot.Item;
@@ -174,7 +174,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (string.IsNullOrEmpty(accountNumber))
             return false;
 
-        if (!TryComp<StackComponent>(cash, out var stack) || stack.StackTypeId != CreditStack)
+        if (!TryComp<StackComponent>(cash, out var stack) || stack.StackTypeId != SharedEconomyConstants.CreditStack)
             return false;
 
         if (!_balance.TryGetByAccount(accountNumber, out var owner))
@@ -278,7 +278,7 @@ public sealed class IdCardAccountSystem : EntitySystem
             return;
         }
 
-        var spawned = _stack.SpawnNextToOrDrop(amount, CreditStack, user);
+        var spawned = _stack.SpawnNextToOrDrop(amount, SharedEconomyConstants.CreditStack, user);
         _hands.TryPickupAnyHand(user, spawned, checkActionBlocker: false);
 
         _popup.PopupEntity(

--- a/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
+++ b/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
@@ -32,8 +32,6 @@ public sealed class VendingPaymentSystem : EntitySystem
     [Dependency] private readonly SharedStackSystem _stacks = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
-    private static readonly ProtoId<StackPrototype> CreditStack = "Credit";
-
     private float _vendCargoMarkup;
     private float _vendMaterialMarkup;
     private int _vendMinPrice;
@@ -183,7 +181,7 @@ public sealed class VendingPaymentSystem : EntitySystem
         // Cash in hand.
         foreach (var held in _hands.EnumerateHeld(buyer))
         {
-            if (TryComp<StackComponent>(held, out var stack) && stack.StackTypeId == CreditStack)
+            if (TryComp<StackComponent>(held, out var stack) && stack.StackTypeId == SharedEconomyConstants.CreditStack)
                 funds += stack.Count;
         }
 
@@ -214,7 +212,7 @@ public sealed class VendingPaymentSystem : EntitySystem
 
         foreach (var held in _hands.EnumerateHeld(buyer))
         {
-            if (!TryComp<StackComponent>(held, out var stack) || stack.StackTypeId != CreditStack)
+            if (!TryComp<StackComponent>(held, out var stack) || stack.StackTypeId != SharedEconomyConstants.CreditStack)
                 continue;
 
             var take = Math.Min(remaining, stack.Count);

--- a/Content.Shared/RussStation/Economy/EconomyConstants.cs
+++ b/Content.Shared/RussStation/Economy/EconomyConstants.cs
@@ -1,3 +1,6 @@
+using Content.Shared.Stacks;
+using Robust.Shared.Prototypes;
+
 namespace Content.Shared.RussStation.Economy;
 
 /// <summary>
@@ -7,6 +10,12 @@ namespace Content.Shared.RussStation.Economy;
 /// </summary>
 public static class EconomyConstants
 {
+    /// <summary>
+    /// Stack prototype for the station currency. Shared by the payment and
+    /// account-deposit paths so a prototype rename only touches one place.
+    /// </summary>
+    public static readonly ProtoId<StackPrototype> CreditStack = "Credit";
+
     /// <summary>
     /// Number of trailing characters of an account number shown as a short suffix
     /// in the balance cartridge UI (e.g. "...ABCD").

--- a/Content.Shared/RussStation/Medical/ManualResuscitatorSystem.cs
+++ b/Content.Shared/RussStation/Medical/ManualResuscitatorSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.RussStation.Damage;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Shared.RussStation.Medical;
@@ -22,9 +23,6 @@ public sealed class ManualResuscitatorSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-
-    private static readonly Robust.Shared.Prototypes.ProtoId<Content.Shared.Damage.Prototypes.DamageTypePrototype>
-        AsphyxiationType = "Asphyxiation";
 
     public override void Initialize()
     {
@@ -112,7 +110,7 @@ public sealed class ManualResuscitatorSystem : EntitySystem
         var damage = _damageable.GetAllDamage(target);
 #pragma warning restore CS0618
 
-        if (!damage.DamageDict.TryGetValue(AsphyxiationType, out var oxy)
+        if (!damage.DamageDict.TryGetValue(DamageTypeIds.Asphyxiation, out var oxy)
             || oxy <= ent.Comp.StopThreshold)
         {
             if (popup)


### PR DESCRIPTION
## About the PR

New **compilation-wide** analyzer **HONK0026** (`Honk.Drift`, `Warning`). Collects `ProtoId<T>` fields initialized from a string literal across fork files and reports when the same `(T, literal)` appears in 2+ files, suggesting one shared constant. Standard `CompilationStart` → `SymbolAction` → `CompilationEnd` pattern with `WellKnownDiagnosticTags.CompilationEnd`; fork-scoped, so upstream copies aren't counted.

## Why / Balance

Each duplicated literal is an independent magic string — when an upstream id is renamed, only the copies someone remembers get updated and the rest drift to a dangling reference.

**Current hits:** `ProtoId<StackPrototype> = "Credit"` in both `IdCardAccountSystem.cs` and `VendingPaymentSystem.cs`; `ProtoId<ToolQualityPrototype> = "Cauterizing"` duplicated in Surgery. PR CI (DebugOpt) passes with warnings; **Release** will block until the constants are unified (follow-up; a low-risk refactor I've left for a build-capable change).

FP note: two genuinely-distinct prototypes that share a name+id across files would be flagged; `Warning` keeps it surfaced but reviewable.

⚠️ Couldn't compile locally (no SDK/submodule); CI is the first real build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZuoozgagZu4MWn1FcNo6)_