### PR TITLE
Refactor SkillchipStationSystem into three subsystems

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipStationTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Skillchips/SkillchipStationTest.cs
@@ -2,6 +2,8 @@ using System;
 using Content.Server.Power.Components;
 using Content.Server.RussStation.Skillchips;
 using Content.Shared.Body;
+using Content.Shared.Destructible;
+using Content.Shared.DragDrop;
 using Content.Shared.Movement.Events;
 using Content.Shared.RussStation.Skillchips;
 using Content.Shared.RussStation.Skillchips.Systems;
@@ -282,6 +284,114 @@ public sealed class SkillchipStationTest
 
             Assert.That(seat.ContainedEntity, Is.Null,
                 "Relay movement should eject the occupant from the body container");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// The can-drop gate accepts a body while the seat is empty and refuses one
+    /// once it is occupied, so a second patient cannot be dropped onto the first.
+    /// </summary>
+    [Test]
+    public async Task CanDragDrop_GatesOnOccupancy()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // Seat empty: a body should be a valid drop target.
+            var (station, op, body, _, _) = SetupSeated(em, containers, mapData.MapCoords, seatBody: false);
+
+            var open = new CanDropTargetEvent(op, body);
+            em.EventBus.RaiseLocalEvent(station, ref open);
+            Assert.That(open.Handled, Is.True, "Station should handle the can-drop query");
+            Assert.That(open.CanDrop, Is.True, "An empty station should accept a body");
+
+            // Now seat the body; a further drop must be refused.
+            var seat = containers.EnsureContainer<ContainerSlot>(station, SkillchipStationComponent.BodyContainerId);
+            containers.Insert(body, seat);
+
+            var other = em.SpawnEntity("StationTestBody", mapData.MapCoords);
+            var occupied = new CanDropTargetEvent(op, other);
+            em.EventBus.RaiseLocalEvent(station, ref occupied);
+            Assert.That(occupied.CanDrop, Is.False, "An occupied station should refuse a second body");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Dragging a body onto the station runs the entry DoAfter and, on
+    /// completion, seats the occupant in the body container.
+    /// </summary>
+    [Test]
+    public async Task DragDrop_SeatsOccupant()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        EntityUid station = default, body = default;
+
+        await server.WaitAssertion(() =>
+        {
+            var (st, op, bodyEnt, _, _) = SetupSeated(em, containers, mapData.MapCoords, seatBody: false);
+            station = st;
+            body = bodyEnt;
+
+            // Shorten the entry delay so the DoAfter completes within a few ticks.
+            em.GetComponent<SkillchipStationComponent>(station).EntryDelay = TimeSpan.FromSeconds(0.1);
+
+            var drop = new DragDropTargetEvent(op, body);
+            em.EventBus.RaiseLocalEvent(station, ref drop);
+            Assert.That(drop.Handled, Is.True, "Station should handle the drag-drop");
+        });
+
+        await server.WaitRunTicks(30);
+
+        await server.WaitAssertion(() =>
+        {
+            var seat = containers.EnsureContainer<ContainerSlot>(station, SkillchipStationComponent.BodyContainerId);
+            Assert.That(seat.ContainedEntity, Is.EqualTo(body),
+                "Entry DoAfter should seat the body in the occupant container");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Destroying the station ejects the occupant rather than deleting them
+    /// along with the machine.
+    /// </summary>
+    [Test]
+    public async Task Destroyed_EjectsOccupant()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var em = server.ResolveDependency<IEntityManager>();
+        var containers = server.System<SharedContainerSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var (station, _, body, _, _) = SetupSeated(em, containers, mapData.MapCoords);
+
+            var seat = containers.EnsureContainer<ContainerSlot>(station, SkillchipStationComponent.BodyContainerId);
+            Assert.That(seat.ContainedEntity, Is.EqualTo(body), "Setup precondition: body seated");
+
+            em.EventBus.RaiseLocalEvent(station, new DestructionEventArgs());
+
+            Assert.That(seat.ContainedEntity, Is.Null,
+                "Destruction should eject the occupant before the machine is removed");
+            Assert.That(em.EntityExists(body), Is.True,
+                "Ejected occupant should survive the station's destruction");
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/RussStation/Skillchips/SkillchipStationOccupantManager.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipStationOccupantManager.cs
@@ -27,7 +27,6 @@ public sealed class SkillchipStationOccupantManager : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SkillchipStationComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SkillchipStationComponent, CanDropTargetEvent>(OnCanDragDropOn);
         SubscribeLocalEvent<SkillchipStationComponent, DragDropTargetEvent>(OnDragDropOn);
         SubscribeLocalEvent<SkillchipStationComponent, SkillchipStationEnterDoAfterEvent>(OnEnterDoAfter);
@@ -35,7 +34,13 @@ public sealed class SkillchipStationOccupantManager : EntitySystem
         SubscribeLocalEvent<SkillchipStationComponent, DestructionEventArgs>(OnDestroyed);
     }
 
-    private void OnInit(EntityUid uid, SkillchipStationComponent comp, ComponentInit args)
+    /// <summary>
+    /// Ensures the body container exists and seeds the occupied/open appearance.
+    /// Driven from <see cref="SkillchipStationSystem"/>'s ComponentInit, which
+    /// holds the component's single subscription to that event (Robust rejects a
+    /// second subscriber for the same component/event pair).
+    /// </summary>
+    public void SetupOccupantContainer(EntityUid uid)
     {
         _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
         UpdateAppearance(uid);

--- a/Content.Server/RussStation/Skillchips/SkillchipStationOccupantManager.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipStationOccupantManager.cs
@@ -1,0 +1,142 @@
+using Content.Shared.Body;
+using Content.Shared.Climbing.Systems;
+using Content.Shared.Destructible;
+using Content.Shared.DoAfter;
+using Content.Shared.DragDrop;
+using Content.Shared.Movement.Events;
+using Content.Shared.RussStation.Skillchips;
+using Robust.Shared.Containers;
+
+namespace Content.Server.RussStation.Skillchips;
+
+/// <summary>
+/// Owns the station's occupant slot: the body-container state machine that
+/// boards a patient via drag-drop (medical-scanner / cryo-pod pattern), ejects
+/// them on relay-move or destruction, and tracks the occupied/open appearance.
+/// Split out of <see cref="SkillchipStationSystem"/> so the implant flow and the
+/// UI builder can ask "who is seated?" without owning the boarding logic.
+/// </summary>
+public sealed class SkillchipStationOccupantManager : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly ClimbSystem _climb = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SkillchipStationComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<SkillchipStationComponent, CanDropTargetEvent>(OnCanDragDropOn);
+        SubscribeLocalEvent<SkillchipStationComponent, DragDropTargetEvent>(OnDragDropOn);
+        SubscribeLocalEvent<SkillchipStationComponent, SkillchipStationEnterDoAfterEvent>(OnEnterDoAfter);
+        SubscribeLocalEvent<SkillchipStationComponent, ContainerRelayMovementEntityEvent>(OnRelayMovement);
+        SubscribeLocalEvent<SkillchipStationComponent, DestructionEventArgs>(OnDestroyed);
+    }
+
+    private void OnInit(EntityUid uid, SkillchipStationComponent comp, ComponentInit args)
+    {
+        _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
+        UpdateAppearance(uid);
+    }
+
+    // ── Occupant insert / eject (medical scanner body-container pattern) ───────
+
+    private void OnCanDragDropOn(EntityUid uid, SkillchipStationComponent comp, ref CanDropTargetEvent args)
+    {
+        args.Handled = true;
+        args.CanDrop |= HasComp<BodyComponent>(args.Dragged) && !IsOccupied(uid);
+    }
+
+    private void OnDragDropOn(EntityUid uid, SkillchipStationComponent comp, ref DragDropTargetEvent args)
+    {
+        // Mirrors CryoPod.HandleDragDropOn: our own EntryDelay DoAfter, then
+        // insert on completion. Mark handled so the climb system skips its
+        // parallel DoAfter.
+        args.Handled = true;
+
+        if (IsOccupied(uid) || !HasComp<BodyComponent>(args.Dragged))
+            return;
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, comp.EntryDelay,
+            new SkillchipStationEnterDoAfterEvent(), uid, target: args.Dragged, used: uid)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = false,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnEnterDoAfter(EntityUid uid, SkillchipStationComponent comp, ref SkillchipStationEnterDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Args.Target is not { } dragged)
+            return;
+
+        InsertBody(uid, dragged);
+        args.Handled = true;
+    }
+
+    private void OnRelayMovement(EntityUid uid, SkillchipStationComponent comp, ref ContainerRelayMovementEntityEvent args)
+    {
+        EjectBody(uid);
+    }
+
+    private void OnDestroyed(EntityUid uid, SkillchipStationComponent comp, DestructionEventArgs args)
+    {
+        EjectBody(uid);
+    }
+
+    /// <summary>
+    /// Returns true when a patient is seated in the body container.
+    /// </summary>
+    public bool IsOccupied(EntityUid uid)
+    {
+        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
+        return body.ContainedEntity != null;
+    }
+
+    /// <summary>
+    /// The patient is whoever is inside the body container, not the operator
+    /// running the console.
+    /// </summary>
+    public bool TryGetOccupant(EntityUid uid, out EntityUid occupant)
+    {
+        occupant = default;
+        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
+        if (body.ContainedEntity is not { } contained)
+            return false;
+
+        occupant = contained;
+        return true;
+    }
+
+    private void InsertBody(EntityUid uid, EntityUid toInsert)
+    {
+        if (!HasComp<BodyComponent>(toInsert) || IsOccupied(uid))
+            return;
+
+        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
+        _containers.Insert(toInsert, body);
+        UpdateAppearance(uid);
+    }
+
+    private void EjectBody(EntityUid uid)
+    {
+        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
+        if (body.ContainedEntity is not { } occupant)
+            return;
+
+        _containers.Remove(occupant, body);
+        _climb.ForciblySetClimbing(occupant, uid);
+        UpdateAppearance(uid);
+    }
+
+    private void UpdateAppearance(EntityUid uid)
+    {
+        var status = IsOccupied(uid) ? SkillchipStationStatus.Occupied : SkillchipStationStatus.Open;
+        _appearance.SetData(uid, SkillchipStationVisuals.Status, status);
+    }
+}

