### PR TITLE
Refactor FloatingChatInputControl: extract channel manager (#863)

### DIFF
--- a/Content.Client/RussStation/Chat/FloatingChatInputChannelManager.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputChannelManager.cs
@@ -1,0 +1,123 @@
+// HONK — channel state + label refresh for the floating chat input.
+// Extracted from FloatingChatInputControl (issue #863) so the widget keeps
+// lifecycle/positioning concerns while this owns channel selection. Pure
+// routing decisions still live in FloatingChatInputRouting; this wires them
+// to the live ChatInputBox.
+
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Client.UserInterface.Systems.Chat.Controls;
+using Content.Shared.Chat;
+using Content.Shared.Radio;
+using Robust.Shared.Maths;
+
+namespace Content.Client.RussStation.Chat;
+
+/// <summary>
+/// Owns the channel-selection state for <see cref="FloatingChatInputControl"/>:
+/// the pending restored radio channel, dropdown/cycle interactions, and the
+/// selector button label refresh.
+/// </summary>
+public sealed class FloatingChatInputChannelManager
+{
+    private readonly ChatInputBox _inputBox;
+    private readonly ChatUIController _chatUi;
+
+    private RadioChannelPrototype? _pendingRadioChannel;
+    private bool _suppressPendingClear;
+
+    /// <summary>
+    /// Specific radio channel to route to when the widget submits on
+    /// <see cref="ChatSelectChannel.Radio"/> without a typed prefix.
+    /// Cleared automatically when the user picks a channel via dropdown
+    /// or cycle hotkey; use <see cref="RestoreChannel"/> to seed it at
+    /// open time.
+    /// </summary>
+    public RadioChannelPrototype? PendingRadioChannel => _pendingRadioChannel;
+
+    public FloatingChatInputChannelManager(ChatInputBox inputBox, ChatUIController chatUi)
+    {
+        _inputBox = inputBox;
+        _chatUi = chatUi;
+    }
+
+    /// <summary>
+    /// Handler for <see cref="ChannelSelectorButton.OnChannelSelect"/>. User
+    /// interaction (dropdown or cycle) overrides any restored radio target.
+    /// Programmatic restore via <see cref="RestoreChannel"/> suppresses this.
+    /// </summary>
+    public void OnChannelSelectorChanged(ChatSelectChannel channel)
+    {
+        if (!_suppressPendingClear)
+            _pendingRadioChannel = null;
+
+        RefreshChannelLabel();
+    }
+
+    /// <summary>
+    /// Open-time channel seed. Selects the channel and, when it is Radio,
+    /// stores the pending radio prototype so both the button label and
+    /// submit routing address it.
+    /// </summary>
+    public void RestoreChannel(ChatSelectChannel channel, RadioChannelPrototype? pendingRadio)
+    {
+        _suppressPendingClear = true;
+        try
+        {
+            _inputBox.ChannelSelector.Select(channel);
+        }
+        finally
+        {
+            _suppressPendingClear = false;
+        }
+
+        _pendingRadioChannel = channel == ChatSelectChannel.Radio ? pendingRadio : null;
+        RefreshChannelLabel();
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="ChatUIController.UpdateSelectedChannel"/>. The button
+    /// text is only refreshed here; <see cref="ChannelSelectorButton.Select"/>
+    /// short-circuits on same-channel and neither it nor the dropdown's
+    /// OnChannelSelect handler repaints the label.
+    /// </summary>
+    public void RefreshChannelLabel()
+    {
+        var (prefixChannel, _, prefixRadio) = _chatUi.SplitInputContents(_inputBox.Input.Text.ToLower());
+        var selected = _inputBox.ChannelSelector.SelectedChannel;
+
+        var source = FloatingChatInputRouting.ResolveLabelSource(
+            selected,
+            _pendingRadioChannel != null,
+            prefixChannel);
+
+        switch (source)
+        {
+            case FloatingChatInputRouting.LabelSource.Prefix:
+                _inputBox.ChannelSelector.UpdateChannelSelectButton(prefixChannel, prefixRadio);
+                break;
+            case FloatingChatInputRouting.LabelSource.PendingRadio:
+                _inputBox.ChannelSelector.UpdateChannelSelectButton(ChatSelectChannel.Radio, _pendingRadioChannel);
+                break;
+            default:
+                _inputBox.ChannelSelector.UpdateChannelSelectButton(selected, null);
+                break;
+        }
+    }
+
+    public void CycleChannel(bool forward)
+    {
+        var order = ChannelSelectorPopup.ChannelSelectorOrder;
+        var idx = Array.IndexOf(order, _inputBox.ChannelSelector.SelectedChannel);
+        do
+        {
+            idx += forward ? 1 : -1;
+            idx = MathHelper.Mod(idx, order.Length);
+        } while ((_chatUi.SelectableChannels & order[idx]) == 0);
+
+        var target = _chatUi.MapLocalIfGhost(order[idx]);
+        if ((_chatUi.SelectableChannels & target) == 0)
+            return;
+
+        _inputBox.ChannelSelector.Select(target);
+    }
+}

--- a/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
+++ b/Content.Client/RussStation/Chat/FloatingChatInputControl.cs
@@ -35,6 +35,7 @@ public sealed class FloatingChatInputControl : Control
     private readonly SharedTransformSystem _transform;
     private readonly StyleBoxFlat _backgroundStyle;
     private readonly ChatUIController _chatUi;
+    private readonly FloatingChatInputChannelManager _channelManager;
 
     public readonly ChatInputBox InputBox;
 
@@ -44,17 +45,11 @@ public sealed class FloatingChatInputControl : Control
     public event Action<string, ChatSelectChannel>? OnSubmit;
     public event Action? OnCancel;
 
-    private RadioChannelPrototype? _pendingRadioChannel;
-    private bool _suppressPendingClear;
-
     /// <summary>
     /// Specific radio channel to route to when the widget submits on
     /// <see cref="ChatSelectChannel.Radio"/> without a typed prefix.
-    /// Cleared automatically when the user picks a channel via dropdown
-    /// or cycle hotkey; use <see cref="RestoreChannel"/> to seed it at
-    /// open time.
     /// </summary>
-    public RadioChannelPrototype? PendingRadioChannel => _pendingRadioChannel;
+    public RadioChannelPrototype? PendingRadioChannel => _channelManager.PendingRadioChannel;
 
     public FloatingChatInputControl()
     {
@@ -78,30 +73,28 @@ public sealed class FloatingChatInputControl : Control
         InputBox.FilterButton.Visible = false;
         AddChild(InputBox);
 
+        _channelManager = new FloatingChatInputChannelManager(InputBox, _chatUi);
+
         InputBox.Input.OnTextEntered += OnTextEntered;
         InputBox.Input.OnKeyBindDown += OnInputKeyBindDown;
         InputBox.Input.OnTextChanged += OnInputTextChanged;
         InputBox.Input.OnFocusEnter += OnInputFocusEnter;
         InputBox.Input.OnFocusExit += OnInputFocusExit;
-        InputBox.ChannelSelector.OnChannelSelect += OnChannelSelectorChanged;
+        InputBox.ChannelSelector.OnChannelSelect += _channelManager.OnChannelSelectorChanged;
 
         // Pick up the accessibility text-opacity knob too so the typed text
         // fades in sync with in-world bubble text.
         ApplyTextOpacity(_config.GetCVar(CCVars.SpeechBubbleTextOpacity));
 
-        _config.OnValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
-        _config.OnValueChanged(CCVars.SpeechBubbleTextOpacity, OnTextOpacityChanged);
+        _config.OnValueChanged(CCVars.SpeechBubbleBackgroundOpacity, ApplyBackgroundOpacity);
+        _config.OnValueChanged(CCVars.SpeechBubbleTextOpacity, ApplyTextOpacity);
     }
 
     private void ApplyTextOpacity(float alpha)
-    {
-        InputBox.Input.ModulateSelfOverride = Color.White.WithAlpha(Math.Clamp(alpha, 0f, 1f));
-    }
+        => InputBox.Input.ModulateSelfOverride = Color.White.WithAlpha(Math.Clamp(alpha, 0f, 1f));
 
-    private void OnTextOpacityChanged(float newAlpha)
-    {
-        ApplyTextOpacity(newAlpha);
-    }
+    private void ApplyBackgroundOpacity(float alpha)
+        => _backgroundStyle.BackgroundColor = BuildBackgroundColor(alpha);
 
     private static Color BuildBackgroundColor(float alpha)
     {
@@ -111,31 +104,16 @@ public sealed class FloatingChatInputControl : Control
             FloatingChatInputConstants.BackgroundBlue).WithAlpha(Math.Clamp(alpha, 0f, 1f));
     }
 
-    private void OnBackgroundOpacityChanged(float newAlpha)
-    {
-        _backgroundStyle.BackgroundColor = BuildBackgroundColor(newAlpha);
-    }
-
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
         if (disposing)
         {
-            _config.UnsubValueChanged(CCVars.SpeechBubbleBackgroundOpacity, OnBackgroundOpacityChanged);
-            _config.UnsubValueChanged(CCVars.SpeechBubbleTextOpacity, OnTextOpacityChanged);
+            _config.UnsubValueChanged(CCVars.SpeechBubbleBackgroundOpacity, ApplyBackgroundOpacity);
+            _config.UnsubValueChanged(CCVars.SpeechBubbleTextOpacity, ApplyTextOpacity);
             // Clear the typing indicator if the widget vanishes mid-message so it doesn't stick.
             _chatUi.NotifyChatFocus(false);
         }
-    }
-
-    private void OnChannelSelectorChanged(ChatSelectChannel channel)
-    {
-        // User interaction (dropdown or cycle) overrides any restored radio
-        // target. Programmatic restore via RestoreChannel suppresses this.
-        if (!_suppressPendingClear)
-            _pendingRadioChannel = null;
-
-        RefreshChannelLabel();
     }
 
     /// <summary>
