### PR TITLE
honksquad: refactor: split MessengerServerSystem into focused helpers

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Messenger/MessengerServerTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Messenger/MessengerServerTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.RussStation.Messenger;
+using Content.Shared.CartridgeLoader;
 using Content.Shared.PDA;
 using Content.Shared.RussStation.Messenger;
 using Content.Shared.StationRecords;
@@ -20,7 +21,9 @@ public sealed class MessengerServerTest
 {
     /// <summary>
     /// Build a cartridge wired into a PDA the way the loader does at runtime: the cartridge's
-    /// transform parent is a PDA, and that PDA optionally holds an ID card.
+    /// transform parent is a PDA, and that PDA optionally holds an ID card. Pass
+    /// <paramref name="withLoader"/> to mark the PDA as a cartridge loader so the cartridge is
+    /// visible to the contact-list discovery scan.
     /// </summary>
     private static EntityUid MakeWiredCartridge(
         IEntityManager entMan,
@@ -28,10 +31,14 @@ public sealed class MessengerServerTest
         MapCoordinates coords,
         string address,
         bool withId = true,
-        bool stationCrewId = false)
+        bool stationCrewId = false,
+        bool withLoader = false)
     {
         var pda = entMan.SpawnEntity(null, coords);
         var pdaComp = entMan.AddComponent<PdaComponent>(pda);
+
+        if (withLoader)
+            entMan.AddComponent<CartridgeLoaderComponent>(pda);
 
         if (withId)
         {
@@ -276,6 +283,122 @@ public sealed class MessengerServerTest
             var crew = MakeWiredCartridge(entMan, xformSys, coords, "NT9012", stationCrewId: true);
             Assert.That(messenger.IsContactReadOnly(crew), Is.False,
                 "A station-roster crew cartridge should be writable.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task GetContactsDiscoversCrewAndGatesStrangersTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var me = MakeWiredCartridge(entMan, xformSys, coords, "NT0001", stationCrewId: true, withLoader: true);
+            var crew = MakeWiredCartridge(entMan, xformSys, coords, "NT0002", stationCrewId: true, withLoader: true);
+            // Antag address: hidden until there's a conversation.
+            var antag = MakeWiredCartridge(entMan, xformSys, coords, "SY0003", stationCrewId: true, withLoader: true);
+            // Crew address but no ID: also hidden until there's a conversation.
+            var noId = MakeWiredCartridge(entMan, xformSys, coords, "NT0004", withId: false, withLoader: true);
+
+            var contacts = messenger.GetContacts(me);
+            var cartridges = contacts.Select(c => entMan.GetEntity(c.Cartridge)).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cartridges, Does.Not.Contain(me), "Own cartridge is excluded.");
+                Assert.That(cartridges, Does.Contain(crew), "Station crew should always be discovered.");
+                Assert.That(cartridges, Does.Not.Contain(antag), "Antag with no conversation should be hidden.");
+                Assert.That(cartridges, Does.Not.Contain(noId), "No-ID stranger with no conversation should be hidden.");
+            });
+
+            var crewContact = contacts.First(c => entMan.GetEntity(c.Cartridge) == crew);
+            Assert.That(crewContact.ReadOnly, Is.False, "Station crew contacts are writable.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task GetContactsIncludesConversationPartnersReadOnlyTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var me = MakeWiredCartridge(entMan, xformSys, coords, "NT0001", stationCrewId: true, withLoader: true);
+            var antag = MakeWiredCartridge(entMan, xformSys, coords, "SY0003", withLoader: true);
+
+            bool Lists(EntityUid cart) =>
+                messenger.GetContacts(me).Any(c => entMan.GetEntity(c.Cartridge) == cart);
+
+            Assert.That(Lists(antag), Is.False, "A stranger with no conversation should not be listed.");
+
+            // Once the antag messages us, they surface as a read-only contact.
+            Assert.That(messenger.SendMessage(antag, me, "knock knock"), Is.True);
+
+            var antagContact = messenger.GetContacts(me).FirstOrDefault(c => entMan.GetEntity(c.Cartridge) == antag);
+            Assert.That(antagContact, Is.Not.Null, "A conversation partner should be listed.");
+            Assert.That(antagContact!.ReadOnly, Is.True, "Non-crew conversation partners are read-only.");
+
+            entMan.DeleteEntity(mapSys.GetMap(mapId));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task GetContactsReconcilesOrphanedConversationsTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+        var messenger = entMan.System<MessengerServerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var coords = new MapCoordinates(0, 0, mapId);
+
+            var me = MakeWiredCartridge(entMan, xformSys, coords, "NT0001", stationCrewId: true, withLoader: true);
+            var other = MakeWiredCartridge(entMan, xformSys, coords, "NT0002", stationCrewId: true, withLoader: true);
+
+            Assert.That(messenger.SendMessage(other, me, "ping"), Is.True);
+
+            // Remove the cartridge component so the discovery scan no longer enumerates it, even
+            // though the entity still exists: it must be reconciled from the stored conversation,
+            // labelled with the last name the partner signed with.
+            entMan.RemoveComponent<MessengerCartridgeComponent>(other);
+
+            var contacts = messenger.GetContacts(me);
+            var orphan = contacts.FirstOrDefault(c => entMan.GetEntity(c.Cartridge) == other);
+
+            Assert.That(orphan, Is.Not.Null, "A conversation partner missing from the scan should still appear.");
+            Assert.That(orphan!.ReadOnly, Is.True, "Reconciled orphan contacts are read-only.");
+            Assert.That(orphan.Name, Is.EqualTo("NT0002"), "Orphan is labelled with the partner's last known name.");
 
             entMan.DeleteEntity(mapSys.GetMap(mapId));
         });