--- a/Content.Server/RussStation/Skillchips/SkillchipStationSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipStationSystem.cs
@@ -43,6 +43,7 @@ public sealed class SkillchipStationSystem : EntitySystem
     private void OnInit(EntityUid uid, SkillchipStationComponent comp, ComponentInit args)
     {
         _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.ChipSlotId);
+        _occupant.SetupOccupantContainer(uid);
     }
 
     // ── Chip-tray interaction ─────────────────────────────────────────────────

--- a/Content.Server/RussStation/Skillchips/SkillchipStationSystem.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipStationSystem.cs
@@ -1,22 +1,21 @@
-using Content.Shared.Body;
-using Content.Shared.Climbing.Systems;
-using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
-using Content.Shared.DragDrop;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
-using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.RussStation.Skillchips;
 using Content.Shared.RussStation.Skillchips.Systems;
-using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.RussStation.Skillchips;
 
+/// <summary>
+/// Drives the skillchip station console: the chip-tray interaction and the
+/// powered implant / remove operations. Occupant boarding lives in
+/// <see cref="SkillchipStationOccupantManager"/> and UI-state serialization in
+/// <see cref="SkillchipStationUiBuilder"/>; this system orchestrates them.
+/// </summary>
 public sealed class SkillchipStationSystem : EntitySystem
 {
     [Dependency] private readonly SharedSkillchipSystem _skillchips = default!;
@@ -25,10 +24,8 @@ public sealed class SkillchipStationSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly ClimbSystem _climb = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SkillchipStationOccupantManager _occupant = default!;
+    [Dependency] private readonly SkillchipStationUiBuilder _uiBuilder = default!;
 
     public override void Initialize()
     {
@@ -36,14 +33,6 @@ public sealed class SkillchipStationSystem : EntitySystem
 
         SubscribeLocalEvent<SkillchipStationComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SkillchipStationComponent, InteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<SkillchipStationComponent, CanDropTargetEvent>(OnCanDragDropOn);
-        SubscribeLocalEvent<SkillchipStationComponent, DragDropTargetEvent>(OnDragDropOn);
-        SubscribeLocalEvent<SkillchipStationComponent, SkillchipStationEnterDoAfterEvent>(OnEnterDoAfter);
-        SubscribeLocalEvent<SkillchipStationComponent, ContainerRelayMovementEntityEvent>(OnRelayMovement);
-        SubscribeLocalEvent<SkillchipStationComponent, DestructionEventArgs>(OnDestroyed);
-        SubscribeLocalEvent<SkillchipStationComponent, BoundUIOpenedEvent>(OnUIOpened);
-        SubscribeLocalEvent<SkillchipStationComponent, EntInsertedIntoContainerMessage>(OnContainerChanged);
-        SubscribeLocalEvent<SkillchipStationComponent, EntRemovedFromContainerMessage>(OnContainerChanged);
         SubscribeLocalEvent<SkillchipStationComponent, SkillchipStationImplantMessage>(OnImplantMessage);
         SubscribeLocalEvent<SkillchipStationComponent, SkillchipStationEjectMessage>(OnEjectMessage);
         SubscribeLocalEvent<SkillchipStationComponent, SkillchipStationRemoveMessage>(OnRemoveMessage);
@@ -54,90 +43,9 @@ public sealed class SkillchipStationSystem : EntitySystem
     private void OnInit(EntityUid uid, SkillchipStationComponent comp, ComponentInit args)
     {
         _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.ChipSlotId);
-        _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
-        UpdateAppearance(uid);
     }
 
-    // ── Occupant insert / eject (medical scanner body-container pattern) ───────
-
-    private void OnCanDragDropOn(EntityUid uid, SkillchipStationComponent comp, ref CanDropTargetEvent args)
-    {
-        args.Handled = true;
-        args.CanDrop |= HasComp<BodyComponent>(args.Dragged) && !IsOccupied(uid);
-    }
-
-    private void OnDragDropOn(EntityUid uid, SkillchipStationComponent comp, ref DragDropTargetEvent args)
-    {
-        // Mirrors CryoPod.HandleDragDropOn: our own EntryDelay DoAfter, then
-        // insert on completion. Mark handled so the climb system skips its
-        // parallel DoAfter.
-        args.Handled = true;
-
-        if (IsOccupied(uid) || !HasComp<BodyComponent>(args.Dragged))
-            return;
-
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, comp.EntryDelay,
-            new SkillchipStationEnterDoAfterEvent(), uid, target: args.Dragged, used: uid)
-        {
-            BreakOnMove = true,
-            BreakOnDamage = true,
-            NeedHand = false,
-        };
-
-        _doAfter.TryStartDoAfter(doAfterArgs);
-    }
-
-    private void OnEnterDoAfter(EntityUid uid, SkillchipStationComponent comp, ref SkillchipStationEnterDoAfterEvent args)
-    {
-        if (args.Cancelled || args.Handled || args.Args.Target is not { } dragged)
-            return;
-
-        InsertBody(uid, dragged);
-        args.Handled = true;
-    }
-
-    private void OnRelayMovement(EntityUid uid, SkillchipStationComponent comp, ref ContainerRelayMovementEntityEvent args)
-    {
-        EjectBody(uid);
-    }
-
-    private void OnDestroyed(EntityUid uid, SkillchipStationComponent comp, DestructionEventArgs args)
-    {
-        EjectBody(uid);
-    }
-
-    private bool IsOccupied(EntityUid uid)
-    {
-        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
-        return body.ContainedEntity != null;
-    }
-
-    private void InsertBody(EntityUid uid, EntityUid toInsert)
-    {
-        if (!HasComp<BodyComponent>(toInsert) || IsOccupied(uid))
-            return;
-
-        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
-        _containers.Insert(toInsert, body);
-        UpdateAppearance(uid);
-    }
-
-    private void EjectBody(EntityUid uid)
-    {
-        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
-        if (body.ContainedEntity is not { } occupant)
-            return;
-
-        _containers.Remove(occupant, body);
-        _climb.ForciblySetClimbing(occupant, uid);
-        UpdateAppearance(uid);
-    }
-
-    private void UpdateAppearance(EntityUid uid)
-    {
-        var status = IsOccupied(uid) ? SkillchipStationStatus.Occupied : SkillchipStationStatus.Open;
-        _appearance.SetData(uid, SkillchipStationVisuals.Status, status);
-    }
+    // ── Chip-tray interaction ─────────────────────────────────────────────────
 
     private void OnInteractUsing(EntityUid uid, SkillchipStationComponent comp, InteractUsingEvent args)
     {
@@ -162,21 +70,7 @@ public sealed class SkillchipStationSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnUIOpened(EntityUid uid, SkillchipStationComponent comp, BoundUIOpenedEvent args)
-    {
-        PushState(uid, comp);
-    }
-
-    private void OnContainerChanged(EntityUid uid, SkillchipStationComponent comp, ContainerModifiedMessage args)
-    {
-        // Tray changes alter the inserted-chip panel; occupant changes alter
-        // the installed-chip list and capacity bar. Both need a refresh.
-        if (args.Container.ID != SkillchipStationComponent.ChipSlotId &&
-            args.Container.ID != SkillchipStationComponent.BodyContainerId)
-            return;
-
-        PushState(uid, comp);
-    }
+    // ── Implant / eject / remove operations ───────────────────────────────────
 
     private void OnImplantMessage(EntityUid uid, SkillchipStationComponent comp, SkillchipStationImplantMessage args)
     {
@@ -199,7 +93,7 @@ public sealed class SkillchipStationSystem : EntitySystem
         if (!TryComp<SkillchipComponent>(chipEnt, out var chipComp))
             return;
 
-        if (TryGetOccupant(uid, out var patient) &&
+        if (_occupant.TryGetOccupant(uid, out var patient) &&
             _skillchips.HasChipInstalled(patient, chipComp.ChipProto))
         {
             _popup.PopupEntity(Loc.GetString("skillchip-station-duplicate"), uid, user);
@@ -214,11 +108,7 @@ public sealed class SkillchipStationSystem : EntitySystem
             NeedHand = false,
         };
 
-        if (!_doAfter.TryStartDoAfter(doAfterArgs))
-            return;
-
-        _audio.PlayPvs(comp.OperationStartSound, uid);
-        PushStateWorking(uid, comp, working: true);
+        TryStartOperation(uid, comp, doAfterArgs);
     }
 
     private void OnEjectMessage(EntityUid uid, SkillchipStationComponent comp, SkillchipStationEjectMessage args)
@@ -243,7 +133,7 @@ public sealed class SkillchipStationSystem : EntitySystem
             return;
         }
 
-        if (!TryGetOccupant(uid, out var patient))
+        if (!_occupant.TryGetOccupant(uid, out var patient))
         {
             _popup.PopupEntity(Loc.GetString("skillchip-station-no-occupant"), uid, user);
             return;
@@ -266,54 +156,25 @@ public sealed class SkillchipStationSystem : EntitySystem
             NeedHand = false,
         };
 
-        if (!_doAfter.TryStartDoAfter(doAfterArgs))
-            return;
-
-        _audio.PlayPvs(comp.OperationStartSound, uid);
-        PushStateWorking(uid, comp, working: true);
-    }
-
-    /// <summary>
-    /// The patient is whoever is inside the body container, not the operator
-    /// running the console.
-    /// </summary>
-    private bool TryGetOccupant(EntityUid uid, out EntityUid occupant)
-    {
-        occupant = default;
-        var body = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.BodyContainerId);
-        if (body.ContainedEntity is not { } contained)
-            return false;
-
-        occupant = contained;
-        return true;
+        TryStartOperation(uid, comp, doAfterArgs);
     }
 
     private void OnImplantDoAfter(EntityUid uid, SkillchipStationComponent comp, SkillchipImplantDoAfterEvent args)
     {
         var user = args.User;
-        PushStateWorking(uid, comp, working: false);
+        _uiBuilder.PushStateWorking(uid, comp, working: false);
 
         if (args.Cancelled)
             return;
 
+        // Resolve the tray chip before the occupant: a chip pulled mid-operation
+        // bails silently, exactly as the operator-facing flow always has.
         var slot = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.ChipSlotId);
