### PR TITLE
honksquad: HONK0030 — discarded Resolve() return value

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkDiscardedResolveAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkDiscardedResolveAnalyzerTest.cs
@@ -1,0 +1,163 @@
+using System.Threading.Tasks;
+using Content.Analyzers.Honk;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkDiscardedResolveAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkDiscardedResolveAnalyzerTest
+{
+    private const string Stubs = """
+        namespace Robust.Shared.GameObjects
+        {
+            public abstract class EntitySystem
+            {
+                protected bool Resolve<T>(int uid, ref T? comp, bool logMissing = true) => true;
+            }
+            public sealed class FooComponent
+            {
+            }
+        }
+        """;
+
+    private const string ForkPath = "Content.Shared/RussStation/SomeForkSystem.cs";
+    private const string UpstreamPath = "Content.Shared/Upstream/SomeSystem.cs";
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    Stubs,
+                    (filePath, code),
+                },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task DiscardedResolve_InEntitySystem_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public void Foo(int uid, ref FooComponent? comp)
+                {
+                    Resolve(uid, ref comp);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath,
+            new DiagnosticResult("HONK0030", DiagnosticSeverity.Warning)
+                .WithSpan(ForkPath, 7, 9, 7, 31));
+    }
+
+    [Test]
+    public async Task ResolveInIfCondition_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public void Foo(int uid, ref FooComponent? comp)
+                {
+                    if (!Resolve(uid, ref comp))
+                        return;
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task ResolveAssignedToLocal_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public void Foo(int uid, ref FooComponent? comp)
+                {
+                    var ok = Resolve(uid, ref comp);
+                }
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task DiscardedResolve_OutsideEntitySystem_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class SomeHelper
+            {
+                public void Foo(int uid, ref FooComponent? comp)
+                {
+                    Resolve(uid, ref comp);
+                }
+
+                private bool Resolve(int uid, ref FooComponent? comp) => true;
+            }
+            """;
+
+        await Verify(code, ForkPath);
+    }
+
+    [Test]
+    public async Task DiscardedResolve_InUpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class MySystem : EntitySystem
+            {
+                public void Foo(int uid, ref FooComponent? comp)
+                {
+                    Resolve(uid, ref comp);
+                }
+            }
+            """;
+
+        await Verify(code, UpstreamPath);
+    }
+
+    [Test]
+    public async Task DiscardedResolve_InHonkPartial_Reports()
+    {
+        const string honkPath = "Content.Shared/Upstream/SomeSystem.Honk.cs";
+        const string code = """
+            using Robust.Shared.GameObjects;
+
+            public sealed class HonkPartialSystem : EntitySystem
+            {
+                public void Foo(int uid, ref FooComponent? comp)
+                {
+                    Resolve(uid, ref comp);
+                }
+            }
+            """;
+
+        await Verify(code, honkPath,
+            new DiagnosticResult("HONK0030", DiagnosticSeverity.Warning)
+                .WithSpan(honkPath, 7, 9, 7, 31));
+    }
+}

--- a/Content.Analyzers.Honk/HonkDiscardedResolveAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkDiscardedResolveAnalyzer.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0030: a bare-statement call to <c>Resolve(...)</c> inside an
+/// <see cref="EntitySystem"/> whose <see langword="bool"/> return value is
+/// discarded. <c>EntitySystem.Resolve</c> returns <see langword="false"/> when
+/// the component is missing; ignoring the bool and using the <c>ref</c>
+/// parameter anyway is a latent NRE/throw. Scoped to fork files (path contains
+/// <c>/RussStation/</c> or ends in <c>.Honk.cs</c>).
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkDiscardedResolveAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0030",
+        title: "Discarded Resolve() return value",
+        messageFormat: "Resolve(...) return value is discarded; if the component is absent the ref parameter is left unusable and later access throws",
+        category: "Honk.EntitySystem",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "EntitySystem.Resolve returns false when the component is missing; ignoring the bool and using the ref parameter anyway is a latent NRE/throw. Scope to Resolve only — bare-statement TryComp with an out var is an intentional idiom and must NOT be flagged.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
+
+        var name = GetInvokedName(invocation);
+        if (name != "Resolve")
+            return;
+
+        if (invocation.Parent is not ExpressionStatementSyntax)
+            return;
+
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType is null || !InheritsEntitySystem(containingType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation()));
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+            _ => null,
+        };
+    }
+
+    private static bool InheritsEntitySystem(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "EntitySystem" &&
+                current.ContainingNamespace?.ToDisplayString() == "Robust.Shared.GameObjects")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## About the PR

New analyzer **HONK0030** (`Honk.EntitySystem`, `Warning`). Flags `Resolve(...)` used as a bare expression statement (return value discarded) inside an `EntitySystem`. `Resolve` returns `false` when the component is missing; ignoring the bool and using the `ref` parameter anyway is a latent NRE/throw. Fork-scoped.

## Why / Balance

`Resolve` mutates a caller-supplied `ref` in place and has no out value — discarding its bool means later code uses that ref believing it's populated.

`TryComp(uid, out var c)` as a bare statement is **intentionally excluded** — that's an established idiom where the out value is wanted and the bool is genuinely throwaway.

**0 current hits** (every fork `Resolve` is already `if (!Resolve(...)) return;`) → green Release build; pure regression guard.

⚠️ Couldn't compile locally (no SDK/submodule); CI is the first real build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZuoozgagZu4MWn1FcNo6)_