### PR TITLE
Fix crash when a grabbed pullee is dragged into a portal

### DIFF
--- a/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
+++ b/Content.Shared/RussStation/EscalatedGrab/Systems/SharedEscalatedGrabSystem.cs
@@ -82,8 +82,18 @@ public abstract class SharedEscalatedGrabSystem : EntitySystem
         if (!HasComp<PortalComponent>(args.OtherEntity))
             return;
 
-        if (component.Puller is { } puller && HasComp<GrabStateComponent>(puller))
-            ClearEscalation(puller);
+        if (component.Puller is not { } puller || !HasComp<GrabStateComponent>(puller))
+            return;
+
+        ClearEscalation(puller);
+
+        // Force-break the pull before the portal teleports the pullee, mirroring the puller-side
+        // handler above. ClearEscalation only drops the escalation state; without also tearing the
+        // pull joint down it can survive the cross-map teleport and crash on the next physics tick
+        // (the same re-prediction race the puller side guards against, but with the pullee as the
+        // entity being SetCoordinates'd through the portal).
+        if (component.BeingPulled)
+            _pulling.TryStopPull(uid, component);
     }
 
     private void OnPullerBuckled(EntityUid uid, GrabStateComponent component, ref BuckledEvent args)

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -16,11 +16,18 @@
 // our parent-changed handler ran before the second transform landed).
 // The sweep runs UpdatesBefore SharedJointSystem.Update so divergent
 // pulls are torn down before InitJoint trips its cross-map assert.
+//
+// Client nullspace drain: prediction resets can re-add a stale
+// JointComponent onto a PVS-detached entity (the re-add-predicted-
+// removals path in ClientGameStateManager skips the Detached check),
+// re-queueing a long-dead pull joint into AddedJoints while the pull
+// link is null on both sides. See Update for the full story.
 using System.Collections.Generic;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Physics.Systems;
@@ -29,6 +36,7 @@ namespace Content.Shared.RussStation.Physics;
 
 public sealed class PullMapGuardSystem : EntitySystem
 {
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
@@ -69,6 +77,53 @@ public sealed class PullMapGuardSystem : EntitySystem
             _joints.ClearJoints(pulled);
             _joints.ClearJoints(uid);
         }
