### PR TITLE
Refactor SharedCarryingSystem into partials

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Carrying/CarryStateValidationTest.cs
@@ -264,6 +264,85 @@ public sealed class CarryStateValidationTest
     }
 
     /// <summary>
+    /// A StoodEvent on the carried entity ends the carry. The carried-side auto-drop
+    /// handlers read the carrier off BeingCarriedComponent and drop that, so this also
+    /// guards that the teardown targets the carrier and not the carried entity itself
+    /// (the by-value carried path, which DownedEvent on the carrier doesn't exercise).
+    /// </summary>
+    [Test]
+    public async Task CarriedStoodDropsCarry()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+            carrying.Carry(carrier, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True);
+
+            var ev = new StoodEvent();
+            Assert.DoesNotThrow(() => entityManager.EventBus.RaiseLocalEvent(target, ev),
+                "A StoodEvent on the carried entity must drop the carry without recursing");
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "Carrier marker must be cleared when the carried entity stands");
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False,
+                "Target marker must be cleared when the carried entity stands");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// A carried entity recovering to <see cref="MobState.Alive"/> ends the carry. This
+    /// covers the conditional carried-side handler (it only drops on the Alive
+    /// transition, unlike the unconditional handlers) driven through the real mob-state
+    /// system rather than a raw event.
+    /// </summary>
+    [Test]
+    public async Task CarriedWakingDropsCarry()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var carrying = server.System<SharedCarryingSystem>();
+        var mobState = server.System<MobStateSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var carrier = entityManager.SpawnEntity("CarryValidationCarrier", mapData.GridCoords);
+            var target = entityManager.SpawnEntity("CarryValidationTarget", mapData.GridCoords);
+
+            mobState.ChangeMobState(target, MobState.Critical);
+            carrying.Carry(carrier, target);
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.True);
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.True);
+
+            Assert.DoesNotThrow(() => mobState.ChangeMobState(target, MobState.Alive),
+                "A carried entity waking up must drop the carry without recursing");
+
+            Assert.That(entityManager.HasComponent<ActiveCarrierComponent>(carrier), Is.False,
+                "Carrier marker must be cleared when the carried entity wakes");
+            Assert.That(entityManager.HasComponent<BeingCarriedComponent>(target), Is.False,
+                "Target marker must be cleared when the carried entity wakes");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
     /// Buckling an entity that isn't being carried should work normally,
     /// unaffected by the carry system's buckle handler.
     /// </summary>

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.AutoDrop.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.AutoDrop.cs
@@ -1,0 +1,95 @@
+using Content.Shared.Buckle.Components;
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using Robust.Shared.Containers;
+
+namespace Content.Shared.RussStation.Carrying.Systems;
+
+// Auto-drop: a carry ends the moment either party hits a state it can't survive
+// (the carried one stands/buckles/wakes, the carrier is stunned/downed/critical,
+// either is stuffed into a container, ...). Most of these are pure "drop now"
+// reactions differing only by event type, so they're wired through the generic
+// SubscribeCarried*/SubscribeCarrier* helpers below; only the conditional ones
+// keep a hand-written handler.
+public abstract partial class SharedCarryingSystem
+{
+    private void InitializeAutoDrop()
+    {
+        // Carried-side interruptions: drop whoever is carrying this entity.
+        SubscribeCarriedDrop<StoodEvent>();
+        SubscribeCarriedDrop<EntGotInsertedIntoContainerMessage>();
+        SubscribeCarriedDropRef<BuckledEvent>();
+        SubscribeCarriedDropRef<BuckleAttemptEvent>();
+
+        // Carrier-side interruptions: drop the carry this entity is performing.
+        SubscribeCarrierDrop<EntGotInsertedIntoContainerMessage>();
+        SubscribeCarrierDropRef<StunnedEvent>();
+        SubscribeCarrierDropRef<DownedEvent>();
+
+        // Conditional interruptions that can't reduce to an unconditional drop.
+        SubscribeLocalEvent<BeingCarriedComponent, MobStateChangedEvent>(OnCarriedMobStateChanged);
+        SubscribeLocalEvent<ActiveCarrierComponent, MobStateChangedEvent>(OnCarrierMobStateChanged);
+        SubscribeLocalEvent<BeingCarriedComponent, EntParentChangedMessage>(OnCarriedParentChanged);
+    }
+
+    /// <summary>
+    /// Ends the carry on behalf of an external interruption (a state change, a
+    /// container insert, ...). A named seam over <see cref="Drop"/> so the auto-drop
+    /// subscriptions all funnel through one entry point.
+    /// </summary>
+    private void DropFromInterrupt(EntityUid carrier) => Drop(carrier);
+
+    /// <summary>Drop the carry when a by-value <typeparamref name="TEvent"/> fires on the carried entity.</summary>
+    private void SubscribeCarriedDrop<TEvent>() where TEvent : notnull
+        => SubscribeLocalEvent<BeingCarriedComponent, TEvent>(
+            (EntityUid uid, BeingCarriedComponent comp, TEvent args) => DropFromInterrupt(comp.Carrier));
+
+    /// <summary>Drop the carry when a by-ref <typeparamref name="TEvent"/> fires on the carried entity.</summary>
+    private void SubscribeCarriedDropRef<TEvent>() where TEvent : notnull
+        => SubscribeLocalEvent<BeingCarriedComponent, TEvent>(
+            (EntityUid uid, BeingCarriedComponent comp, ref TEvent args) => DropFromInterrupt(comp.Carrier));
+
+    /// <summary>Drop the carry when a by-value <typeparamref name="TEvent"/> fires on the carrier.</summary>
+    private void SubscribeCarrierDrop<TEvent>() where TEvent : notnull
+        => SubscribeLocalEvent<ActiveCarrierComponent, TEvent>(
+            (EntityUid uid, ActiveCarrierComponent comp, TEvent args) => DropFromInterrupt(uid));
+
+    /// <summary>Drop the carry when a by-ref <typeparamref name="TEvent"/> fires on the carrier.</summary>
+    private void SubscribeCarrierDropRef<TEvent>() where TEvent : notnull
+        => SubscribeLocalEvent<ActiveCarrierComponent, TEvent>(
+            (EntityUid uid, ActiveCarrierComponent comp, ref TEvent args) => DropFromInterrupt(uid));
+
+    private void OnCarriedMobStateChanged(EntityUid uid, BeingCarriedComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Alive)
+            DropFromInterrupt(component.Carrier);
+    }
+
+    private void OnCarrierMobStateChanged(EntityUid uid, ActiveCarrierComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState is MobState.Critical or MobState.Dead)
+            DropFromInterrupt(uid);
+    }
+
+    private void OnCarriedParentChanged(EntityUid uid, BeingCarriedComponent component, ref EntParentChangedMessage args)
+    {
+        // Ignore the reparent we trigger ourselves during Carry() setup.
+        if (_transitioning.Contains(component.Carrier))
+            return;
+
+        // Entity deletion detaches before component shutdown. Skip — the marker's
+        // own ComponentShutdown handler will run the teardown for the deletion case.
+        if (Terminating(uid))
+            return;
+
+        // PlaceNextTo inside OnBeingCarriedShutdown fires a parent change mid-teardown;
+        // bail so we don't re-enter Drop on an already-Stopping component.
+        if (IsShuttingDown(component))
+            return;
+
+        if (Transform(uid).ParentUid != component.Carrier)
+            DropFromInterrupt(component.Carrier);
+    }
+}

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.Cleanup.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.Cleanup.cs
@@ -1,0 +1,126 @@
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Events;
+using Content.Shared.Hands;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+
+namespace Content.Shared.RussStation.Carrying.Systems;
+
+// Teardown. Removing either marker is the single point of truth for ending a carry:
+// the marker shutdowns mirror the removal to their partner and OnBeingCarriedShutdown
+// performs the visible cleanup, broken out into per-side helpers.
+public abstract partial class SharedCarryingSystem
+{
+    private void InitializeCleanup()
+    {
+        SubscribeLocalEvent<BeingCarriedComponent, ComponentShutdown>(OnBeingCarriedShutdown);
+        SubscribeLocalEvent<ActiveCarrierComponent, ComponentShutdown>(OnActiveCarrierShutdown);
+        SubscribeLocalEvent<ActiveCarrierComponent, DropHandItemsEvent>(OnDropHandItems);
+        SubscribeLocalEvent<CarrierComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
+    }
+
+    /// <summary>
+    /// The single teardown path for a carry. Fires when the target's marker is removed —
+    /// whether that removal came from <see cref="Drop"/>, the carrier-side shutdown handler,
+    /// or because the target entity itself is being deleted. Reads the carrier reference
+    /// off the marker so it never depends on any other component still being intact.
+    /// </summary>
+    private void OnBeingCarriedShutdown(EntityUid uid, BeingCarriedComponent component, ComponentShutdown args)
+    {
+        var carrier = component.Carrier;
+
+        // Remove the symmetric carrier-side marker. TryRemovePaired skips if the carrier
+        // is terminating or its marker is already shutting down — without that guard the
+        // two handlers recurse (HasComp stays true during ComponentShutdown).
+        TryRemovePaired<ActiveCarrierComponent>(carrier);
+
+        if (Exists(carrier) && !Terminating(carrier))
+            TeardownCarrier(carrier, uid);
+
+        if (!Terminating(uid))
+        {
+            if (Exists(carrier) && !Terminating(carrier))
+                Reparent(uid, carrier);
+
+            RestorePosture(uid, carrier);
+        }
+
+        var ev = new CarryStoppedEvent(carrier, uid);
+        if (Exists(carrier))
+            RaiseLocalEvent(carrier, ref ev);
+        RaiseLocalEvent(uid, ref ev);
+    }
+
+    /// <summary>
+    /// Carrier-side teardown: deletes the carry's virtual hand items, restores the
+    /// carrier's movement speed and shows its drop popup. The <see cref="_transitioning"/>
+    /// guard stops the virtual-item deletion from re-entering <see cref="Drop"/>.
+    /// </summary>
+    private void TeardownCarrier(EntityUid carrier, EntityUid target)
+    {
+        _transitioning.Add(carrier);
+        _virtualItem.DeleteInHandsMatching(carrier, target);
+        _transitioning.Remove(carrier);
+        _movementSpeed.RefreshMovementSpeedModifiers(carrier);
+
+        _popup.PopupClient(Loc.GetString("carrying-drop-carrier", ("target", target)), carrier, carrier);
+    }
+
+    /// <summary>
+    /// Detaches the carried entity from the carrier and places it back into the world
+    /// next to them, ending the carry lerp. No-op if it's no longer parented to the carrier.
+    /// </summary>
+    private void Reparent(EntityUid target, EntityUid carrier)
+    {
+        var targetXform = Transform(target);
+        if (targetXform.ParentUid != carrier)
+            return;
+
+        _transform.PlaceNextTo((target, targetXform), (carrier, Transform(carrier)));
+        targetXform.ActivelyLerping = false;
+        Dirty(target, targetXform);
+    }
+
+    /// <summary>
+    /// Target-side teardown: re-enables movement, stands the dropped entity back up
+    /// (unless it's incapacitated or knocked down) and shows its drop popup.
+    /// </summary>
+    private void RestorePosture(EntityUid target, EntityUid carrier)
+    {
+        _joints.RefreshRelay(target);
+        _actionBlocker.UpdateCanMove(target);
+
+        if (!_mobState.IsIncapacitated(target) && !HasComp<KnockedDownComponent>(target))
+            _standing.Stand(target);
+
+        _popup.PopupClient(Loc.GetString("carrying-drop-carried", ("carrier", carrier)), target, target);
+    }
+
+    /// <summary>
+    /// Symmetric handler for when the carrier-side marker is removed first — typically
+    /// from <see cref="Drop"/> or the carrier entity itself being deleted. Mirrors removal
+    /// to the target marker; the rest of the teardown then runs from
+    /// <see cref="OnBeingCarriedShutdown"/>.
+    /// </summary>
+    private void OnActiveCarrierShutdown(EntityUid uid, ActiveCarrierComponent component, ComponentShutdown args)
+    {
+        // TryRemovePaired skips if the target is terminating or its marker is already
+        // shutting down — without that guard the two handlers recurse when teardown
+        // enters via BeingCarried first.
+        TryRemovePaired<BeingCarriedComponent>(component.Target);
+    }
+
+    private void OnDropHandItems(EntityUid uid, ActiveCarrierComponent component, DropHandItemsEvent args)
+    {
+        Drop(uid);
+    }
+
+    private void OnVirtualItemDeleted(EntityUid uid, CarrierComponent component, VirtualItemDeletedEvent args)
+    {
+        if (_transitioning.Contains(uid))
+            return;
+
+        if (TryComp<ActiveCarrierComponent>(uid, out var active) && active.Target == args.BlockingEntity)
+            Drop(uid);
+    }
+}

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.DragDrop.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.DragDrop.cs
@@ -1,0 +1,49 @@
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.DragDrop;
+
+namespace Content.Shared.RussStation.Carrying.Systems;
+
+// Adapts SS14's drag-drop interaction onto the carry do-after: dragging a valid
+// carriable onto yourself is equivalent to invoking the carry verb.
+public abstract partial class SharedCarryingSystem
+{
+    private void InitializeDragDrop()
+    {
+        SubscribeLocalEvent<CarriableComponent, DragDropDraggedEvent>(OnDragDropDragged);
+        SubscribeLocalEvent<CarriableComponent, CanDropDraggedEvent>(OnCanDropDragged);
+        SubscribeLocalEvent<CarrierComponent, CanDropTargetEvent>(OnCanDropTarget);
+    }
+
+    private void OnCanDropDragged(EntityUid uid, CarriableComponent component, ref CanDropDraggedEvent args)
+    {
+        if (args.Target != args.User)
+            return;
+
+        if (CanCarry(args.User, uid))
+        {
+            args.CanDrop = true;
+            args.Handled = true;
+        }
+    }
+
+    private void OnCanDropTarget(EntityUid uid, CarrierComponent component, ref CanDropTargetEvent args)
+    {
+        args.CanDrop = CanCarry(uid, args.Dragged);
+        args.Handled = true;
+    }
+
+    private void OnDragDropDragged(EntityUid uid, CarriableComponent component, ref DragDropDraggedEvent args)
+    {
+        if (args.Handled || args.Target != args.User)
+            return;
+
+        if (!CanCarry(args.User, uid))
+            return;
+
+        if (!TryComp<CarrierComponent>(args.User, out var carrierComp))
+            return;
+
+        StartCarryDoAfter(args.User, uid, carrierComp);
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.Verbs.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.Verbs.cs
@@ -1,0 +1,146 @@
+using Content.Shared.Buckle.Components;
+using Content.Shared.RussStation.Carrying.Components;
+using Content.Shared.RussStation.Carrying.Events;
+using Content.Shared.DoAfter;
+using Content.Shared.Interaction;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.RussStation.Carrying.Systems;
+
+// Verb providers for starting a carry, dropping it, and the third-party interrupt,
+// plus the interrupt do-after that backs the latter.
+public abstract partial class SharedCarryingSystem
+{
+    private void InitializeVerbs()
+    {
+        SubscribeLocalEvent<CarriableComponent, GetVerbsEvent<InteractionVerb>>(AddCarryVerb);
+        SubscribeLocalEvent<BeingCarriedComponent, GetVerbsEvent<InteractionVerb>>(AddCarriedVerbs);
+
+        SubscribeLocalEvent<BeingCarriedComponent, CarryInterruptDoAfterEvent>(OnCarryInterruptDoAfter);
+    }
+
+    private void AddCarryVerb(EntityUid uid, CarriableComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (args.User == args.Target)
+            return;
+
+        if (!CanCarry(args.User, args.Target))
+            return;
+
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("carrying-verb-carry"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png")),
+            Act = () =>
+            {
+                if (TryComp<CarrierComponent>(args.User, out var carrier) && CanCarry(args.User, args.Target))
+                    StartCarryDoAfter(args.User, args.Target, carrier);
+            },
+        });
+    }
+
+    private void AddCarriedVerbs(EntityUid uid, BeingCarriedComponent component, GetVerbsEvent<InteractionVerb> args)
+    {
+        if (args.User == component.Carrier)
+        {
+            args.Verbs.Add(new InteractionVerb
+            {
+                Text = Loc.GetString("carrying-verb-drop"),
+                Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
+                Act = () => Drop(args.User),
+            });
+            return;
+        }
+
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        // Carried is the target itself; only third parties get the interrupt.
+        if (args.User == uid)
+            return;
+
+        if (!TryComp<CarriableComponent>(uid, out var carriable))
+            return;
+
+        if (!CanInterruptCarry(args.User, carriable))
+            return;
+
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("carrying-verb-interrupt"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
+            Act = () => StartInterruptDoAfter(args.User, uid, carriable),
+        });
+    }
+
+    private bool CanInterruptCarry(EntityUid user, CarriableComponent carriable)
+    {
+        if (_standing.IsDown(user) || _mobState.IsIncapacitated(user))
+            return false;
+
+        if (TryComp<BuckleComponent>(user, out var buckle) && buckle.Buckled)
+            return false;
+
+        if (carriable.InterruptRequiresFreeHand && _hands.CountFreeHands(user) < 1)
+            return false;
+
+        return true;
+    }
+
+    private void StartInterruptDoAfter(EntityUid user, EntityUid target, CarriableComponent carriable)
+    {
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, carriable.InterruptDuration, new CarryInterruptDoAfterEvent(), target, target: target)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = carriable.InterruptRequiresFreeHand,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnCarryInterruptDoAfter(EntityUid uid, BeingCarriedComponent component, CarryInterruptDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.User == uid || args.User == component.Carrier)
+            return;
+
+        args.Handled = true;
+        InterruptCarry(args.User, uid);
+    }
+
+    /// <summary>
+    /// Third-party interrupt completion path: ends the carry on
+    /// <paramref name="target"/>, stuns the carrier, and plays popups.
+    /// No-ops silently if the carry ended (or swapped carriers) between
+    /// DoAfter start and completion. Public so tests can exercise the
+    /// completion outcome without running the full DoAfter.
+    /// </summary>
+    public void InterruptCarry(EntityUid user, EntityUid target)
+    {
+        if (!TryComp<BeingCarriedComponent>(target, out var being))
+            return;
+
+        var carrier = being.Carrier;
+        if (!HasComp<ActiveCarrierComponent>(carrier))
+            return;
+
+        if (TryComp<CarriableComponent>(target, out var carriable))
+            _stun.TryUpdateStunDuration(carrier, carriable.InterruptStunDuration);
+
+        Drop(carrier);
+
+        _popup.PopupPredicted(
+            Loc.GetString("carrying-interrupt-user", ("target", target), ("carrier", carrier)),
+            Loc.GetString("carrying-interrupt-carrier", ("user", user), ("target", target)),
+            user,
+            user);
+        _popup.PopupEntity(
+            Loc.GetString("carrying-interrupt-carried", ("user", user), ("carrier", carrier)),
+            target,
+            target);
+    }
+}

