### PR TITLE
Extract UI builders in MessengerCartridgeUiFragment

### DIFF
--- a/Content.Client/RussStation/Messenger/MessengerCartridgeUiFragment.xaml.cs
+++ b/Content.Client/RussStation/Messenger/MessengerCartridgeUiFragment.xaml.cs
@@ -13,16 +13,23 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
     public event Action? OnBackPressed;
     public event Action? OnMuteToggled;
 
-    private readonly BoxContainer _contactList;
+    private BoxContainer _contactList = default!;
     private readonly BoxContainer _chatView;
-    private readonly BoxContainer _messageList;
-    private readonly LineEdit _messageInput;
-    private readonly Button _sendButton;
-    private readonly Button _backButton;
+    private BoxContainer _messageList = default!;
+    private LineEdit _messageInput = default!;
+    private Button _sendButton = default!;
+    private Button _backButton = default!;
     private readonly Button _muteButton;
     private readonly Label _addressLabel;
 
     private NetEntity? _activeTarget;
+
+    // Cached lookup of the active conversation's contact, keyed by the conversation
+    // it was resolved for, so repeated renders of the same conversation skip the
+    // per-render O(n) scan of the contact list.
+    private NetEntity? _cachedContactTarget;
+    private string _cachedContactName = "";
+    private bool _cachedContactReadOnly;
 
     public MessengerCartridgeUiFragment()
     {
@@ -31,80 +38,8 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
 
         var content = (BoxContainer) GetChild(MessengerConstants.RootContentChildIndex);
 
-        // Contact list view.
-        _contactList = new BoxContainer
-        {
-            Orientation = LayoutOrientation.Vertical,
-            HorizontalExpand = true,
-            VerticalExpand = true,
-        };
-
-        var contactScroll = new ScrollContainer
-        {
-            VerticalExpand = true,
-            HorizontalExpand = true,
-        };
-        contactScroll.AddChild(_contactList);
-
-        // Chat view (hidden by default).
-        _chatView = new BoxContainer
-        {
-            Orientation = LayoutOrientation.Vertical,
-            HorizontalExpand = true,
-            VerticalExpand = true,
-            Visible = false,
-        };
-
-        _backButton = new Button
-        {
-            Text = Loc.GetString("messenger-back"),
-            StyleClasses = { "OpenBoth" },
-            HorizontalAlignment = HAlignment.Left,
-            Margin = new Thickness(MessengerConstants.BackButtonLeftMargin, MessengerConstants.BackButtonTopMargin, MessengerConstants.BackButtonRightMargin, MessengerConstants.BackButtonBottomMargin),
-        };
-        _backButton.OnPressed += _ => OnBackPressed?.Invoke();
-
-        _messageList = new BoxContainer
-        {
-            Orientation = LayoutOrientation.Vertical,
-            HorizontalExpand = true,
-        };
-
-        var messageScroll = new ScrollContainer
-        {
-            VerticalExpand = true,
-            HorizontalExpand = true,
-        };
-        messageScroll.AddChild(_messageList);
-
-        var inputRow = new BoxContainer
-        {
-            Orientation = LayoutOrientation.Horizontal,
-            HorizontalExpand = true,
-            Margin = new Thickness(MessengerConstants.InputRowLeftMargin, MessengerConstants.InputRowTopMargin, MessengerConstants.InputRowRightMargin, MessengerConstants.InputRowBottomMargin),
-        };
-
-        _messageInput = new LineEdit
-        {
-            HorizontalExpand = true,
-            PlaceHolder = Loc.GetString("messenger-placeholder"),
-        };
-        _messageInput.OnTextEntered += _ => SendCurrentMessage();
-
-        _sendButton = new Button
-        {
-            Text = Loc.GetString("messenger-send"),
-            StyleClasses = { "OpenBoth" },
-            Margin = new Thickness(MessengerConstants.SendButtonLeftMargin, MessengerConstants.SendButtonTopMargin, MessengerConstants.SendButtonRightMargin, MessengerConstants.SendButtonBottomMargin),
-        };
-        _sendButton.OnPressed += _ => SendCurrentMessage();
-
-        inputRow.AddChild(_messageInput);
-        inputRow.AddChild(_sendButton);
-
-        _chatView.AddChild(_backButton);
-        _chatView.AddChild(messageScroll);
-        _chatView.AddChild(inputRow);
+        var contactScroll = BuildContactListSection();
+        _chatView = BuildChatViewSection();
 
         _muteButton = new Button
         {
@@ -137,6 +72,105 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
         content.AddChild(_addressLabel);
     }
 
+    /// <summary>
+    /// Builds the scrollable contact-list view and captures <see cref="_contactList"/>.
+    /// </summary>
+    private ScrollContainer BuildContactListSection()
+    {
+        _contactList = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            VerticalExpand = true,
+        };
+
+        var contactScroll = new ScrollContainer
+        {
+            VerticalExpand = true,
+            HorizontalExpand = true,
+        };
+        contactScroll.AddChild(_contactList);
+
+        return contactScroll;
+    }
+
+    /// <summary>
+    /// Builds the (initially hidden) conversation view: back button, scrollable
+    /// message list and the message input row.
+    /// </summary>
+    private BoxContainer BuildChatViewSection()
+    {
+        var chatView = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            VerticalExpand = true,
+            Visible = false,
+        };
+
+        _backButton = new Button
+        {
+            Text = Loc.GetString("messenger-back"),
+            StyleClasses = { "OpenBoth" },
+            HorizontalAlignment = HAlignment.Left,
+            Margin = new Thickness(MessengerConstants.BackButtonLeftMargin, MessengerConstants.BackButtonTopMargin, MessengerConstants.BackButtonRightMargin, MessengerConstants.BackButtonBottomMargin),
+        };
+        _backButton.OnPressed += _ => OnBackPressed?.Invoke();
+
+        _messageList = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+        };
+
+        var messageScroll = new ScrollContainer
+        {
+            VerticalExpand = true,
+            HorizontalExpand = true,
+        };
+        messageScroll.AddChild(_messageList);
+
+        chatView.AddChild(_backButton);
+        chatView.AddChild(messageScroll);
+        chatView.AddChild(BuildInputRow());
+
+        return chatView;
+    }
+
+    /// <summary>
+    /// Builds the message input row and captures <see cref="_messageInput"/> and
+    /// <see cref="_sendButton"/>.
+    /// </summary>
+    private BoxContainer BuildInputRow()
+    {
+        var inputRow = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            HorizontalExpand = true,
+            Margin = new Thickness(MessengerConstants.InputRowLeftMargin, MessengerConstants.InputRowTopMargin, MessengerConstants.InputRowRightMargin, MessengerConstants.InputRowBottomMargin),
+        };
+
+        _messageInput = new LineEdit
+        {
+            HorizontalExpand = true,
+            PlaceHolder = Loc.GetString("messenger-placeholder"),
+        };
+        _messageInput.OnTextEntered += _ => SendCurrentMessage();
+
+        _sendButton = new Button
+        {
+            Text = Loc.GetString("messenger-send"),
+            StyleClasses = { "OpenBoth" },
+            Margin = new Thickness(MessengerConstants.SendButtonLeftMargin, MessengerConstants.SendButtonTopMargin, MessengerConstants.SendButtonRightMargin, MessengerConstants.SendButtonBottomMargin),
+        };
+        _sendButton.OnPressed += _ => SendCurrentMessage();
+
+        inputRow.AddChild(_messageInput);
+        inputRow.AddChild(_sendButton);
+
+        return inputRow;
+    }
+
     public void UpdateState(MessengerUiState state)
     {
         _addressLabel.Text = state.Address;
@@ -167,12 +201,7 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
 
         if (!state.HasId)
         {
-            _contactList.AddChild(new Label
-            {
-                Text = Loc.GetString("messenger-no-id"),
-                StyleClasses = { "LabelSubText" },
-                HorizontalAlignment = HAlignment.Center,
-            });
+            _contactList.AddChild(CreateEmptyStateLabel("messenger-no-id"));
 
             if (state.Contacts.Count == 0)
                 return;
@@ -180,64 +209,12 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
 
         if (state.Contacts.Count == 0)
         {
-            _contactList.AddChild(new Label
-            {
-                Text = Loc.GetString("messenger-no-contacts"),
-                StyleClasses = { "LabelSubText" },
-                HorizontalAlignment = HAlignment.Center,
-            });
+            _contactList.AddChild(CreateEmptyStateLabel("messenger-no-contacts"));
             return;
         }
 
         foreach (var contact in state.Contacts)
-        {
-            var row = new Button
-            {
-                StyleClasses = { "OpenBoth" },
-                HorizontalExpand = true,
-                Margin = new Thickness(MessengerConstants.ContactRowLeftMargin, MessengerConstants.ContactRowTopMargin, MessengerConstants.ContactRowRightMargin, MessengerConstants.ContactRowBottomMargin),
-            };
-
-            var rowContent = new BoxContainer
-            {
-                Orientation = LayoutOrientation.Horizontal,
-                HorizontalExpand = true,
-            };
-
-            var nameLabel = new Label
-            {
-                Text = contact.Name,
-                HorizontalExpand = true,
-            };
-
-            var jobLabel = new Label
-            {
-                Text = contact.JobTitle,
-                StyleClasses = { "LabelSubText" },
-                Margin = new Thickness(MessengerConstants.JobLabelLeftMargin, MessengerConstants.JobLabelTopMargin, MessengerConstants.JobLabelRightMargin, MessengerConstants.JobLabelBottomMargin),
-            };
-
-            rowContent.AddChild(nameLabel);
-            rowContent.AddChild(jobLabel);
-
-            if (contact.HasUnread)
-            {
-                var unreadDot = new Label
-                {
-                    Text = "*",
-                    StyleClasses = { "LabelKeyValueStatValue" },
-                    Margin = new Thickness(MessengerConstants.UnreadDotLeftMargin, MessengerConstants.UnreadDotTopMargin, MessengerConstants.UnreadDotRightMargin, MessengerConstants.UnreadDotBottomMargin),
-                };
-                rowContent.AddChild(unreadDot);
-            }
-
-            row.AddChild(rowContent);
-
-            var target = contact.Cartridge;
-            row.OnPressed += _ => OnContactSelected?.Invoke(target);
-
-            _contactList.AddChild(row);
-        }
+            _contactList.AddChild(CreateContactRowButton(contact));
     }
 
     private void ShowChatView(MessengerUiState state)
@@ -247,22 +224,11 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
         _muteButton.Visible = false;
         _activeTarget = state.ActiveConversation;
 
-        // Find the active contact.
-        var contactName = "";
-        var readOnly = false;
-        foreach (var contact in state.Contacts)
-        {
-            if (contact.Cartridge == state.ActiveConversation)
-            {
-                contactName = contact.Name;
-                readOnly = contact.ReadOnly;
-                break;
-            }
-        }
+        ResolveActiveContact(state);
 
-        HeaderLabel.Text = contactName;
+        HeaderLabel.Text = _cachedContactName;
 
-        var canSend = !readOnly && state.HasId;
+        var canSend = !_cachedContactReadOnly && state.HasId;
         _messageInput.Visible = canSend;
         _sendButton.Visible = canSend;
 
@@ -270,40 +236,118 @@ public sealed partial class MessengerCartridgeUiFragment : BoxContainer
 
         if (state.Messages == null || state.Messages.Count == 0)
         {
-            _messageList.AddChild(new Label
-            {
-                Text = Loc.GetString("messenger-no-messages"),
-                StyleClasses = { "LabelSubText" },
-                HorizontalAlignment = HAlignment.Center,
-            });
+            _messageList.AddChild(CreateEmptyStateLabel("messenger-no-messages"));
             return;
         }
 
         foreach (var msg in state.Messages)
+            _messageList.AddChild(CreateMessageRow(msg));
+    }
+
+    /// <summary>
+    /// Resolves the active conversation's display name and read-only flag, caching
+    /// the result so subsequent renders of the same conversation avoid re-scanning
+    /// the contact list.
+    /// </summary>
+    private void ResolveActiveContact(MessengerUiState state)
+    {
+        if (_cachedContactTarget == state.ActiveConversation)
+            return;
+
+        _cachedContactName = "";
+        _cachedContactReadOnly = false;
+
+        foreach (var contact in state.Contacts)
         {
-            var row = new BoxContainer
+            if (contact.Cartridge == state.ActiveConversation)
             {
-                Orientation = LayoutOrientation.Vertical,
-                HorizontalExpand = true,
-                Margin = new Thickness(MessengerConstants.MessageRowLeftMargin, MessengerConstants.MessageRowTopMargin, MessengerConstants.MessageRowRightMargin, MessengerConstants.MessageRowBottomMargin),
-            };
-
-            var senderLabel = new Label
-            {
-                Text = msg.SenderName,
-                StyleClasses = { msg.FromSelf ? "LabelKeyValueStatValue" : "LabelSubText" },
-            };
-
-            var textLabel = new Label
-            {
-                Text = msg.Text,
-                HorizontalExpand = true,
-            };
-
-            row.AddChild(senderLabel);
-            row.AddChild(textLabel);
-            _messageList.AddChild(row);
+                _cachedContactName = contact.Name;
+                _cachedContactReadOnly = contact.ReadOnly;
+                break;
+            }
         }