--- a/Content.Server/RussStation/Messenger/AntagAddressFilter.cs
+++ b/Content.Server/RussStation/Messenger/AntagAddressFilter.cs
@@ -1,0 +1,77 @@
+namespace Content.Server.RussStation.Messenger;
+
+/// <summary>
+/// Classifies messenger addresses by antag category and derives the address prefix for a PDA name.
+/// The keyword/prefix map is injectable so it can be exercised (or overridden) in isolation.
+/// </summary>
+public sealed class AntagAddressFilter
+{
+    /// <summary>
+    /// Default address prefix used for station crew (Nanotrasen) and anything that isn't an antag.
+    /// </summary>
+    public const string CrewAddressPrefix = "NT";
+
+    /// <summary>
+    /// Default keyword -> prefix map for antag categories. A PDA whose name contains one of the
+    /// keywords is assigned that prefix, and any address starting with one of the prefixes is
+    /// treated as an antag address.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> DefaultAntagPrefixes = new Dictionary<string, string>
+    {
+        { "syndicate", "SY" },
+        { "ninja", "NJ" },
+        { "pirate", "PR" },
+        { "wizard", "WZ" },
+        { "CBURN", "CB" },
+    };
+
+    /// <summary>
+    /// Shared default instance backed by <see cref="DefaultAntagPrefixes"/> and <see cref="CrewAddressPrefix"/>.
+    /// </summary>
+    public static readonly AntagAddressFilter Default = new();
+
+    private readonly IReadOnlyDictionary<string, string> _antagPrefixes;
+    private readonly string _crewPrefix;
+
+    public AntagAddressFilter(
+        IReadOnlyDictionary<string, string>? antagPrefixes = null,
+        string crewPrefix = CrewAddressPrefix)
+    {
+        _antagPrefixes = antagPrefixes ?? DefaultAntagPrefixes;
+        _crewPrefix = crewPrefix;
+    }
+
+    /// <summary>
+    /// The prefix handed to non-antag (station crew) cartridges.
+    /// </summary>
+    public string CrewPrefix => _crewPrefix;
+
+    /// <summary>
+    /// Pick the address prefix for a PDA based on keywords in its name. Antag PDAs (Syndicate,
+    /// ninja, ...) get their category prefix; everything else gets the crew prefix.
+    /// </summary>
+    public string GetAddressPrefix(string pdaName)
+    {
+        foreach (var (keyword, prefix) in _antagPrefixes)
+        {
+            if (pdaName.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+                return prefix;
+        }
+
+        return _crewPrefix;
+    }
+
+    /// <summary>
+    /// True if the address belongs to an antag category (i.e. starts with one of the antag prefixes).
+    /// </summary>
+    public bool IsAntagAddress(string address)
+    {
+        foreach (var (_, prefix) in _antagPrefixes)
+        {
+            if (address.StartsWith(prefix))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/RussStation/Messenger/CartridgeIdentityValidator.cs
+++ b/Content.Server/RussStation/Messenger/CartridgeIdentityValidator.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Access.Components;
+using Content.Shared.PDA;
+using Content.Shared.RussStation.Messenger;
+using Content.Shared.StationRecords;
+
+namespace Content.Server.RussStation.Messenger;
+
+/// <summary>
+/// Consolidates the cartridge / ID-card predicates the messenger uses to decide who counts as
+/// writable station crew and to resolve sender names. Wraps an <see cref="IEntityManager"/> and an
+/// <see cref="AntagAddressFilter"/> so the chained component lookups live in one place.
+/// </summary>
+public sealed class CartridgeIdentityValidator
+{
+    private readonly IEntityManager _entMan;
+    private readonly AntagAddressFilter _antagFilter;
+
+    public CartridgeIdentityValidator(IEntityManager entMan, AntagAddressFilter antagFilter)
+    {
+        _entMan = entMan;
+        _antagFilter = antagFilter;
+    }
+
+    /// <summary>
+    /// Resolve the PDA a cartridge is loaded into (its transform parent), or false if that parent
+    /// isn't a PDA.
+    /// </summary>
+    public bool TryGetPda(EntityUid cartUid, out EntityUid loaderUid, [NotNullWhen(true)] out PdaComponent? pda)
+    {
+        loaderUid = _entMan.GetComponent<TransformComponent>(cartUid).ParentUid;
+        return _entMan.TryGetComponent(loaderUid, out pda);
+    }
+
+    /// <summary>
+    /// Check if the cartridge's PDA has an ID card inserted.
+    /// </summary>
+    public bool HasIdCard(EntityUid cartUid)
+    {
+        return TryGetPda(cartUid, out _, out var pda) && pda.ContainedId != null;
+    }
+
+    /// <summary>
+    /// Get the ID card name for a cartridge's PDA, or null if no ID is inserted. Falls back to the
+    /// cartridge address when the inserted ID has no name.
+    /// </summary>
+    public string? GetCartridgeIdName(EntityUid cartUid)
+    {
+        if (!TryGetPda(cartUid, out _, out var pda) || pda.ContainedId == null)
+            return null;
+
+        if (_entMan.TryGetComponent<IdCardComponent>(pda.ContainedId.Value, out var idCard) &&
+            !string.IsNullOrEmpty(idCard.FullName))
+        {
+            return idCard.FullName;
+        }
+
+        return _entMan.GetComponentOrNull<MessengerCartridgeComponent>(cartUid)?.Address ?? "?";
+    }
+
+    /// <summary>
+    /// True if the ID card was issued through station records (i.e. the holder is on the station
+    /// crew roster). CentComm/ERT IDs spawn directly from prototypes and lack a station record key.
+    /// </summary>
+    public bool IsStationCrewId(EntityUid idCard)
+    {
+        return _entMan.TryGetComponent<StationRecordKeyStorageComponent>(idCard, out var keyStorage)
+               && keyStorage.Key != null;
+    }
+
+    /// <summary>
+    /// Station crew = not an antag address, holds an ID, and that ID is registered in station
+    /// records. Overload for when the address and PDA have already been resolved.
+    /// </summary>
+    public bool IsStationCrew(string address, PdaComponent pda)
+    {
+        return !_antagFilter.IsAntagAddress(address)
+               && pda.ContainedId is { } id
+               && IsStationCrewId(id);
+    }
+
+    /// <summary>
+    /// True only when the cartridge belongs to station crew: not an antag address, has an ID
+    /// inserted, and that ID is on the station records roster (so CentComm and ERT IDs are excluded).
+    /// </summary>
+    public bool IsStationCrewCartridge(EntityUid cartUid)
+    {
+        return _entMan.TryGetComponent<MessengerCartridgeComponent>(cartUid, out var comp)
+               && TryGetPda(cartUid, out _, out var pda)
+               && IsStationCrew(comp.Address, pda);
+    }
+}

--- a/Content.Server/RussStation/Messenger/ContactListBuilder.cs
+++ b/Content.Server/RussStation/Messenger/ContactListBuilder.cs
@@ -1,0 +1,148 @@
+using Content.Shared.Access.Components;
+using Content.Shared.CartridgeLoader;
+using Content.Shared.PDA;
+using Content.Shared.RussStation.Messenger;
+
+namespace Content.Server.RussStation.Messenger;
+
+/// <summary>
+/// A conversation partner discovered from the message store, paired with the most recent name the
+/// <em>other</em> party signed their messages with (used to label orphaned conversations).
+/// </summary>
+public readonly record struct ConversationPartner(EntityUid Other, string LastSenderName);
+
+/// <summary>
+/// Read-only view of the message store that <see cref="ContactListBuilder"/> needs. Keeping it
+/// behind an interface lets the builder be exercised without a full message system.
+/// </summary>
+public interface IMessengerMessageStore
+{
+    /// <summary>True if the two cartridges have at least one stored message between them.</summary>
+    bool HasConversation(EntityUid a, EntityUid b);
+
+    /// <summary>True if <paramref name="viewerCart"/> has unread messages from <paramref name="otherCart"/>.</summary>
+    bool HasUnread(EntityUid viewerCart, EntityUid otherCart);
+
+    /// <summary>
+    /// Every cartridge <paramref name="myCart"/> shares a non-empty conversation with, each paired
+    /// with the most recent name the other party used.
+    /// </summary>
+    IEnumerable<ConversationPartner> GetConversationPartners(EntityUid myCart);
+}
+
+/// <summary>
+/// Builds the messenger contact list for a cartridge in two named stages: discovering live
+/// cartridges in the world, then reconciling orphaned conversations whose cartridges are no longer
+/// in the scan (destroyed, unloaded, etc.).
+/// </summary>
+public sealed class ContactListBuilder
+{
+    private readonly IEntityManager _entMan;
+    private readonly CartridgeIdentityValidator _identity;
+    private readonly IMessengerMessageStore _store;
+
+    public ContactListBuilder(
+        IEntityManager entMan,
+        CartridgeIdentityValidator identity,
+        IMessengerMessageStore store)
+    {
+        _entMan = entMan;
+        _identity = identity;
+        _store = store;
+    }
+
+    /// <summary>
+    /// Build the full contact list for <paramref name="myCart"/>.
+    /// </summary>
+    public List<MessengerContact> Build(EntityUid myCart)
+    {
+        if (!_entMan.HasComponent<MessengerCartridgeComponent>(myCart))
+            return new List<MessengerContact>();
+
+        var contacts = new List<MessengerContact>();
+        var seen = new HashSet<EntityUid> { myCart };
+
+        DiscoverLiveCartridges(myCart, contacts, seen);
+        ReconcileOrphanedConversations(myCart, contacts, seen);
+
+        return contacts;
+    }
+
+    /// <summary>
+    /// Stage 1: scan every messenger cartridge in the world. Station crew always show up (writable);
+    /// anyone else (antag, no ID, CentComm/ERT) only shows up when there's already a conversation,
+    /// and is always read-only.
+    /// </summary>
+    private void DiscoverLiveCartridges(EntityUid myCart, List<MessengerContact> contacts, HashSet<EntityUid> seen)
+    {
+        var query = _entMan.EntityQueryEnumerator<MessengerCartridgeComponent>();
+        while (query.MoveNext(out var cartUid, out var cartComp))
+        {
+            if (!seen.Add(cartUid))
+                continue;
+
+            if (!_identity.TryGetPda(cartUid, out var loaderUid, out var pda))
+                continue;
+
+            if (!_entMan.HasComponent<CartridgeLoaderComponent>(loaderUid))
+                continue;
+
+            var isCrew = _identity.IsStationCrew(cartComp.Address, pda);
+            if (!isCrew && !_store.HasConversation(myCart, cartUid))
+                continue;
+
+            contacts.Add(BuildContact(myCart, cartUid, pda, readOnly: !isCrew));
+        }
+    }
+
+    /// <summary>
+    /// Stage 2: surface conversation partners whose cartridges weren't found in the scan (destroyed,
+    /// unloaded, etc.). These are always read-only and labelled with the partner's last known name.
+    /// </summary>
+    private void ReconcileOrphanedConversations(EntityUid myCart, List<MessengerContact> contacts, HashSet<EntityUid> seen)
+    {
+        foreach (var partner in _store.GetConversationPartners(myCart))
+        {
+            if (!seen.Add(partner.Other))
+                continue;
+
+            if (!_entMan.EntityExists(partner.Other))
+                continue;
+
+            contacts.Add(new MessengerContact(
+                _entMan.GetNetEntity(partner.Other),
+                partner.LastSenderName,
+                "",
+                "",
+                _store.HasUnread(myCart, partner.Other),
+                true));
+        }
+    }
+
+    /// <summary>
+    /// Build a contact entry for a live cartridge, preferring the inserted ID's name and job title
+    /// over the bare cartridge address.
+    /// </summary>
+    private MessengerContact BuildContact(EntityUid myCart, EntityUid otherCart, PdaComponent pda, bool readOnly)
+    {
+        var name = _entMan.GetComponentOrNull<MessengerCartridgeComponent>(otherCart)?.Address ?? "?";
+        var jobTitle = "";
+        var jobIcon = "";
+
+        if (pda.ContainedId is { } idUid &&
+            _entMan.TryGetComponent<IdCardComponent>(idUid, out var idCard))
+        {
+            if (!string.IsNullOrEmpty(idCard.FullName))
+                name = idCard.FullName;
+            jobTitle = idCard.LocalizedJobTitle ?? "";
+        }
+
+        return new MessengerContact(
+            _entMan.GetNetEntity(otherCart),
+            name,
+            jobTitle,
+            jobIcon,
+            _store.HasUnread(myCart, otherCart),
+            readOnly);
+    }
+}

--- a/Content.Server/RussStation/Messenger/MessengerServerSystem.cs
+++ b/Content.Server/RussStation/Messenger/MessengerServerSystem.cs
@@ -90,7 +90,7 @@ public sealed class MessengerServerSystem : EntitySystem, IMessengerMessageStore
 
         // The entire 4-hex address space for this prefix is exhausted (~65k cartridges); a collision
         // is now unavoidable. This should never happen in a real round.
-        Log.Error($"Messenger address space exhausted for prefix '{prefix}'; addresses may now collide.");
+        Log.Error("Messenger address space exhausted for prefix '{Prefix}'; addresses may now collide.", prefix);
         return $"{prefix}{_random.Next(MessengerConstants.CrewAddressHexRange):X4}";
     }
 

--- a/Content.Server/RussStation/Messenger/MessengerServerSystem.cs
+++ b/Content.Server/RussStation/Messenger/MessengerServerSystem.cs
@@ -1,9 +1,6 @@
-using Content.Shared.Access.Components;
-using Content.Shared.CartridgeLoader;
 using Content.Shared.GameTicking;
 using Content.Shared.PDA;
 using Content.Shared.RussStation.Messenger;
-using Content.Shared.StationRecords;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -14,7 +11,7 @@ namespace Content.Server.RussStation.Messenger;
 /// Messages are keyed by cartridge entity pairs and wiped on round restart.
 /// Each cartridge gets a unique short address (like a MAC) on init.
 /// </summary>
-public sealed class MessengerServerSystem : EntitySystem
+public sealed class MessengerServerSystem : EntitySystem, IMessengerMessageStore
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
@@ -23,16 +20,10 @@ public sealed class MessengerServerSystem : EntitySystem
     public const int MaxMessagesPerConversation = 50;
 
     /// <summary>
-    /// Address prefixes for antag categories. Any address starting with one of these is filtered.
+    /// Default address prefix for station crew. Kept for backwards compatibility; the canonical
+    /// value lives on <see cref="AntagAddressFilter"/>.
     /// </summary>
-    private static readonly Dictionary<string, string> AntagPrefixes = new()
-    {
-        { "syndicate", "SY" },
-        { "ninja", "NJ" },
-        { "pirate", "PR" },
-        { "wizard", "WZ" },
-        { "CBURN", "CB" },
-    };
+    public const string CrewAddressPrefix = AntagAddressFilter.CrewAddressPrefix;
 
     /// <summary>
     /// Messages keyed by canonical cartridge UID pair (lower first).
@@ -46,9 +37,18 @@ public sealed class MessengerServerSystem : EntitySystem
 
     private readonly HashSet<string> _usedAddresses = new();
 
+    private AntagAddressFilter _antagFilter = default!;
+    private CartridgeIdentityValidator _identity = default!;
+    private ContactListBuilder _contactBuilder = default!;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _antagFilter = AntagAddressFilter.Default;
+        _identity = new CartridgeIdentityValidator(EntityManager, _antagFilter);
+        _contactBuilder = new ContactListBuilder(EntityManager, _identity, this);
+
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
         SubscribeLocalEvent<MessengerCartridgeComponent, MapInitEvent>(OnMapInit);
     }
@@ -63,24 +63,11 @@ public sealed class MessengerServerSystem : EntitySystem
     private void OnMapInit(EntityUid uid, MessengerCartridgeComponent comp, MapInitEvent args)
     {
         var loaderUid = Transform(uid).ParentUid;
-        var prefix = CrewAddressPrefix;
+        var prefix = _antagFilter.CrewPrefix;
         if (HasComp<PdaComponent>(loaderUid))
-            prefix = GetAddressPrefix(MetaData(loaderUid).EntityName);
+            prefix = _antagFilter.GetAddressPrefix(MetaData(loaderUid).EntityName);
         comp.Address = GenerateAddress(prefix);
         Dirty(uid, comp);
-    }
-
-    public const string CrewAddressPrefix = "NT";
-
-    private static string GetAddressPrefix(string pdaName)
-    {
-        foreach (var (keyword, prefix) in AntagPrefixes)
-        {
-            if (pdaName.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                return prefix;
-        }
-
-        return CrewAddressPrefix;
     }
 
     private string GenerateAddress(string prefix)
@@ -92,20 +79,19 @@ public sealed class MessengerServerSystem : EntitySystem
                 return addr;
         }
 
-        var fallback = $"{prefix}{_usedAddresses.Count:X4}";
-        _usedAddresses.Add(fallback);
-        return fallback;
-    }
-
-    private static bool IsAntagAddress(string address)
-    {
-        foreach (var (_, prefix) in AntagPrefixes)
+        // Random generation kept colliding; deterministically scan the address space for the first
+        // free slot so we never silently hand out a duplicate address.
+        for (var n = 0; n < MessengerConstants.CrewAddressHexRange; n++)
         {
-            if (address.StartsWith(prefix))
-                return true;
+            var addr = $"{prefix}{n:X4}";
+            if (_usedAddresses.Add(addr))
+                return addr;
         }
 
-        return false;
+        // The entire 4-hex address space for this prefix is exhausted (~65k cartridges); a collision
+        // is now unavoidable. This should never happen in a real round.
+        Log.Error($"Messenger address space exhausted for prefix '{prefix}'; addresses may now collide.");
+        return $"{prefix}{_random.Next(MessengerConstants.CrewAddressHexRange):X4}";
     }
 
     /// <summary>
@@ -116,11 +102,11 @@ public sealed class MessengerServerSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(text))
             return false;
 
