### PR TITLE
Extract shared ScannerUpdateHelper and OrganReplacementHelper (#865)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Body/OrganReplacementHelperTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Body/OrganReplacementHelperTest.cs
@@ -1,0 +1,183 @@
+using System.Linq;
+using Content.Shared.Body;
+using Content.Shared.RussStation.Body;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Body;
+
+[TestFixture]
+[TestOf(typeof(OrganReplacementHelper))]
+public sealed class OrganReplacementHelperTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: OrganReplaceTestHeart
+  components:
+  - type: Organ
+    category: Heart
+
+- type: entity
+  id: OrganReplaceTestLungs
+  components:
+  - type: Organ
+    category: Lungs
+
+- type: entity
+  id: OrganReplaceTestUncategorized
+  components:
+  - type: Organ
+
+- type: entity
+  id: OrganReplaceTestExistingHeart
+  components:
+  - type: Organ
+    category: Heart
+
+- type: entity
+  id: OrganReplaceTestBodyWithHeart
+  components:
+  - type: Body
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Critical
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      100: Critical
+      200: Dead
+  - type: Damageable
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 0.5
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: SolutionContainerManager
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: OrganReplaceTestExistingHeart
+";
+
+    /// <summary>
+    /// The lookup matches a categorized organ already in the body, ignores categories with no organ,
+    /// and never matches on a null category (uncategorized organs deduplicate by prototype, not here).
+    /// </summary>
+    [Test]
+    public async Task TryFindOrganByCategoryTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var body = entMan.SpawnEntity("OrganReplaceTestBodyWithHeart", mapData.GridCoords);
+            var bodyComp = entMan.GetComponent<BodyComponent>(body);
+            Assert.That(bodyComp.Organs, Is.Not.Null, "Body should have an organs container");
+
+            // Source real category values off spawned organs so the test carries no prototype-id literals.
+            var heartCategory = entMan.GetComponent<OrganComponent>(
+                entMan.SpawnEntity("OrganReplaceTestHeart", mapData.GridCoords)).Category;
+            var lungsCategory = entMan.GetComponent<OrganComponent>(
+                entMan.SpawnEntity("OrganReplaceTestLungs", mapData.GridCoords)).Category;
+
+            Assert.That(OrganReplacementHelper.TryFindOrganByCategory(entMan, bodyComp.Organs!, heartCategory, out var found),
+                Is.True, "The pre-filled heart should be found by its category");
+            Assert.That(entMan.GetComponent<OrganComponent>(found).Category, Is.EqualTo(heartCategory));
+            Assert.That(bodyComp.Organs!.ContainedEntities.Contains(found), Is.True);
+
+            Assert.That(OrganReplacementHelper.TryFindOrganByCategory(entMan, bodyComp.Organs, lungsCategory, out _),
+                Is.False, "No lungs organ is present, so the lookup should miss");
+
+            Assert.That(OrganReplacementHelper.TryFindOrganByCategory(entMan, bodyComp.Organs, null, out _),
+                Is.False, "A null category should never match");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Replacing a categorized organ removes the old one (dropping it out of the body) and inserts the new
+    /// one, leaving exactly one organ of that category. This is the rule the autosurgeon relies on.
+    /// </summary>
+    [Test]
+    public async Task ReplaceOrganByCategoryReplacesSameCategoryTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var containerSys = entMan.System<SharedContainerSystem>();
+            var transformSys = entMan.System<SharedTransformSystem>();
+
+            var body = entMan.SpawnEntity("OrganReplaceTestBodyWithHeart", mapData.GridCoords);
+            var bodyComp = entMan.GetComponent<BodyComponent>(body);
+            Assert.That(bodyComp.Organs, Is.Not.Null);
+
+            var newHeart = entMan.SpawnEntity("OrganReplaceTestHeart", mapData.GridCoords);
+            var heartCategory = entMan.GetComponent<OrganComponent>(newHeart).Category;
+
+            Assert.That(OrganReplacementHelper.TryFindOrganByCategory(entMan, bodyComp.Organs!, heartCategory, out var oldHeart),
+                Is.True);
+
+            OrganReplacementHelper.ReplaceOrganByCategory(
+                entMan, containerSys, transformSys, body, bodyComp.Organs!, newHeart, heartCategory);
+
+            Assert.That(bodyComp.Organs!.ContainedEntities.Contains(oldHeart), Is.False,
+                "Old heart should be removed from the body");
+            Assert.That(bodyComp.Organs.ContainedEntities.Contains(newHeart), Is.True,
+                "New heart should be inserted into the body");
+
+            var heartCount = bodyComp.Organs.ContainedEntities.Count(o =>
+                entMan.TryGetComponent<OrganComponent>(o, out var organ) && organ.Category == heartCategory);
+            Assert.That(heartCount, Is.EqualTo(1), "Body should have exactly one heart after replacement");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// An uncategorized organ has no slot to displace, so it is inserted without removing anything.
+    /// </summary>
+    [Test]
+    public async Task ReplaceOrganByCategoryInsertsUncategorizedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var containerSys = entMan.System<SharedContainerSystem>();
+            var transformSys = entMan.System<SharedTransformSystem>();
+
+            var body = entMan.SpawnEntity("OrganReplaceTestBodyWithHeart", mapData.GridCoords);
+            var bodyComp = entMan.GetComponent<BodyComponent>(body);
+            Assert.That(bodyComp.Organs, Is.Not.Null);
+
+            var countBefore = bodyComp.Organs!.ContainedEntities.Count;
+
+            var extra = entMan.SpawnEntity("OrganReplaceTestUncategorized", mapData.GridCoords);
+            OrganReplacementHelper.ReplaceOrganByCategory(
+                entMan, containerSys, transformSys, body, bodyComp.Organs, extra, category: null);
+
+            Assert.That(bodyComp.Organs.ContainedEntities.Contains(extra), Is.True);
+            Assert.That(bodyComp.Organs.ContainedEntities.Count, Is.EqualTo(countBefore + 1),
+                "Nothing should have been displaced");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Scanner/ScannerUpdateHelperTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Scanner/ScannerUpdateHelperTest.cs
@@ -1,0 +1,78 @@
+using System.Numerics;
+using Content.Shared.RussStation.Scanner;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.RussStation.Scanner;
+
+[TestFixture]
+[TestOf(typeof(ScannerUpdateHelper))]
+public sealed class ScannerUpdateHelperTest
+{
+    /// <summary>
+    /// Pins the shared scan-loop decision table: rate-limit, drop a gone target, pause out of range,
+    /// otherwise push. Also checks the timer-advance rule, which is the easy thing to get wrong when
+    /// copying the loop: the timer only moves once the rate-limit passes and the target is still
+    /// valid, so a deleted target leaves it untouched (matching upstream HealthAnalyzerSystem).
+    /// </summary>
+    [Test]
+    public async Task EvaluateDecisionTableTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var transform = entMan.System<SharedTransformSystem>();
+
+            var now = TimeSpan.FromSeconds(10);
+            var interval = TimeSpan.FromSeconds(1);
+            var due = now - TimeSpan.FromSeconds(1);    // update timer already elapsed
+            var notDue = now + TimeSpan.FromSeconds(5); // still rate-limited
+            var advanced = now + interval;
+
+            var coords = mapData.GridCoords;
+            var farCoords = coords.Offset(new Vector2(1000f, 0f));
+
+            var target = entMan.SpawnEntity(null, coords);
+
+            // No target -> Idle, timer untouched.
+            var noTarget = ScannerUpdateHelper.Evaluate(transform, now, null, due, interval,
+                null, coords, _ => false, _ => coords);
+            Assert.That(noTarget.Action, Is.EqualTo(ScannerUpdateHelper.ScanAction.Idle));
+            Assert.That(noTarget.NextUpdate, Is.EqualTo(due));
+
+            // Rate-limited -> Idle, timer untouched.
+            var rateLimited = ScannerUpdateHelper.Evaluate(transform, now, target, notDue, interval,
+                null, coords, _ => false, _ => coords);
+            Assert.That(rateLimited.Action, Is.EqualTo(ScannerUpdateHelper.ScanAction.Idle));
+            Assert.That(rateLimited.NextUpdate, Is.EqualTo(notDue));
+
+            // Gone target -> Drop, timer untouched.
+            var gone = ScannerUpdateHelper.Evaluate(transform, now, target, due, interval,
+                null, coords, _ => true, _ => coords);
+            Assert.That(gone.Action, Is.EqualTo(ScannerUpdateHelper.ScanAction.Drop));
+            Assert.That(gone.NextUpdate, Is.EqualTo(due));
+
+            // Infinite (null) range -> Push, timer advanced.
+            var infinite = ScannerUpdateHelper.Evaluate(transform, now, target, due, interval,
+                null, coords, _ => false, _ => coords);
+            Assert.That(infinite.Action, Is.EqualTo(ScannerUpdateHelper.ScanAction.Push));
+            Assert.That(infinite.NextUpdate, Is.EqualTo(advanced));
+
+            // In range with a finite range (same coords) -> Push.
+            var inRange = ScannerUpdateHelper.Evaluate(transform, now, target, due, interval,
+                5f, coords, _ => false, _ => coords);
+            Assert.That(inRange.Action, Is.EqualTo(ScannerUpdateHelper.ScanAction.Push));
+
+            // Out of range -> Pause, timer still advanced (the paused state ships once).
+            var outOfRange = ScannerUpdateHelper.Evaluate(transform, now, target, due, interval,
+                5f, coords, _ => false, _ => farCoords);
+            Assert.That(outOfRange.Action, Is.EqualTo(ScannerUpdateHelper.ScanAction.Pause));
+            Assert.That(outOfRange.NextUpdate, Is.EqualTo(advanced));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Botany/Systems/PlantAnalyzerSystem.cs
+++ b/Content.Server/RussStation/Botany/Systems/PlantAnalyzerSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.RussStation.Botany;
 using Content.Shared.RussStation.Botany.Components;
+using Content.Shared.RussStation.Scanner;
 using Content.Shared.Sprite;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
@@ -57,38 +58,37 @@ public sealed class PlantAnalyzerSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
+        // Shared analyzer tick (rate limit, range-check, edge-paused on range exit); see ScannerUpdateHelper.
         var query = EntityQueryEnumerator<PlantAnalyzerComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var comp, out var transform))
         {
-            if (comp.NextUpdate > _timing.CurTime)
-                continue;
+            var target = comp.ScannedEntity;
+            var result = ScannerUpdateHelper.Evaluate(
+                _transformSystem,
+                _timing.CurTime,
+                target,
+                comp.NextUpdate,
+                comp.UpdateInterval,
+                comp.MaxScanRange,
+                transform.Coordinates,
+                isTargetGone: t => Deleted(t) || !TryGetSeed(t, out _),
+                getTargetCoords: t => Transform(t).Coordinates);
 
-            if (comp.ScannedEntity is not {} target)
-                continue;
+            comp.NextUpdate = result.NextUpdate;
 
-            if (Deleted(target))
+            switch (result.Action)
             {
-                StopAnalyzing((uid, comp), target);
-                continue;
+                case ScannerUpdateHelper.ScanAction.Drop:
+                    StopAnalyzing((uid, comp), target!.Value);
+                    break;
+                case ScannerUpdateHelper.ScanAction.Pause:
+                    PauseAnalyzing((uid, comp), target!.Value);
+                    break;
+                case ScannerUpdateHelper.ScanAction.Push:
+                    comp.IsAnalyzerActive = true;
+                    SendUiUpdate(uid, target!.Value);
+                    break;
             }
-
-            if (!TryGetSeed(target, out _))
-            {
-                StopAnalyzing((uid, comp), target);
-                continue;
-            }
-
-            comp.NextUpdate = _timing.CurTime + comp.UpdateInterval;
-
-            var targetCoords = Transform(target).Coordinates;
-            if (comp.MaxScanRange != null && !_transformSystem.InRange(targetCoords, transform.Coordinates, comp.MaxScanRange.Value))
-            {
-                PauseAnalyzing((uid, comp), target);
-                continue;
-            }
-
-            comp.IsAnalyzerActive = true;
-            SendUiUpdate(uid, target);
         }
     }
 