@@ -144,24 +122,11 @@ public sealed class FloatingChatInputControl : Control
     /// submit routing address it.
     /// </summary>
     public void RestoreChannel(ChatSelectChannel channel, RadioChannelPrototype? pendingRadio)
-    {
-        _suppressPendingClear = true;
-        try
-        {
-            InputBox.ChannelSelector.Select(channel);
-        }
-        finally
-        {
-            _suppressPendingClear = false;
-        }
-
-        _pendingRadioChannel = channel == ChatSelectChannel.Radio ? pendingRadio : null;
-        RefreshChannelLabel();
-    }
+        => _channelManager.RestoreChannel(channel, pendingRadio);
 
     private void OnInputTextChanged(LineEditEventArgs args)
     {
-        RefreshChannelLabel();
+        _channelManager.RefreshChannelLabel();
         // Mirror ChatBox: the typing-indicator system listens for these notifications, so the
         // floating input has to call them too or bystanders never see the indicator while the
         // local player is typing here.
@@ -176,55 +141,6 @@ public sealed class FloatingChatInputControl : Control
     private void OnInputFocusExit(LineEditEventArgs args)
     {
         _chatUi.NotifyChatFocus(false);
-    }
-
-    /// <summary>
-    /// Mirrors <see cref="ChatUIController.UpdateSelectedChannel"/>. The button
-    /// text is only refreshed here; <see cref="ChannelSelectorButton.Select"/>
-    /// short-circuits on same-channel and neither it nor the dropdown's
-    /// OnChannelSelect handler repaints the label.
-    /// </summary>
-    private void RefreshChannelLabel()
-    {
-        var chatUi = _uiManager.GetUIController<ChatUIController>();
-        var (prefixChannel, _, prefixRadio) = chatUi.SplitInputContents(InputBox.Input.Text.ToLower());
-        var selected = InputBox.ChannelSelector.SelectedChannel;
-
-        var source = FloatingChatInputRouting.ResolveLabelSource(
-            selected,
-            _pendingRadioChannel != null,
-            prefixChannel);
-
-        switch (source)
-        {
-            case FloatingChatInputRouting.LabelSource.Prefix:
-                InputBox.ChannelSelector.UpdateChannelSelectButton(prefixChannel, prefixRadio);
-                break;
-            case FloatingChatInputRouting.LabelSource.PendingRadio:
-                InputBox.ChannelSelector.UpdateChannelSelectButton(ChatSelectChannel.Radio, _pendingRadioChannel);
-                break;
-            default:
-                InputBox.ChannelSelector.UpdateChannelSelectButton(selected, null);
-                break;
-        }
-    }
-
-    private void CycleChannel(bool forward)
-    {
-        var chatUi = _uiManager.GetUIController<ChatUIController>();
-        var order = ChannelSelectorPopup.ChannelSelectorOrder;
-        var idx = Array.IndexOf(order, InputBox.ChannelSelector.SelectedChannel);
-        do
-        {
-            idx += forward ? 1 : -1;
-            idx = MathHelper.Mod(idx, order.Length);
-        } while ((chatUi.SelectableChannels & order[idx]) == 0);
-
-        var target = chatUi.MapLocalIfGhost(order[idx]);
-        if ((chatUi.SelectableChannels & target) == 0)
-            return;
-
-        InputBox.ChannelSelector.Select(target);
     }
 
     /// <summary>
@@ -269,14 +185,14 @@ public sealed class FloatingChatInputControl : Control
 
         if (args.Function == ContentKeyFunctions.CycleChatChannelForward)
         {
-            CycleChannel(true);
+            _channelManager.CycleChannel(true);
             args.Handle();
             return;
         }
 
         if (args.Function == ContentKeyFunctions.CycleChatChannelBackward)
         {
-            CycleChannel(false);
+            _channelManager.CycleChannel(false);
             args.Handle();
         }
     }