-        if (!TryComp<MessengerCartridgeComponent>(senderCart, out var senderComp))
+        if (!TryComp<MessengerCartridgeComponent>(senderCart, out _))
             return false;
 
         // Must have an ID card to send.
-        var senderName = GetCartridgeIdName(senderCart);
+        var senderName = _identity.GetCartridgeIdName(senderCart);
         if (senderName == null)
             return false;
 
@@ -182,56 +168,40 @@ public sealed class MessengerServerSystem : EntitySystem
     /// <summary>
     /// Build a contact list for a given cartridge. Scans all other cartridges.
     /// </summary>
-    public List<MessengerContact> GetContacts(EntityUid myCart)
+    public List<MessengerContact> GetContacts(EntityUid myCart) => _contactBuilder.Build(myCart);
+
+    /// <summary>
+    /// Check if a target cartridge is read-only. A cartridge is writable only when it belongs
+    /// to station crew: not an antag address, has an ID inserted, and that ID is on the station
+    /// records roster (so CentComm and ERT IDs are excluded).
+    /// </summary>
+    public bool IsContactReadOnly(EntityUid targetCart) => !_identity.IsStationCrewCartridge(targetCart);
+
+    /// <summary>
+    /// Check if the cartridge's PDA has an ID card inserted.
+    /// </summary>
+    public bool HasIdCard(EntityUid cartUid) => _identity.HasIdCard(cartUid);
+
+    /// <inheritdoc/>
+    public bool HasConversation(EntityUid a, EntityUid b)
     {
-        if (!TryComp<MessengerCartridgeComponent>(myCart, out var myComp))
-            return new List<MessengerContact>();
+        var key = MakeKey(a, b);
+        return _messages.TryGetValue(key, out var msgs) && msgs.Count > 0;
+    }
 