--- a/Content.Server/RussStation/Medical/AutosurgeonSystem.cs
+++ b/Content.Server/RussStation/Medical/AutosurgeonSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.RussStation.Body;
 using Content.Shared.RussStation.Medical;
 using Robust.Shared.Containers;
 
@@ -105,23 +106,9 @@ public sealed class AutosurgeonSystem : EntitySystem
             return;
         }
 
-        // Remove existing organ of the same category if present
-        if (organComp.Category != null)
-        {
-            foreach (var existing in body.Organs.ContainedEntities)
-            {
-                if (TryComp<OrganComponent>(existing, out var existingOrgan) &&
-                    existingOrgan.Category == organComp.Category)
-                {
-                    _container.Remove(existing, body.Organs);
-                    _xform.DropNextTo(existing, target);
-                    break;
-                }
-            }
-        }
-
-        // Insert the new organ
-        _container.Insert(organ, body.Organs, force: true);
+        // Remove any same-category organ (dropping it next to the body) and install the new one.
+        OrganReplacementHelper.ReplaceOrganByCategory(
+            EntityManager, _container, _xform, target, body.Organs, organ, organComp.Category);
 
         var organName = MetaData(organ).EntityName;
         _popup.PopupEntity(

--- a/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
+++ b/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.MedicalScanner;
 using Content.Shared.RussStation.MedicalScanner;
+using Content.Shared.RussStation.Scanner;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -76,35 +77,38 @@ public sealed class HealthAnalyzerReagentSystem : SharedHealthAnalyzerReagentSys
 
     public override void Update(float frameTime)
     {
-        // Mirrors upstream HealthAnalyzerSystem.Update: rate limit, range-check, edge-paused on range exit.
+        // Shared analyzer tick (rate limit, range-check, edge-paused on range exit); see ScannerUpdateHelper.
         var query = EntityQueryEnumerator<HealthAnalyzerReagentScannerComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var scanner, out var xform))
         {
-            if (scanner.ReagentScanTarget is not { } target)
-                continue;
+            var target = scanner.ReagentScanTarget;
+            var result = ScannerUpdateHelper.Evaluate(
+                _transform,
+                _timing.CurTime,
+                target,
+                scanner.NextReagentUpdate,
+                scanner.ReagentUpdateInterval,
+                scanner.MaxReagentScanRange,
+                xform.Coordinates,
+                isTargetGone: t => Deleted(t),
+                getTargetCoords: t => Transform(t).Coordinates);
 
-            if (scanner.NextReagentUpdate > _timing.CurTime)
-                continue;
+            scanner.NextReagentUpdate = result.NextUpdate;
 
-            if (Deleted(target))
+            switch (result.Action)
             {
-                StopReagentScan((uid, scanner));
-                continue;
+                case ScannerUpdateHelper.ScanAction.Drop:
+                    StopReagentScan((uid, scanner));
+                    break;
+                case ScannerUpdateHelper.ScanAction.Pause:
+                    PauseReagentScan((uid, scanner), target!.Value);
+                    break;
+                case ScannerUpdateHelper.ScanAction.Push:
+                    scanner.IsReagentScanActive = true;
+                    Dirty(uid, scanner);
+                    PushReagentState(uid, target!.Value, active: true);
+                    break;
             }
-
-            scanner.NextReagentUpdate = _timing.CurTime + scanner.ReagentUpdateInterval;
-
-            var targetCoords = Transform(target).Coordinates;
-            if (scanner.MaxReagentScanRange != null
-                && !_transform.InRange(targetCoords, xform.Coordinates, scanner.MaxReagentScanRange.Value))
-            {
-                PauseReagentScan((uid, scanner), target);
-                continue;
-            }
-
-            scanner.IsReagentScanActive = true;
-            Dirty(uid, scanner);
-            PushReagentState(uid, target, active: true);
         }
     }
 

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared.Body;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
+using Content.Shared.RussStation.Body;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.RussStation.Surgery.Effects;
@@ -28,30 +29,35 @@ public sealed partial class SurgerySystem
             return;
         }
 