--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -3,15 +3,11 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.RussStation.Carrying.Components;
 using Content.Shared.RussStation.Carrying.Events;
 using Content.Shared.DoAfter;
-using Content.Shared.DragDrop;
 using Content.Shared.RussStation.EscalatedGrab;
 using Content.Shared.RussStation.EscalatedGrab.Systems;
 using Content.Shared.RussStation.Shared;
-using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Interaction;
 using Content.Shared.Inventory.VirtualItem;
-using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
@@ -20,17 +16,22 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
-using Content.Shared.Verbs;
-using Robust.Shared.Containers;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.RussStation.Carrying.Systems;
 
-public abstract class SharedCarryingSystem : PairedMarkerSystem
+/// <summary>
+/// Core of the carry mechanic: deciding whether a carry is allowed
+/// (<see cref="CanCarry"/>), wiring one up (<see cref="Carry"/>) and tearing it
+/// down (<see cref="Drop"/>). The surrounding concerns are split across partials:
+/// <see cref="AddCarryVerb"/> and friends in <c>.Verbs.cs</c>, drag-drop in
+/// <c>.DragDrop.cs</c>, the auto-drop interruption handlers in <c>.AutoDrop.cs</c>,
+/// and the symmetric teardown in <c>.Cleanup.cs</c>.
+/// </summary>
+public abstract partial class SharedCarryingSystem : PairedMarkerSystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedEscalatedGrabSystem _grab = default!;
@@ -55,141 +56,16 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CarriableComponent, GetVerbsEvent<InteractionVerb>>(AddCarryVerb);
-        SubscribeLocalEvent<BeingCarriedComponent, GetVerbsEvent<InteractionVerb>>(AddCarriedVerbs);
-
-        SubscribeLocalEvent<CarriableComponent, DragDropDraggedEvent>(OnDragDropDragged);
-        SubscribeLocalEvent<CarriableComponent, CanDropDraggedEvent>(OnCanDropDragged);
-        SubscribeLocalEvent<CarrierComponent, CanDropTargetEvent>(OnCanDropTarget);
         SubscribeLocalEvent<CarrierComponent, CarryDoAfterEvent>(OnCarryDoAfter);
