### PR TITLE
Refactor LightReplacerRecyclerSystem bulb-replacement flow

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Light/LightReplacerRecyclerTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Light/LightReplacerRecyclerTest.cs
@@ -1,0 +1,335 @@
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Server.Light.EntitySystems;
+using Content.Server.RussStation.Light;
+using Content.Shared.Interaction;
+using Content.Shared.Light.Components;
+using Content.Shared.RussStation.Light;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Light;
+
+/// <summary>
+/// Covers <see cref="LightReplacerRecyclerSystem"/>: recycle-point accounting, the storage cap,
+/// and the three-tier replacement strategy (exact prototype match, same-type fallback, print)
+/// plus the no-replacement-possible case. The replace flow is driven through the same
+/// <see cref="LightReplacerRecycleReplaceEvent"/> the base light replacer raises, so these
+/// exercise the real selection and execution code rather than reimplementing it.
+/// </summary>
+[TestOf(typeof(LightReplacerRecyclerSystem))]
+public sealed class LightReplacerRecyclerTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: TestRecyclerReplacer
+  components:
+  - type: LightReplacer
+  - type: LightReplacerRecycler
+  - type: Transform
+
+- type: entity
+  id: TestRecyclerFixture
+  components:
+  - type: PoweredLight
+    bulb: Bulb
+  - type: Transform
+
+- type: entity
+  id: TestRecyclerBulbA
+  components:
+  - type: LightBulb
+    bulb: Bulb
+  - type: Transform
+
+- type: entity
+  id: TestRecyclerBulbB
+  components:
+  - type: LightBulb
+    bulb: Bulb
+  - type: Transform
+
+- type: entity
+  id: TestRecyclerShard
+  components:
+  - type: Tag
+    tags:
+    - GlassShard
+  - type: Transform
+
+- type: entity
+  id: TestRecyclerUser
+  components:
+  - type: Transform
+";
+
+    /// <summary>
+    /// The component registers and carries the expected default tuning.
+    /// </summary>
+    [Test]
+    public async Task ComponentRegisteredWithDefaults()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+
+            Assert.That(entityManager.HasComponent<LightReplacerRecyclerComponent>(replacer), Is.True);
+
+            var recycler = entityManager.GetComponent<LightReplacerRecyclerComponent>(replacer);
+            Assert.Multiple(() =>
+            {
+                Assert.That(recycler.RecyclePoints, Is.EqualTo(0));
+                Assert.That(recycler.PointsPerRecycle, Is.EqualTo(LightReplacerRecyclerConstants.DefaultPointsPerRecycle));
+                Assert.That(recycler.PrintCost, Is.EqualTo(LightReplacerRecyclerConstants.DefaultPrintCost));
+                Assert.That(recycler.MaxStoredBulbs, Is.EqualTo(LightReplacerRecyclerConstants.DefaultMaxStoredBulbs));
+                Assert.That(recycler.PrintablePrototypes.Select(p => p.Id), Does.Contain("LightBulb"));
+            });
+        });
+    }
+
+    /// <summary>
+    /// Feeding a glass shard via interaction grants recycle points and consumes the interaction.
+    /// </summary>
+    [Test]
+    public async Task GlassShardRecycleAddsPoints()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var user = entityManager.SpawnEntity("TestRecyclerUser", mapData.GridCoords);
+            var shard = entityManager.SpawnEntity("TestRecyclerShard", mapData.GridCoords);
+            var recycler = entityManager.GetComponent<LightReplacerRecyclerComponent>(replacer);
+            var coords = entityManager.GetComponent<TransformComponent>(replacer).Coordinates;
+
+            var args = new InteractUsingEvent(user, shard, replacer, coords);
+            entityManager.EventBus.RaiseLocalEvent(replacer, args);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(args.Handled, Is.True);
+                Assert.That(recycler.RecyclePoints, Is.EqualTo(recycler.PointsPerRecycle));
+            });
+        });
+    }
+
+    /// <summary>
+    /// A broken bulb routed to the recycler grants a point and reports the insert as handled.
+    /// </summary>
+    [Test]
+    public async Task BrokenBulbInsertAddsPoints()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var recycler = entityManager.GetComponent<LightReplacerRecyclerComponent>(replacer);
+
+            var broken = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+            entityManager.GetComponent<LightBulbComponent>(broken).State = LightBulbState.Broken;
+
+            var ev = new LightReplacerBrokenBulbInsertEvent(broken, null);
+            entityManager.EventBus.RaiseLocalEvent(replacer, ref ev);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ev.Handled, Is.True);
+                Assert.That(recycler.RecyclePoints, Is.EqualTo(recycler.PointsPerRecycle));
+            });
+        });
+    }
+
+    /// <summary>
+    /// The storage cap rejects inserts once <see cref="LightReplacerRecyclerComponent.MaxStoredBulbs"/>
+    /// bulbs are held.
+    /// </summary>
+    [Test]
+    public async Task StorageCapRejectsOverfill()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entityManager.System<SharedContainerSystem>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var recycler = entityManager.GetComponent<LightReplacerRecyclerComponent>(replacer);
+            var storage = entityManager.GetComponent<LightReplacerComponent>(replacer).InsertedBulbs;
+
+            for (var i = 0; i < recycler.MaxStoredBulbs; i++)
+            {
+                var bulb = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+                Assert.That(containerSystem.Insert(bulb, storage), Is.True, $"insert {i} should fit");
+            }
+
+            var overflow = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+            Assert.Multiple(() =>
+            {
+                Assert.That(containerSystem.Insert(overflow, storage), Is.False, "insert past the cap should be rejected");
+                Assert.That(storage.ContainedEntities, Has.Count.EqualTo(recycler.MaxStoredBulbs));
+            });
+        });
+    }
+
+    /// <summary>
+    /// When storage holds a bulb whose prototype matches the broken one, that exact bulb is used in
+    /// preference to a same-type bulb of a different prototype.
+    /// </summary>
+    [Test]
+    public async Task ReplacePrefersExactPrototype()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entityManager.System<SharedContainerSystem>();
+        var poweredLight = entityManager.System<PoweredLightSystem>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var fixture = entityManager.SpawnEntity("TestRecyclerFixture", mapData.GridCoords);
+            var storage = entityManager.GetComponent<LightReplacerComponent>(replacer).InsertedBulbs;
+
+            var exact = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+            var other = entityManager.SpawnEntity("TestRecyclerBulbB", mapData.GridCoords);
+            containerSystem.Insert(exact, storage);
+            containerSystem.Insert(other, storage);
+
+            // Stand-in for the broken fixture bulb; shares the prototype of the "exact" stored bulb.
+            var broken = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+
+            var ev = new LightReplacerRecycleReplaceEvent(fixture, null, broken);
+            entityManager.EventBus.RaiseLocalEvent(replacer, ref ev);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ev.Handled, Is.True);
+                Assert.That(ev.Success, Is.True);
+                Assert.That(poweredLight.GetBulb(fixture), Is.EqualTo(exact));
+                Assert.That(storage.ContainedEntities, Is.EqualTo(new[] { other }));
+            });
+        });
+    }
+
+    /// <summary>
+    /// With no exact prototype match, any stored bulb of the right type is used as a fallback.
+    /// </summary>
+    [Test]
+    public async Task ReplaceFallsBackToSameType()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entityManager.System<SharedContainerSystem>();
+        var poweredLight = entityManager.System<PoweredLightSystem>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var fixture = entityManager.SpawnEntity("TestRecyclerFixture", mapData.GridCoords);
+            var storage = entityManager.GetComponent<LightReplacerComponent>(replacer).InsertedBulbs;
+
+            // Only a different-prototype, same-type bulb is available.
+            var fallback = entityManager.SpawnEntity("TestRecyclerBulbB", mapData.GridCoords);
+            containerSystem.Insert(fallback, storage);
+
+            var broken = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+
+            var ev = new LightReplacerRecycleReplaceEvent(fixture, null, broken);
+            entityManager.EventBus.RaiseLocalEvent(replacer, ref ev);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ev.Success, Is.True);
+                Assert.That(poweredLight.GetBulb(fixture), Is.EqualTo(fallback));
+                Assert.That(storage.ContainedEntities, Is.Empty);
+            });
+        });
+    }
+
+    /// <summary>
+    /// With empty storage but enough points, a bulb is printed into the fixture and the cost is spent.
+    /// </summary>
+    [Test]
+    public async Task ReplacePrintsWhenStorageEmpty()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var poweredLight = entityManager.System<PoweredLightSystem>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var fixture = entityManager.SpawnEntity("TestRecyclerFixture", mapData.GridCoords);
+            var recycler = entityManager.GetComponent<LightReplacerRecyclerComponent>(replacer);
+
+            // Earn exactly the print cost by recycling broken bulbs through the real point path.
+            for (var i = 0; i < recycler.PrintCost; i++)
+            {
+                var scrap = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+                entityManager.GetComponent<LightBulbComponent>(scrap).State = LightBulbState.Broken;
+                var insert = new LightReplacerBrokenBulbInsertEvent(scrap, null);
+                entityManager.EventBus.RaiseLocalEvent(replacer, ref insert);
+            }
+
+            Assert.That(recycler.RecyclePoints, Is.EqualTo(recycler.PrintCost));
+
+            // No broken bulb passed, so points only come from the stockpile above.
+            var ev = new LightReplacerRecycleReplaceEvent(fixture, null, null);
+            entityManager.EventBus.RaiseLocalEvent(replacer, ref ev);
+
+            var printed = poweredLight.GetBulb(fixture);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ev.Success, Is.True);
+                Assert.That(printed, Is.Not.Null);
+                Assert.That(recycler.RecyclePoints, Is.EqualTo(0));
+            });
+            Assert.That(entityManager.GetComponent<MetaDataComponent>(printed!.Value).EntityPrototype?.ID, Is.EqualTo("LightBulb"));
+        });
+    }
+
+    /// <summary>
+    /// With empty storage and too few points, the replace fails and spends nothing.
+    /// </summary>
+    [Test]
+    public async Task ReplaceFailsWhenNothingAvailable()
+    {
+        var server = Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var poweredLight = entityManager.System<PoweredLightSystem>();
+        var mapData = await Pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var replacer = entityManager.SpawnEntity("TestRecyclerReplacer", mapData.GridCoords);
+            var fixture = entityManager.SpawnEntity("TestRecyclerFixture", mapData.GridCoords);
+            var recycler = entityManager.GetComponent<LightReplacerRecyclerComponent>(replacer);
+            var broken = entityManager.SpawnEntity("TestRecyclerBulbA", mapData.GridCoords);
+
+            var ev = new LightReplacerRecycleReplaceEvent(fixture, null, broken);
+            entityManager.EventBus.RaiseLocalEvent(replacer, ref ev);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ev.Handled, Is.True);
+                Assert.That(ev.Success, Is.False);
+                Assert.That(recycler.RecyclePoints, Is.EqualTo(0));
+                Assert.That(poweredLight.GetBulb(fixture), Is.Null);
+            });
+        });
+    }
+}