-        var contacts = new List<MessengerContact>();
-        var seen = new HashSet<EntityUid>();
-        seen.Add(myCart);
-
-        var query = EntityQueryEnumerator<MessengerCartridgeComponent>();
-        while (query.MoveNext(out var cartUid, out var cartComp))
-        {
-            if (!seen.Add(cartUid))
-                continue;
-
-            var loaderUid = Transform(cartUid).ParentUid;
-            if (!HasComp<CartridgeLoaderComponent>(loaderUid))
-                continue;
-
-            if (!TryComp<PdaComponent>(loaderUid, out var pda))
-                continue;
-
-            // Station crew = not an antag, holds an ID, ID is registered in station records.
-            // Anyone else (antag, no ID, CentComm/ERT) only shows up when there's already a
-            // conversation, and is always read-only.
-            var isCrew = !IsAntagAddress(cartComp.Address)
-                         && pda.ContainedId is { } id
-                         && IsStationCrewId(id);
-
-            if (!isCrew && !HasConversation(myCart, cartUid))
-                continue;
-
-            var contact = BuildContact(myCart, cartUid, pda, readOnly: !isCrew);
-            contacts.Add(contact);
-        }
-
-        // Find conversation partners whose cartridges aren't in the scan (destroyed, etc.)
+    /// <inheritdoc/>
+    public IEnumerable<ConversationPartner> GetConversationPartners(EntityUid myCart)
+    {
         foreach (var ((a, b), msgs) in _messages)
         {
             if (msgs.Count == 0)
                 continue;
 
             var other = a == myCart ? b : b == myCart ? a : EntityUid.Invalid;
-            if (other == EntityUid.Invalid || !seen.Add(other))
+            if (other == EntityUid.Invalid)
                 continue;
 
-            if (!Exists(other))
-                continue;
-
-            // Use the last known sender name from the conversation.
+            // Use the last name the other party signed with, falling back to their address.
             var lastName = CompOrNull<MessengerCartridgeComponent>(other)?.Address ?? "?";
             for (var i = msgs.Count - 1; i >= 0; i--)
             {
@@ -242,86 +212,8 @@ public sealed class MessengerServerSystem : EntitySystem
                 }
             }
 
-            contacts.Add(new MessengerContact(GetNetEntity(other), lastName, "", "", HasUnread(myCart, other), true));
+            yield return new ConversationPartner(other, lastName);
         }
