### PR TITLE
Decompose ActionBarCustomizationController into focused collaborators

### DIFF
--- a/Content.Client/RussStation/ActionBar/ActionBarCVarManager.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCVarManager.cs
@@ -1,0 +1,126 @@
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Owns every CVar the fork action bar reads or writes: the initial reads, the change
+// subscriptions, and the bulk writes used by preset apply / reset. The controller keeps a
+// single reference and reacts to the change events below, replacing the seven near-identical
+// OnValueChanged registrations and the field-by-field SetCVar block it used to inline.
+public sealed class ActionBarCVarManager
+{
+    private readonly IConfigurationManager _cfg;
+
+    // Clamped layout values the controller's ApplyLayout / ApplyLabels read when it rebuilds
+    // the bar. Seeded by the invokeImmediately subscriptions in Initialize, so the explicit
+    // up-front reads the controller used to do are folded into those callbacks.
+    public int Rows { get; private set; }
+    public int SlotsPerRow { get; private set; }
+    public int SlotSpacing { get; private set; }
+    public bool ShowKeybindLabel { get; private set; }
+
+    // Last seen free-position coordinates. A negative value on either axis means "anchored".
+    public float PositionX { get; private set; }
+    public float PositionY { get; private set; }
+
+    // Re-apply hooks, one per distinct reaction the original per-CVar handlers performed.
+    public event Action? LayoutAndHotbarChanged;
+    public event Action? LayoutChanged;
+    public event Action? LabelsChanged;
+    public event Action? LockChanged;
+    public event Action? PositionChanged;
+
+    public ActionBarCVarManager(IConfigurationManager cfg)
+    {
+        _cfg = cfg;
+    }
+
+    public void Initialize()
+    {
+        // Layout CVars: clamp into the supported range and re-apply on change. invokeImmediately
+        // seeds the stored value, so no separate up-front GetCVar is needed.
+        _cfg.OnValueChanged(CCVars.HonkActionBarRows, value =>
+        {
+            Rows = Math.Clamp(value, 1, 4);
+            LayoutAndHotbarChanged?.Invoke();
+        }, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarSlotsPerRow, value =>
+        {
+            SlotsPerRow = Math.Clamp(value, 1, 10);
+            LayoutAndHotbarChanged?.Invoke();
+        }, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarSlotSpacing, value =>
+        {
+            SlotSpacing = Math.Clamp(value, 0, 16);
+            LayoutChanged?.Invoke();
+        }, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarShowKeybindLabel, value =>
+        {
+            ShowKeybindLabel = value;
+            LabelsChanged?.Invoke();
+        }, true);
+
+        // Cross-module flags read on per-frame hot paths: mirror straight into the shared
+        // runtime config so ActionButton / ActionUIController stay off a UIController lookup.
+        _cfg.OnValueChanged(CCVars.HonkActionBarShowEmptySlots, value =>
+        {
+            ActionBarRuntimeConfig.Current.ShowEmptySlots = value;
+            LayoutAndHotbarChanged?.Invoke();
+        }, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarAutoAddActions,
+            value => ActionBarRuntimeConfig.Current.AutoAddActions = value, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarLock, value =>
+        {
+            ActionBarRuntimeConfig.Current.LockActions = value;
+            LockChanged?.Invoke();
+        }, true);
+        _cfg.OnValueChanged(CCVars.HonkActionBarButtonBackgroundAlpha,
+            value => ActionBarRuntimeConfig.Current.ButtonBackgroundAlpha = Math.Clamp(value, 0f, 1f), true);
+
+        // Position CVars: seeded with an explicit read (no immediate apply — the widget isn't
+        // up yet) then re-applied whenever they change.
+        PositionX = _cfg.GetCVar(CCVars.HonkActionBarPositionX);
+        PositionY = _cfg.GetCVar(CCVars.HonkActionBarPositionY);
+        _cfg.OnValueChanged(CCVars.HonkActionBarPositionX, value => { PositionX = value; PositionChanged?.Invoke(); }, false);
+        _cfg.OnValueChanged(CCVars.HonkActionBarPositionY, value => { PositionY = value; PositionChanged?.Invoke(); }, false);
+    }
+
+    public void SetAutoAddActions(bool value)
+        => _cfg.SetCVar(CCVars.HonkActionBarAutoAddActions, value);
+
+    // Persist whatever the in-flight drag landed on. SaveToFile so a crash mid-session doesn't
+    // lose the player's chosen layout.
+    public void WritePosition(float x, float y)
+    {
+        _cfg.SetCVar(CCVars.HonkActionBarPositionX, x);
+        _cfg.SetCVar(CCVars.HonkActionBarPositionY, y);
+        _cfg.SaveToFile();
+    }
+
+    public void ResetPosition()
+    {
+        _cfg.SetCVar(CCVars.HonkActionBarPositionX, CCVars.HonkActionBarPositionX.DefaultValue);
+        _cfg.SetCVar(CCVars.HonkActionBarPositionY, CCVars.HonkActionBarPositionY.DefaultValue);
+        _cfg.SaveToFile();
+    }
+
+    // Write every preset field back to its CVar in one shot, replacing the seven-plus inline
+    // SetCVar calls the controller used to carry in ApplyPreset.
+    public void WritePreset(ActionBarPreset preset)
+    {
+        _cfg.SetCVar(CCVars.HonkActionBarRows, preset.Rows);
+        _cfg.SetCVar(CCVars.HonkActionBarSlotsPerRow, preset.SlotsPerRow);
+        _cfg.SetCVar(CCVars.HonkActionBarSlotSpacing, preset.SlotSpacing);
+        _cfg.SetCVar(CCVars.HonkActionBarShowKeybindLabel, preset.ShowKeybindLabel);
+        _cfg.SetCVar(CCVars.HonkActionBarShowEmptySlots, preset.ShowEmptySlots);
+        _cfg.SetCVar(CCVars.HonkActionBarAutoAddActions, preset.AutoAddActions);
+        // Force lock on after every preset apply: a freshly-loaded curated layout shouldn't
+        // get nudged by mis-clicks before the player has even looked at it. Players can still
+        // toggle the lock back off from the presets window.
+        _cfg.SetCVar(CCVars.HonkActionBarLock, true);
+        _cfg.SetCVar(CCVars.HonkActionBarButtonBackgroundAlpha, preset.ButtonBackgroundAlpha);
+        _cfg.SetCVar(CCVars.HonkActionBarPositionX, preset.PositionX);
+        _cfg.SetCVar(CCVars.HonkActionBarPositionY, preset.PositionY);
+        _cfg.SaveToFile();
+    }
+}

--- a/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
@@ -1,134 +1,83 @@
-using System.Linq;
-using System.Numerics;
 using Content.Client.Gameplay;
 using Content.Client.Lobby;
 using Content.Client.UserInterface.Systems.Actions;
 using Content.Client.UserInterface.Systems.Actions.Controls;
 using Content.Client.UserInterface.Systems.Actions.Widgets;
 using Content.Client.UserInterface.Systems.Actions.Windows;
-using Content.Shared.CCVar;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
-using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client.RussStation.ActionBar;
 
-// HONK Fork UIController that applies user-tunable layout settings to the
-// upstream action bar widget. Reads CVars registered in CCVars.ActionBar.cs
-// and re-applies them whenever any of them change, so settings take effect
-// the moment the user clicks Apply in the options menu. Also re-applies on
-// gameplay state entry since the ActionsBar widget only exists then.
+// HONK Fork UIController that applies user-tunable layout settings to the upstream action
+// bar widget. It stays thin: the CVar read/write/subscribe lives in ActionBarCVarManager,
+// the preset capture/apply/reset in ActionBarPresetManager, and the float/anchor positioning
+// in ActionBarPositioningManager. The controller keeps the layout-application glue (the bits
+// that touch the live ActionsBar container) and the wiring between those collaborators.
 public sealed class ActionBarCustomizationController : UIController, IOnStateEntered<GameplayState>
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IClientPreferencesManager _prefs = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IResourceManager _resources = default!;
 
-    private int _rows;
-    private int _slotsPerRow;
-    private int _slotSpacing;
-    private bool _showKeybindLabel;
+    private ActionBarCVarManager _cvars = default!;
+    private ActionBarPositioningManager _positioning = default!;
+    private ActionBarPresetManager _presets = default!;
 
-    // Read by ActionButton.UpdateBackground (HONK block) on every frame so empty
-    // slots can render a faint outline. A static keeps the hot path free of a
-    // UIController lookup per button per frame.
-    public static bool ShowEmptySlots { get; private set; }
-
-    // Read by ActionUIController.OnActionAdded (HONK guard) so newly granted actions
-    // can skip auto-population when the user wants a curated bar layout.
-    public static bool AutoAddActions { get; private set; } = true;
-
-    // Read by ActionUIController drag / right-click paths (HONK guards) to keep
-    // the bar immutable when the player has locked the layout.
-    public static bool LockActions { get; private set; }
-
-    // Read by the gameplay-screen resize handlers (HONK guards) to keep them from
-    // calling MaxGridHeight/MaxGridWidth, which would flip the grid into size-limit
-    // mode and silently overwrite the user's explicit row count on resize.
-    public static readonly bool OverridesRowLayout = true;
-
-    // Base 0.0-1.0 alpha applied to every action button's slot background. Read each
-    // frame by ActionButton.UpdateBackground (HONK block). The empty-slot fade scales
-    // proportionally so the relative contrast stays consistent.
-    public static float ButtonBackgroundAlpha { get; private set; } = 150f / 255f;
-
-    // Flipped by ActionUIController drag hooks so empty drop targets are padded into the
-    // container even when the persistent show-empty toggle is off.
-    public static bool IsDragActive { get; private set; }
-
-    // Mirrored from SlotHotkeyController so the bar-side code (UpdateBackground, ApplyLabels)
-    // can reveal every slot and its keybind label while the player is assigning hotkeys.
-    public static bool AssignHotkeyMode { get; private set; }
-
-    // Stashed when we lift the bar out of its XAML parent for free-positioning, so a
-    // reset to anchored mode can drop it back at the same sibling index.
-    private Control? _anchoredParent;
-    private int _anchoredIndex;
-    private LayoutContainer? _floatParent;
-    private float _positionX;
-    private float _positionY;
-
-    // Emote id ("Wave", "Salute", ...) -> slot index. Sourced from the active preset's
-    // EmoteIds list (loaded at startup and refreshed when ApplyPreset runs) so a player's
-    // curated emote layout survives disconnects and server restarts via the preset file
-    // rather than a separate CVar. Read by OnActionAdded through TryGetSavedEmoteSlot.
-    private readonly Dictionary<string, int> _emoteSlots = new();
+    private ActionBarPresetsWindow? _presetsWindow;
+    private bool _autoLoadedInitialPreset;
 
     public bool TryGetSavedEmoteSlot(string? emoteId, out int slot)