-        var organProtoId = MetaData(organ).EntityPrototype?.ID;
-
         // Block if the patient already has an equivalent organ.
-        // Categorized organs deduplicate by category; null-category organs deduplicate by prototype ID.
-        foreach (var existing in body.Organs.ContainedEntities)
+        // Categorized organs deduplicate by category (shared with the autosurgeon via
+        // OrganReplacementHelper); null-category organs deduplicate by prototype ID.
+        if (organComp.Category != null)
         {
-            if (!TryComp<OrganComponent>(existing, out var existingOrgan))
-                continue;
+            if (OrganReplacementHelper.TryFindOrganByCategory(EntityManager, body.Organs, organComp.Category, out var existing))
+            {
+                _popup.PopupEntity(
+                    Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
+                    patient, surgeon);
+                return;
+            }
+        }
+        else
+        {
+            var organProtoId = MetaData(organ).EntityPrototype?.ID;
+            foreach (var existing in body.Organs.ContainedEntities)
+            {
+                if (!TryComp<OrganComponent>(existing, out var existingOrgan) || existingOrgan.Category != null)
+                    continue;
 
-            bool isDuplicate;
-            if (organComp.Category != null && existingOrgan.Category != null)
-                isDuplicate = existingOrgan.Category == organComp.Category;
-            else if (organComp.Category == null && existingOrgan.Category == null)
-                isDuplicate = organProtoId != null && organProtoId == MetaData(existing).EntityPrototype?.ID;
-            else
-                isDuplicate = false;
+                if (organProtoId == null || organProtoId != MetaData(existing).EntityPrototype?.ID)
+                    continue;
 
-            if (!isDuplicate)
-                continue;
-
-            _popup.PopupEntity(
-                Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
-                patient, surgeon);
-            return;
+                _popup.PopupEntity(
+                    Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
+                    patient, surgeon);
+                return;
+            }
         }
 
         _container.Insert(organ, body.Organs, force: true);