-
-        return contacts;
-    }
-
-    private MessengerContact BuildContact(EntityUid myCart, EntityUid otherCart, PdaComponent pda, bool readOnly)
-    {
-        var name = CompOrNull<MessengerCartridgeComponent>(otherCart)?.Address ?? "?";
-        var jobTitle = "";
-        var jobIcon = "";
-
-        if (pda.ContainedId is { } idUid &&
-            TryComp<IdCardComponent>(idUid, out var idCard))
-        {
-            if (!string.IsNullOrEmpty(idCard.FullName))
-                name = idCard.FullName;
-            jobTitle = idCard.LocalizedJobTitle ?? "";
-        }
-
-        return new MessengerContact(GetNetEntity(otherCart), name, jobTitle, jobIcon, HasUnread(myCart, otherCart), readOnly);
-    }
-
-    /// <summary>
-    /// Check if a target cartridge is read-only. A cartridge is writable only when it belongs
-    /// to station crew: not an antag address, has an ID inserted, and that ID is on the station
-    /// records roster (so CentComm and ERT IDs are excluded).
-    /// </summary>
-    public bool IsContactReadOnly(EntityUid targetCart) => !IsStationCrewCartridge(targetCart);
-
-    private bool IsStationCrewCartridge(EntityUid cartUid)
-    {
-        return TryComp<MessengerCartridgeComponent>(cartUid, out var comp)
-               && !IsAntagAddress(comp.Address)
-               && TryComp<PdaComponent>(Transform(cartUid).ParentUid, out var pda)
-               && pda.ContainedId is { } id
-               && IsStationCrewId(id);
-    }
-
-    /// <summary>
-    /// True if the ID card was issued through station records (i.e. the holder is on the station crew roster).
-    /// CentComm/ERT IDs spawn directly from prototypes and lack a station record key.
-    /// </summary>
-    private bool IsStationCrewId(EntityUid idCard)
-    {
-        return TryComp<StationRecordKeyStorageComponent>(idCard, out var keyStorage)
-               && keyStorage.Key != null;
-    }
-
-    /// <summary>
-    /// Get the ID card name for a cartridge's PDA, or null if no ID is inserted.
-    /// </summary>
-    private string? GetCartridgeIdName(EntityUid cartUid)
-    {
-        var loaderUid = Transform(cartUid).ParentUid;
-        if (!TryComp<PdaComponent>(loaderUid, out var pda) || pda.ContainedId == null)
-            return null;
-
-        if (TryComp<IdCardComponent>(pda.ContainedId.Value, out var idCard) &&
-            !string.IsNullOrEmpty(idCard.FullName))
-        {
-            return idCard.FullName;
-        }
-
-        return CompOrNull<MessengerCartridgeComponent>(cartUid)?.Address ?? "?";
-    }
-
-    /// <summary>
-    /// Check if the cartridge's PDA has an ID card inserted.
-    /// </summary>
-    public bool HasIdCard(EntityUid cartUid)
-    {
-        var loaderUid = Transform(cartUid).ParentUid;
-        return TryComp<PdaComponent>(loaderUid, out var pda) && pda.ContainedId != null;
-    }
-
-    private bool HasConversation(EntityUid a, EntityUid b)
-    {
-        var key = MakeKey(a, b);
-        return _messages.TryGetValue(key, out var msgs) && msgs.Count > 0;
     }
 
     private static (EntityUid, EntityUid) MakeKey(EntityUid a, EntityUid b)