--- a/Content.Server/RussStation/Light/LightReplacerRecyclerCacheComponent.cs
+++ b/Content.Server/RussStation/Light/LightReplacerRecyclerCacheComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.RussStation.Light;
+
+namespace Content.Server.RussStation.Light;
+
+/// <summary>
+///     Server-only cache of the recycler's stored-bulb summary shown in the UI. Kept off the
+///     networked <see cref="LightReplacerRecyclerComponent"/> so the per-prototype count is rebuilt
+///     only when the storage container changes, not on every state push. Added lazily and cleared
+///     by the recycler system on container change.
+/// </summary>
+[RegisterComponent]
+public sealed partial class LightReplacerRecyclerCacheComponent : Component
+{
+    /// <summary>
+    ///     Cached per-prototype counts, or null when invalidated and awaiting a rebuild.
+    /// </summary>
+    public List<LightReplacerStoredBulb>? StoredBulbs;
+}

--- a/Content.Server/RussStation/Light/LightReplacerRecyclerSystem.cs
+++ b/Content.Server/RussStation/Light/LightReplacerRecyclerSystem.cs
@@ -30,6 +30,29 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
     // deliberately excluded because they're rarer or have higher-value refine paths elsewhere.
     private static readonly ProtoId<TagPrototype> GlassShardTag = "GlassShard";
 
