### PR TITLE
honksquad: HONK0028 — interpolated string in a log call

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkInterpolatedLogAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkInterpolatedLogAnalyzerTest.cs
@@ -68,7 +68,7 @@ public sealed class HonkInterpolatedLogAnalyzerTest
             """;
 
         await Verify(code, "Content.Server/RussStation/Foo/Bar.cs",
-            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Warning)
                 .WithSpan("Content.Server/RussStation/Foo/Bar.cs", 7, 9, 7, 29)
                 .WithArguments("Warning"));
     }
@@ -109,7 +109,7 @@ public sealed class HonkInterpolatedLogAnalyzerTest
             """;
 
         await Verify(code, "Content.Server/RussStation/Foo/Bar.cs",
-            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Warning)
                 .WithSpan("Content.Server/RussStation/Foo/Bar.cs", 9, 9, 9, 32)
                 .WithArguments("Debug"));
     }
@@ -130,7 +130,7 @@ public sealed class HonkInterpolatedLogAnalyzerTest
             """;
 
         await Verify(code, "Content.Server/RussStation/Foo/Bar.cs",
-            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Warning)
                 .WithSpan("Content.Server/RussStation/Foo/Bar.cs", 7, 9, 7, 27)
                 .WithArguments("Error"));
     }
@@ -187,7 +187,7 @@ public sealed class HonkInterpolatedLogAnalyzerTest
             """;
 
         await Verify(code, "Content.Server/Foo/Bar.Honk.cs",
-            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Warning)
                 .WithSpan("Content.Server/Foo/Bar.Honk.cs", 7, 9, 7, 29)
                 .WithArguments("Warning"));
     }