+
+        // Client only: drain joints the engine deferred into SharedJointSystem.AddedJoints
+        // while their owner sat detached in nullspace. Prediction resets can resurrect a stale
+        // JointComponent (last server state from before the pull broke - the pullee left PVS
+        // before the joint-removal state could arrive) onto a PVS-detached pullee via the
+        // "re-add predicted removals" path, which skips the Detached check. The client engine
+        // defers those joints into AddedJoints because the transform reads Nullspace, then
+        // inits them on the next tick with no map re-check, tripping the cross-map assert.
+        // By then the pull link is already null on BOTH sides, so the link sweep above and the
+        // parent-changed handlers below can't see it. ClearJoints is the only public API that
+        // drains AddedJoints; on a nullspace entity with an empty Joints dict it is a pure
+        // drain with no side effects. A joint on a nullspace entity can never legally init
+        // anyway (AddJoint itself refuses nullspace), and legitimately re-entering entities
+        // have left nullspace by the time this runs, so they are never touched.
+        if (_net.IsClient)
+        {
+            var jointQuery = EntityQueryEnumerator<JointComponent, TransformComponent>();
+            while (jointQuery.MoveNext(out var uid, out var joint, out var xform))
+            {
+                if (xform.MapID != MapId.Nullspace)
+                    continue;
+
+                if (!ShouldDrainDetached(uid, joint))
+                    continue;
+
+                _joints.ClearJoints(uid, joint);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether a nullspace entity's joints should be drained. Co-detached pairs (both
+    /// endpoints in nullspace, e.g. two jointed entities that left PVS together) keep their
+    /// stale-but-consistent data so PVS re-entry can reconcile it; anything else - an empty
+    /// dict possibly hiding a pending <c>AddedJoints</c> entry, or a dict joint whose other
+    /// endpoint is on a real map - gets cleared before it can init cross-map.
+    /// </summary>
+    private bool ShouldDrainDetached(EntityUid uid, JointComponent joint)
+    {
+        foreach (var j in joint.GetJoints.Values)
+        {
+            var other = j.BodyAUid == uid ? j.BodyBUid : j.BodyAUid;
+            if (_transform.GetMapId(other) == MapId.Nullspace)
+                return false;
+        }
+
+        return true;
     }
 
     private void OnJointParentChanged(Entity<JointComponent> ent, ref EntParentChangedMessage args)

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -17,11 +17,19 @@
 // The sweep runs UpdatesBefore SharedJointSystem.Update so divergent
 // pulls are torn down before InitJoint trips its cross-map assert.
 //
-// Client nullspace drain: prediction resets can re-add a stale
+// Deferred-joint drain: prediction resets can re-add a stale
 // JointComponent onto a PVS-detached entity (the re-add-predicted-
 // removals path in ClientGameStateManager skips the Detached check),
-// re-queueing a long-dead pull joint into AddedJoints while the pull
-// link is null on both sides. See Update for the full story.
+// re-queueing a long-dead pull joint into the engine-private
+// SharedJointSystem.AddedJoints while the pull link is null on both
+// sides, so no link- or event-keyed teardown can see it. That re-add
+// always creates a fresh JointComponent (subscribing to the component's
+// ComponentHandleState directly is impossible - the engine's client
+// JointSystem holds that subscription exclusively), so we arm on
+// ComponentStartup and one-shot drain armed owners that sit in
+// nullspace, via ClearJoints - the one public API that also drains
+// AddedJoints - before SharedJointSystem inits them with no map
+// re-check.
 using System.Collections.Generic;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
@@ -44,14 +52,27 @@ public sealed class PullMapGuardSystem : EntitySystem
 
     private readonly List<Joint> _toBreak = new();
 
+    // Entities that just gained a JointComponent, checked once in the next Update and then
+    // forgotten. Client-only: the crash feeder (stale state re-added onto a detached entity)
+    // is client state machinery, and a fresh server-side JointComponent in nullspace has no
+    // joints to drain anyway.
+    private readonly HashSet<EntityUid> _freshJointComps = new();
+
     public override void Initialize()
     {
         base.Initialize();
         UpdatesBefore.Add(typeof(SharedJointSystem));
         SubscribeLocalEvent<JointComponent, EntParentChangedMessage>(OnJointParentChanged);
+        SubscribeLocalEvent<JointComponent, ComponentStartup>(OnJointStartup);
         SubscribeLocalEvent<PullerComponent, EntParentChangedMessage>(OnPullerParentChanged);
         SubscribeLocalEvent<PullableComponent, EntParentChangedMessage>(OnPullableParentChanged);
 
+    }
+
+    private void OnJointStartup(Entity<JointComponent> ent, ref ComponentStartup args)
+    {
+        if (_net.IsClient)
+            _freshJointComps.Add(ent.Owner);
     }
 
     public override void Update(float frameTime)
@@ -78,56 +99,31 @@ public sealed class PullMapGuardSystem : EntitySystem
             _joints.ClearJoints(uid);
         }
 
-        // Client only: drain joints the engine deferred into SharedJointSystem.AddedJoints
-        // while their owner sat detached in nullspace. Prediction resets can resurrect a stale
-        // JointComponent (last server state from before the pull broke - the pullee left PVS
-        // before the joint-removal state could arrive) onto a PVS-detached pullee via the
-        // "re-add predicted removals" path, which skips the Detached check. The client engine
-        // defers those joints into AddedJoints because the transform reads Nullspace, then
-        // inits them on the next tick with no map re-check, tripping the cross-map assert.
-        // By then the pull link is already null on BOTH sides, so the link sweep above and the
-        // parent-changed handlers below can't see it. ClearJoints is the only public API that
-        // drains AddedJoints; on a nullspace entity with an empty Joints dict it is a pure
-        // drain with no side effects. A joint on a nullspace entity can never legally init
-        // anyway (AddJoint itself refuses nullspace), and legitimately re-entering entities
-        // have left nullspace by the time this runs, so they are never touched.
-        // AllEntityQuery, not EntityQueryEnumerator: PVS-detached entities are marked paused
-        // (ClientGameStateManager.Detach does this without raising a pause event), and the
-        // plain enumerator skips paused entities - which is exactly the population this sweep
-        // exists to visit.
-        if (_net.IsClient)
+        // One-shot check on freshly added JointComponents. The one that matters: a stale pull
+        // joint resurrected onto a PVS-detached pullee by the prediction reset (see header) -
+        // the engine defers it into AddedJoints because the pullee's transform reads
+        // Nullspace, and the drain in SharedJointSystem.Update, which runs right after us,
+        // inits it with no map re-check, tripping the cross-map assert. A joint on a
+        // nullspace entity can never legally init this tick (AddJoint itself refuses
+        // nullspace), so drain it; owners on real maps are legitimate joint setups and pass
+        // untouched. The set is cleared every Update, so this does nothing at all on ticks
+        // without new joint components, and fires at most once per component addition -
+        // repeating it every tick would spam the engine's ClearJoints debug log.
+        if (_freshJointComps.Count > 0)
         {
-            var jointQuery = AllEntityQuery<JointComponent, TransformComponent>();
-            while (jointQuery.MoveNext(out var uid, out var joint, out var xform))
+            foreach (var uid in _freshJointComps)
             {
-                if (xform.MapID != MapId.Nullspace)
+                if (TerminatingOrDeleted(uid))
                     continue;
 
-                if (!ShouldDrainDetached(uid, joint))
+                if (_transform.GetMapId(uid) != MapId.Nullspace)
                     continue;
 
-                _joints.ClearJoints(uid, joint);
+                _joints.ClearJoints(uid);
             }
-        }
-    }
 