--- a/Content.Tests/Server/RussStation/Messenger/AntagAddressFilterTest.cs
+++ b/Content.Tests/Server/RussStation/Messenger/AntagAddressFilterTest.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Content.Server.RussStation.Messenger;
+using NUnit.Framework;
+
+namespace Content.Tests.Server.RussStation.Messenger;
+
+[TestFixture, TestOf(typeof(AntagAddressFilter))]
+[Parallelizable(ParallelScope.All)]
+public sealed class AntagAddressFilterTest
+{
+    private static readonly AntagAddressFilter Filter = AntagAddressFilter.Default;
+
+    [Test]
+    public void GetAddressPrefix_PlainPda_ReturnsCrewPrefix()
+    {
+        Assert.That(Filter.GetAddressPrefix("PDA"), Is.EqualTo(AntagAddressFilter.CrewAddressPrefix));
+        Assert.That(Filter.GetAddressPrefix("Captain PDA"), Is.EqualTo(AntagAddressFilter.CrewAddressPrefix));
+    }
+
+    [Test]
+    public void GetAddressPrefix_AntagPda_ReturnsCategoryPrefix()
+    {
+        Assert.That(Filter.GetAddressPrefix("Syndicate PDA"), Is.EqualTo("SY"));
+        Assert.That(Filter.GetAddressPrefix("Space Ninja PDA"), Is.EqualTo("NJ"));
+        Assert.That(Filter.GetAddressPrefix("Pirate PDA"), Is.EqualTo("PR"));
+        Assert.That(Filter.GetAddressPrefix("Wizard PDA"), Is.EqualTo("WZ"));
+    }
+
+    [Test]
+    public void GetAddressPrefix_IsCaseInsensitive()
+    {
+        Assert.That(Filter.GetAddressPrefix("syndicate pda"), Is.EqualTo("SY"));
+        Assert.That(Filter.GetAddressPrefix("SYNDICATE PDA"), Is.EqualTo("SY"));
+    }
+
+    [Test]
+    public void IsAntagAddress_AntagPrefixedAddresses_AreAntag()
+    {
+        Assert.That(Filter.IsAntagAddress("SY1234"), Is.True);
+        Assert.That(Filter.IsAntagAddress("NJABCD"), Is.True);
+        Assert.That(Filter.IsAntagAddress("CB0001"), Is.True);
+    }
+
+    [Test]
+    public void IsAntagAddress_CrewAddress_IsNotAntag()
+    {
+        Assert.That(Filter.IsAntagAddress("NT1234"), Is.False);
+    }
+
+    [Test]
+    public void CustomPrefixes_AreRespected()
+    {
+        var custom = new AntagAddressFilter(
+            new Dictionary<string, string> { { "revolution", "RV" } },
+            crewPrefix: "ZZ");
+
+        Assert.That(custom.CrewPrefix, Is.EqualTo("ZZ"));
+        Assert.That(custom.GetAddressPrefix("Revolution PDA"), Is.EqualTo("RV"));
+        Assert.That(custom.GetAddressPrefix("Captain PDA"), Is.EqualTo("ZZ"));
+        Assert.That(custom.IsAntagAddress("RV9999"), Is.True);
+        // The default antag prefixes no longer apply to a custom map.
+        Assert.That(custom.IsAntagAddress("SY1234"), Is.False);
+    }
+}


