### PR TITLE
Extract SeedDataFormatter from PlantAnalyzerSystem

### DIFF
--- a/Content.Server/RussStation/Botany/Systems/PlantAnalyzerSystem.cs
+++ b/Content.Server/RussStation/Botany/Systems/PlantAnalyzerSystem.cs
@@ -1,12 +1,8 @@
 using Content.Server.Botany;
 using Content.Server.Botany.Components;
 using Content.Server.Botany.Systems;
-using Content.Server.Ghost.Roles.Components;
-using Content.Shared.Atmos;
 using Content.Shared.Atmos.EntitySystems;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.DoAfter;
-using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item.ItemToggle;
@@ -14,7 +10,6 @@ using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Botany;
 using Content.Shared.RussStation.Botany.Components;
-using Content.Shared.Slippery;
 using Content.Shared.Sprite;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
@@ -205,105 +200,6 @@ public sealed class PlantAnalyzerSystem : EntitySystem
 
     private PlantAnalyzerUiState BuildState(EntityUid target, SeedData seed)
     {
-        var traits = new List<string>();
-
-        if (seed.Seedless)
-            traits.Add(Loc.GetString("plant-analyzer-trait-seedless"));
-        if (!seed.Viable)
-            traits.Add(Loc.GetString("plant-analyzer-trait-unviable"));
-        if (seed.Ligneous)
-            traits.Add(Loc.GetString("plant-analyzer-trait-ligneous"));
-        if (seed.TurnIntoKudzu)
-            traits.Add(Loc.GetString("plant-analyzer-trait-kudzufication"));
-        if (seed.CanScream)
-            traits.Add(Loc.GetString("plant-analyzer-trait-screaming"));
-        if (HasComp<GhostTakeoverAvailableComponent>(target))
-            traits.Add(Loc.GetString("plant-analyzer-trait-sentient"));
-        if (HasComp<SlipperyComponent>(target))
-            traits.Add(Loc.GetString("plant-analyzer-trait-slippery"));
-        if (seed.SplatPrototype != null)
-            traits.Add(Loc.GetString("plant-analyzer-trait-splatter"));
-
-        var chemicals = new Dictionary<string, FixedPoint2>();
-        foreach (var (reagentId, q) in seed.Chemicals)
-        {
-            var amount = q.Min;
-            if (q.PotencyDivisor > 0 && seed.Potency > 0)
-                amount += seed.Potency / q.PotencyDivisor;
-            amount = FixedPoint2.Clamp(amount, q.Min, q.Max);
-
-            if (!_prototypeManager.TryIndex<ReagentPrototype>(reagentId, out var reagent))
-            {
-                Log.Warning($"PlantAnalyzer: reagent '{reagentId}' not found for seed '{seed.Name}'.");
-                continue;
-            }
-
-            chemicals[reagent.LocalizedName] = amount;
-        }
-
-        var consumeGases = BuildGasDict(seed.ConsumeGasses);
-        var exudeGases = BuildGasDict(seed.ExudeGasses);
-
-        string harvestRepeatKey;
-        switch (seed.HarvestRepeat)
-        {
-            case HarvestType.NoRepeat:
-                harvestRepeatKey = "plant-analyzer-harvest-no-repeat";
-                break;
-            case HarvestType.Repeat:
-                harvestRepeatKey = "plant-analyzer-harvest-repeat";
-                break;
-            case HarvestType.SelfHarvest:
-                harvestRepeatKey = "plant-analyzer-harvest-self-harvest";
-                break;
-            default:
-                Log.Warning($"PlantAnalyzer: unrecognized HarvestType {seed.HarvestRepeat}.");
-                harvestRepeatKey = "plant-analyzer-harvest-no-repeat";
-                break;
-        }
-
-        return new PlantAnalyzerUiState
-        {
-            SeedName = Loc.GetString(seed.DisplayName),
-            Lifespan = seed.Lifespan,
-            Maturation = seed.Maturation,
-            Production = seed.Production,
-            Yield = seed.Yield,
-            Potency = seed.Potency,
-            GrowthStages = seed.GrowthStages,
-            HarvestRepeat = Loc.GetString(harvestRepeatKey),
-            Endurance = seed.Endurance,
-            IdealLight = seed.IdealLight,
-            WaterConsumption = seed.WaterConsumption,
-            NutrientConsumption = seed.NutrientConsumption,
-            IdealHeat = seed.IdealHeat,
-            HeatTolerance = seed.HeatTolerance,
-            LightTolerance = seed.LightTolerance,
-            ToxinsTolerance = seed.ToxinsTolerance,
-            LowPressureTolerance = seed.LowPressureTolerance,
-            HighPressureTolerance = seed.HighPressureTolerance,
-            PestTolerance = seed.PestTolerance,
-            WeedTolerance = seed.WeedTolerance,
-            Traits = traits,
-            Chemicals = chemicals,
-            ConsumeGases = consumeGases,
-            ExudeGases = exudeGases,
-        };
-    }
-
-    private Dictionary<string, float> BuildGasDict(Dictionary<Gas, float> gases)
-    {
-        var result = new Dictionary<string, float>();
-        foreach (var (gas, rate) in gases)
-        {
-            var proto = _atmosphere.GetGas(gas);
-            if (proto == null)
-            {
-                Log.Warning($"PlantAnalyzer: unknown gas ID {(int)gas}, skipping.");
-                continue;
-            }
-            result[Loc.GetString(proto.Name)] = rate;
-        }
-        return result;
+        return SeedDataFormatter.FormatSeedData(seed, target, EntityManager, _prototypeManager, _atmosphere, Log);
     }
 }