-        if (slot.ContainedEntity is not { } chipEnt)
+        if (slot.ContainedEntity is not { } chipEnt || !TryComp<SkillchipComponent>(chipEnt, out var chipComp))
             return;
 
-        if (!TryComp<SkillchipComponent>(chipEnt, out var chipComp))
+        if (!TryResolveOperationBrain(uid, user, popupOnMissing: true, out var brain))
             return;
-
-        if (!TryGetOccupant(uid, out var patient))
-        {
-            _popup.PopupEntity(Loc.GetString("skillchip-station-no-occupant"), uid, user);
-            return;
-        }
-
-        if (!_skillchips.TryGetBrain(patient, out var brain))
-        {
-            _popup.PopupEntity(Loc.GetString("skillchip-station-no-brain"), uid, user);
-            return;
-        }
 
         if (!_skillchips.TryInstall(brain, chipComp.ChipProto))
         {
@@ -330,12 +191,14 @@ public sealed class SkillchipStationSystem : EntitySystem
     private void OnRemoveDoAfter(EntityUid uid, SkillchipStationComponent comp, SkillchipRemoveDoAfterEvent args)
     {
         var user = args.User;
-        PushStateWorking(uid, comp, working: false);
+        _uiBuilder.PushStateWorking(uid, comp, working: false);
 
         if (args.Cancelled)
             return;
 
-        if (!TryGetOccupant(uid, out var patient) || !_skillchips.TryGetBrain(patient, out var brain))
+        // The remove flow validated the occupant when it started the do-after,
+        // so a target that has since left simply bails without a popup.
+        if (!TryResolveOperationBrain(uid, user, popupOnMissing: false, out var brain))
             return;
 
         if (!_skillchips.TryRemove(brain, args.ChipProto))
@@ -345,53 +208,46 @@ public sealed class SkillchipStationSystem : EntitySystem
         _popup.PopupEntity(Loc.GetString("skillchip-station-removed"), uid, user);
     }
 
-    // ── State helpers ─────────────────────────────────────────────────────────
+    // ── Shared do-after plumbing ──────────────────────────────────────────────
 
-    private void PushState(EntityUid uid, SkillchipStationComponent comp)
+    /// <summary>
+    /// Starts an operation do-after and, on success, plays the start cue and
+    /// flips the UI into its working state. Shared by the implant and remove
+    /// message handlers, which build identical do-afters bar their event.
+    /// </summary>
+    private void TryStartOperation(EntityUid uid, SkillchipStationComponent comp, DoAfterArgs doAfterArgs)
     {
-        PushStateWorking(uid, comp, false);
-    }
-
-    private void PushStateWorking(EntityUid uid, SkillchipStationComponent comp, bool working)
-    {
-        if (!_ui.IsUiOpen(uid, SkillchipStationUiKey.Key))
+        if (!_doAfter.TryStartDoAfter(doAfterArgs))
             return;
 
-        var slot = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.ChipSlotId);
-        SkillchipStationChipInfo? insertedInfo = null;
-
-        if (slot.ContainedEntity is { } chipEnt && TryComp<SkillchipComponent>(chipEnt, out var chipComp))
-            insertedInfo = BuildChipInfo(chipComp.ChipProto);
-
-        // Installed chips and capacity belong to the occupant being operated
-        // on, not whoever opened the console. With no occupant the lists are
-        // empty so the UI shows nothing to remove.
-        var implanted = new List<SkillchipStationChipInfo>();
-        var usedCapacity = 0;
-        var maxCapacity = 0;
-
-        if (TryGetOccupant(uid, out var patient))
-        {
-            (usedCapacity, maxCapacity) = _skillchips.GetCapacity(patient);
-            foreach (var protoId in _skillchips.GetInstalledChips(patient))
-                implanted.Add(BuildChipInfo(protoId));
-        }
-
-        var state = new SkillchipStationBoundUserInterfaceState(
-            working, insertedInfo, implanted, usedCapacity, maxCapacity);
-
-        _ui.SetUiState(uid, SkillchipStationUiKey.Key, state);
+        _audio.PlayPvs(comp.OperationStartSound, uid);
+        _uiBuilder.PushStateWorking(uid, comp, working: true);
     }
 