-        SubscribeLocalEvent<BeingCarriedComponent, CarryInterruptDoAfterEvent>(OnCarryInterruptDoAfter);
         SubscribeLocalEvent<BeingCarriedComponent, Content.Shared.Pulling.Events.BeingPulledAttemptEvent>(OnCarriedPullAttempt);
         SubscribeLocalEvent<ActiveCarrierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
         SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnCarriedCanMove);
 
-        // Auto-drop conditions
-        SubscribeLocalEvent<BeingCarriedComponent, MobStateChangedEvent>(OnCarriedMobStateChanged);
-        SubscribeLocalEvent<BeingCarriedComponent, StoodEvent>(OnCarriedStood);
-        SubscribeLocalEvent<BeingCarriedComponent, BuckledEvent>(OnCarriedBuckled);
-        SubscribeLocalEvent<ActiveCarrierComponent, MobStateChangedEvent>(OnCarrierMobStateChanged);
-        SubscribeLocalEvent<ActiveCarrierComponent, StunnedEvent>(OnCarrierStunned);
-        SubscribeLocalEvent<ActiveCarrierComponent, DownedEvent>(OnCarrierDowned);
-        SubscribeLocalEvent<BeingCarriedComponent, EntGotInsertedIntoContainerMessage>(OnCarriedInserted);
-        SubscribeLocalEvent<ActiveCarrierComponent, EntGotInsertedIntoContainerMessage>(OnCarrierInserted);
-
-        // Drop carry when the carried entity gets buckled
-        SubscribeLocalEvent<BeingCarriedComponent, BuckleAttemptEvent>(OnCarriedBuckleAttempt);
-
-        // Reactive escape detection: if something reparents the target away from the carrier
-        // without going through Drop(), we need to tear the carry down immediately.
-        SubscribeLocalEvent<BeingCarriedComponent, EntParentChangedMessage>(OnCarriedParentChanged);
-
-        // Cleanup
-        SubscribeLocalEvent<BeingCarriedComponent, ComponentShutdown>(OnBeingCarriedShutdown);
-        SubscribeLocalEvent<ActiveCarrierComponent, ComponentShutdown>(OnActiveCarrierShutdown);
-        SubscribeLocalEvent<ActiveCarrierComponent, DropHandItemsEvent>(OnDropHandItems);
-        SubscribeLocalEvent<CarrierComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
+        InitializeVerbs();
+        InitializeDragDrop();
+        InitializeAutoDrop();
+        InitializeCleanup();
     }
