### PR TITLE
honksquad: HONK0031 — Timer.Spawn without a CancellationToken

### DIFF
--- a/Content.Analyzers.Honk.Tests/HonkTimerSpawnWithoutTokenAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkTimerSpawnWithoutTokenAnalyzerTest.cs
@@ -55,7 +55,7 @@ public sealed class HonkTimerSpawnWithoutTokenAnalyzerTest
             """;
 
         await Verify(code, "Content.Client/RussStation/Foo/FooSystem.cs",
-            new DiagnosticResult("HONK0031", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0031", DiagnosticSeverity.Warning)
                 .WithSpan("Content.Client/RussStation/Foo/FooSystem.cs", 7, 9, 7, 36));
     }
 
@@ -133,7 +133,7 @@ public sealed class HonkTimerSpawnWithoutTokenAnalyzerTest
             """;
 
         await Verify(code, "Content.Client/Foo/FooSystem.Honk.cs",
-            new DiagnosticResult("HONK0031", DiagnosticSeverity.Info)
+            new DiagnosticResult("HONK0031", DiagnosticSeverity.Warning)
                 .WithSpan("Content.Client/Foo/FooSystem.Honk.cs", 7, 9, 7, 36));
     }
 }

--- a/Content.Analyzers.Honk.Tests/HonkTimerSpawnWithoutTokenAnalyzerTest.cs
+++ b/Content.Analyzers.Honk.Tests/HonkTimerSpawnWithoutTokenAnalyzerTest.cs
@@ -1,0 +1,139 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Content.Analyzers.Honk.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<HonkTimerSpawnWithoutTokenAnalyzer, DefaultVerifier>;
+
+[TestFixture]
+public sealed class HonkTimerSpawnWithoutTokenAnalyzerTest
+{
+    private const string Stubs = """
+        namespace System.Threading
+        {
+            public struct CancellationToken { }
+        }
+        namespace Robust.Shared.Timing
+        {
+            public static class Timer
+            {
+                public static void Spawn(int ms, System.Action onFired) { }
+                public static void Spawn(int ms, System.Action onFired, System.Threading.CancellationToken ct) { }
+            }
+        }
+        """;
+
+    private static Task Verify(string code, string filePath, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS
+        {
+            TestState =
+            {
+                Sources = { Stubs, (filePath, code) },
+            },
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task TimerSpawnWithoutToken_ForkFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Timing;
+
+            public sealed class FooSystem
+            {
+                public void Go()
+                {
+                    Timer.Spawn(1000, () => {});
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Client/RussStation/Foo/FooSystem.cs",
+            new DiagnosticResult("HONK0031", DiagnosticSeverity.Info)
+                .WithSpan("Content.Client/RussStation/Foo/FooSystem.cs", 7, 9, 7, 36));
+    }
+
+    [Test]
+    public async Task TimerSpawnWithToken_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Timing;
+            using System.Threading;
+
+            public sealed class FooSystem
+            {
+                public void Go(CancellationToken token)
+                {
+                    Timer.Spawn(1000, () => {}, token);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Client/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task UnrelatedSpawn_DoesNotReport()
+    {
+        const string code = """
+            public static class Foo
+            {
+                public static void Spawn(int ms) { }
+            }
+
+            public sealed class FooSystem
+            {
+                public void Go()
+                {
+                    Foo.Spawn(1000);
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Client/RussStation/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task UpstreamFile_DoesNotReport()
+    {
+        const string code = """
+            using Robust.Shared.Timing;
+
+            public sealed class FooSystem
+            {
+                public void Go()
+                {
+                    Timer.Spawn(1000, () => {});
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Client/Foo/FooSystem.cs");
+    }
+
+    [Test]
+    public async Task HonkPartialFile_Reports()
+    {
+        const string code = """
+            using Robust.Shared.Timing;
+
+            public sealed class FooSystem
+            {
+                public void Go()
+                {
+                    Timer.Spawn(1000, () => {});
+                }
+            }
+            """;
+
+        await Verify(code, "Content.Client/Foo/FooSystem.Honk.cs",
+            new DiagnosticResult("HONK0031", DiagnosticSeverity.Info)
+                .WithSpan("Content.Client/Foo/FooSystem.Honk.cs", 7, 9, 7, 36));
+    }
+}

--- a/Content.Analyzers.Honk/HonkTimerSpawnWithoutTokenAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkTimerSpawnWithoutTokenAnalyzer.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Content.Analyzers.Honk;
+
+/// <summary>
+/// HONK0031: <c>Timer.Spawn(...)</c> with no <see cref="System.Threading.CancellationToken"/>
+/// argument. Fire-and-forget <see cref="Robust.Shared.Timing.Timer"/> callbacks that capture
+/// an entity run after the delay regardless of intervening state changes, so a stale or
+/// overlapping callback can fire after the entity/state has changed. Passing a
+/// <c>CancellationToken</c> lets the system cancel them.
+/// Scoped to fork files (path contains <c>/RussStation/</c> or ends in
+/// <c>.Honk.cs</c>) so upstream drift is not this rule's problem.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HonkTimerSpawnWithoutTokenAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "HONK0031",
+        title: "Timer.Spawn without a CancellationToken",
+        messageFormat: "Timer.Spawn has no CancellationToken; a stale or overlapping callback can fire after the entity/state has changed",
+        category: "Honk.Lifecycle",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Fire-and-forget Timer.Spawn callbacks capturing an entity run after the delay regardless of intervening state changes; passing a CancellationToken lets the system cancel them.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsForkFile(invocation.SyntaxTree.FilePath))
+            return;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax member)
+            return;
+
+        if (member.Name.Identifier.ValueText != "Spawn")
+            return;
+
+        if (!IsTimerReceiver(member.Expression))
+            return;
+
+        foreach (var arg in invocation.ArgumentList.Arguments)
+        {
+            if (IsCancellationToken(context, arg))
+                return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocation.GetLocation()));
+    }
+
+    private static bool IsTimerReceiver(ExpressionSyntax expr)
+    {
+        return expr switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText == "Timer",
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText == "Timer",
+            _ => false,
+        };
+    }
+
+    private static bool IsCancellationToken(SyntaxNodeAnalysisContext context, ArgumentSyntax arg)
+    {
+        var type = context.SemanticModel.GetTypeInfo(arg.Expression).Type;
+        if (type is not null)
+            return type.Name == "CancellationToken";
+
+        // Fall back to a textual hint when the model can't resolve the type.
+        var text = arg.Expression.ToString();
+        return text.Contains("Token") || text.Contains("token");
+    }
+
+    private static bool IsForkFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return path!.Replace('\\', '/').Contains("/RussStation/")
+            || path.EndsWith(".Honk.cs", StringComparison.Ordinal);
+    }
+}