+
+        _cachedContactTarget = state.ActiveConversation;
+    }
+
+    private static Label CreateEmptyStateLabel(string locKey)
+    {
+        return new Label
+        {
+            Text = Loc.GetString(locKey),
+            StyleClasses = { "LabelSubText" },
+            HorizontalAlignment = HAlignment.Center,
+        };
+    }
+
+    private Button CreateContactRowButton(MessengerContact contact)
+    {
+        var row = new Button
+        {
+            StyleClasses = { "OpenBoth" },
+            HorizontalExpand = true,
+            Margin = new Thickness(MessengerConstants.ContactRowLeftMargin, MessengerConstants.ContactRowTopMargin, MessengerConstants.ContactRowRightMargin, MessengerConstants.ContactRowBottomMargin),
+        };
+
+        var rowContent = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Horizontal,
+            HorizontalExpand = true,
+        };
+
+        rowContent.AddChild(new Label
+        {
+            Text = contact.Name,
+            HorizontalExpand = true,
+        });
+
+        rowContent.AddChild(new Label
+        {
+            Text = contact.JobTitle,
+            StyleClasses = { "LabelSubText" },
+            Margin = new Thickness(MessengerConstants.JobLabelLeftMargin, MessengerConstants.JobLabelTopMargin, MessengerConstants.JobLabelRightMargin, MessengerConstants.JobLabelBottomMargin),
+        });
+
+        if (contact.HasUnread)
+        {
+            rowContent.AddChild(new Label
+            {
+                Text = "*",
+                StyleClasses = { "LabelKeyValueStatValue" },
+                Margin = new Thickness(MessengerConstants.UnreadDotLeftMargin, MessengerConstants.UnreadDotTopMargin, MessengerConstants.UnreadDotRightMargin, MessengerConstants.UnreadDotBottomMargin),
+            });
+        }
+
+        row.AddChild(rowContent);
+
+        var target = contact.Cartridge;
+        row.OnPressed += _ => OnContactSelected?.Invoke(target);
+
+        return row;
+    }
+
+    private static BoxContainer CreateMessageRow(MessengerMessageEntry msg)
+    {
+        var row = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            Margin = new Thickness(MessengerConstants.MessageRowLeftMargin, MessengerConstants.MessageRowTopMargin, MessengerConstants.MessageRowRightMargin, MessengerConstants.MessageRowBottomMargin),
+        };
+
+        row.AddChild(new Label
+        {
+            Text = msg.SenderName,
+            StyleClasses = { msg.FromSelf ? "LabelKeyValueStatValue" : "LabelSubText" },
+        });
+
+        row.AddChild(new Label
+        {
+            Text = msg.Text,
+            HorizontalExpand = true,
+        });
+
+        return row;
     }
 
     private void SendCurrentMessage()