-
-    #region Verbs
-
-    private void AddCarryVerb(EntityUid uid, CarriableComponent component, GetVerbsEvent<InteractionVerb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        if (args.User == args.Target)
-            return;
-
-        if (!CanCarry(args.User, args.Target))
-            return;
-
-        args.Verbs.Add(new InteractionVerb
-        {
-            Text = Loc.GetString("carrying-verb-carry"),
-            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png")),
-            Act = () =>
-            {
-                if (TryComp<CarrierComponent>(args.User, out var carrier) && CanCarry(args.User, args.Target))
-                    StartCarryDoAfter(args.User, args.Target, carrier);
-            },
-        });
-    }
-
-    private void AddCarriedVerbs(EntityUid uid, BeingCarriedComponent component, GetVerbsEvent<InteractionVerb> args)
-    {
-        if (args.User == component.Carrier)
-        {
-            args.Verbs.Add(new InteractionVerb
-            {
-                Text = Loc.GetString("carrying-verb-drop"),
-                Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
-                Act = () => Drop(args.User),
-            });
-            return;
-        }
-
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        // Carried is the target itself; only third parties get the interrupt.
-        if (args.User == uid)
-            return;
-
-        if (!TryComp<CarriableComponent>(uid, out var carriable))
-            return;
-
-        if (!CanInterruptCarry(args.User, carriable))
-            return;
-
-        args.Verbs.Add(new InteractionVerb
-        {
-            Text = Loc.GetString("carrying-verb-interrupt"),
-            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
-            Act = () => StartInterruptDoAfter(args.User, uid, carriable),
-        });
-    }
-
-    #endregion
-
-    #region Drag-Drop
-
-    private void OnCanDropDragged(EntityUid uid, CarriableComponent component, ref CanDropDraggedEvent args)
-    {
-        if (args.Target != args.User)
-            return;
-
-        if (CanCarry(args.User, uid))
-        {
-            args.CanDrop = true;
-            args.Handled = true;
-        }
-    }
-
-    private void OnCanDropTarget(EntityUid uid, CarrierComponent component, ref CanDropTargetEvent args)
-    {
-        args.CanDrop = CanCarry(uid, args.Dragged);
-        args.Handled = true;
-    }
-
-    private void OnDragDropDragged(EntityUid uid, CarriableComponent component, ref DragDropDraggedEvent args)
-    {
-        if (args.Handled || args.Target != args.User)
-            return;
-
-        if (!CanCarry(args.User, uid))
-            return;
-
-        if (!TryComp<CarrierComponent>(args.User, out var carrierComp))
-            return;
-
-        StartCarryDoAfter(args.User, uid, carrierComp);
-        args.Handled = true;
-    }
-
-    #endregion
-
-    #region Carry Logic
 
     private bool CanCarry(EntityUid carrier, EntityUid target)
     {
@@ -250,41 +126,6 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
         Carry(uid, args.Target.Value);
     }
 