-    /// <summary>
-    /// Whether a nullspace entity's joints should be drained. Co-detached pairs (both
-    /// endpoints in nullspace, e.g. two jointed entities that left PVS together) keep their
-    /// stale-but-consistent data so PVS re-entry can reconcile it; anything else - an empty
-    /// dict possibly hiding a pending <c>AddedJoints</c> entry, or a dict joint whose other
-    /// endpoint is on a real map - gets cleared before it can init cross-map.
-    /// </summary>
-    private bool ShouldDrainDetached(EntityUid uid, JointComponent joint)
-    {
-        foreach (var j in joint.GetJoints.Values)
-        {
-            var other = j.BodyAUid == uid ? j.BodyBUid : j.BodyAUid;
-            if (_transform.GetMapId(other) == MapId.Nullspace)
-                return false;
+            _freshJointComps.Clear();
         }
-
-        return true;
     }
 
     private void OnJointParentChanged(Entity<JointComponent> ent, ref EntParentChangedMessage args)

--- a/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
+++ b/Content.Shared/RussStation/Physics/PullMapGuardSystem.cs
@@ -91,9 +91,13 @@ public sealed class PullMapGuardSystem : EntitySystem
         // drain with no side effects. A joint on a nullspace entity can never legally init
         // anyway (AddJoint itself refuses nullspace), and legitimately re-entering entities
         // have left nullspace by the time this runs, so they are never touched.
+        // AllEntityQuery, not EntityQueryEnumerator: PVS-detached entities are marked paused
+        // (ClientGameStateManager.Detach does this without raising a pause event), and the
+        // plain enumerator skips paused entities - which is exactly the population this sweep
+        // exists to visit.
         if (_net.IsClient)
         {
-            var jointQuery = EntityQueryEnumerator<JointComponent, TransformComponent>();
+            var jointQuery = AllEntityQuery<JointComponent, TransformComponent>();
             while (jointQuery.MoveNext(out var uid, out var joint, out var xform))
             {
                 if (xform.MapID != MapId.Nullspace)


### PR DESCRIPTION
## About the PR

Fixes the client crash when a grabbed pullee is dragged through a cross-map portal: the pullee-side collide teardown (mirroring the puller side from #476), plus the actual root-cause fix in `PullMapGuardSystem`, added after the collide teardown turned out not to close the crash on its own.

## Why / Balance

#476 fixed the grabber-walks-into-portal crash. The pullee side kept crashing debug clients with the engine's "Attempted to initialize cross-map joint" assert even after the collide handler got the matching teardown, because the offending joint is not created by any content code path the collide handlers can pre-empt.

The real mechanism, confirmed with engine-side logging on a live repro, is a client prediction race. When the pull breaks and the pullee teleports out of PVS in the same server tick, the last state the client ever holds for the pullee still contains the pull joint. During prediction resets, `ClientGameStateManager`'s re-add-predicted-removals path restores that stale `JointComponent` onto the detached pullee (unlike the normal reset path, it does not check `MetaDataFlags.Detached`). The client `JointSystem` then defers the resurrected joint into `SharedJointSystem.AddedJoints` because the pullee's transform reads nullspace, and that deferred init path never re-validates map eligibility the way `AddJoint` does. One tick later `InitJoint` trips the assert. By that point the pull link is null on both the puller and the pullee, so every teardown keyed off pull links or parent-change events sees nothing. This also isn't specific to escalated grabs; plain pulls hit the same race, the grab was just the repro.

On release builds the assert is compiled out and the symptom is a brief physics jolt on the grabber instead of a crash, so this mainly kills the dev-build crash.

## Technical details

- `SharedEscalatedGrabSystem.OnPullableStartCollide`: clears escalation and stops the pull when the grabbed pullee touches a portal, mirroring the puller-side handler. Sensible symmetry, but it did not close the crash on its own.
- `PullMapGuardSystem`: the stale re-add always creates a fresh `JointComponent` (the reset path calls `AddComponent` before raising the state), so the guard arms on `ComponentStartup` and runs a one-shot check in its `Update`, which already runs before `SharedJointSystem`: an armed owner still in nullspace gets `ClearJoints`, the one public engine API that also drains the private `AddedJoints` deferred set. A joint on a nullspace entity can never legally initialize anyway (`AddJoint` itself refuses nullspace), and owners on real maps pass untouched, so normal joint setups and PVS re-entry are unaffected. The check fires at most once per component addition and does nothing on quiet ticks, so it adds no per-tick cost and no log noise.

Two approaches that did not survive, for the record: subscribing to the component's `ComponentHandleState` throws `Duplicate Subscriptions` (state-handling subscriptions are exclusive and the engine's client `JointSystem` owns it, caught by the integration tests), and a per-tick nullspace sweep worked but spammed the engine's `ClearJoints` debug log every tick while an entity stayed detached.

Verified in-game: before, the client asserted within a couple frames of the pullee entering the portal; after, no assert and a quiet log. The existing `CrossMapPullGuardTest` suite still passes. The underlying engine holes (the `AddedJoints` drain skips `AddJoint`'s eligibility check, and the reset re-add path ignores `Detached`) are worth an upstream issue separately.

## Media

None. Code-only fix.

## Breaking changes

None.

## Changelog

:cl:

- fix: Dragging a grabbed target into a portal no longer crashes the client or jolts the puller.