-    private SkillchipStationChipInfo BuildChipInfo(ProtoId<SkillchipPrototype> protoId)
+    /// <summary>
+    /// Resolves the seated patient's brain when an operation do-after completes.
+    /// The implant flow surfaces the missing-occupant / missing-brain popups it
+    /// has always shown via <paramref name="popupOnMissing"/>; the remove flow
+    /// passes false because it validated the occupant before the do-after began.
+    /// </summary>
+    private bool TryResolveOperationBrain(EntityUid uid, EntityUid user, bool popupOnMissing, out Entity<SkillchipHolderComponent> brain)
     {
-        var proto = _proto.Index(protoId);
-        return new SkillchipStationChipInfo
+        brain = default;
+
+        if (!_occupant.TryGetOccupant(uid, out var patient))
         {
-            ChipProto = protoId,
-            Name = proto.Name,
-            Description = proto.Description,
-            CapacityCost = proto.CapacityCost,
-        };
+            if (popupOnMissing)
+                _popup.PopupEntity(Loc.GetString("skillchip-station-no-occupant"), uid, user);
+            return false;
+        }
+
+        if (!_skillchips.TryGetBrain(patient, out brain))
+        {
+            if (popupOnMissing)
+                _popup.PopupEntity(Loc.GetString("skillchip-station-no-brain"), uid, user);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Content.Server/RussStation/Skillchips/SkillchipStationUiBuilder.cs
+++ b/Content.Server/RussStation/Skillchips/SkillchipStationUiBuilder.cs
@@ -1,0 +1,103 @@
+using Content.Shared.RussStation.Skillchips;
+using Content.Shared.RussStation.Skillchips.Systems;
+using Robust.Server.GameObjects;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.Skillchips;
+
+/// <summary>
+/// Serializes the station's bound-UI state: the inserted-tray chip, the seated
+/// patient's installed chips, and their capacity bar. Split out of
+/// <see cref="SkillchipStationSystem"/> so the refresh triggers (UI opened,
+/// container changes) and the state-building both live in one place rather than
+/// being interleaved with the implant/remove flow.
+/// </summary>
+public sealed class SkillchipStationUiBuilder : EntitySystem
+{
+    [Dependency] private readonly SkillchipStationOccupantManager _occupant = default!;
+    [Dependency] private readonly SharedSkillchipSystem _skillchips = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SkillchipStationComponent, BoundUIOpenedEvent>(OnUIOpened);
+        SubscribeLocalEvent<SkillchipStationComponent, EntInsertedIntoContainerMessage>(OnContainerChanged);
+        SubscribeLocalEvent<SkillchipStationComponent, EntRemovedFromContainerMessage>(OnContainerChanged);
+    }
+
+    private void OnUIOpened(EntityUid uid, SkillchipStationComponent comp, BoundUIOpenedEvent args)
+    {
+        PushState(uid, comp);
+    }
+
+    private void OnContainerChanged(EntityUid uid, SkillchipStationComponent comp, ContainerModifiedMessage args)
+    {
+        // Tray changes alter the inserted-chip panel; occupant changes alter
+        // the installed-chip list and capacity bar. Both need a refresh.
+        if (args.Container.ID != SkillchipStationComponent.ChipSlotId &&
+            args.Container.ID != SkillchipStationComponent.BodyContainerId)
+            return;
+
+        PushState(uid, comp);
+    }
+
+    /// <summary>
+    /// Pushes a fresh, non-working state to the open UI.
+    /// </summary>
+    public void PushState(EntityUid uid, SkillchipStationComponent comp)
+    {
+        PushStateWorking(uid, comp, false);
+    }
+
+    /// <summary>
+    /// Pushes the UI state, optionally flagging an operation as in progress so
+    /// the console shows its working indicator and disables further actions.
+    /// </summary>
+    public void PushStateWorking(EntityUid uid, SkillchipStationComponent comp, bool working)
+    {
+        if (!_ui.IsUiOpen(uid, SkillchipStationUiKey.Key))
+            return;
+
+        var slot = _containers.EnsureContainer<ContainerSlot>(uid, SkillchipStationComponent.ChipSlotId);
+        SkillchipStationChipInfo? insertedInfo = null;
+
+        if (slot.ContainedEntity is { } chipEnt && TryComp<SkillchipComponent>(chipEnt, out var chipComp))
+            insertedInfo = BuildChipInfo(chipComp.ChipProto);
+
+        // Installed chips and capacity belong to the occupant being operated
+        // on, not whoever opened the console. With no occupant the lists are
+        // empty so the UI shows nothing to remove.
+        var implanted = new List<SkillchipStationChipInfo>();
+        var usedCapacity = 0;
+        var maxCapacity = 0;
+
+        if (_occupant.TryGetOccupant(uid, out var patient))
+        {
+            (usedCapacity, maxCapacity) = _skillchips.GetCapacity(patient);
+            foreach (var protoId in _skillchips.GetInstalledChips(patient))
+                implanted.Add(BuildChipInfo(protoId));
+        }
+
+        var state = new SkillchipStationBoundUserInterfaceState(
+            working, insertedInfo, implanted, usedCapacity, maxCapacity);
+
+        _ui.SetUiState(uid, SkillchipStationUiKey.Key, state);
+    }
+
+    private SkillchipStationChipInfo BuildChipInfo(ProtoId<SkillchipPrototype> protoId)
+    {
+        var proto = _proto.Index(protoId);
+        return new SkillchipStationChipInfo
+        {
+            ChipProto = protoId,
+            Name = proto.Name,
+            Description = proto.Description,
+            CapacityCost = proto.CapacityCost,
+        };
+    }
+}