--- a/Content.IntegrationTests/Tests/RussStation/Messenger/MessengerCartridgeUiFragmentTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Messenger/MessengerCartridgeUiFragmentTest.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using Content.Client.RussStation.Messenger;
+using Content.Shared.RussStation.Messenger;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+
+namespace Content.IntegrationTests.Tests.RussStation.Messenger;
+
+/// <summary>
+/// Client-side regression coverage for <see cref="MessengerCartridgeUiFragment"/>. Drives the
+/// public <c>UpdateState</c> entry point and asserts the one cleanly observable output, the header
+/// label, across the contact-list / chat-view transitions. The chat-view cases in particular guard
+/// the cached active-contact lookup: switching conversations must refresh the resolved name rather
+/// than reuse the previous one.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(MessengerCartridgeUiFragment))]
+public sealed class MessengerCartridgeUiFragmentTest
+{
+    private static MessengerUiState ContactListState(List<MessengerContact> contacts) =>
+        new(contacts, activeConversation: null, messages: null, muted: false, hasId: true, address: "NT0001");
+
+    private static MessengerUiState ChatViewState(List<MessengerContact> contacts, NetEntity active) =>
+        new(contacts, active, new List<MessengerMessageEntry>(), muted: false, hasId: true, address: "NT0001");
+
+    [Test]
+    public async Task HeaderTracksActiveConversationTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var client = pair.Client;
+
+        await client.WaitAssertion(() =>
+        {
+            var alice = new NetEntity(1);
+            var bob = new NetEntity(2);
+            var contacts = new List<MessengerContact>
+            {
+                new(alice, "Alice Smith", "Engineer", "JobIconEngineer"),
+                new(bob, "Bob Jones", "Botanist", "JobIconBotanist"),
+            };
+
+            var fragment = new MessengerCartridgeUiFragment();
+            var header = fragment.FindControl<Label>("HeaderLabel");
+
+            // Contact list: header shows the program name.
+            fragment.UpdateState(ContactListState(contacts));
+            Assert.That(header.Text, Is.EqualTo(Loc.GetString("messenger-program-name")));
+
+            // Opening a conversation resolves the contact's display name.
+            fragment.UpdateState(ChatViewState(contacts, alice));
+            Assert.That(header.Text, Is.EqualTo("Alice Smith"));
+
+            // Switching conversations must refresh the cached name, not reuse Alice's.
+            fragment.UpdateState(ChatViewState(contacts, bob));
+            Assert.That(header.Text, Is.EqualTo("Bob Jones"),
+                "Header should follow the new active conversation, proving the cache keys on the conversation.");
+
+            // Returning to the contact list restores the program name.
+            fragment.UpdateState(ContactListState(contacts));
+            Assert.That(header.Text, Is.EqualTo(Loc.GetString("messenger-program-name")));
+
+            // An active conversation with no matching contact (e.g. the cartridge reopened while a
+            // conversation persisted) resolves to an empty name rather than a stale one.
+            fragment.UpdateState(ChatViewState(contacts, new NetEntity(99)));
+            Assert.That(header.Text, Is.EqualTo(string.Empty));
+
+            fragment.Dispose();
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
## About the PR

Pulls the UI-building code in `MessengerCartridgeUiFragment.xaml.cs` out of the 111-line constructor and the two inline render loops into small named build and factory methods. The control stays a single code-behind file, which is the convention here.

## Why / Balance

Closes #862, part of the RussStation fork audit (#853). The code-behind built the whole control tree inline, so the constructor was long and `ShowContactList` / `ShowChatView` each repeated the same element-construction boilerplate and an empty-state label that was written out four times.

## Technical details

- Constructor split into `BuildContactListSection`, `BuildChatViewSection` and `BuildInputRow`. Each builds its subtree and captures the controls the render methods touch.
- Element factories: `CreateEmptyStateLabel(locKey)`, `CreateContactRowButton(contact)` and `CreateMessageRow(msg)`.
- `ShowContactList` is now ~28 lines and `ShowChatView` ~25.
- `ShowChatView` no longer scans the contact list on every render. `ResolveActiveContact` caches the active conversation's name and read-only flag, keyed on the conversation, and re-resolves only when the active conversation changes. A conversation with no matching contact (for example, the cartridge reopened while a conversation persisted server-side) resolves to an empty name instead of a stale one.
- Added a client test that drives `UpdateState` through the contact-list and chat-view transitions and checks the header label. The conversation-switch case covers the cache: the header has to follow the new conversation rather than reuse the previous name.

Fields that the build helpers assign lost their `readonly` and carry a `default!` initializer, since a method called from the constructor cannot satisfy definite assignment on a `readonly` field. `_chatView`, `_muteButton` and `_addressLabel` are still assigned directly in the constructor and stay `readonly`.

## Media

None. Code-only refactor with no visible in-game change.

## Breaking changes

None.