-    private bool CanInterruptCarry(EntityUid user, CarriableComponent carriable)
-    {
-        if (_standing.IsDown(user) || _mobState.IsIncapacitated(user))
-            return false;
-
-        if (TryComp<BuckleComponent>(user, out var buckle) && buckle.Buckled)
-            return false;
-
-        if (carriable.InterruptRequiresFreeHand && _hands.CountFreeHands(user) < 1)
-            return false;
-
-        return true;
-    }
-
-    private void StartInterruptDoAfter(EntityUid user, EntityUid target, CarriableComponent carriable)
-    {
-        var doAfterArgs = new DoAfterArgs(EntityManager, user, carriable.InterruptDuration, new CarryInterruptDoAfterEvent(), target, target: target)
-        {
-            BreakOnMove = true,
-            BreakOnDamage = true,
-            NeedHand = carriable.InterruptRequiresFreeHand,
-        };
-
-        _doAfter.TryStartDoAfter(doAfterArgs);
-    }
-
-    private void OnCarryInterruptDoAfter(EntityUid uid, BeingCarriedComponent component, CarryInterruptDoAfterEvent args)
-    {
-        if (args.Handled || args.Cancelled || args.User == uid || args.User == component.Carrier)
-            return;
-
-        args.Handled = true;
-        InterruptCarry(args.User, uid);
-    }
-
     /// <summary>
     /// Block third-party pull attempts on a carried entity. Pull-while-carried races
     /// with the carry's reparent and drop hooks (the puller's virtual item handles
