### PR TITLE
ci: document YAML Linter also validates C# static prototype-ID fields

### DIFF
--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -1,3 +1,7 @@
+# Despite the name, this validates BOTH:
+#   - YAML prototypes (/Prototypes, /EnginePrototypes)
+#   - C# static prototype-ID fields (EntProtoId/ProtoId) via ValidateStaticFields
+# So C# changes to prototype-ID constants ARE gated by this check.
 name: YAML Linter
 
 on:
@@ -31,5 +35,5 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --configuration Release --no-restore /p:WarningsAsErrors= /m
-      - name: Run Linter
+      - name: Validate YAML prototypes + C# static prototype-ID fields
         run: dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj --no-build


### PR DESCRIPTION
Comment-only change. The `Content.YAMLLinter` check validates **both** YAML prototypes and C# static `EntProtoId`/`ProtoId` fields (via `ValidateStaticFields`), but the name implies YAML only.

Adds a header comment to `.github/workflows/yaml-linter.yml` and a descriptive step name so the check's true scope is discoverable (including by grep) without a rename that would touch `bors.toml` and branch protection.

No behavior change — documentation only.

https://claude.ai/code/session_01RsLyssP2DkABiBwt5f8aJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsLyssP2DkABiBwt5f8aJN)_