+    // How the recycler intends to source a replacement bulb for a fixture, in preference order.
+    private enum BulbReplacementStrategy
+    {
+        // Nothing available: no stored bulb and not enough points to print.
+        None,
+
+        // A stored bulb whose prototype exactly matches the bulb being replaced.
+        Exact,
+
+        // A stored bulb of the right BulbType but a different prototype.
+        TypeFallback,
+
+        // A freshly printed bulb funded by accumulated recycle points.
+        Print,
+    }
+
+    // The concrete replacement chosen by SelectReplacement. Exactly one payload is populated:
+    // StorageBulb for Exact/TypeFallback, PrintProto for Print, neither for None.
+    private readonly record struct BulbReplacementPlan(
+        BulbReplacementStrategy Strategy,
+        EntityUid? StorageBulb,
+        string? PrintProto);
+
     public override void Initialize()
     {
         base.Initialize();
@@ -69,9 +92,9 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         args.Success = RunRecycleReplace(uid, recycler, replacer, args.FixtureUid, fixture, args.FixtureBulbUid, args.UserUid);
     }
 
-    // Flow: eat the broken bulb for a point, then pick a replacement, preferring an exact prototype
-    // match from storage, then any stored bulb of the same BulbType, then a printed copy funded by
-    // accumulated points (including the point just earned).
+    // Flow: eat the broken bulb for a point, pick a replacement strategy (storage exact-match, then
+    // same-type fallback, then a printed copy funded by the points including the one just earned),
+    // then execute it. Strategy selection lives in SelectReplacement; this method just runs it.
     private bool RunRecycleReplace(
         EntityUid replacerUid,
         LightReplacerRecyclerComponent recycler,
@@ -84,14 +107,11 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         var brokenProto = brokenBulbUid is { } bUid
             ? MetaData(bUid).EntityPrototype?.ID
             : null;
-
-        var storageBulb = FindStorageBulb(replacer, fixture.BulbType, brokenProto);
         var projectedPoints = recycler.RecyclePoints + (brokenBulbUid != null ? recycler.PointsPerRecycle : 0);
-        string? printProto = null;
-        if (storageBulb == null && projectedPoints >= recycler.PrintCost)
-            printProto = PickPrintPrototype(recycler, brokenProto, fixture.BulbType);
 
-        if (storageBulb == null && printProto == null)
+        var plan = SelectReplacement(recycler, replacer, fixture, brokenProto, projectedPoints);
+
+        if (plan.Strategy == BulbReplacementStrategy.None)
         {
             if (userUid != null)
             {
@@ -105,19 +125,18 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
             RecycleBulb(replacerUid, recycler, broken, userUid);
 
         EntityUid replacement;
-        var printed = false;
-        if (storageBulb is { } stored)
-        {
-            if (!_container.Remove(stored, replacer.InsertedBulbs))
-                return false;
-            replacement = stored;
-        }
-        else
+        var printed = plan.Strategy == BulbReplacementStrategy.Print;
+        if (printed)
         {
             recycler.RecyclePoints -= recycler.PrintCost;
             Dirty(replacerUid, recycler);
-            replacement = Spawn(printProto!, Transform(replacerUid).Coordinates);
-            printed = true;
+            replacement = Spawn(plan.PrintProto!, Transform(replacerUid).Coordinates);
+        }
+        else
+        {
+            if (!_container.Remove(plan.StorageBulb!.Value, replacer.InsertedBulbs))
+                return false;
+            replacement = plan.StorageBulb.Value;
         }
 
         var replaced = _poweredLight.ReplaceBulb(fixtureUid, replacement, fixture);
@@ -131,7 +150,31 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         return replaced;
     }
 
-    private EntityUid? FindStorageBulb(LightReplacerComponent replacer, LightBulbType bulbType, string? preferredProto)
+    // Picks the replacement source without mutating anything: storage first (exact prototype match
+    // beats same-type fallback), then a fundable print, otherwise None.
+    private BulbReplacementPlan SelectReplacement(
+        LightReplacerRecyclerComponent recycler,
+        LightReplacerComponent replacer,
+        PoweredLightComponent fixture,
+        string? brokenProto,
+        int projectedPoints)
+    {
+        if (FindStorageBulb(replacer, fixture.BulbType, brokenProto) is { } storage)
+        {
+            var strategy = storage.Exact ? BulbReplacementStrategy.Exact : BulbReplacementStrategy.TypeFallback;
+            return new BulbReplacementPlan(strategy, storage.Bulb, null);
+        }
+
+        if (projectedPoints >= recycler.PrintCost
+            && PickPrintPrototype(recycler, brokenProto, fixture.BulbType) is { } printProto)
+        {
+            return new BulbReplacementPlan(BulbReplacementStrategy.Print, null, printProto);
+        }
+
+        return new BulbReplacementPlan(BulbReplacementStrategy.None, null, null);
+    }
+
+    private (EntityUid Bulb, bool Exact)? FindStorageBulb(LightReplacerComponent replacer, LightBulbType bulbType, string? preferredProto)
     {
         EntityUid? sameTypeFallback = null;
         foreach (var ent in replacer.InsertedBulbs.ContainedEntities)
@@ -139,15 +182,15 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
             if (!TryComp<LightBulbComponent>(ent, out var bulb) || bulb.Type != bulbType)
                 continue;
             if (preferredProto != null && MetaData(ent).EntityPrototype?.ID == preferredProto)
-                return ent;
+                return (ent, true);
             sameTypeFallback ??= ent;
         }
-        return sameTypeFallback;
+        return sameTypeFallback is { } fb ? (fb, false) : null;
     }
 
     private string? PickPrintPrototype(LightReplacerRecyclerComponent recycler, string? preferredProto, LightBulbType bulbType)
     {
-        if (preferredProto != null && recycler.PrintablePrototypes.Any(p => p.Id == preferredProto))
+        if (preferredProto != null && IsPrintable(recycler, preferredProto))
             return preferredProto;
 
         foreach (var protoId in recycler.PrintablePrototypes)
@@ -205,10 +248,7 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
     {
         var user = args.Actor;
 
-        if (!recycler.PrintablePrototypes.Contains(args.PrototypeId))
-            return;
-
-        if (!_protoManager.HasIndex<EntityPrototype>(args.PrototypeId))
+        if (!IsPrintable(recycler, args.PrototypeId))
             return;
 
         if (recycler.RecyclePoints < recycler.PrintCost)
@@ -255,24 +295,35 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         if (!TryComp<LightReplacerComponent>(uid, out var replacer))
             return;
 
-        EntityUid? target = null;
+        // Extract pulls any stored bulb matching the requested prototype. Unlike printing, it is
+        // intentionally not gated on PrintablePrototypes: players can manually insert bulbs the
+        // recycler can't print, and must still be able to take those back out.
+        if (FindStoredBulb(replacer, args.PrototypeId) is not { } target)
+            return;
+
+        if (!_container.Remove(target, replacer.InsertedBulbs, destination: Transform(user).Coordinates))
+            return;
+
+        _hands.PickupOrDrop(user, target);
+        PushState(uid, recycler);
+    }
+
+    // Shared validator for the print paths (radial print + exact-match print fallback): the id must
+    // be one the recycler advertises and must resolve to a real entity prototype.
+    private bool IsPrintable(LightReplacerRecyclerComponent recycler, EntProtoId protoId)
+    {
+        return recycler.PrintablePrototypes.Contains(protoId)
+            && _protoManager.HasIndex<EntityPrototype>(protoId);
+    }
+
+    private EntityUid? FindStoredBulb(LightReplacerComponent replacer, EntProtoId protoId)
+    {
         foreach (var ent in replacer.InsertedBulbs.ContainedEntities)
         {
-            if (MetaData(ent).EntityPrototype is { } proto && proto.ID == args.PrototypeId)
-            {
-                target = ent;
-                break;
-            }
+            if (MetaData(ent).EntityPrototype is { } proto && proto.ID == protoId)
+                return ent;
         }
-
-        if (target == null)
-            return;
-
-        if (!_container.Remove(target.Value, replacer.InsertedBulbs, destination: Transform(user).Coordinates))
-            return;
-
-        _hands.PickupOrDrop(user, target.Value);
-        PushState(uid, recycler);
+        return null;
     }
 
     private void OnUIOpened(EntityUid uid, LightReplacerRecyclerComponent recycler, BoundUIOpenedEvent args)
@@ -288,6 +339,7 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         if (args.Container.Owner != uid)
             return;
 
+        recycler.CachedInventory = null;
         PushState(uid, recycler);
     }
 
@@ -310,6 +362,23 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         if (!TryComp<LightReplacerComponent>(uid, out var replacer))
             return;
 
+        var state = new LightReplacerRecyclerBoundUserInterfaceState(
+            recycler.RecyclePoints,
+            recycler.PrintCost,
+            recycler.PointsPerRecycle,
+            GetStoredInventory(recycler, replacer),
+            recycler.PrintablePrototypes.ToList());
+
+        _ui.SetUiState(uid, LightReplacerRecyclerUiKey.Key, state);
+    }
+
+    // Returns the per-prototype stored-bulb summary, rebuilding it only when the cache has been
+    // invalidated by a storage container change (see OnContainerChanged).
+    private List<LightReplacerStoredBulb> GetStoredInventory(LightReplacerRecyclerComponent recycler, LightReplacerComponent replacer)
+    {
+        if (recycler.CachedInventory is { } cached)
+            return cached;
+
         var counts = new Dictionary<string, int>();
         foreach (var ent in replacer.InsertedBulbs.ContainedEntities)
         {
@@ -324,14 +393,8 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
             .OrderBy(e => e.ProtoId.Id)
             .ToList();
 
-        var state = new LightReplacerRecyclerBoundUserInterfaceState(
-            recycler.RecyclePoints,
-            recycler.PrintCost,
-            recycler.PointsPerRecycle,
-            stored,
-            recycler.PrintablePrototypes.ToList());
-
-        _ui.SetUiState(uid, LightReplacerRecyclerUiKey.Key, state);
+        recycler.CachedInventory = stored;
+        return stored;
     }
 
     private void OnExamined(EntityUid uid, LightReplacerRecyclerComponent recycler, ExaminedEvent args)

--- a/Content.Server/RussStation/Light/LightReplacerRecyclerSystem.cs
+++ b/Content.Server/RussStation/Light/LightReplacerRecyclerSystem.cs
@@ -339,7 +339,8 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
         if (args.Container.Owner != uid)
             return;
 
-        recycler.CachedInventory = null;
+        if (TryComp<LightReplacerRecyclerCacheComponent>(uid, out var cache))
+            cache.StoredBulbs = null;
         PushState(uid, recycler);
     }
 