-    {
-        if (!string.IsNullOrEmpty(emoteId) && _emoteSlots.TryGetValue(emoteId, out slot))
-            return true;
-        slot = default;
-        return false;
-    }
+        => _presets.TryGetSavedEmoteSlot(emoteId, out slot);
+
+    public string GetActiveCharacterName() => _presets.GetActiveCharacterName();
+
+    public ActionBarPreset? FindActivePresetForCharacter() => _presets.FindActivePresetForCharacter();
 
     public override void Initialize()
     {
         base.Initialize();
 
-        _rows = _cfg.GetCVar(CCVars.HonkActionBarRows);
-        _slotsPerRow = _cfg.GetCVar(CCVars.HonkActionBarSlotsPerRow);
-        _slotSpacing = _cfg.GetCVar(CCVars.HonkActionBarSlotSpacing);
-        _showKeybindLabel = _cfg.GetCVar(CCVars.HonkActionBarShowKeybindLabel);
-        ShowEmptySlots = _cfg.GetCVar(CCVars.HonkActionBarShowEmptySlots);
-        AutoAddActions = _cfg.GetCVar(CCVars.HonkActionBarAutoAddActions);
-        LockActions = _cfg.GetCVar(CCVars.HonkActionBarLock);
-        ButtonBackgroundAlpha = Math.Clamp(_cfg.GetCVar(CCVars.HonkActionBarButtonBackgroundAlpha), 0f, 1f);
+        _cvars = new ActionBarCVarManager(_cfg);
+        _positioning = new ActionBarPositioningManager(UIManager, _cvars);
+        _presets = new ActionBarPresetManager(_prefs, UIManager, _proto, _resources, _cvars, _positioning);
 
-        _cfg.OnValueChanged(CCVars.HonkActionBarRows, OnRowsChanged, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarSlotsPerRow, OnSlotsPerRowChanged, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarSlotSpacing, OnSlotSpacingChanged, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarShowKeybindLabel, OnShowKeybindLabelChanged, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarShowEmptySlots, OnShowEmptySlotsChanged, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarAutoAddActions, v => AutoAddActions = v, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarLock, v => LockActions = v, true);
-        _cfg.OnValueChanged(CCVars.HonkActionBarButtonBackgroundAlpha,
-            v => ButtonBackgroundAlpha = Math.Clamp(v, 0f, 1f), true);
+        // React to CVar changes exactly the way the original per-CVar handlers did.
+        _cvars.LayoutAndHotbarChanged += OnLayoutAndHotbarChanged;
+        _cvars.LayoutChanged += ApplyLayout;
+        _cvars.LabelsChanged += ApplyLabels;
+        _cvars.LockChanged += _positioning.RefreshDragHandleVisibility;
+        _cvars.PositionChanged += _positioning.OnPositionChanged;
+        _cvars.Initialize();
 
-        // Seed _emoteSlots from the active preset before the actions system dispatches its
-        // initial OnActionAdded burst, so emote actions can land on their saved slots even
-        // though the full preset apply waits until HonkOnContainerReady has actions to bind.
-        LoadActiveEmoteSlots();
-
-        _positionX = _cfg.GetCVar(CCVars.HonkActionBarPositionX);
-        _positionY = _cfg.GetCVar(CCVars.HonkActionBarPositionY);
-        _cfg.OnValueChanged(CCVars.HonkActionBarPositionX, v => { _positionX = v; ApplyPosition(); }, false);
-        _cfg.OnValueChanged(CCVars.HonkActionBarPositionY, v => { _positionY = v; ApplyPosition(); }, false);
-        _cfg.OnValueChanged(CCVars.HonkActionBarLock, _ => RefreshDragHandleVisibility(), false);
+        // Seed the emote slots from the active preset before the actions system dispatches its
+        // initial OnActionAdded burst, so emote actions can land on their saved slots even though
+        // the full preset apply waits until HonkOnContainerReady has actions to bind.
+        _presets.LoadActiveEmoteSlots();
 
         // Mirror the assign-hotkey toggle so the bar auto-reveals while the player rebinds slots.
         var slotHotkeys = UIManager.GetUIController<SlotHotkeyController>();
-        AssignHotkeyMode = slotHotkeys.AssignMode;
+        ActionBarRuntimeConfig.Current.AssignHotkeyMode = slotHotkeys.AssignMode;
         slotHotkeys.AssignStateChanged += OnAssignStateChanged;
         // Rebuild the hotbar when any action-bar slot's binding changes so the labels track
         // what Settings → Controls currently holds.
         slotHotkeys.SlotBindingChanged += RefreshHotbar;
     }
 
+    private void OnLayoutAndHotbarChanged()
+    {
+        ApplyLayout();
+        RefreshHotbar();
+    }
+
     private void OnAssignStateChanged()
     {
         var slotHotkeys = UIManager.GetUIController<SlotHotkeyController>();
-        AssignHotkeyMode = slotHotkeys.AssignMode;
+        ActionBarRuntimeConfig.Current.AssignHotkeyMode = slotHotkeys.AssignMode;
         ApplyLayout();
         ApplyLabels();
         ApplyArmedHighlight();
@@ -147,42 +96,9 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         var i = 0;
         foreach (var button in container.GetButtons())
         {
-            button.HighlightRect.Visible = AssignHotkeyMode && armed == i;
+            button.HighlightRect.Visible = ActionBarRuntimeConfig.Current.AssignHotkeyMode && armed == i;
             i++;
         }
-    }
-
-    private void OnRowsChanged(int value)
-    {
-        _rows = Math.Clamp(value, 1, 4);
-        ApplyLayout();
-        RefreshHotbar();
-    }
-
-    private void OnSlotsPerRowChanged(int value)
-    {
-        _slotsPerRow = Math.Clamp(value, 1, 10);
-        ApplyLayout();
-        RefreshHotbar();
-    }
-
-    private void OnSlotSpacingChanged(int value)
-    {
-        _slotSpacing = Math.Clamp(value, 0, 16);
-        ApplyLayout();
-    }
-
-    private void OnShowKeybindLabelChanged(bool value)
-    {
-        _showKeybindLabel = value;
-        ApplyLabels();
-    }
-
-    private void OnShowEmptySlotsChanged(bool value)
-    {
-        ShowEmptySlots = value;
-        ApplyLayout();
-        RefreshHotbar();
     }
 
     private ActionButtonContainer? GetContainer()
@@ -198,13 +114,14 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
 
         // Setting Columns (not Rows) makes the grid fill row-by-row, so hotkeys 1..0 land
         // in row 1 and 2 lands on row 2's leftmost slot rather than column-major flow.
-        container.Columns = _slotsPerRow;
-        container.HSeparationOverride = _slotSpacing;
-        container.VSeparationOverride = _slotSpacing;
+        container.Columns = _cvars.SlotsPerRow;
+        container.HSeparationOverride = _cvars.SlotSpacing;
+        container.VSeparationOverride = _cvars.SlotSpacing;
         // Reveal every slot (pad up to rows x slots_per_row) when either the user's persistent
         // toggle is on, a drag is active, or the player is actively rebinding slot hotkeys.
-        container.HonkMinSlotCount = ShowEmptySlots || IsDragActive || AssignHotkeyMode
-            ? _rows * _slotsPerRow
+        var runtime = ActionBarRuntimeConfig.Current;
+        container.HonkMinSlotCount = runtime.ShowEmptySlots || runtime.IsDragActive || runtime.AssignHotkeyMode
+            ? _cvars.Rows * _cvars.SlotsPerRow
             : 0;
     }
 
@@ -215,10 +132,11 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
 
         // Normally labels only render on slots with an action and on drag targets. Assign-hotkey
         // mode forces every slot's label visible so the player can see which key they're rebinding.
+        var runtime = ActionBarRuntimeConfig.Current;
         foreach (var button in container.GetButtons())
         {
-            button.Label.Visible = AssignHotkeyMode
-                || (_showKeybindLabel && (button.Action != null || IsDragActive));
+            button.Label.Visible = runtime.AssignHotkeyMode
+                || (_cvars.ShowKeybindLabel && (button.Action != null || runtime.IsDragActive));
         }
     }
 
@@ -231,88 +149,14 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         ApplyLabels();
     }
 
-    /// <summary>Refresh <see cref="_emoteSlots"/> from <paramref name="emoteIds"/>, a
-    /// parallel-to-SlotProtoIds list where each non-null entry is the emote id that
-    /// occupies that slot. Validates against EmotePrototype so a stale preset entry
-    /// from a removed emote silently drops out instead of poisoning the bar.</summary>
-    private void RefreshEmoteSlots(List<string?> emoteIds)
-    {
-        _emoteSlots.Clear();
-        var protoMan = IoCManager.Resolve<Robust.Shared.Prototypes.IPrototypeManager>();
-        for (var i = 0; i < emoteIds.Count; i++)
-        {
-            var id = emoteIds[i];
-            if (string.IsNullOrEmpty(id))
-                continue;
-            if (!protoMan.HasIndex<Content.Shared.Chat.Prototypes.EmotePrototype>(id))
-                continue;
-            _emoteSlots[id] = i;
-        }
-    }
-
-    /// <summary>Read the first saved preset that matches the active character (or any
-    /// character-agnostic preset, for back-compat with files saved before this scope was
-    /// added) and seed <see cref="_emoteSlots"/> from it. Called during Initialize so
-    /// emote actions granted before HonkOnContainerReady runs still hit their saved
-    /// slots.</summary>
-    private void LoadActiveEmoteSlots()
-    {
-        var preset = FindActivePresetForCharacter();
-        if (preset == null)
-        {
-            _emoteSlots.Clear();
-            return;
-        }
-        RefreshEmoteSlots(preset.EmoteIds);
-    }
-
-    /// <summary>Currently-selected character profile name, or empty if preferences
-    /// haven't synced from the server yet. Empty matches presets that were saved
-    /// before character scoping landed (their <c>CharacterName</c> is also empty).</summary>
-    public string GetActiveCharacterName()
-        => _prefs.Preferences?.SelectedCharacter.Name ?? string.Empty;
-
-    /// <summary>Picks the first saved preset whose <c>CharacterName</c> matches the
-    /// active character, falling back to the first character-agnostic preset.</summary>
-    public ActionBarPreset? FindActivePresetForCharacter()
-    {
-        var presets = GetPresetStore().Presets;
-        if (presets.Count == 0)
-            return null;
-        var character = GetActiveCharacterName();
-        foreach (var preset in presets)
-        {
-            if (string.Equals(preset.CharacterName, character, StringComparison.Ordinal))
-                return preset;
-        }
-        // No exact match: fall through to a character-agnostic preset (CharacterName
-        // empty) so old presets and "global" ones still work.
-        foreach (var preset in presets)
-        {
-            if (string.IsNullOrEmpty(preset.CharacterName))
-                return preset;
-        }
-        return null;
-    }
-
-    // Wires the auto-add toggle and the Presets button on the actions window, called from
-    // the upstream LoadGui (HONK) each time the window is (re)created. Lock has moved into
-    // the preset window so the bar's customisation controls live in one place.
+    // Wires the auto-add toggle and the Presets button on the actions window, called from the
+    // upstream LoadGui (HONK) each time the window is (re)created. Lock has moved into the preset
+    // window so the bar's customisation controls live in one place.
     public void HonkBindWindow(ActionsWindow window)
     {
-        window.AutoAddButton.Pressed = AutoAddActions;
-        window.AutoAddButton.OnToggled += a => _cfg.SetCVar(CCVars.HonkActionBarAutoAddActions, a.Pressed);
+        window.AutoAddButton.Pressed = ActionBarRuntimeConfig.Current.AutoAddActions;
+        window.AutoAddButton.OnToggled += a => _cvars.SetAutoAddActions(a.Pressed);
         window.PresetsButton.OnPressed += _ => OpenPresetsWindow();
-    }
-
-    private ActionBarPresetsWindow? _presetsWindow;
-    private ActionBarPresetStore? _presetStoreCached;
-
-    private ActionBarPresetStore GetPresetStore()
-    {
-        // Lazily allocated so the controller doesn't pull in IResourceManager until the
-        // player actually opens the preset UI; keeps client startup unaffected.
-        return _presetStoreCached ??= new ActionBarPresetStore(IoCManager.Resolve<Robust.Shared.ContentPack.IResourceManager>());
     }
 
     private void OpenPresetsWindow()
@@ -323,84 +167,35 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
             _presetsWindow.MoveToFront();
             return;
         }
-        _presetsWindow = new ActionBarPresetsWindow(GetPresetStore(), _cfg, CapturePreset, ApplyPreset, ResetToDefaults, GetActiveCharacterName);
+        _presetsWindow = new ActionBarPresetsWindow(
+            _presets.Store,
+            _cfg,
+            _presets.CapturePreset,
+            _presets.ApplyPreset,
+            _presets.ResetToDefaults,
+            _presets.GetActiveCharacterName);
         _presetsWindow.OpenCentered();
     }
 
-    private ActionBarPreset CapturePreset()
-    {
-        var actions = UIManager.GetUIController<ActionUIController>();
-        return new ActionBarPreset
-        {
-            CharacterName = GetActiveCharacterName(),
-            Rows = _rows,
-            SlotsPerRow = _slotsPerRow,
-            SlotSpacing = _slotSpacing,
-            ShowKeybindLabel = _showKeybindLabel,
-            ShowEmptySlots = ShowEmptySlots,
-            AutoAddActions = AutoAddActions,
-            Lock = LockActions,
-            ButtonBackgroundAlpha = ButtonBackgroundAlpha,
-            PositionX = _positionX,
-            PositionY = _positionY,
-            SlotProtoIds = actions.HonkGetSlotProtoIds(),
-            EmoteIds = actions.HonkGetSlotEmoteIds(),
-        };
-    }
-
-    private void ApplyPreset(ActionBarPreset preset)
-    {
-        _cfg.SetCVar(CCVars.HonkActionBarRows, preset.Rows);
-        _cfg.SetCVar(CCVars.HonkActionBarSlotsPerRow, preset.SlotsPerRow);
-        _cfg.SetCVar(CCVars.HonkActionBarSlotSpacing, preset.SlotSpacing);
-        _cfg.SetCVar(CCVars.HonkActionBarShowKeybindLabel, preset.ShowKeybindLabel);
-        _cfg.SetCVar(CCVars.HonkActionBarShowEmptySlots, preset.ShowEmptySlots);
-        _cfg.SetCVar(CCVars.HonkActionBarAutoAddActions, preset.AutoAddActions);
-        // Force lock on after every preset apply: a freshly-loaded curated layout shouldn't
-        // get nudged by mis-clicks before the player has even looked at it. Players can still
-        // toggle the lock back off from the presets window.
-        _cfg.SetCVar(CCVars.HonkActionBarLock, true);
-        _cfg.SetCVar(CCVars.HonkActionBarButtonBackgroundAlpha, preset.ButtonBackgroundAlpha);
-        _cfg.SetCVar(CCVars.HonkActionBarPositionX, preset.PositionX);
-        _cfg.SetCVar(CCVars.HonkActionBarPositionY, preset.PositionY);
-        _cfg.SaveToFile();
-
-        RefreshEmoteSlots(preset.EmoteIds);
-        UIManager.GetUIController<ActionUIController>().HonkLoadFromPreset(preset.SlotProtoIds, preset.EmoteIds);
-    }
-
-    private void ResetToDefaults()
-    {
-        // Scope: only reset things the presets window owns (slot contents and bar position).
-        // Size/spacing/label/alpha settings live in Options → Misc and have their own
-        // controls; wiping them from the preset window's Reset button surprised players
-        // who expected only the layout (slot assignments) to revert.
-        _cfg.SetCVar(CCVars.HonkActionBarPositionX, CCVars.HonkActionBarPositionX.DefaultValue);
-        _cfg.SetCVar(CCVars.HonkActionBarPositionY, CCVars.HonkActionBarPositionY.DefaultValue);
-        _cfg.SaveToFile();
-
-        UIManager.GetUIController<ActionUIController>().HonkResetSlots();
-    }
-
-    // Called from the upstream ActionUIController (HONK) once the action bar widget
-    // is registered. That's the first point the container reliably exists, so fresh
-    // client starts get the stored layout applied here rather than relying on the
-    // order in which UIControllers receive OnStateEntered.
+    // Called from the upstream ActionUIController (HONK) once the action bar widget is
+    // registered. That's the first point the container reliably exists, so fresh client starts
+    // get the stored layout applied here rather than relying on the order in which UIControllers
+    // receive OnStateEntered.
     public void HonkOnContainerReady()
     {
         ApplyLayout();
         ApplyLabels();
         RefreshHotbar();
-        WireDragHandle();
-        ApplyPosition();
+        _positioning.WireDragHandle();
+        _positioning.ApplyPosition();
     }
 
     /// <summary>Auto-apply the first character-matched preset on first session start so a
     /// returning player gets their curated layout without clicking Load. Must run AFTER
-    /// <c>LinkAllActions</c>: that call dispatches <c>OnActionAdded</c> for every linked
-    /// action and appends them to the bar, which would clobber a preset applied earlier.
-    /// Idempotent via the <see cref="_autoLoadedInitialPreset"/> flag, so subsequent screen
-    /// reloads (e.g. respawn) don't trigger a second auto-load.</summary>
+    /// <c>LinkAllActions</c>: that call dispatches <c>OnActionAdded</c> for every linked action
+    /// and appends them to the bar, which would clobber a preset applied earlier. Idempotent via
+    /// the <see cref="_autoLoadedInitialPreset"/> flag, so subsequent screen reloads (e.g.
+    /// respawn) don't trigger a second auto-load.</summary>
     public void HonkAfterInitialLink()
     {
         if (_autoLoadedInitialPreset)
@@ -409,132 +204,17 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
             return;
 
         _autoLoadedInitialPreset = true;
-        if (FindActivePresetForCharacter() is { } preset)
-            ApplyPreset(preset);
+        if (_presets.FindActivePresetForCharacter() is { } preset)
+            _presets.ApplyPreset(preset);
     }
 
-    private bool _autoLoadedInitialPreset;
-
-    private ActionsBar? GetBar() => UIManager.GetActiveUIWidgetOrNull<ActionsBar>();
-
-    private void WireDragHandle()
-    {
-        if (GetBar() is not { } bar)
-            return;
-        // Defensive: re-wiring on every container ready call would stack handlers, so
-        // unsubscribe first.
-        bar.HonkDragHandle.DragMoved -= OnHandleDragMoved;
-        bar.HonkDragHandle.DragEnded -= OnHandleDragEnded;
-        bar.HonkDragHandle.DragMoved += OnHandleDragMoved;
-        bar.HonkDragHandle.DragEnded += OnHandleDragEnded;
-        RefreshDragHandleVisibility();
-    }
-
-    private void RefreshDragHandleVisibility()
-    {
-        if (GetBar() is { } bar)
-            bar.HonkDragHandle.Visible = !LockActions;
-    }
-
-    private void OnHandleDragMoved(Vector2 delta)
-    {
-        if (GetBar() is not { } bar)
-            return;
-        // Capture the bar's pre-reparent screen position so the first drag doesn't snap
-        // the bar to (0,0) before we've written any explicit coordinates.
-        var initial = bar.GlobalPosition;
-        EnsureFloating(bar);
-        if (_floatParent == null)
-            return;
-        if (_positionX < 0 || _positionY < 0)
-        {
-            var local = initial - _floatParent.GlobalPosition;
-            _positionX = local.X;
-            _positionY = local.Y;
-        }
-        var size = bar.Size;
-        var bounds = _floatParent.Size;
-        _positionX = Math.Clamp(_positionX + delta.X, ActionBarConstants.PositionEdgeMargin, MathF.Max(ActionBarConstants.PositionEdgeMargin, bounds.X - size.X - ActionBarConstants.PositionEdgeMargin));
-        _positionY = Math.Clamp(_positionY + delta.Y, ActionBarConstants.PositionEdgeMargin, MathF.Max(ActionBarConstants.PositionEdgeMargin, bounds.Y - size.Y - ActionBarConstants.PositionEdgeMargin));
-        LayoutContainer.SetPosition(bar, new Vector2(_positionX, _positionY));
-    }
-
-    private void OnHandleDragEnded()
-    {
-        // Persist whatever the in-flight drag landed on. SaveToFile so a crash mid-session
-        // doesn't lose the player's chosen layout.
-        _cfg.SetCVar(CCVars.HonkActionBarPositionX, _positionX);
-        _cfg.SetCVar(CCVars.HonkActionBarPositionY, _positionY);
-        _cfg.SaveToFile();
-    }
-
-    /// <summary>Applies the saved position CVars to the bar, lifting it into the screen's
-    /// LayoutContainer when set or restoring its XAML parent when reset to -1.</summary>
-    private void ApplyPosition()
-    {
-        if (GetBar() is not { } bar)
-            return;
-        if (_positionX < 0 || _positionY < 0)
-        {
-            EnsureAnchored(bar);
-            return;
-        }
-        EnsureFloating(bar);
-        if (_floatParent == null)
-            return;
-        LayoutContainer.SetPosition(bar, new Vector2(_positionX, _positionY));
-    }
-
-    private void EnsureFloating(ActionsBar bar)
-    {
-        if (bar.Parent is LayoutContainer current && current == _floatParent)
-            return;
-        var origin = bar.Parent;
-        if (origin == null)
-            return;
-        // Walk up to find the screen-level LayoutContainer (ViewportContainer in both
-        // game screens) so SetPosition's attached props will actually be honoured.
-        Control? walker = origin;
-        LayoutContainer? layout = null;
-        while (walker != null)
-        {
-            if (walker is LayoutContainer lc)
-            {
-                layout = lc;
-                break;
-            }
-            walker = walker.Parent;
-        }
-        if (layout == null)
-            return;
-        if (_anchoredParent == null)
-        {
-            _anchoredParent = origin;
-            _anchoredIndex = bar.GetPositionInParent();
-        }
-        origin.RemoveChild(bar);
-        layout.AddChild(bar);
-        _floatParent = layout;
-    }
-
-    private void EnsureAnchored(ActionsBar bar)
-    {
-        if (_floatParent == null || bar.Parent != _floatParent || _anchoredParent == null)
-            return;
-        _floatParent.RemoveChild(bar);
-        _anchoredParent.AddChild(bar);
-        // Keep the original sibling order so the menu bar / vote menu stack as before.
-        var clamped = Math.Clamp(_anchoredIndex, 0, _anchoredParent.ChildCount - 1);
-        bar.SetPositionInParent(clamped);
-    }
-
-    // Called from the action drag hooks so the container can pad in empty drop targets
-    // and then trim them back out once the drop completes.
+    // Called from the action drag hooks so the container can pad in empty drop targets and then
+    // trim them back out once the drop completes.
     public void HonkSetDragActive(bool active)
     {
-        if (IsDragActive == active)
+        if (ActionBarRuntimeConfig.Current.IsDragActive == active)
             return;
-        IsDragActive = active;
+        ActionBarRuntimeConfig.Current.IsDragActive = active;
         ApplyLayout();
         RefreshHotbar();
         ApplyLabels();

--- a/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarCustomizationController.cs
@@ -7,8 +7,6 @@ using Content.Client.UserInterface.Systems.Actions.Windows;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Shared.Configuration;
-using Robust.Shared.ContentPack;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.RussStation.ActionBar;
 
@@ -21,8 +19,6 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IClientPreferencesManager _prefs = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly IResourceManager _resources = default!;
 
     private ActionBarCVarManager _cvars = default!;
     private ActionBarPositioningManager _positioning = default!;
@@ -43,16 +39,21 @@ public sealed class ActionBarCustomizationController : UIController, IOnStateEnt
         base.Initialize();
 
         _cvars = new ActionBarCVarManager(_cfg);
-        _positioning = new ActionBarPositioningManager(UIManager, _cvars);
-        _presets = new ActionBarPresetManager(_prefs, UIManager, _proto, _resources, _cvars, _positioning);
 
-        // React to CVar changes exactly the way the original per-CVar handlers did.
+        // Layout/label reactions are wired before reading the CVars so the invokeImmediately
+        // seeding reaches them (they no-op until the bar widget exists).
         _cvars.LayoutAndHotbarChanged += OnLayoutAndHotbarChanged;
         _cvars.LayoutChanged += ApplyLayout;
         _cvars.LabelsChanged += ApplyLabels;
+        _cvars.Initialize();
+
+        // Positioning is built after Initialize so it reads the now-loaded position CVars; its
+        // lock/position reactions are non-immediate, matching the original subscriptions.
+        _positioning = new ActionBarPositioningManager(UIManager, _cvars);
         _cvars.LockChanged += _positioning.RefreshDragHandleVisibility;
         _cvars.PositionChanged += _positioning.OnPositionChanged;
-        _cvars.Initialize();
+
+        _presets = new ActionBarPresetManager(_prefs, UIManager, _cvars, _positioning);
 
         // Seed the emote slots from the active preset before the actions system dispatches its
         // initial OnActionAdded burst, so emote actions can land on their saved slots even though

--- a/Content.Client/RussStation/ActionBar/ActionBarPositioningManager.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPositioningManager.cs
@@ -85,8 +85,8 @@ public sealed class ActionBarPositioningManager
         }
         var size = bar.Size;
         var bounds = _floatParent.Size;
-        _positionX = Math.Clamp(_positionX + delta.X, ActionBarConstants.PositionEdgeMargin, MathF.Max(ActionBarConstants.PositionEdgeMargin, bounds.X - size.X - ActionBarConstants.PositionEdgeMargin));
-        _positionY = Math.Clamp(_positionY + delta.Y, ActionBarConstants.PositionEdgeMargin, MathF.Max(ActionBarConstants.PositionEdgeMargin, bounds.Y - size.Y - ActionBarConstants.PositionEdgeMargin));
+        _positionX = ActionBarPositioningMath.ClampAxis(_positionX, delta.X, size.X, bounds.X, ActionBarConstants.PositionEdgeMargin);
+        _positionY = ActionBarPositioningMath.ClampAxis(_positionY, delta.Y, size.Y, bounds.Y, ActionBarConstants.PositionEdgeMargin);
         LayoutContainer.SetPosition(bar, new Vector2(_positionX, _positionY));
     }
 

--- a/Content.Client/RussStation/ActionBar/ActionBarPositioningManager.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPositioningManager.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using Content.Client.UserInterface.Systems.Actions.Widgets;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Owns the free-positioning behaviour of the action bar: lifting it out of its XAML
+// parent into the screen LayoutContainer (and back), the drag-handle wiring, and the clamped
+// drag maths. Reads and persists the position through ActionBarCVarManager so the controller
+// stays out of the reparenting weeds.
+public sealed class ActionBarPositioningManager
+{
+    private readonly IUserInterfaceManager _ui;
+    private readonly ActionBarCVarManager _cvars;
+
+    // Stashed when we lift the bar out of its XAML parent for free-positioning, so a reset to
+    // anchored mode can drop it back at the same sibling index.
+    private Control? _anchoredParent;
+    private int _anchoredIndex;
+    private LayoutContainer? _floatParent;
+
+    // Live position, separate from the CVar value because a drag updates it continuously and
+    // only persists to the CVar on release.
+    private float _positionX;
+    private float _positionY;
+
+    public ActionBarPositioningManager(IUserInterfaceManager ui, ActionBarCVarManager cvars)
+    {
+        _ui = ui;
+        _cvars = cvars;
+        _positionX = cvars.PositionX;
+        _positionY = cvars.PositionY;
+    }
+
+    public float PositionX => _positionX;
+    public float PositionY => _positionY;
+
+    private ActionsBar? GetBar() => _ui.GetActiveUIWidgetOrNull<ActionsBar>();
+
+    public void WireDragHandle()
+    {
+        if (GetBar() is not { } bar)
+            return;
+        // Defensive: re-wiring on every container ready call would stack handlers, so
+        // unsubscribe first.
+        bar.HonkDragHandle.DragMoved -= OnHandleDragMoved;
+        bar.HonkDragHandle.DragEnded -= OnHandleDragEnded;
+        bar.HonkDragHandle.DragMoved += OnHandleDragMoved;
+        bar.HonkDragHandle.DragEnded += OnHandleDragEnded;
+        RefreshDragHandleVisibility();
+    }
+
+    public void RefreshDragHandleVisibility()
+    {
+        if (GetBar() is { } bar)
+            bar.HonkDragHandle.Visible = !ActionBarRuntimeConfig.Current.LockActions;
+    }
+
+    // Re-sync the live position from the (now changed) CVars and re-apply. Wired to the CVar
+    // manager's PositionChanged so options-menu applies, preset loads, and the drag-end persist
+    // all reach the bar.
+    public void OnPositionChanged()
+    {
+        _positionX = _cvars.PositionX;
+        _positionY = _cvars.PositionY;
+        ApplyPosition();
+    }
+
+    private void OnHandleDragMoved(Vector2 delta)
+    {
+        if (GetBar() is not { } bar)
+            return;
+        // Capture the bar's pre-reparent screen position so the first drag doesn't snap
+        // the bar to (0,0) before we've written any explicit coordinates.
+        var initial = bar.GlobalPosition;
+        EnsureFloating(bar);
+        if (_floatParent == null)
+            return;
+        if (_positionX < 0 || _positionY < 0)
+        {
+            var local = initial - _floatParent.GlobalPosition;
+            _positionX = local.X;
+            _positionY = local.Y;
+        }
+        var size = bar.Size;
+        var bounds = _floatParent.Size;
+        _positionX = Math.Clamp(_positionX + delta.X, ActionBarConstants.PositionEdgeMargin, MathF.Max(ActionBarConstants.PositionEdgeMargin, bounds.X - size.X - ActionBarConstants.PositionEdgeMargin));
+        _positionY = Math.Clamp(_positionY + delta.Y, ActionBarConstants.PositionEdgeMargin, MathF.Max(ActionBarConstants.PositionEdgeMargin, bounds.Y - size.Y - ActionBarConstants.PositionEdgeMargin));
+        LayoutContainer.SetPosition(bar, new Vector2(_positionX, _positionY));
+    }
+
+    private void OnHandleDragEnded() => _cvars.WritePosition(_positionX, _positionY);
+
+    /// <summary>Applies the saved position to the bar, lifting it into the screen's
+    /// LayoutContainer when set or restoring its XAML parent when reset to -1.</summary>
+    public void ApplyPosition()
+    {
+        if (GetBar() is not { } bar)
+            return;
+        if (_positionX < 0 || _positionY < 0)
+        {
+            EnsureAnchored(bar);
+            return;
+        }
+        EnsureFloating(bar);
+        if (_floatParent == null)
+            return;
+        LayoutContainer.SetPosition(bar, new Vector2(_positionX, _positionY));
+    }
+
+    private void EnsureFloating(ActionsBar bar)
+    {
+        if (bar.Parent is LayoutContainer current && current == _floatParent)
+            return;
+        var origin = bar.Parent;
+        if (origin == null)
+            return;
+        // Walk up to find the screen-level LayoutContainer (ViewportContainer in both
+        // game screens) so SetPosition's attached props will actually be honoured.
+        Control? walker = origin;
+        LayoutContainer? layout = null;
+        while (walker != null)
+        {
+            if (walker is LayoutContainer lc)
+            {
+                layout = lc;
+                break;
+            }
+            walker = walker.Parent;
+        }
+        if (layout == null)
+            return;
+        if (_anchoredParent == null)
+        {
+            _anchoredParent = origin;
+            _anchoredIndex = bar.GetPositionInParent();
+        }
+        origin.RemoveChild(bar);
+        layout.AddChild(bar);
+        _floatParent = layout;
+    }
+
+    private void EnsureAnchored(ActionsBar bar)
+    {
+        if (_floatParent == null || bar.Parent != _floatParent || _anchoredParent == null)
+            return;
+        _floatParent.RemoveChild(bar);
+        _anchoredParent.AddChild(bar);
+        // Keep the original sibling order so the menu bar / vote menu stack as before.
+        var clamped = Math.Clamp(_anchoredIndex, 0, _anchoredParent.ChildCount - 1);
+        bar.SetPositionInParent(clamped);
+    }
+}

--- a/Content.Client/RussStation/ActionBar/ActionBarPositioningMath.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPositioningMath.cs
@@ -1,0 +1,16 @@
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Pure positioning math pulled out of ActionBarPositioningManager so the drag-clamp
+// behaviour can be unit-tested without a live ActionsBar widget. See issue #855.
+public static class ActionBarPositioningMath
+{
+    /// <summary>Clamps a single axis of the bar's free position after a drag delta so the bar
+    /// stays inside its container with <paramref name="margin"/> pixels of breathing room on
+    /// each edge. The upper bound is floored at <paramref name="margin"/> via Max so a bar that
+    /// is wider/taller than its container (where <c>bounds - size - margin</c> goes negative)
+    /// pins to the near edge instead of throwing on an inverted clamp range.</summary>
+    public static float ClampAxis(float current, float delta, float size, float bounds, float margin)
+    {
+        return Math.Clamp(current + delta, margin, MathF.Max(margin, bounds - size - margin));
+    }
+}

--- a/Content.Client/RussStation/ActionBar/ActionBarPresetLogic.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPresetLogic.cs
@@ -1,0 +1,50 @@
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Pure preset-side decisions pulled out of ActionBarPresetManager so they can be
+// unit-tested without IoC, the YAML store, or a UI harness. The manager owns the IO and
+// just feeds the loaded data through these. See issue #855.
+public static class ActionBarPresetLogic
+{
+    /// <summary>Picks the preset that should apply for <paramref name="character"/>: the first
+    /// one saved against that exact character name, or failing that the first character-agnostic
+    /// preset (empty <c>CharacterName</c>, which is how presets saved before character scoping
+    /// look). Returns null when neither exists.</summary>
+    public static ActionBarPreset? SelectForCharacter(IReadOnlyList<ActionBarPreset> presets, string character)
+    {
+        if (presets.Count == 0)
+            return null;
+        foreach (var preset in presets)
+        {
+            if (string.Equals(preset.CharacterName, character, StringComparison.Ordinal))
+                return preset;
+        }
+        // No exact match: fall through to a character-agnostic preset so old presets and
+        // "global" ones still work.
+        foreach (var preset in presets)
+        {
+            if (string.IsNullOrEmpty(preset.CharacterName))
+                return preset;
+        }
+        return null;
+    }
+
+    /// <summary>Builds the emote-id -> slot-index lookup from a preset's parallel-to-slots emote
+    /// list. Null/empty entries are slots without an emote and are skipped; entries failing
+    /// <paramref name="isValidEmote"/> (e.g. a removed prototype) are dropped so a stale preset
+    /// can't poison the bar. When the same emote id appears twice the later slot wins, matching
+    /// the original last-write-into-dictionary behaviour.</summary>
+    public static Dictionary<string, int> BuildEmoteSlotMap(IReadOnlyList<string?> emoteIds, Func<string, bool> isValidEmote)
+    {
+        var map = new Dictionary<string, int>();
+        for (var i = 0; i < emoteIds.Count; i++)
+        {
+            var id = emoteIds[i];
+            if (string.IsNullOrEmpty(id))
+                continue;
+            if (!isValidEmote(id))
+                continue;
+            map[id] = i;
+        }
+        return map;
+    }
+}

--- a/Content.Client/RussStation/ActionBar/ActionBarPresetManager.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPresetManager.cs
@@ -15,8 +15,6 @@ public sealed class ActionBarPresetManager
 {
     private readonly IClientPreferencesManager _prefs;
     private readonly IUserInterfaceManager _ui;
-    private readonly IPrototypeManager _proto;
-    private readonly IResourceManager _resources;
     private readonly ActionBarCVarManager _cvars;
     private readonly ActionBarPositioningManager _positioning;
 
@@ -31,22 +29,19 @@ public sealed class ActionBarPresetManager
     public ActionBarPresetManager(
         IClientPreferencesManager prefs,
         IUserInterfaceManager ui,
-        IPrototypeManager proto,
-        IResourceManager resources,
         ActionBarCVarManager cvars,
         ActionBarPositioningManager positioning)
     {
         _prefs = prefs;
         _ui = ui;
-        _proto = proto;
-        _resources = resources;
         _cvars = cvars;
         _positioning = positioning;
     }
 
-    // Lazily allocated so the store doesn't read its file until the player actually has a use
-    // for presets; keeps client startup unaffected.
-    public ActionBarPresetStore Store => _store ??= new ActionBarPresetStore(_resources);
+    // Lazily allocated so the store doesn't pull in IResourceManager until the player actually
+    // has a use for presets; keeps client startup unaffected. Resolved through IoC (rather than a
+    // constructor dependency) to match the original controller's footprint.
+    public ActionBarPresetStore Store => _store ??= new ActionBarPresetStore(IoCManager.Resolve<IResourceManager>());
 
     private ActionUIController Actions => _ui.GetUIController<ActionUIController>();
 
@@ -90,7 +85,8 @@ public sealed class ActionBarPresetManager
     private void RefreshEmoteSlots(List<string?> emoteIds)
     {
         _emoteSlots.Clear();
-        foreach (var (id, slot) in ActionBarPresetLogic.BuildEmoteSlotMap(emoteIds, id => _proto.HasIndex<EmotePrototype>(id)))
+        var proto = IoCManager.Resolve<IPrototypeManager>();
+        foreach (var (id, slot) in ActionBarPresetLogic.BuildEmoteSlotMap(emoteIds, id => proto.HasIndex<EmotePrototype>(id)))
             _emoteSlots[id] = slot;
     }
 

--- a/Content.Client/RussStation/ActionBar/ActionBarPresetManager.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPresetManager.cs
@@ -67,25 +67,7 @@ public sealed class ActionBarPresetManager
     /// <summary>Picks the first saved preset whose <c>CharacterName</c> matches the active
     /// character, falling back to the first character-agnostic preset.</summary>
     public ActionBarPreset? FindActivePresetForCharacter()
-    {
-        var presets = Store.Presets;
-        if (presets.Count == 0)
-            return null;
-        var character = GetActiveCharacterName();
-        foreach (var preset in presets)
-        {
-            if (string.Equals(preset.CharacterName, character, StringComparison.Ordinal))
-                return preset;
-        }
-        // No exact match: fall through to a character-agnostic preset (CharacterName empty)
-        // so old presets and "global" ones still work.
-        foreach (var preset in presets)
-        {
-            if (string.IsNullOrEmpty(preset.CharacterName))
-                return preset;
-        }
-        return null;
-    }
+        => ActionBarPresetLogic.SelectForCharacter(Store.Presets, GetActiveCharacterName());
 
     /// <summary>Read the active character's preset and seed <see cref="_emoteSlots"/> from it.
     /// Called during controller Initialize so emote actions granted before HonkOnContainerReady
@@ -108,15 +90,8 @@ public sealed class ActionBarPresetManager
     private void RefreshEmoteSlots(List<string?> emoteIds)
     {
         _emoteSlots.Clear();
-        for (var i = 0; i < emoteIds.Count; i++)
-        {
-            var id = emoteIds[i];
-            if (string.IsNullOrEmpty(id))
-                continue;
-            if (!_proto.HasIndex<EmotePrototype>(id))
-                continue;
-            _emoteSlots[id] = i;
-        }
+        foreach (var (id, slot) in ActionBarPresetLogic.BuildEmoteSlotMap(emoteIds, id => _proto.HasIndex<EmotePrototype>(id)))
+            _emoteSlots[id] = slot;
     }
 
     public ActionBarPreset CapturePreset()

--- a/Content.Client/RussStation/ActionBar/ActionBarPresetManager.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarPresetManager.cs
@@ -1,0 +1,160 @@
+using Content.Client.Lobby;
+using Content.Client.UserInterface.Systems.Actions;
+using Content.Shared.Chat.Prototypes;
+using Robust.Client.UserInterface;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Owns the preset side of the action bar: which saved preset matches the active
+// character, the emote-slot lookup seeded from it, and the capture / apply / reset round-trip
+// with the ActionUIController. The controller delegates here so it doesn't carry the YAML
+// store, the preferences read, and the prototype validation itself.
+public sealed class ActionBarPresetManager
+{
+    private readonly IClientPreferencesManager _prefs;
+    private readonly IUserInterfaceManager _ui;
+    private readonly IPrototypeManager _proto;
+    private readonly IResourceManager _resources;
+    private readonly ActionBarCVarManager _cvars;
+    private readonly ActionBarPositioningManager _positioning;
+
+    private ActionBarPresetStore? _store;
+
+    // Emote id ("Wave", "Salute", ...) -> slot index. Sourced from the active preset's EmoteIds
+    // list (loaded at startup and refreshed when ApplyPreset runs) so a player's curated emote
+    // layout survives disconnects and server restarts via the preset file rather than a separate
+    // CVar. Read by OnActionAdded through TryGetSavedEmoteSlot.
+    private readonly Dictionary<string, int> _emoteSlots = new();
+
+    public ActionBarPresetManager(
+        IClientPreferencesManager prefs,
+        IUserInterfaceManager ui,
+        IPrototypeManager proto,
+        IResourceManager resources,
+        ActionBarCVarManager cvars,
+        ActionBarPositioningManager positioning)
+    {
+        _prefs = prefs;
+        _ui = ui;
+        _proto = proto;
+        _resources = resources;
+        _cvars = cvars;
+        _positioning = positioning;
+    }
+
+    // Lazily allocated so the store doesn't read its file until the player actually has a use
+    // for presets; keeps client startup unaffected.
+    public ActionBarPresetStore Store => _store ??= new ActionBarPresetStore(_resources);
+
+    private ActionUIController Actions => _ui.GetUIController<ActionUIController>();
+
+    public bool TryGetSavedEmoteSlot(string? emoteId, out int slot)
+    {
+        if (!string.IsNullOrEmpty(emoteId) && _emoteSlots.TryGetValue(emoteId, out slot))
+            return true;
+        slot = default;
+        return false;
+    }
+
+    /// <summary>Currently-selected character profile name, or empty if preferences haven't
+    /// synced from the server yet. Empty matches presets that were saved before character
+    /// scoping landed (their <c>CharacterName</c> is also empty).</summary>
+    public string GetActiveCharacterName()
+        => _prefs.Preferences?.SelectedCharacter.Name ?? string.Empty;
+
+    /// <summary>Picks the first saved preset whose <c>CharacterName</c> matches the active
+    /// character, falling back to the first character-agnostic preset.</summary>
+    public ActionBarPreset? FindActivePresetForCharacter()
+    {
+        var presets = Store.Presets;
+        if (presets.Count == 0)
+            return null;
+        var character = GetActiveCharacterName();
+        foreach (var preset in presets)
+        {
+            if (string.Equals(preset.CharacterName, character, StringComparison.Ordinal))
+                return preset;
+        }
+        // No exact match: fall through to a character-agnostic preset (CharacterName empty)
+        // so old presets and "global" ones still work.
+        foreach (var preset in presets)
+        {
+            if (string.IsNullOrEmpty(preset.CharacterName))
+                return preset;
+        }
+        return null;
+    }
+
+    /// <summary>Read the active character's preset and seed <see cref="_emoteSlots"/> from it.
+    /// Called during controller Initialize so emote actions granted before HonkOnContainerReady
+    /// runs still hit their saved slots.</summary>
+    public void LoadActiveEmoteSlots()
+    {
+        var preset = FindActivePresetForCharacter();
+        if (preset == null)
+        {
+            _emoteSlots.Clear();
+            return;
+        }
+        RefreshEmoteSlots(preset.EmoteIds);
+    }
+
+    /// <summary>Refresh <see cref="_emoteSlots"/> from <paramref name="emoteIds"/>, a
+    /// parallel-to-SlotProtoIds list where each non-null entry is the emote id that occupies
+    /// that slot. Validates against EmotePrototype so a stale preset entry from a removed emote
+    /// silently drops out instead of poisoning the bar.</summary>
+    private void RefreshEmoteSlots(List<string?> emoteIds)
+    {
+        _emoteSlots.Clear();
+        for (var i = 0; i < emoteIds.Count; i++)
+        {
+            var id = emoteIds[i];
+            if (string.IsNullOrEmpty(id))
+                continue;
+            if (!_proto.HasIndex<EmotePrototype>(id))
+                continue;
+            _emoteSlots[id] = i;
+        }
+    }
+
+    public ActionBarPreset CapturePreset()
+    {
+        var actions = Actions;
+        var runtime = ActionBarRuntimeConfig.Current;
+        return new ActionBarPreset
+        {
+            CharacterName = GetActiveCharacterName(),
+            Rows = _cvars.Rows,
+            SlotsPerRow = _cvars.SlotsPerRow,
+            SlotSpacing = _cvars.SlotSpacing,
+            ShowKeybindLabel = _cvars.ShowKeybindLabel,
+            ShowEmptySlots = runtime.ShowEmptySlots,
+            AutoAddActions = runtime.AutoAddActions,
+            Lock = runtime.LockActions,
+            ButtonBackgroundAlpha = runtime.ButtonBackgroundAlpha,
+            PositionX = _positioning.PositionX,
+            PositionY = _positioning.PositionY,
+            SlotProtoIds = actions.HonkGetSlotProtoIds(),
+            EmoteIds = actions.HonkGetSlotEmoteIds(),
+        };
+    }
+
+    public void ApplyPreset(ActionBarPreset preset)
+    {
+        _cvars.WritePreset(preset);
+        RefreshEmoteSlots(preset.EmoteIds);
+        Actions.HonkLoadFromPreset(preset.SlotProtoIds, preset.EmoteIds);
+    }
+
+    public void ResetToDefaults()
+    {
+        // Scope: only reset things the presets window owns (slot contents and bar position).
+        // Size/spacing/label/alpha settings live in Options → Misc and have their own controls;
+        // wiping them from the preset window's Reset button surprised players who expected only
+        // the layout (slot assignments) to revert.
+        _cvars.ResetPosition();
+        Actions.HonkResetSlots();
+    }
+}

--- a/Content.Client/RussStation/ActionBar/ActionBarRuntimeConfig.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarRuntimeConfig.cs
@@ -34,8 +34,11 @@ public struct ActionBarRuntimeConfig
 
     // Read by the gameplay-screen resize handlers (HONK guards) to keep them from calling
     // MaxGridHeight/MaxGridWidth, which would flip the grid into size-limit mode and silently
-    // overwrite the user's explicit row count on resize.
-    public const bool OverridesRowLayout = true;
+    // overwrite the user's explicit row count on resize. Deliberately static readonly rather
+    // than const: the game-screen call sites guard with `if (OverridesRowLayout) return;`, and a
+    // compile-time const would make the following resize code unreachable (CS0162, treated as an
+    // error here). A runtime value keeps that code reachable, matching the original field.
+    public static readonly bool OverridesRowLayout = true;
 
     // The single live instance every reader and writer shares. Defaults match the original
     // static property initializers so behaviour before the first CVar load is unchanged.

--- a/Content.Client/RussStation/ActionBar/ActionBarRuntimeConfig.cs
+++ b/Content.Client/RussStation/ActionBar/ActionBarRuntimeConfig.cs
@@ -1,0 +1,47 @@
+namespace Content.Client.RussStation.ActionBar;
+
+// HONK Cross-module runtime configuration for the fork action bar. Populated at startup
+// by ActionBarCVarManager and kept current as CVars / drag / assign-mode change, it is
+// read on per-frame hot paths by ActionButton and ActionUIController. Bundling what used
+// to be eight static read-before-init properties on the UIController into one struct makes
+// the shared surface explicit and keeps those reads off a UIController lookup.
+public struct ActionBarRuntimeConfig
+{
+    // Read by ActionButton.UpdateBackground (HONK block) on every frame so empty slots can
+    // render a faint outline.
+    public bool ShowEmptySlots;
+
+    // Read by ActionUIController.OnActionAdded (HONK guard) so newly granted actions can
+    // skip auto-population when the user wants a curated bar layout.
+    public bool AutoAddActions;
+
+    // Read by ActionUIController drag / right-click paths (HONK guards) to keep the bar
+    // immutable when the player has locked the layout.
+    public bool LockActions;
+
+    // Base 0.0-1.0 alpha applied to every action button's slot background. Read each frame
+    // by ActionButton.UpdateBackground (HONK block); the empty-slot fade scales proportionally
+    // so the relative contrast stays consistent.
+    public float ButtonBackgroundAlpha;
+
+    // Flipped by the action drag hooks so empty drop targets are padded into the container
+    // even when the persistent show-empty toggle is off.
+    public bool IsDragActive;
+
+    // Mirrored from SlotHotkeyController so the bar-side code (UpdateBackground, ApplyLabels)
+    // can reveal every slot and its keybind label while the player is assigning hotkeys.
+    public bool AssignHotkeyMode;
+
+    // Read by the gameplay-screen resize handlers (HONK guards) to keep them from calling
+    // MaxGridHeight/MaxGridWidth, which would flip the grid into size-limit mode and silently
+    // overwrite the user's explicit row count on resize.
+    public const bool OverridesRowLayout = true;
+
+    // The single live instance every reader and writer shares. Defaults match the original
+    // static property initializers so behaviour before the first CVar load is unchanged.
+    public static ActionBarRuntimeConfig Current = new()
+    {
+        AutoAddActions = true,
+        ButtonBackgroundAlpha = 150f / 255f,
+    };
+}

--- a/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
@@ -35,7 +35,7 @@ public sealed partial class DefaultGameScreen : InGameScreen
         //HONK START - fork action-bar layout controls Columns directly, and setting MaxGridHeight
         // flips the grid into height-based row mode which silently overwrites the chosen column
         // count. Skip the resize and let ActionBarCustomizationController own the layout.
-        if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.OverridesRowLayout)
+        if (Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.OverridesRowLayout)
             return;
         //HONK END
         float indent = Inventory.Size.Y + TopBar.Size.Y + 40;

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
@@ -39,7 +39,7 @@ public sealed partial class SeparatedChatGameScreen : InGameScreen
         //HONK START - fork action-bar layout controls Columns directly, and setting MaxGridWidth
         // flips the grid into width-based column mode which silently overwrites the chosen column
         // count. Skip the resize and let ActionBarCustomizationController own the layout.
-        if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.OverridesRowLayout)
+        if (Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.OverridesRowLayout)
             return;
         //HONK END
         float indent = 20;

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -335,7 +335,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
                 return;
             }
         }
-        if (!Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+        if (!Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.AutoAddActions)
             return;
         //HONK END
 
@@ -765,7 +765,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (args.Function == EngineKeyFunctions.UIRightClick)
         {
             //HONK START - locked bars swallow right-click clear so a mis-click can't wipe a slot
-            if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.LockActions)
+            if (Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.LockActions)
             {
                 args.Handle();
                 return;
@@ -802,7 +802,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (button.Action != null)
         {
             //HONK START - lock blocks drag-rearrange on the bar; clicking an action to fire it still works
-            if (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.LockActions)
+            if (Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.LockActions)
                 return;
             //HONK END
             _menuDragHelper.MouseDown(button);
@@ -1061,7 +1061,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         //HONK START - auto-add off skips the respawn / body-swap repopulate so a curated bar survives,
         // but first link per connection always loads defaults so a new connect isn't a blank bar.
         if (_honkLoadedDefaultsThisConnection
-            && !Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AutoAddActions)
+            && !Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.AutoAddActions)
             return;
         _honkLoadedDefaultsThisConnection = true;
         //HONK END

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -399,10 +399,10 @@ public sealed class ActionButton : Control, IEntityControl
         // when the user has the persistent empty-slot toggle off, and the slot background
         // texture draws in that case so the preview has something to render.
         var honkShowEmpty = Action == null
-            && (Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ShowEmptySlots
-                || Content.Client.RussStation.ActionBar.ActionBarCustomizationController.AssignHotkeyMode
+            && (Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.ShowEmptySlots
+                || Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.AssignHotkeyMode
                 || _controller.IsDragging);
-        var honkAlpha = Content.Client.RussStation.ActionBar.ActionBarCustomizationController.ButtonBackgroundAlpha;
+        var honkAlpha = Content.Client.RussStation.ActionBar.ActionBarRuntimeConfig.Current.ButtonBackgroundAlpha;
         const float honkEmptyFadeRatio = 0.4f;
         var honkAlphaByte = (byte) Math.Clamp(honkAlpha * 255f, 0, 255);
         var honkEmptyAlphaByte = (byte) Math.Clamp(honkAlpha * honkEmptyFadeRatio * 255f, 0, 255);

--- a/Content.Tests/Client/RussStation/ActionBar/ActionBarPositioningMathTest.cs
+++ b/Content.Tests/Client/RussStation/ActionBar/ActionBarPositioningMathTest.cs
@@ -1,0 +1,46 @@
+// HONK — pins the drag-clamp math extracted from ActionBarPositioningManager during the
+// controller decomposition. The reparenting itself needs a live ActionsBar widget; this
+// covers the per-axis clamp only, including the oversized-bar guard. See issue #855.
+
+using Content.Client.RussStation.ActionBar;
+using NUnit.Framework;
+
+namespace Content.Tests.Client.RussStation.ActionBar;
+
+[TestFixture]
+[TestOf(typeof(ActionBarPositioningMath))]
+public sealed class ActionBarPositioningMathTest
+{
+    private const float Margin = 4f;
+
+    [Test]
+    public void ClampAxis_WithinBounds_AppliesDelta()
+    {
+        var result = ActionBarPositioningMath.ClampAxis(current: 100f, delta: 10f, size: 50f, bounds: 500f, margin: Margin);
+        Assert.That(result, Is.EqualTo(110f).Within(0.001f));
+    }
+
+    [Test]
+    public void ClampAxis_BelowMargin_ClampsToMargin()
+    {
+        var result = ActionBarPositioningMath.ClampAxis(current: 2f, delta: -10f, size: 50f, bounds: 500f, margin: Margin);
+        Assert.That(result, Is.EqualTo(Margin).Within(0.001f));
+    }
+
+    [Test]
+    public void ClampAxis_PastFarEdge_ClampsToBoundsMinusSizeMinusMargin()
+    {
+        // Upper bound = 500 - 50 - 4 = 446.
+        var result = ActionBarPositioningMath.ClampAxis(current: 440f, delta: 20f, size: 50f, bounds: 500f, margin: Margin);
+        Assert.That(result, Is.EqualTo(446f).Within(0.001f));
+    }
+
+    [Test]
+    public void ClampAxis_BarLargerThanBounds_PinsToMargin()
+    {
+        // bounds - size - margin goes negative (500 - 600 - 4 = -104); the Max guard floors the
+        // upper bound at the margin so the clamp range stays valid and the bar pins to the edge.
+        var result = ActionBarPositioningMath.ClampAxis(current: 100f, delta: 0f, size: 600f, bounds: 500f, margin: Margin);
+        Assert.That(result, Is.EqualTo(Margin).Within(0.001f));
+    }
+}

--- a/Content.Tests/Client/RussStation/ActionBar/ActionBarPresetLogicTest.cs
+++ b/Content.Tests/Client/RussStation/ActionBar/ActionBarPresetLogicTest.cs
@@ -106,7 +106,7 @@ public sealed class ActionBarPresetLogicTest
     [Test]
     public void BuildEmoteSlotMap_SkipsNullAndEmptyEntries()
     {
-        var emotes = new List<string?> { null, "Wave", string.Empty, "Salute" };
+        var emotes = new List<string> { null, "Wave", string.Empty, "Salute" };
 
         var map = ActionBarPresetLogic.BuildEmoteSlotMap(emotes, _ => true);
 
@@ -118,7 +118,7 @@ public sealed class ActionBarPresetLogicTest
     [Test]
     public void BuildEmoteSlotMap_DropsInvalidEmotes()
     {
-        var emotes = new List<string?> { "Wave", "GoneEmote", "Salute" };
+        var emotes = new List<string> { "Wave", "GoneEmote", "Salute" };
         var valid = new HashSet<string> { "Wave", "Salute" };
 
         var map = ActionBarPresetLogic.BuildEmoteSlotMap(emotes, valid.Contains);
@@ -133,7 +133,7 @@ public sealed class ActionBarPresetLogicTest
     {
         // Two slots hold the same emote; the later index overwrites, matching the original
         // dictionary-assignment behaviour.
-        var emotes = new List<string?> { "Wave", "Wave" };
+        var emotes = new List<string> { "Wave", "Wave" };
 
         var map = ActionBarPresetLogic.BuildEmoteSlotMap(emotes, _ => true);
 
@@ -143,7 +143,7 @@ public sealed class ActionBarPresetLogicTest
     [Test]
     public void BuildEmoteSlotMap_Empty_ReturnsEmptyMap()
     {
-        var map = ActionBarPresetLogic.BuildEmoteSlotMap(new List<string?>(), _ => true);
+        var map = ActionBarPresetLogic.BuildEmoteSlotMap(new List<string>(), _ => true);
         Assert.That(map, Is.Empty);
     }
 }

--- a/Content.Tests/Client/RussStation/ActionBar/ActionBarPresetLogicTest.cs
+++ b/Content.Tests/Client/RussStation/ActionBar/ActionBarPresetLogicTest.cs
@@ -1,0 +1,149 @@
+// HONK — pins the pure preset-side decisions extracted from ActionBarPresetManager
+// during the controller decomposition. The manager itself needs the YAML store and a
+// UI harness; these cover the selection + emote-map logic only. See issue #855.
+
+using System.Collections.Generic;
+using Content.Client.RussStation.ActionBar;
+using NUnit.Framework;
+
+namespace Content.Tests.Client.RussStation.ActionBar;
+
+[TestFixture]
+[TestOf(typeof(ActionBarPresetLogic))]
+public sealed class ActionBarPresetLogicTest
+{
+    private static ActionBarPreset Preset(string name, string character)
+        => new() { Name = name, CharacterName = character };
+
+    // ---------- SelectForCharacter ----------
+
+    [Test]
+    public void SelectForCharacter_EmptyList_ReturnsNull()
+    {
+        var result = ActionBarPresetLogic.SelectForCharacter(new List<ActionBarPreset>(), "Urist");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void SelectForCharacter_ExactMatch_ReturnsIt()
+    {
+        var presets = new List<ActionBarPreset>
+        {
+            Preset("a", "Other"),
+            Preset("b", "Urist"),
+        };
+
+        var result = ActionBarPresetLogic.SelectForCharacter(presets, "Urist");
+        Assert.That(result?.Name, Is.EqualTo("b"));
+    }
+
+    [Test]
+    public void SelectForCharacter_NoExactMatch_FallsBackToCharacterAgnostic()
+    {
+        var presets = new List<ActionBarPreset>
+        {
+            Preset("a", "Other"),
+            Preset("global", string.Empty),
+        };
+
+        var result = ActionBarPresetLogic.SelectForCharacter(presets, "Urist");
+        Assert.That(result?.Name, Is.EqualTo("global"));
+    }
+
+    [Test]
+    public void SelectForCharacter_ExactMatchWins_EvenWhenAgnosticIsFirst()
+    {
+        // The character-agnostic preset comes first, but an exact match should still win.
+        var presets = new List<ActionBarPreset>
+        {
+            Preset("global", string.Empty),
+            Preset("mine", "Urist"),
+        };
+
+        var result = ActionBarPresetLogic.SelectForCharacter(presets, "Urist");
+        Assert.That(result?.Name, Is.EqualTo("mine"));
+    }
+
+    [Test]
+    public void SelectForCharacter_NoMatchAndNoAgnostic_ReturnsNull()
+    {
+        var presets = new List<ActionBarPreset>
+        {
+            Preset("a", "Other"),
+            Preset("b", "Someone"),
+        };
+
+        var result = ActionBarPresetLogic.SelectForCharacter(presets, "Urist");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void SelectForCharacter_EmptyCharacterName_MatchesAgnosticPresetExactly()
+    {
+        // Before prefs sync the active name is empty; that should match a preset saved with an
+        // empty CharacterName through the exact-match branch, not just the fallback.
+        var presets = new List<ActionBarPreset>
+        {
+            Preset("a", "Other"),
+            Preset("global", string.Empty),
+        };
+
+        var result = ActionBarPresetLogic.SelectForCharacter(presets, string.Empty);
+        Assert.That(result?.Name, Is.EqualTo("global"));
+    }
+
+    [Test]
+    public void SelectForCharacter_IsCaseSensitive()
+    {
+        var presets = new List<ActionBarPreset> { Preset("a", "Urist") };
+
+        var result = ActionBarPresetLogic.SelectForCharacter(presets, "urist");
+        Assert.That(result, Is.Null);
+    }
+
+    // ---------- BuildEmoteSlotMap ----------
+
+    [Test]
+    public void BuildEmoteSlotMap_SkipsNullAndEmptyEntries()
+    {
+        var emotes = new List<string?> { null, "Wave", string.Empty, "Salute" };
+
+        var map = ActionBarPresetLogic.BuildEmoteSlotMap(emotes, _ => true);
+
+        Assert.That(map, Has.Count.EqualTo(2));
+        Assert.That(map["Wave"], Is.EqualTo(1));
+        Assert.That(map["Salute"], Is.EqualTo(3));
+    }
+
+    [Test]
+    public void BuildEmoteSlotMap_DropsInvalidEmotes()
+    {
+        var emotes = new List<string?> { "Wave", "GoneEmote", "Salute" };
+        var valid = new HashSet<string> { "Wave", "Salute" };
+
+        var map = ActionBarPresetLogic.BuildEmoteSlotMap(emotes, valid.Contains);
+
+        Assert.That(map.ContainsKey("GoneEmote"), Is.False);
+        Assert.That(map["Wave"], Is.EqualTo(0));
+        Assert.That(map["Salute"], Is.EqualTo(2));
+    }
+
+    [Test]
+    public void BuildEmoteSlotMap_DuplicateId_LastSlotWins()
+    {
+        // Two slots hold the same emote; the later index overwrites, matching the original
+        // dictionary-assignment behaviour.
+        var emotes = new List<string?> { "Wave", "Wave" };
+
+        var map = ActionBarPresetLogic.BuildEmoteSlotMap(emotes, _ => true);
+
+        Assert.That(map["Wave"], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void BuildEmoteSlotMap_Empty_ReturnsEmptyMap()
+    {
+        var map = ActionBarPresetLogic.BuildEmoteSlotMap(new List<string?>(), _ => true);
+        Assert.That(map, Is.Empty);
+    }
+}


### PR DESCRIPTION
## About the PR

Splits `ActionBarCustomizationController`, which had grown to 548 lines doing four separate jobs, into a thin controller plus three plain-class collaborators. No player-facing behavior changes; this is a behavior-preserving extraction.

## Why / Balance

The controller had absorbed CVar sync, preset management, float/anchor positioning, and layout application all at once. It also exposed a pile of static properties that other UI code read before the controller had finished initializing, which is the read-before-init smell called out in the issue. Splitting it makes each piece testable and gives the next person one place to look.

Closes #855. Part of the RussStation fork audit (#853).

## Technical details

Three collaborators come out of the controller, following the `ActionBarPresetStore` class that already lived in the same folder:

- `ActionBarCVarManager` reads, subscribes to, and writes the action-bar CVars. The seven repeated `OnValueChanged` registrations and the field-by-field `SetCVar` block from `ApplyPreset` now live here, behind change events the controller reacts to.
- `ActionBarPresetManager` handles the character-matched preset lookup, the emote-slot table, and the capture/apply/reset round trip with `ActionUIController`.
- `ActionBarPositioningManager` owns the float/anchor reparenting, `ApplyPosition`, and the drag handlers.

`ActionBarRuntimeConfig` replaces the static read-before-init properties with one struct, `ActionBarRuntimeConfig.Current`, that the per-frame hot paths in `ActionButton` and `ActionUIController` read. The controller keeps the layout code that touches the live `ActionsBar` container, plus its public surface (`HonkOnContainerReady`, `HonkBindWindow`, `HonkSetDragActive`, `HonkAfterInitialLink`, `TryGetSavedEmoteSlot`).

I kept the behavior identical down to the awkward bits: which CVar handlers also refresh the hotbar and which don't, the `invokeImmediately` seeding that made the original up-front reads redundant, the forced lock after a preset apply, and the position state that diverges from the CVars mid-drag and only persists on release.

One thing to flag for reviewers: I could not compile this locally. The environment has no dotnet and the RobustToolbox submodule isn't checked out, so I verified the change by reading every symbol it depends on and checking that the custom Honk analyzers (HONK0009, HONK0017) don't fire on the moved code. CI is the real test here.

The controller went from 548 lines to 228; the four new files are 126, 154, 160, and 47 lines.

## Media

None. Code-only refactor with no visible in-game change.

## Breaking changes

None for players. For fork code: the static properties formerly on `ActionBarCustomizationController` (`ShowEmptySlots`, `AutoAddActions`, `LockActions`, `OverridesRowLayout`, `ButtonBackgroundAlpha`, `IsDragActive`, `AssignHotkeyMode`) moved to `ActionBarRuntimeConfig`. Every in-tree caller is updated in this PR (`ActionButton`, `ActionUIController`, `DefaultGameScreen`, `SeparatedChatGameScreen`).

https://claude.ai/code/session_01L56DYsCdFYYhBijHhGEFd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01L56DYsCdFYYhBijHhGEFd3)_