--- a/Content.Server/RussStation/Botany/Systems/SeedDataFormatter.cs
+++ b/Content.Server/RussStation/Botany/Systems/SeedDataFormatter.cs
@@ -1,0 +1,151 @@
+using Content.Server.Botany;
+using Content.Server.Ghost.Roles.Components;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Botany;
+using Content.Shared.Slippery;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Botany.Systems;
+
+/// <summary>
+///     Serializes <see cref="SeedData"/> into a <see cref="PlantAnalyzerUiState"/> for the plant analyzer UI.
+/// </summary>
+public static class SeedDataFormatter
+{
+    /// <summary>
+    ///     Builds the full UI state shown by the plant analyzer for the given seed.
+    /// </summary>
+    public static PlantAnalyzerUiState FormatSeedData(
+        SeedData seed,
+        EntityUid target,
+        IEntityManager entityManager,
+        IPrototypeManager prototypeManager,
+        SharedAtmosphereSystem atmosphere,
+        ISawmill log)
+    {
+        var chemicals = new Dictionary<string, FixedPoint2>();
+        foreach (var (reagentId, q) in seed.Chemicals)
+        {
+            if (!prototypeManager.TryIndex<ReagentPrototype>(reagentId, out var reagent))
+            {
+                log.Warning($"PlantAnalyzer: reagent '{reagentId}' not found for seed '{seed.Name}'.");
+                continue;
+            }
+
+            chemicals[reagent.LocalizedName] = CalculateChemicalAmount(q, seed.Potency);
+        }
+
+        return new PlantAnalyzerUiState
+        {
+            SeedName = Loc.GetString(seed.DisplayName),
+            Lifespan = seed.Lifespan,
+            Maturation = seed.Maturation,
+            Production = seed.Production,
+            Yield = seed.Yield,
+            Potency = seed.Potency,
+            GrowthStages = seed.GrowthStages,
+            HarvestRepeat = FormatHarvestRepeat(seed.HarvestRepeat, log),
+            Endurance = seed.Endurance,
+            IdealLight = seed.IdealLight,
+            WaterConsumption = seed.WaterConsumption,
+            NutrientConsumption = seed.NutrientConsumption,
+            IdealHeat = seed.IdealHeat,
+            HeatTolerance = seed.HeatTolerance,
+            LightTolerance = seed.LightTolerance,
+            ToxinsTolerance = seed.ToxinsTolerance,
+            LowPressureTolerance = seed.LowPressureTolerance,
+            HighPressureTolerance = seed.HighPressureTolerance,
+            PestTolerance = seed.PestTolerance,
+            WeedTolerance = seed.WeedTolerance,
+            Traits = EnumerateSeedTraits(seed, target, entityManager),
+            Chemicals = chemicals,
+            ConsumeGases = BuildGasDict(seed.ConsumeGasses, atmosphere, log),
+            ExudeGases = BuildGasDict(seed.ExudeGasses, atmosphere, log),
+        };
+    }
+
+    /// <summary>
+    ///     Computes the amount of a chemical a seed produces: the minimum plus a potency-scaled
+    ///     bonus, clamped between the chemical's configured minimum and maximum.
+    /// </summary>
+    public static FixedPoint2 CalculateChemicalAmount(SeedChemQuantity quantity, float potency)
+    {
+        var amount = quantity.Min;
+        if (quantity.PotencyDivisor > 0 && potency > 0)
+            amount += potency / quantity.PotencyDivisor;
+        return FixedPoint2.Clamp(amount, quantity.Min, quantity.Max);
+    }
+
+    /// <summary>
+    ///     Maps a <see cref="HarvestType"/> to its localized description.
+    /// </summary>
+    public static string FormatHarvestRepeat(HarvestType harvestRepeat, ISawmill log)
+    {
+        string key;
+        switch (harvestRepeat)
+        {
+            case HarvestType.NoRepeat:
+                key = "plant-analyzer-harvest-no-repeat";
+                break;
+            case HarvestType.Repeat:
+                key = "plant-analyzer-harvest-repeat";
+                break;
+            case HarvestType.SelfHarvest:
+                key = "plant-analyzer-harvest-self-harvest";
+                break;
+            default:
+                log.Warning($"PlantAnalyzer: unrecognized HarvestType {harvestRepeat}.");
+                key = "plant-analyzer-harvest-no-repeat";
+                break;
+        }
+
+        return Loc.GetString(key);
+    }
+
+    /// <summary>
+    ///     Collects the localized trait descriptions for a seed, including traits derived from
+    ///     components on the scanned entity.
+    /// </summary>
+    public static List<string> EnumerateSeedTraits(SeedData seed, EntityUid target, IEntityManager entityManager)
+    {
+        var traits = new List<string>();
+
+        if (seed.Seedless)
+            traits.Add(Loc.GetString("plant-analyzer-trait-seedless"));
+        if (!seed.Viable)
+            traits.Add(Loc.GetString("plant-analyzer-trait-unviable"));
+        if (seed.Ligneous)
+            traits.Add(Loc.GetString("plant-analyzer-trait-ligneous"));
+        if (seed.TurnIntoKudzu)
+            traits.Add(Loc.GetString("plant-analyzer-trait-kudzufication"));
+        if (seed.CanScream)
+            traits.Add(Loc.GetString("plant-analyzer-trait-screaming"));
+        if (entityManager.HasComponent<GhostTakeoverAvailableComponent>(target))
+            traits.Add(Loc.GetString("plant-analyzer-trait-sentient"));
+        if (entityManager.HasComponent<SlipperyComponent>(target))
+            traits.Add(Loc.GetString("plant-analyzer-trait-slippery"));
+        if (seed.SplatPrototype != null)
+            traits.Add(Loc.GetString("plant-analyzer-trait-splatter"));
+
+        return traits;
+    }
+
+    private static Dictionary<string, float> BuildGasDict(Dictionary<Gas, float> gases, SharedAtmosphereSystem atmosphere, ISawmill log)
+    {
+        var result = new Dictionary<string, float>();
+        foreach (var (gas, rate) in gases)
+        {
+            var proto = atmosphere.GetGas(gas);
+            if (proto == null)
+            {
+                log.Warning($"PlantAnalyzer: unknown gas ID {(int)gas}, skipping.");
+                continue;
+            }
+            result[Loc.GetString(proto.Name)] = rate;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## About the PR

Moves the seed serialization logic out of `PlantAnalyzerSystem` into a new `SeedDataFormatter` class. No behavior changes.

## Why / Balance

Part of the RussStation fork audit (#853), and closes #864. `PlantAnalyzerSystem` was 309 lines, and `BuildState` was 87 of them on its own: trait collection, the chemical amount formula, the harvest-repeat string mapping, and the 20-field UI state construction. Pulling that out leaves the system responsible for the scan loop and the event handlers, and keeps the serialization in one place that can be tested without spinning up the system.

## Technical details

`SeedDataFormatter` is a static helper in the same namespace. It follows the existing `ReactionHelper` / `RadiationPulseHelper` style of taking the services it needs as parameters (entity manager, prototype manager, atmosphere system, sawmill) rather than holding dependencies.

- `FormatSeedData(...)` returns the `PlantAnalyzerUiState`.
- `CalculateChemicalAmount` holds the `Min + Potency / divisor` clamp.
- `FormatHarvestRepeat` maps the `HarvestType` enum to its localized string.
- `EnumerateSeedTraits` builds the trait list, including the component checks on the scanned entity.

`BuildState` stays on the system as a one-line call into the formatter, so `SendUiUpdate` and its callers are untouched. The file goes from 309 to 205 lines. Every branch, warning, and field assignment carries over unchanged.

One caveat for reviewers: I could not compile this locally, since the environment has no .NET SDK (`global.json` pins 10.0.100). I checked the change against the `SeedData` / `SeedChemQuantity` type definitions and confirmed no tests reference the moved methods, but CI is the first real build.

## Breaking changes

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUD7rRejH8FkK3eQigjivj)_