### PR TITLE
Add tests for SeedDataFormatter

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Botany/SeedDataFormatterTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Botany/SeedDataFormatterTest.cs
@@ -1,0 +1,101 @@
+using Content.Server.Botany;
+using Content.Server.RussStation.Botany.Systems;
+using Content.Shared.Slippery;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Log;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Botany;
+
+// Covers the two SeedDataFormatter helpers that need engine services (Loc, the
+// entity manager) and so can't live in the pure Content.Tests fixture. The
+// chemical-amount formula is unit-tested separately there.
+[TestFixture]
+[TestOf(typeof(SeedDataFormatter))]
+public sealed class SeedDataFormatterTest
+{
+    [Test]
+    public async Task FormatHarvestRepeat_MapsEachEnumValue()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var sawmill = server.ResolveDependency<ILogManager>().GetSawmill("test.seed-data-formatter");
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(SeedDataFormatter.FormatHarvestRepeat(HarvestType.NoRepeat, sawmill),
+                    Is.EqualTo(Loc.GetString("plant-analyzer-harvest-no-repeat")));
+                Assert.That(SeedDataFormatter.FormatHarvestRepeat(HarvestType.Repeat, sawmill),
+                    Is.EqualTo(Loc.GetString("plant-analyzer-harvest-repeat")));
+                Assert.That(SeedDataFormatter.FormatHarvestRepeat(HarvestType.SelfHarvest, sawmill),
+                    Is.EqualTo(Loc.GetString("plant-analyzer-harvest-self-harvest")));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EnumerateSeedTraits_CollectsSeedFlags()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var seed = new SeedData
+            {
+                Seedless = true,
+                Viable = false,
+                Ligneous = true,
+            };
+
+            // A bare entity carries none of the component-derived traits.
+            var target = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+
+            var traits = SeedDataFormatter.EnumerateSeedTraits(seed, target, entityManager);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(traits, Does.Contain(Loc.GetString("plant-analyzer-trait-seedless")));
+                Assert.That(traits, Does.Contain(Loc.GetString("plant-analyzer-trait-unviable")));
+                Assert.That(traits, Does.Contain(Loc.GetString("plant-analyzer-trait-ligneous")));
+                Assert.That(traits, Does.Not.Contain(Loc.GetString("plant-analyzer-trait-slippery")));
+            });
+
+            entityManager.DeleteEntity(target);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task EnumerateSeedTraits_IncludesSlipperyFromTargetEntity()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            // A blank seed has no intrinsic traits; the slippery trait comes from
+            // a component on the scanned entity, not the seed.
+            var seed = new SeedData();
+            var target = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+            entityManager.EnsureComponent<SlipperyComponent>(target);
+
+            var traits = SeedDataFormatter.EnumerateSeedTraits(seed, target, entityManager);
+
+            Assert.That(traits, Does.Contain(Loc.GetString("plant-analyzer-trait-slippery")),
+                "A SlipperyComponent on the scanned entity should surface the slippery trait.");
+
+            entityManager.DeleteEntity(target);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Tests/Server/RussStation/Botany/SeedDataFormatterTest.cs
+++ b/Content.Tests/Server/RussStation/Botany/SeedDataFormatterTest.cs
@@ -1,0 +1,77 @@
+using Content.Server.Botany;
+using Content.Server.RussStation.Botany.Systems;
+using Content.Shared.FixedPoint;
+using NUnit.Framework;
+
+namespace Content.Tests.Server.RussStation.Botany;
+
+[TestFixture, TestOf(typeof(SeedDataFormatter))]
+[Parallelizable(ParallelScope.All)]
+public sealed class SeedDataFormatterTest
+{
+    // Mirrors the worked example documented on SeedChemQuantity.PotencyDivisor:
+    // a divisor of 20 with potency 55 gives 2.75, added on top of the Min of 1
+    // for a final 3.75.
+    [Test]
+    public void CalculateChemicalAmount_AddsPotencyBonusOnTopOfMin()
+    {
+        var quantity = new SeedChemQuantity
+        {
+            Min = FixedPoint2.New(1),
+            Max = FixedPoint2.New(100),
+            PotencyDivisor = 20f,
+        };
+
+        var amount = SeedDataFormatter.CalculateChemicalAmount(quantity, 55f);
+
+        Assert.That(amount, Is.EqualTo(FixedPoint2.New(3.75f)));
+    }
+
+    [Test]
+    public void CalculateChemicalAmount_ClampsToMax()
+    {
+        var quantity = new SeedChemQuantity
+        {
+            Min = FixedPoint2.New(1),
+            Max = FixedPoint2.New(2),
+            PotencyDivisor = 20f,
+        };
+
+        // Min + 55/20 would be 3.75, but Max caps the result at 2.
+        var amount = SeedDataFormatter.CalculateChemicalAmount(quantity, 55f);
+
+        Assert.That(amount, Is.EqualTo(FixedPoint2.New(2)));
+    }
+
+    [Test]
+    public void CalculateChemicalAmount_ZeroDivisorYieldsMinOnly()
+    {
+        var quantity = new SeedChemQuantity
+        {
+            Min = FixedPoint2.New(5),
+            Max = FixedPoint2.New(100),
+            PotencyDivisor = 0f,
+        };
+
+        // A divisor of 0 disables the potency bonus, regardless of potency.
+        var amount = SeedDataFormatter.CalculateChemicalAmount(quantity, 55f);
+
+        Assert.That(amount, Is.EqualTo(FixedPoint2.New(5)));
+    }
+
+    [Test]
+    public void CalculateChemicalAmount_ZeroPotencyYieldsMinOnly()
+    {
+        var quantity = new SeedChemQuantity
+        {
+            Min = FixedPoint2.New(5),
+            Max = FixedPoint2.New(100),
+            PotencyDivisor = 20f,
+        };
+
+        // Zero potency means no bonus even when a divisor is set.
+        var amount = SeedDataFormatter.CalculateChemicalAmount(quantity, 0f);
+
+        Assert.That(amount, Is.EqualTo(FixedPoint2.New(5)));
+    }
+}


### PR DESCRIPTION
## About the PR

Adds the tests for `SeedDataFormatter`, the helper extracted in #870. That PR merged before the tests were in, so this is the follow-up that covers the moved logic.

## Why / Balance

#870 pulled the seed serialization out of `PlantAnalyzerSystem` as a behavior-preserving change, but the test commit landed on the branch after the squash-merge had already taken the head. The extraction is the thing that makes this logic testable on its own, so the tests belong with it. Nothing here changes runtime behavior.

## Technical details

Two fixtures, split by what they need:

- `Content.Tests` (pure, no server pair, following the `RadiationBlobMath` fixture): `CalculateChemicalAmount` with the documented 20-divisor / 55-potency case, the `Max` clamp, and the zero-divisor and zero-potency guards.
- `Content.IntegrationTests` (needs `Loc` and the entity manager): `FormatHarvestRepeat` mapping each `HarvestType` to its localized string, and `EnumerateSeedTraits` for both seed flags and the `SlipperyComponent`-derived trait read off the scanned entity.

I left `FormatSeedData` itself without a direct test. It is composition over the three helpers plus the gas loop, and `SeedData.DisplayName` has a private setter, so exercising the full path means standing up a seed prototype and a plant holder rather than building a `SeedData` in the test. Happy to add that if you want the end-to-end coverage.

Same caveat as #870: no .NET SDK in my environment, so CI is the first build for these.

## Breaking changes

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUD7rRejH8FkK3eQigjivj)_