--- a/Content.Shared/RussStation/Body/OrganReplacementHelper.cs
+++ b/Content.Shared/RussStation/Body/OrganReplacementHelper.cs
@@ -1,0 +1,65 @@
+using Content.Shared.Body;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.RussStation.Body;
+
+/// <summary>
+/// Shared organ-slot lookup and replacement so the find-by-category rule lives in one place
+/// instead of being copy-pasted between the autosurgeon and manual surgery. Categorized organs
+/// occupy a single slot per <see cref="OrganCategoryPrototype"/> (one heart, one set of lungs, ...).
+/// </summary>
+public static class OrganReplacementHelper
+{
+    /// <summary>
+    /// Find the first organ in <paramref name="organs"/> whose <see cref="OrganComponent.Category"/>
+    /// matches <paramref name="category"/>. Uncategorized organs (null category) never match, mirroring
+    /// the callers that only deduplicate categorized slots by category.
+    /// </summary>
+    public static bool TryFindOrganByCategory(
+        IEntityManager entMan,
+        BaseContainer organs,
+        ProtoId<OrganCategoryPrototype>? category,
+        out EntityUid found)
+    {
+        found = default;
+
+        if (category == null)
+            return false;
+
+        foreach (var organ in organs.ContainedEntities)
+        {
+            if (entMan.TryGetComponent<OrganComponent>(organ, out var organComp) &&
+                organComp.Category == category)
+            {
+                found = organ;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Install <paramref name="newOrgan"/> into <paramref name="organs"/>, first removing any existing
+    /// organ that occupies the same category slot and dropping it next to <paramref name="body"/>.
+    /// Uncategorized organs are simply inserted without displacing anything.
+    /// </summary>
+    public static void ReplaceOrganByCategory(
+        IEntityManager entMan,
+        SharedContainerSystem container,
+        SharedTransformSystem transform,
+        EntityUid body,
+        BaseContainer organs,
+        EntityUid newOrgan,
+        ProtoId<OrganCategoryPrototype>? category)
+    {
+        if (TryFindOrganByCategory(entMan, organs, category, out var existing))
+        {
+            container.Remove(existing, organs);
+            transform.DropNextTo(existing, body);
+        }
+
+        container.Insert(newOrgan, organs, force: true);
+    }
+}

--- a/Content.Shared/RussStation/Scanner/ScannerUpdateHelper.cs
+++ b/Content.Shared/RussStation/Scanner/ScannerUpdateHelper.cs
@@ -1,0 +1,75 @@
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.RussStation.Scanner;
+
+/// <summary>
+/// Shared per-tick decision for continuous-scan handheld analyzers (health, reagent, plant, ...).
+/// Mirrors upstream <c>HealthAnalyzerSystem.Update</c> so the fork's copies cannot drift: rate-limit,
+/// drop deleted/invalid targets, pause when the target leaves range, otherwise push live state.
+///
+/// The helper only makes the decision; the caller owns the component fields and performs the
+/// matching side effect (stop / pause / push) for its own analyzer type. This keeps the loop's
+/// ordering and the "advance the timer only after the rate-limit passes and the target is still
+/// valid" rule in one place, while respecting each component's <c>[Access]</c> lock.
+/// </summary>
+public static class ScannerUpdateHelper
+{
+    public enum ScanAction
+    {
+        /// <summary>Not yet time to update, or no target pinned. The caller does nothing.</summary>
+        Idle,
+
+        /// <summary>Target deleted or no longer valid. The caller should stop the scan.</summary>
+        Drop,
+
+        /// <summary>Target out of range this tick. The caller should pause (ship the "paused" state once).</summary>
+        Pause,
+
+        /// <summary>Target present and in range. The caller should push an active update.</summary>
+        Push,
+    }
+
+    /// <summary>
+    /// What an analyzer should do this tick, plus the value to write back to its update-timer field.
+    /// </summary>
+    /// <param name="Action">The side effect the caller should perform.</param>
+    /// <param name="NextUpdate">
+    /// The timer the caller should store. Advanced only once the rate-limit passes and the target is
+    /// still valid (matching upstream's ordering where a deleted target leaves the timer untouched);
+    /// otherwise left equal to the supplied current timer, so writing it back unconditionally is safe.
+    /// </param>
+    public readonly record struct ScanResult(ScanAction Action, TimeSpan NextUpdate);
+
+    /// <summary>
+    /// Decide what a single analyzer should do this tick.
+    /// </summary>
+    public static ScanResult Evaluate(
+        SharedTransformSystem transform,
+        TimeSpan now,
+        EntityUid? target,
+        TimeSpan nextUpdate,
+        TimeSpan updateInterval,
+        float? maxRange,
+        EntityCoordinates analyzerCoords,
+        Func<EntityUid, bool> isTargetGone,
+        Func<EntityUid, EntityCoordinates> getTargetCoords)
+    {
+        if (target is not { } targetUid)
+            return new ScanResult(ScanAction.Idle, nextUpdate);
+
+        if (nextUpdate > now)
+            return new ScanResult(ScanAction.Idle, nextUpdate);
+
+        if (isTargetGone(targetUid))
+            return new ScanResult(ScanAction.Drop, nextUpdate);
+
+        var advanced = now + updateInterval;
+
+        // null max range means infinite range.
+        if (maxRange != null && !transform.InRange(getTargetCoords(targetUid), analyzerCoords, maxRange.Value))
+            return new ScanResult(ScanAction.Pause, advanced);
+
+        return new ScanResult(ScanAction.Push, advanced);
+    }
+}


### PR DESCRIPTION
## About the PR

Two bits of copy-pasted logic in the fork now live in one place each: the analyzer scan loop and the "find an organ by category" lookup.

## Why / Balance

Part of the fork audit (#853), closes #865. The scan loop and the organ-matching rule were each duplicated across a couple of systems, so a fix in one copy could quietly miss the other. Pulling each into a single helper keeps them in sync, and it trims a few of the per-file audit issues along the way.

## Technical details

ScannerUpdateHelper (in Content.Shared/RussStation/Scanner/) holds the per-tick scan logic that got mirrored from upstream HealthAnalyzerSystem into HealthAnalyzerReagentSystem and PlantAnalyzerSystem: rate-limit, drop a deleted or invalid target, pause when it leaves range, otherwise push fresh state. Both systems now call Evaluate, which hands back a ScanResult with the action to take and the new timer value. Each system writes the timer and runs its own stop/pause/push. The parts that actually differ get passed in as delegates: reagent checks Deleted, plant checks Deleted or "no seed", and the two use different field names.

OrganReplacementHelper (in Content.Shared/RussStation/Body/) has TryFindOrganByCategory plus ReplaceOrganByCategory built on top of it. AutosurgeonSystem.InstallOrgan uses the replace path; SurgerySystem.TryInsertOrgan uses the lookup for its category check. Surgery keeps its own null-category dedup by prototype id inline, since that piece is being handled over in the OrganDuplicateValidator issue.

No behavior change. Surgery's old loop checked category and prototype in a single pass, but any given organ has exactly one category state, so only one of those rules could ever fire for a given candidate. Splitting it into two branches reports the same organ in the same popup. The existing AutosurgeonTest cases still cover the replace path.

## Media

None, code-only refactor.

## Breaking changes

None.