@@ -296,38 +137,6 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
     private void OnCarriedPullAttempt(EntityUid uid, BeingCarriedComponent component, Content.Shared.Pulling.Events.BeingPulledAttemptEvent args)
     {
         args.Cancel();
-    }
-
-    /// <summary>
-    /// Third-party interrupt completion path: ends the carry on
-    /// <paramref name="target"/>, stuns the carrier, and plays popups.
-    /// No-ops silently if the carry ended (or swapped carriers) between
-    /// DoAfter start and completion. Public so tests can exercise the
-    /// completion outcome without running the full DoAfter.
-    /// </summary>
-    public void InterruptCarry(EntityUid user, EntityUid target)
-    {
-        if (!TryComp<BeingCarriedComponent>(target, out var being))
-            return;
-
-        var carrier = being.Carrier;
-        if (!HasComp<ActiveCarrierComponent>(carrier))
-            return;
-
-        if (TryComp<CarriableComponent>(target, out var carriable))
-            _stun.TryUpdateStunDuration(carrier, carriable.InterruptStunDuration);
-
-        Drop(carrier);
-
-        _popup.PopupPredicted(
-            Loc.GetString("carrying-interrupt-user", ("target", target), ("carrier", carrier)),
-            Loc.GetString("carrying-interrupt-carrier", ("user", user), ("target", target)),
-            user,
-            user);
-        _popup.PopupEntity(
-            Loc.GetString("carrying-interrupt-carried", ("user", user), ("carrier", carrier)),
-            target,
-            target);
     }
 
     /// <summary>