### PR DESCRIPTION
## About the PR

Splits the 397-line `SkillchipStationSystem` into three smaller systems, one per concern. Behavior is unchanged.

## Why / Balance

Closes #859, part of the RussStation fork audit (#853). The file held three loosely-coupled subsystems (occupant boarding, chip-tray interaction, and UI-state building) plus two do-after handlers that repeated the same occupant lookup and validation. One 397-line file made each part harder to read and change in isolation.

## Technical details

`SkillchipStationOccupantManager` owns the body-container occupant state machine: drag-drop boarding via its own `EntryDelay` do-after, eject on relay-move or destruction, and the occupied/open appearance. It exposes `IsOccupied` and `TryGetOccupant`.

`SkillchipStationUiBuilder` owns UI-state serialization and the refresh triggers (UI opened, container changes), so the chip-slot and occupant lookups sit in one place. It exposes `PushState` and `PushStateWorking`.

`SkillchipStationSystem` keeps the chip-tray interaction and the powered implant and remove flow, reaching the two helpers through dependencies.

Two private helpers cover the duplication the issue named. `TryResolveOperationBrain` does the occupant lookup and brain validation that both do-afters shared; a `popupOnMissing` flag keeps the original split, where the install flow shows the no-occupant and no-brain popups while the remove flow stays silent. `TryStartOperation` folds the identical do-after-start tail (start the do-after, play the start sound, push the working state).

A couple of orderings are kept on purpose. The implant do-after checks the tray chip before the occupant, so a chip pulled out partway through bails silently as it always did. Both the occupant manager and the main system subscribe to `ComponentInit` on `SkillchipStationComponent`: the manager ensures the body container and sets the appearance, the main system ensures the chip slot.

Covered by `SkillchipGrantTest.cs` and `SkillchipStationTest.cs`; the latter's `[TestOf(typeof(SkillchipStationSystem))]` still resolves.

## Media

None. Code-only refactor.

## Breaking changes

None.

https://claude.ai/code/session_01LGxjvkJsvbkHKaHtTE347G

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGxjvkJsvbkHKaHtTE347G)_