### PR TITLE
Move PairedMarkerSystem out of nested Shared folder into Markers/

### DIFF
--- a/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
+++ b/Content.Shared/RussStation/Carrying/Systems/SharedCarryingSystem.cs
@@ -5,7 +5,7 @@ using Content.Shared.RussStation.Carrying.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.RussStation.EscalatedGrab;
 using Content.Shared.RussStation.EscalatedGrab.Systems;
-using Content.Shared.RussStation.Shared;
+using Content.Shared.RussStation.Markers;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Mobs.Systems;

--- a/Content.Shared/RussStation/Markers/PairedMarkerSystem.cs
+++ b/Content.Shared/RussStation/Markers/PairedMarkerSystem.cs
@@ -1,4 +1,4 @@
-namespace Content.Shared.RussStation.Shared;
+namespace Content.Shared.RussStation.Markers;
 
 /// <summary>
 /// Base class for systems that manage a pair of marker components whose shutdown


### PR DESCRIPTION
## About the PR

Moves `PairedMarkerSystem` out of `Content.Shared/RussStation/Shared/` into a new `Markers/` folder. Part of #867.

## Why / Balance

`Content.Shared/RussStation` had a `Shared` folder nested inside it, which is redundant and confusing (a Shared folder living inside the Shared project). The class is the base for systems that manage paired marker components, so `Markers/` names the domain it actually belongs to. Part of the RussStation fork audit, #853.

The second half of #867 (standardizing the `Systems/` sub-folder layout) is out of scope here. It lives in #881 and its per-project children #882, #883, #884.

## Technical details

`git mv` of the single file, plus two one-line edits: the namespace goes from `Content.Shared.RussStation.Shared` to `Content.Shared.RussStation.Markers`, and its only consumer, `SharedCarryingSystem`, gets its `using` updated to match. No logic changed. No other file references the old namespace.

## Media

None. Code-only refactor.

## Breaking changes

Namespace change: `Content.Shared.RussStation.Shared` is now `Content.Shared.RussStation.Markers`. Internal only, no prototypes or public API affected.