@@ -427,10 +236,6 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
             "OnActiveCarrierShutdown should have removed the BeingCarriedComponent");
     }
 
-    #endregion
-
-    #region Speed & Movement
-
     private void OnRefreshMoveSpeed(EntityUid uid, ActiveCarrierComponent component, RefreshMovementSpeedModifiersEvent args)
     {
         if (!TryComp<CarrierComponent>(uid, out var carrier))
@@ -443,162 +248,4 @@ public abstract class SharedCarryingSystem : PairedMarkerSystem
     {
         args.Cancel();
     }
-
-    #endregion
-
-    #region Auto-Drop
-
-    private void OnCarriedMobStateChanged(EntityUid uid, BeingCarriedComponent component, MobStateChangedEvent args)
-    {
-        if (args.NewMobState == MobState.Alive)
-            Drop(component.Carrier);
-    }
-
-    private void OnCarriedStood(EntityUid uid, BeingCarriedComponent component, StoodEvent args)
-    {
-        Drop(component.Carrier);
-    }
-
-    private void OnCarriedBuckled(EntityUid uid, BeingCarriedComponent component, ref BuckledEvent args)
-    {
-        Drop(component.Carrier);
-    }
-
-    private void OnCarrierMobStateChanged(EntityUid uid, ActiveCarrierComponent component, MobStateChangedEvent args)
-    {
-        if (args.NewMobState is MobState.Critical or MobState.Dead)
-            Drop(uid);
-    }
-
-    private void OnCarrierStunned(EntityUid uid, ActiveCarrierComponent component, ref StunnedEvent args)
-    {
-        Drop(uid);
-    }
-
-    private void OnCarrierDowned(EntityUid uid, ActiveCarrierComponent component, ref DownedEvent args)
-    {
-        Drop(uid);
-    }
-
-    private void OnCarriedInserted(EntityUid uid, BeingCarriedComponent component, EntGotInsertedIntoContainerMessage args)
-    {
-        Drop(component.Carrier);
-    }
-
-    private void OnCarrierInserted(EntityUid uid, ActiveCarrierComponent component, EntGotInsertedIntoContainerMessage args)
-    {
-        Drop(uid);
-    }
-
-    private void OnCarriedBuckleAttempt(EntityUid uid, BeingCarriedComponent component, ref BuckleAttemptEvent args)
-    {
-        Drop(component.Carrier);
-    }
-
-    private void OnCarriedParentChanged(EntityUid uid, BeingCarriedComponent component, ref EntParentChangedMessage args)
-    {
-        // Ignore the reparent we trigger ourselves during Carry() setup.
-        if (_transitioning.Contains(component.Carrier))
-            return;
-
-        // Entity deletion detaches before component shutdown. Skip — the marker's
-        // own ComponentShutdown handler will run the teardown for the deletion case.
-        if (Terminating(uid))
-            return;
-
-        // PlaceNextTo inside OnBeingCarriedShutdown fires a parent change mid-teardown;
-        // bail so we don't re-enter Drop on an already-Stopping component.
-        if (IsShuttingDown(component))
-            return;
-
-        if (Transform(uid).ParentUid != component.Carrier)
-            Drop(component.Carrier);
-    }
-
-    #endregion
-
-    #region Cleanup
-
-    /// <summary>
-    /// The single teardown path for a carry. Fires when the target's marker is removed —
-    /// whether that removal came from <see cref="Drop"/>, the carrier-side shutdown handler,
-    /// or because the target entity itself is being deleted. Reads the carrier reference
-    /// off the marker so it never depends on any other component still being intact.
-    /// </summary>
-    private void OnBeingCarriedShutdown(EntityUid uid, BeingCarriedComponent component, ComponentShutdown args)
-    {
-        var carrier = component.Carrier;
-
-        // Remove the symmetric carrier-side marker. TryRemovePaired skips if the carrier
-        // is terminating or its marker is already shutting down — without that guard the
-        // two handlers recurse (HasComp stays true during ComponentShutdown).
-        TryRemovePaired<ActiveCarrierComponent>(carrier);
-
-        if (Exists(carrier) && !Terminating(carrier))
-        {
-            _transitioning.Add(carrier);
-            _virtualItem.DeleteInHandsMatching(carrier, uid);
-            _transitioning.Remove(carrier);
-            _movementSpeed.RefreshMovementSpeedModifiers(carrier);
-
-            _popup.PopupClient(Loc.GetString("carrying-drop-carrier", ("target", uid)), carrier, carrier);
-        }
-
-        if (!Terminating(uid))
-        {
-            if (Exists(carrier) && !Terminating(carrier))
-            {
-                var targetXform = Transform(uid);
-                if (targetXform.ParentUid == carrier)
-                {
-                    _transform.PlaceNextTo((uid, targetXform), (carrier, Transform(carrier)));
-                    targetXform.ActivelyLerping = false;
-                    Dirty(uid, targetXform);
-                }
-            }
-
-            _joints.RefreshRelay(uid);
-            _actionBlocker.UpdateCanMove(uid);
-
-            if (!_mobState.IsIncapacitated(uid) && !HasComp<KnockedDownComponent>(uid))
-                _standing.Stand(uid);
-
-            _popup.PopupClient(Loc.GetString("carrying-drop-carried", ("carrier", carrier)), uid, uid);
-        }
-
-        var ev = new CarryStoppedEvent(carrier, uid);
-        if (Exists(carrier))
-            RaiseLocalEvent(carrier, ref ev);
-        RaiseLocalEvent(uid, ref ev);
-    }
-
-    /// <summary>
-    /// Symmetric handler for when the carrier-side marker is removed first — typically
-    /// from <see cref="Drop"/> or the carrier entity itself being deleted. Mirrors removal
-    /// to the target marker; the rest of the teardown then runs from
-    /// <see cref="OnBeingCarriedShutdown"/>.
-    /// </summary>
-    private void OnActiveCarrierShutdown(EntityUid uid, ActiveCarrierComponent component, ComponentShutdown args)
-    {
-        // TryRemovePaired skips if the target is terminating or its marker is already
-        // shutting down — without that guard the two handlers recurse when teardown
-        // enters via BeingCarried first.
-        TryRemovePaired<BeingCarriedComponent>(component.Target);
-    }
-
-    private void OnDropHandItems(EntityUid uid, ActiveCarrierComponent component, DropHandItemsEvent args)
-    {
-        Drop(uid);
-    }
-
-    private void OnVirtualItemDeleted(EntityUid uid, CarrierComponent component, VirtualItemDeletedEvent args)
-    {
-        if (_transitioning.Contains(uid))
-            return;
-
-        if (TryComp<ActiveCarrierComponent>(uid, out var active) && active.Target == args.BlockingEntity)
-            Drop(uid);
-    }
-
-    #endregion
 }