@@ -366,17 +367,19 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
             recycler.RecyclePoints,
             recycler.PrintCost,
             recycler.PointsPerRecycle,
-            GetStoredInventory(recycler, replacer),
+            GetStoredInventory(uid, replacer),
             recycler.PrintablePrototypes.ToList());
 
         _ui.SetUiState(uid, LightReplacerRecyclerUiKey.Key, state);
     }
 
     // Returns the per-prototype stored-bulb summary, rebuilding it only when the cache has been
-    // invalidated by a storage container change (see OnContainerChanged).
-    private List<LightReplacerStoredBulb> GetStoredInventory(LightReplacerRecyclerComponent recycler, LightReplacerComponent replacer)
+    // invalidated by a storage container change (see OnContainerChanged). The cache lives on a
+    // server-only component so it never has to be networked.
+    private List<LightReplacerStoredBulb> GetStoredInventory(EntityUid uid, LightReplacerComponent replacer)
     {
-        if (recycler.CachedInventory is { } cached)
+        var cache = EnsureComp<LightReplacerRecyclerCacheComponent>(uid);
+        if (cache.StoredBulbs is { } cached)
             return cached;
 
         var counts = new Dictionary<string, int>();
@@ -393,7 +396,7 @@ public sealed class LightReplacerRecyclerSystem : SharedLightReplacerRecyclerSys
             .OrderBy(e => e.ProtoId.Id)
             .ToList();
 
-        recycler.CachedInventory = stored;
+        cache.StoredBulbs = stored;
         return stored;
     }
 