--- a/Content.Analyzers.Honk.Tests/HonkInterpolatedLogAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkInterpolatedLogAnalyzerTest.cs
@@ -1,0 +1,194 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkInterpolatedLogAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkInterpolatedLogAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Honk.Logging
+        {
+            public static class Log
+            {
+                public static void Debug(string s) { }
+                public static void Info(string s) { }
+                public static void Warning(string s) { }
+                public static void Error(string s) { }
+                public static void Fatal(string s) { }
+                public static void Verbose(string s) { }
+            }
+
+            public sealed class StubSawmill
+            {
+                public void Debug(string s) { }
+                public void Info(string s) { }
+                public void Warning(string s) { }
+                public void Error(string s) { }
+            }
+
+            public static class Foo
+            {
+                public static void Warning(string s) { }
+            }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task InterpolatedLogWarning_ForkFile_Reports()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                public void Run(int y)
+                {
+                    Log.Warning($"x{y}");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/Bar.cs",
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+                .WithSpan("Content.Server/RussStation/Foo/Bar.cs", 7, 9, 7, 29)
+                .WithArguments("Warning"));
+    }
+
+    [Test]
+    public async Task PlainLiteralLog_DoesNotReport()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                public void Run()
+                {
+                    Log.Warning("plain literal");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/Bar.cs");
+    }
+
+    [Test]
+    public async Task SawmillFieldInterpolated_ForkFile_Reports()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                private readonly StubSawmill _sawmill = new();
+
+                public void Run(int b)
+                {
+                    _sawmill.Debug($"a{b}");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/Bar.cs",
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+                .WithSpan("Content.Server/RussStation/Foo/Bar.cs", 9, 9, 9, 32)
+                .WithArguments("Debug"));
+    }
+
+    [Test]
+    public async Task StringConcatLog_ForkFile_Reports()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                public void Run(string b)
+                {
+                    Log.Error("a" + b);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/Bar.cs",
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+                .WithSpan("Content.Server/RussStation/Foo/Bar.cs", 7, 9, 7, 27)
+                .WithArguments("Error"));
+    }
+
+    [Test]
+    public async Task NonLoggerReceiver_DoesNotReport()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                public void Run(int y)
+                {
+                    Foo.Warning($"x{y}");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/RussStation/Foo/Bar.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                public void Run(int y)
+                {
+                    Log.Warning($"x{y}");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/Foo/Bar.cs");
+    }
+
+    [Test]
+    public async Task HonkPartialFile_Reports()
+    {
+        const string code = """
+            using Honk.Logging;
+
+            public sealed class Bar
+            {
+                public void Run(int y)
+                {
+                    Log.Warning($"x{y}");
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Server/Foo/Bar.Honk.cs",
+            new DiagnosticResult("HONK0028", DiagnosticSeverity.Info)
+                .WithSpan("Content.Server/Foo/Bar.Honk.cs", 7, 9, 7, 29)
+                .WithArguments("Warning"));
+    }
+}

--- a/Content.Analyzers.Honk/HonkInterpolatedLogAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkInterpolatedLogAnalyzer.cs
@@ -25,7 +25,7 @@ public sealed class HonkInterpolatedLogAnalyzer : DiagnosticAnalyzer
         title: "Interpolated string in a log call",
         messageFormat: "Log.{0} builds an interpolated/concatenated string before the level check; it allocates even when the level is disabled",
         category: "Honk.Logging",
-        defaultSeverity: DiagnosticSeverity.Info,
+        defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "ISawmill/Log levels are filtered at call time; building the message string eagerly wastes allocations on disabled levels.");
 

--- a/Content.Analyzers.Honk/HonkInterpolatedLogAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkInterpolatedLogAnalyzer.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0028: a logger call such as <c>Log.Warning($"...")</c> /
+/// <c>_sawmill.Debug("a" + b)</c> whose first argument is an interpolated
+/// or concatenated string. ISawmill/Log levels are filtered at call time,
+/// so building the message eagerly allocates even when the level is
+/// disabled. The receiver is matched by name (Log/Logger/*sawmill*)
+/// because Robust is not referenced in the analyzer tests.
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkInterpolatedLogAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0028",
+        title: "Interpolated string in a log call",
+        messageFormat: "Log.{0} builds an interpolated/concatenated string before the level check; it allocates even when the level is disabled",
+        category: "Honk.Logging",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "ISawmill/Log levels are filtered at call time; building the message string eagerly wastes allocations on disabled levels.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax member)
+            return;
+
+        var methodName = member.Name.Identifier.ValueText;
+        if (methodName is not ("Debug" or "Info" or "Warning" or "Error" or "Fatal" or "Verbose"))
+            return;
+
+        if (!IsLoggerReceiver(member.Expression))
+            return;
+
+        if (invocation.ArgumentList.Arguments.Count < 1)
+            return;
+
+        var firstArg = invocation.ArgumentList.Arguments[0].Expression;
+        if (!IsEagerString(firstArg))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation(), methodName));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static bool IsLoggerReceiver(ExpressionSyntax receiver)
+    {
+        var name = receiver switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+            _ => null,
+        };
+
+        if (name is null)
+            return false;
+
+        if (name == "Log" || name == "Logger")
+            return true;
+
+        return name.IndexOf("sawmill", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static bool IsEagerString(ExpressionSyntax expr)
+    {
+        return expr is InterpolatedStringExpressionSyntax
+            || (expr is BinaryExpressionSyntax binary && binary.IsKind(SyntaxKind.AddExpression));
+    }
+}

--- a/Content.Client/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Client/RussStation/Surgery/SurgerySystem.cs
@@ -30,7 +30,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
         {
             if (!ProtoManager.TryIndex<SurgeryProcedurePrototype>(procedureId, out var proto))
             {
-                Log.Warning($"Server sent unknown surgery procedure prototype: {procedureId}");
+                Log.Warning("Server sent unknown surgery procedure prototype: {ProcedureId}", procedureId);
                 continue;
             }
 

--- a/Content.Server/RussStation/Cloning/RussStationCloningSystem.cs
+++ b/Content.Server/RussStation/Cloning/RussStationCloningSystem.cs
@@ -35,7 +35,7 @@ public sealed class RussStationCloningSystem : EntitySystem
         {
             if (!Factory.TryGetRegistration(componentName, out var registration))
             {
-                Log.Error($"RussStationCloningSystem: invalid component name in {ForkExtensionsId}: {componentName}");
+                Log.Error("RussStationCloningSystem: invalid component name in {ForkExtensionsId}: {ComponentName}", ForkExtensionsId, componentName);
                 continue;
             }
 

--- a/Content.Server/RussStation/Medical/AutosurgeonSystem.cs
+++ b/Content.Server/RussStation/Medical/AutosurgeonSystem.cs
@@ -100,7 +100,7 @@ public sealed class AutosurgeonSystem : EntitySystem
 
         if (!TryComp<OrganComponent>(organ, out var organComp))
         {
-            Log.Error($"Autosurgeon organ prototype {comp.OrganPrototype} missing OrganComponent");
+            Log.Error("Autosurgeon organ prototype {OrganPrototype} missing OrganComponent", comp.OrganPrototype);
             QueueDel(organ);
             return;
         }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
@@ -123,7 +123,7 @@ public sealed partial class SurgerySystem
                 break;
 
             default:
-                Log.Warning($"Unhandled surgery effect type: {effect.GetType().Name} on {ToPrettyString(patient)}");
+                Log.Warning("Unhandled surgery effect type: {EffectType} on {Patient}", effect.GetType().Name, ToPrettyString(patient));
                 break;
         }
     }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -230,7 +230,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         var drapeContainer = _container.EnsureContainer<Container>(target.Value, SurgeryConstants.SurgeryDrapeContainerId);
         if (!_container.Insert(bedsheet.Value, drapeContainer))
         {
-            Log.Warning($"Failed to insert bedsheet {ToPrettyString(bedsheet.Value)} into surgery drape container on {ToPrettyString(target.Value)}");
+            Log.Warning("Failed to insert bedsheet {Bedsheet} into surgery drape container on {Target}", ToPrettyString(bedsheet.Value), ToPrettyString(target.Value));
             RemComp<SurgeryDrapedComponent>(target.Value);
             return;
         }
@@ -364,7 +364,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         if (active.ProcedureId == null ||
             !ProtoManager.TryIndex<SurgeryProcedurePrototype>(active.ProcedureId.Value, out var proto))
         {
-            Log.Warning($"Surgery step DoAfter completed but procedure {active.ProcedureId} is invalid on {ToPrettyString(patient)}");
+            Log.Warning("Surgery step DoAfter completed but procedure {ProcedureId} is invalid on {Patient}", active.ProcedureId, ToPrettyString(patient));
             return;
         }
 

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -373,9 +373,9 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
         Dirty(target, being);
 
         if (!_virtualItem.TrySpawnVirtualItemInHand(target, carrier))
-            Log.Warning($"Failed to spawn first carry virtual item on {ToPrettyString(carrier)}");
+            Log.Warning("Failed to spawn first carry virtual item on {Carrier}", ToPrettyString(carrier));
         if (!_virtualItem.TrySpawnVirtualItemInHand(target, carrier))
-            Log.Warning($"Failed to spawn second carry virtual item on {ToPrettyString(carrier)}");
+            Log.Warning("Failed to spawn second carry virtual item on {Carrier}", ToPrettyString(carrier));
 
         // Parent target to carrier. The client's FrameUpdate handles the visual offset.
         var xform = Transform(target);


### PR DESCRIPTION
## About the PR

New analyzer **HONK0028** (`Honk.Logging`, `Warning`). Flags logger calls (`Debug/Info/Warning/Error/Fatal/Verbose`) whose receiver is name-matched as a logger (`Log`/`Logger`/`*sawmill*`) and whose first argument is an interpolated `$"..."` or a string concatenation — these build the message eagerly, before the level filter. Fork-scoped.

## Why / Balance

`ISawmill`/`Log` levels are filtered at call time; building the string eagerly allocates even when the level is disabled.

**~13 current hits** in fork code (e.g. `SurgerySystem.Healing.cs`, `PlantAnalyzerSystem.cs`, `SharedCarryingSystem.cs`). PR CI (DebugOpt) passes with warnings; **Release** will block until the calls are guarded (follow-up).

FP note: the receiver check is name-based (no symbol resolution in the stubbed tests), so a non-logger named `Log`/`Logger`/`*sawmill*` exposing a matching method could match. `Warning` keeps it surfaced.

⚠️ Couldn't compile locally (no SDK/submodule); CI is the first real build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZuoozgagZu4MWn1FcNo6)_