### PR DESCRIPTION
## About the PR

Extracts channel-selection logic out of `FloatingChatInputControl` into a new `FloatingChatInputChannelManager`, leaving the control responsible only for widget lifecycle and on-screen positioning. The trivial opacity handlers are inlined. Behavior-preserving; the control drops from 310 to 226 lines.

## Why / Balance

Part of the RussStation fork audit (#853). Closes #863. `FloatingChatInputControl` mixed widget lifecycle, opacity/styling, and channel selection in one 310-line file. Splitting the channel concern out makes each piece easier to read and lands the control near the audit's size target.

## Technical details

- New `FloatingChatInputChannelManager` (constructed with the `ChatInputBox` and `ChatUIController`) owns the channel state (`_pendingRadioChannel`, `_suppressPendingClear`, `PendingRadioChannel`) and the moved methods: `OnChannelSelectorChanged`, `RestoreChannel`, `RefreshChannelLabel`, `CycleChannel`.
- The control keeps thin delegators (`RestoreChannel`, `PendingRadioChannel`) and subscribes the manager's handlers to the input/selector events.
- Inlined the two trivial opacity forwarders: removed `OnTextOpacityChanged` and `OnBackgroundOpacityChanged`, and subscribed the appliers (`ApplyTextOpacity` / `ApplyBackgroundOpacity`) to the CVar changes directly, with matching unsubscribes in `Dispose`.
- `FloatingChatInputRouting` (the pure decision helper) is left untouched, so its existing unit tests in `FloatingChatInputRoutingTest` continue to cover all the decision logic. No new logic was introduced.

## Media

N/A, code-only refactor with no visible in-game change.

## Breaking changes

None.