--- a/Content.Shared/RussStation/Light/LightReplacerRecyclerComponent.cs
+++ b/Content.Shared/RussStation/Light/LightReplacerRecyclerComponent.cs
@@ -69,12 +69,4 @@ public sealed partial class LightReplacerRecyclerComponent : Component
         "ExteriorLightTube",
         "SodiumLightTube",
     };
-
-    /// <summary>
-    ///     Server-side cache of the per-prototype stored-bulb counts shown in the UI. Rebuilt
-    ///     lazily on the next state push after the storage container changes, so repeated pushes
-    ///     (e.g. UI re-opens) don't re-walk the whole inventory. Never networked or serialized.
-    /// </summary>
-    [ViewVariables]
-    public List<LightReplacerStoredBulb>? CachedInventory;
 }

--- a/Content.Shared/RussStation/Light/LightReplacerRecyclerComponent.cs
+++ b/Content.Shared/RussStation/Light/LightReplacerRecyclerComponent.cs
@@ -69,4 +69,12 @@ public sealed partial class LightReplacerRecyclerComponent : Component
         "ExteriorLightTube",
         "SodiumLightTube",
     };
+
+    /// <summary>
+    ///     Server-side cache of the per-prototype stored-bulb counts shown in the UI. Rebuilt
+    ///     lazily on the next state push after the storage container changes, so repeated pushes
+    ///     (e.g. UI re-opens) don't re-walk the whole inventory. Never networked or serialized.
+    /// </summary>
+    [ViewVariables]
+    public List<LightReplacerStoredBulb>? CachedInventory;
 }