### PR DESCRIPTION
## About the PR

Splits the 604-line `SharedCarryingSystem` into five partial-class files, one per responsibility, and folds the duplicated auto-drop handlers together. No behavior changes. This is the P0 cleanup from the fork audit (#853).

## Why / Balance

The single file had turned into five systems sharing a class: verb creation, the drag-drop adapter, the core carry and drop logic, the auto-drop conditions, and teardown, held together only by `#region`s. There was also genuine duplication. About seven of the auto-drop handlers (`OnCarried*` and `OnCarrier*`) were plain `Drop(uid)` delegations that differed only by event type, and the `TryRemovePaired` teardown pattern was copied into both shutdown handlers. Closes #854.

## Technical details

The type is now `abstract partial`, declared across five files:

- `SharedCarryingSystem.cs` keeps `Initialize` and the `Carry` / `Drop` / `CanCarry` core, along with the shared carry do-after, the pull-block, and the speed and move-cancel hooks.
- `SharedCarryingSystem.Verbs.cs` has the carry, drop, and interrupt verb providers plus the interrupt do-after.
- `SharedCarryingSystem.DragDrop.cs` has the drag-drop handlers.
- `SharedCarryingSystem.AutoDrop.cs` folds the seven unconditional handlers into one `DropFromInterrupt(uid)`, reached through generic `SubscribeCarriedDrop` / `SubscribeCarrierDrop` helpers (and their `Ref` variants). Only the handlers that actually branch keep a hand-written body: mob-state-changed on each side, and the reactive parent-change.
- `SharedCarryingSystem.Cleanup.cs` breaks the 46-line `OnBeingCarriedShutdown` into `TeardownCarrier`, `Reparent`, and `RestorePosture`.

Every `SubscribeLocalEvent` stays as it was, including whether it dispatches by ref or by value. I checked each consolidated event's `[ByRefEvent]` against the original handler signature so the generic helpers line up: `StoodEvent` by value, `BuckledEvent`, `StunnedEvent`, and `DownedEvent` by ref, and so on. All subscriptions still run out of `Initialize` through `InitializeXxx` and `SubscribeXxx` helpers, which is what HONK0009 wants. The public `Carry`, `Drop`, and `InterruptCarry` methods are unchanged and stay covered by `Content.IntegrationTests/Tests/RussStation/Carrying`.

One caveat for reviewers: I couldn't build this locally. The environment has no .NET SDK and the `RobustToolbox` submodule isn't checked out. I verified the split against the analyzers (HONK0009 and the `.Honk.cs`-scoped partial rules, none of which this trips), the event definitions, and the test call sites, but CI is the first real compile.

## Breaking changes

None.

https://claude.ai/code/session_01GTgBG3rycRhtdBtD1drrn9