### PR DESCRIPTION
## About the PR

Refactors the 347-line `MessengerServerSystem` into a thin facade plus three focused collaborators (`AntagAddressFilter`, `CartridgeIdentityValidator`, `ContactListBuilder`), and hardens the cartridge address-collision fallback. The system file drops to 239 lines.

## Why / Balance

Part of the RussStation fork audit (#853). Closes #860 (P2). `GetContacts` was a 65-line three-pass algorithm, the ID-classification predicates chained nested `TryComp`s repeatedly, and the address generator had an ad-hoc collision fallback that could silently hand out duplicate addresses.

## Technical details

- **`AntagAddressFilter`**: the antag prefix map plus prefix-derivation and classification logic, extracted as an injectable class (custom keyword-to-prefix maps supported) with a shared `Default` instance.
- **`CartridgeIdentityValidator`**: consolidates the ID-card predicates (`HasIdCard`, `GetCartridgeIdName`, `IsStationCrewId`, `IsStationCrewCartridge`) behind a single `TryGetPda` lookup instead of repeated nested `TryComp`s.
- **`ContactListBuilder`**: `GetContacts` split into two named stages, `DiscoverLiveCartridges` and `ReconcileOrphanedConversations`, reading the message store through a small `IMessengerMessageStore` interface implemented by the system.
- **Address collision hardening**: instead of a count-based fallback whose `HashSet.Add` result was ignored (a silent collision), `GenerateAddress` now deterministically scans for the first free slot in the prefix's 4-hex address space, logging an error only if it is fully exhausted (~65k cartridges).

`MessengerServerSystem` now just owns the round-scoped message store and delegates to the helpers. Its public API (`SendMessage`, `GetConversation`, `GetContacts`, `IsContactReadOnly`, `HasIdCard`, etc.) is unchanged.

**Tests:** pure unit tests for `AntagAddressFilter`, and new integration tests covering `GetContacts` (previously uncovered): discovery gating of crew vs. strangers, conversation partners surfacing read-only, and orphan reconciliation.

## Media

N/A, code-only refactor, no in-game visual changes.

## Breaking changes

None. Behavior is preserved aside from the documented address-collision fix; the system's public API is unchanged.