### PR DESCRIPTION
## About the PR

Breaks the recycler's bulb-replacement logic into smaller pieces and stops re-counting the whole inventory on every UI push. Behavior stays the same. This is the P2 cleanup from the fork audit.

## Why / Balance

`RunRecycleReplace` had turned into one method that picked a replacement bulb, charged points, moved containers, played audio, and synced the UI all at once, so the three-tier fallback was hard to follow. `PushState` also rebuilt the full per-prototype bulb count every time it ran. Closes #861 (part of the audit in #853).

## Technical details

- Pulled the replacement choice out into a pure `SelectReplacement` step that returns a `BulbReplacementPlan`. It tries an exact prototype match first, then any stored bulb of the same type, then a printed copy. `RunRecycleReplace` just executes the plan now, so the decision is separate from the side effects.
- Added a `CachedInventory` field on the component. `PushState` builds the count once and reuses it, and it gets cleared whenever the storage container changes (insert and remove both fire `ContainerModifiedMessage`), so it won't go stale.
- Printing now runs through a single `IsPrintable` check shared by the radial menu and the exact-match print fallback. Extract keeps its own stored-bulb lookup on purpose: players can manually insert bulbs the recycler can't print, and they still need to pull those back out, so gating extract on the printable list would have changed behavior.

## Breaking changes

None.