--- a/Content.Analyzers.Honk/HonkTimerSpawnWithoutTokenAnalyzer.cs
+++ b/Content.Analyzers.Honk/HonkTimerSpawnWithoutTokenAnalyzer.cs
@@ -24,7 +24,7 @@ public sealed class HonkTimerSpawnWithoutTokenAnalyzer : DiagnosticAnalyzer
         title: "Timer.Spawn without a CancellationToken",
         messageFormat: "Timer.Spawn has no CancellationToken; a stale or overlapping callback can fire after the entity/state has changed",
         category: "Honk.Lifecycle",
-        defaultSeverity: DiagnosticSeverity.Info,
+        defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Fire-and-forget Timer.Spawn callbacks capturing an entity run after the delay regardless of intervening state changes; passing a CancellationToken lets the system cancel them.");
 

--- a/Content.Client/RussStation/Emotes/SpriteEmoteAnimationSystem.cs
+++ b/Content.Client/RussStation/Emotes/SpriteEmoteAnimationSystem.cs
@@ -1,3 +1,4 @@
+using CancellationTokenSource = System.Threading.CancellationTokenSource;
 using Content.Shared.RussStation.Emotes;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
@@ -16,6 +17,10 @@ public sealed class SpriteEmoteAnimationSystem : EntitySystem
     [Dependency] private readonly AnimationPlayerSystem _anim = default!;
 
     private const string AnimationKey = "russstation-sprite-emote";
+
+    // Per-entity cancellation for the Timer.Spawn-driven spin cycle, so a new (or spammed)
+    // spin cancels the previous one's leftover step timers instead of letting them fight.
+    private readonly Dictionary<EntityUid, CancellationTokenSource> _spinCancellers = new();
 
     // Counterclockwise as viewed on screen: S → E → N → W.
     private static readonly Direction[] SpinSequence =
@@ -100,6 +105,17 @@ public sealed class SpriteEmoteAnimationSystem : EntitySystem
         if (steps <= 0)
             return;
 
+        // Cancel any spin still cycling on this entity so its leftover timers don't fight this one.
+        if (_spinCancellers.Remove(uid, out var previous))
+        {
+            previous.Cancel();
+            previous.Dispose();
+        }
+
+        var cts = new CancellationTokenSource();
+        _spinCancellers[uid] = cts;
+        var token = cts.Token;
+
         // DirectionOverride/EnableDirectionOverride aren't [Animatable], so drive the cycle
         // off ticks via Timer.Spawn instead of an Animation track.
         var stepInterval = duration.TotalMilliseconds / steps;
@@ -112,12 +128,19 @@ public sealed class SpriteEmoteAnimationSystem : EntitySystem
             {
                 if (TryComp<SpriteComponent>(entity, out var s))
                     s.DirectionOverride = dir;
-            });
+            }, token);
         }
         Timer.Spawn(duration, () =>
         {
             if (TryComp<SpriteComponent>(uid, out var s))
                 s.EnableDirectionOverride = false;
-        });
+
+            // Only this spin's own token reaches here (a newer spin cancels it), so retire it.
+            if (_spinCancellers.TryGetValue(uid, out var current) && current == cts)
+            {
+                _spinCancellers.Remove(uid);
+                cts.Dispose();
+            }
+        }, token);
     }
 }


### PR DESCRIPTION
## About the PR

New analyzer **HONK0031** (`Honk.Lifecycle`, `Warning`). Flags `Timer.Spawn(...)` calls with no `CancellationToken` argument (semantic check, with a name-based fallback). Fork-scoped.

## Why / Balance

Fire-and-forget `Timer.Spawn` callbacks capturing an entity run after the delay regardless of intervening state changes; a `CancellationToken` lets the system cancel stale/overlapping callbacks.

**2 current hits** (`SpriteEmoteAnimationSystem.cs` ~lines 111/117, in a loop → N uncancellable timers per spin). PR CI (DebugOpt) passes with warnings; **Release** will block until a token is plumbed through (follow-up — needs a component-stored CTS, not zero-risk to auto-apply).

FP note: low frequency; mostly a regression guard against new fire-and-forget timers.

⚠️ Couldn't compile locally (no SDK/submodule); CI is the first real build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRZuoozgagZu4MWn1FcNo6)_