### PR TITLE
honksquad: refactor: consolidate payment collection (#866)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Economy/IdCardAccountInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/IdCardAccountInteractionTest.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.Administration;
+using Content.Server.RussStation.Economy;
+using Content.Server.Verbs;
+using Content.Shared.Administration;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.RussStation.Economy.Components;
+using Content.Shared.Stacks;
+using Content.Shared.Verbs;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+/// <summary>
+/// End-to-end coverage of <see cref="IdCardAccountSystem"/> cash flows, which #866
+/// re-pointed at <see cref="PaymentCollectionSystem"/> for card -> account
+/// resolution. Deposit runs through the real interaction (cash used on the card);
+/// withdraw runs through the real verb and quick-dialog round trip.
+/// </summary>
+public sealed class IdCardAccountInteractionTest : InteractionTest
+{
+    private const string IdCardProtoId = "PassengerIDCard";
+
+    /// <summary>
+    /// Using spesos on an ID card linked to a live account credits that account
+    /// and consumes the cash.
+    /// </summary>
+    [Test]
+    public async Task DepositCreditsLinkedAccountTest()
+    {
+        await SpawnTarget(IdCardProtoId);
+        var idEnt = ToServer(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var balance = SEntMan.System<PlayerBalanceSystem>();
+            // CreateAccount resets balance to zero; link the spawned card to it.
+            var account = balance.CreateAccount(SPlayer);
+            SEntMan.EnsureComponent<BankLinkedCardComponent>(idEnt).AccountNumber = account;
+        });
+
+        // Use a 200-speso stack on the card.
+        await InteractUsing("SpaceCash", 200);
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SEntMan.System<PlayerBalanceSystem>().GetBalance(SPlayer), Is.EqualTo(200),
+                "Deposit should credit the card's linked account.");
+            Assert.That(PlayerHoldsCredits(out _), Is.False,
+                "Deposited cash should be consumed.");
+        });
+    }
+
+    /// <summary>
+    /// Depositing onto a card whose account number no longer resolves credits
+    /// nobody and leaves the cash untouched.
+    /// </summary>
+    [Test]
+    public async Task DepositToStaleAccountIsNoOpTest()
+    {
+        await SpawnTarget(IdCardProtoId);
+        var idEnt = ToServer(Target!.Value);
+
+        await Server.WaitPost(() =>
+        {
+            var balance = SEntMan.System<PlayerBalanceSystem>();
+            // The player has a real account, but the card points at an unknown one.
+            balance.CreateAccount(SPlayer);
+            balance.SetBalance(SPlayer, 0);
+            SEntMan.EnsureComponent<BankLinkedCardComponent>(idEnt).AccountNumber = "DEADBEEF";
+        });
+
+        await InteractUsing("SpaceCash", 200);
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SEntMan.System<PlayerBalanceSystem>().GetBalance(SPlayer), Is.EqualTo(0),
+                "An unresolvable card account should not be credited.");
+            Assert.That(PlayerHoldsCredits(out var count), Is.True, "Cash should not be consumed on a failed deposit.");
+            Assert.That(count, Is.EqualTo(200));
+        });
+    }
+
+    /// <summary>
+    /// The withdraw verb, answered with an amount, deducts from the owner's
+    /// account and hands back physical spesos.
+    /// </summary>
+    [Test]
+    public async Task WithdrawDeductsOwnerAccountTest()
+    {
+        // Hold an ID card linked to the player's own account.
+        var idEnt = ToServer(await PlaceInHands(IdCardProtoId));
+
+        await Server.WaitPost(() =>
+        {
+            var balance = SEntMan.System<PlayerBalanceSystem>();
+            var account = balance.CreateAccount(SPlayer);
+            balance.SetBalance(SPlayer, 500);
+            SEntMan.EnsureComponent<BankLinkedCardComponent>(idEnt).AccountNumber = account;
+        });
+
+        // Execute the withdraw alt-verb; it opens an amount dialog for the session.
+        var dialogId = 0;
+        await Server.WaitPost(() =>
+        {
+            var verbs = SEntMan.System<VerbSystem>();
+            var withdraw = verbs.GetLocalVerbs(idEnt, SPlayer, typeof(AlternativeVerb))
+                .FirstOrDefault(v => v.Text == Loc.GetString("id-card-withdraw-verb"));
+
+            Assert.That(withdraw, Is.Not.Null, "A card linked to a live account should offer the withdraw verb.");
+            verbs.ExecuteVerb(withdraw!, SPlayer, idEnt);
+
+            dialogId = LatestDialogId(ServerSession);
+        });
+
+        // Answer the dialog from the client, as the real UI would.
+        await Client.WaitPost(() =>
+        {
+            Client.ResolveDependency<IEntityNetworkManager>().SendSystemNetworkMessage(
+                new QuickDialogResponseEvent(
+                    dialogId,
+                    new Dictionary<string, string> { ["1"] = "200" },
+                    QuickDialogButtonFlag.OkButton));
+        });
+        await RunTicks(5);
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SEntMan.System<PlayerBalanceSystem>().GetBalance(SPlayer), Is.EqualTo(300),
+                "Withdrawing 200 from a 500 balance should leave 300.");
+        });
+    }
+
+    /// <summary>
+    /// Reads the most recently opened quick-dialog id for a session. The server
+    /// hands these out internally, so a test playing the client's part has to
+    /// peek at them to reply with a valid id.
+    /// </summary>
+    private int LatestDialogId(ICommonSession session)
+    {
+        var quickDialog = SEntMan.System<QuickDialogSystem>();
+        var field = typeof(QuickDialogSystem).GetField("_openDialogsByUser", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.That(field, Is.Not.Null, "QuickDialogSystem._openDialogsByUser field not found -- did it get renamed?");
+
+        var byUser = (Dictionary<NetUserId, List<int>>) field!.GetValue(quickDialog)!;
+        return byUser[session.UserId].Last();
+    }
+
+    /// <summary>
+    /// True if the player is holding a credit stack; reports its count.
+    /// Must be called on the server thread.
+    /// </summary>
+    private bool PlayerHoldsCredits(out int count)
+    {
+        count = 0;
+        foreach (var held in SEntMan.System<SharedHandsSystem>().EnumerateHeld(SPlayer))
+        {
+            if (SEntMan.TryGetComponent<StackComponent>(held, out var stack))
+            {
+                count = stack.Count;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Content.IntegrationTests/Tests/RussStation/Economy/PaymentCollectionSystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Economy/PaymentCollectionSystemTest.cs
@@ -1,0 +1,151 @@
+using Content.Server.RussStation.Economy;
+using Content.Shared.RussStation.Economy.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.RussStation.Economy;
+
+/// <summary>
+/// Covers the consolidated payment seam (#866). These exercise the
+/// ID-card -> account resolution and account-debit logic that vending and
+/// ID-card interactions previously each re-implemented against
+/// <see cref="PlayerBalanceSystem"/> directly. The existing vending tests only
+/// hit the direct-on-mob balance fallback, so the card-linked path lives here.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(PaymentCollectionSystem))]
+public sealed class PaymentCollectionSystemTest
+{
+    /// <summary>
+    /// A card linked to a live account resolves to the owning entity and its balance.
+    /// </summary>
+    [Test]
+    public async Task CardResolvesToLinkedAccountTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var balance = entMan.System<PlayerBalanceSystem>();
+            var payment = entMan.System<PaymentCollectionSystem>();
+
+            // Owner mob with a real account registered in the ledger index.
+            var owner = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            var account = balance.CreateAccount(owner);
+            balance.SetBalance(owner, 500);
+
+            // A card stamped with that account number.
+            var card = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<BankLinkedCardComponent>(card).AccountNumber = account;
+
+            Assert.That(payment.TryGetAccountByCard(card, out var resolved, out var comp), Is.True,
+                "A card linked to a live account should resolve.");
+            Assert.That(resolved, Is.EqualTo(owner), "Resolution should point at the account owner.");
+            Assert.That(comp.Balance, Is.EqualTo(500), "Resolved balance component should be the owner's.");
+
+            entMan.DeleteEntity(card);
+            entMan.DeleteEntity(owner);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Cards with no link, or a stale/unknown account number, do not resolve.
+    /// </summary>
+    [Test]
+    public async Task UnlinkedOrStaleCardDoesNotResolveTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var payment = entMan.System<PaymentCollectionSystem>();
+
+            // No BankLinkedCardComponent at all.
+            var blank = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            Assert.That(payment.TryGetAccountByCard(blank, out _, out _), Is.False,
+                "A card with no linked account should not resolve.");
+
+            // Linked, but to an account number that was never registered.
+            var stale = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<BankLinkedCardComponent>(stale).AccountNumber = "DEADBEEF";
+            Assert.That(payment.TryGetAccountByCard(stale, out _, out _), Is.False,
+                "A card pointing at an unknown account should not resolve.");
+
+            entMan.DeleteEntity(blank);
+            entMan.DeleteEntity(stale);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// A mob carrying a balance directly (no ID) is the resolution fallback.
+    /// </summary>
+    [Test]
+    public async Task DirectMobBalanceIsFallbackTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var balance = entMan.System<PlayerBalanceSystem>();
+            var payment = entMan.System<PaymentCollectionSystem>();
+
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<PlayerBalanceComponent>(mob);
+            balance.SetBalance(mob, 250);
+
+            Assert.That(payment.TryGetAccount(mob, out var owner, out var comp), Is.True,
+                "A mob with a direct balance should resolve to itself.");
+            Assert.That(owner, Is.EqualTo(mob));
+            Assert.That(comp.Balance, Is.EqualTo(250));
+            Assert.That(payment.GetAvailableFunds(mob), Is.EqualTo(250),
+                "Available funds with no cash in hand should equal the account balance.");
+
+            entMan.DeleteEntity(mob);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Account payment deducts when affordable and is a no-op when it is not.
+    /// </summary>
+    [Test]
+    public async Task TryPayByAccountDeductsAndRespectsBalanceTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var balance = entMan.System<PlayerBalanceSystem>();
+            var payment = entMan.System<PaymentCollectionSystem>();
+
+            var mob = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.AddComponent<PlayerBalanceComponent>(mob);
+            balance.SetBalance(mob, 100);
+
+            Assert.That(payment.TryPayByAccount(mob, 30), Is.True, "An affordable charge should succeed.");
+            Assert.That(balance.GetBalance(mob), Is.EqualTo(70), "Balance should drop by the charged amount.");
+
+            Assert.That(payment.TryPayByAccount(mob, 1000), Is.False,
+                "An unaffordable charge should fail.");
+            Assert.That(balance.GetBalance(mob), Is.EqualTo(70),
+                "A failed charge should leave the balance untouched.");
+
+            entMan.DeleteEntity(mob);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
+++ b/Content.Server/RussStation/Economy/IdCardAccountSystem.cs
@@ -29,6 +29,7 @@ public sealed class IdCardAccountSystem : EntitySystem
     [Dependency] private readonly TrackedDialogSystem _trackedDialog = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly PlayerBalanceSystem _balance = default!;
+    [Dependency] private readonly PaymentCollectionSystem _payment = default!;
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
 
@@ -77,7 +78,7 @@ public sealed class IdCardAccountSystem : EntitySystem
                 Impact = LogImpact.Low,
             });
         }
-        else if (_balance.TryGetByAccount(accountNumber, out _))
+        else if (_payment.TryGetAccountByCard(uid, out _, out _))
         {
             args.Verbs.Add(new AlternativeVerb
             {
@@ -128,8 +129,7 @@ public sealed class IdCardAccountSystem : EntitySystem
 
         using (args.PushGroup(nameof(IdCardAccountSystem)))
         {
-            if (!_balance.TryGetByAccount(accountNumber, out var owner)
-                || !TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
+            if (!_payment.TryGetAccountByCard(uid, out _, out var balanceComp))
             {
                 args.PushMarkup(Loc.GetString("id-card-account-invalid-examine"));
                 return;
@@ -177,7 +177,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (!TryComp<StackComponent>(cash, out var stack) || stack.StackTypeId != SharedEconomyConstants.CreditStack)
             return false;
 
-        if (!_balance.TryGetByAccount(accountNumber, out var owner))
+        if (!_payment.TryGetAccountByCard(idCard, out var owner, out var balanceComp))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, user, PopupType.MediumCaution);
             return true;
@@ -187,7 +187,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (amount <= 0)
             return false;
 
-        _balance.AddBalance(owner, amount, description: Loc.GetString("transaction-deposit"));
+        _balance.AddBalance(owner, amount, balanceComp, Loc.GetString("transaction-deposit"));
         QueueDel(cash);
 
         _popup.PopupEntity(
@@ -259,7 +259,7 @@ public sealed class IdCardAccountSystem : EntitySystem
         if (amount <= 0)
             return;
 
-        if (!_balance.TryGetByAccount(accountNumber, out var owner))
+        if (!_payment.TryGetAccountByCard(idCard, out var owner, out var balanceComp))
         {
             _popup.PopupEntity(Loc.GetString("id-card-account-invalid"), idCard, session, PopupType.MediumCaution);
             return;
@@ -272,7 +272,7 @@ public sealed class IdCardAccountSystem : EntitySystem
             return;
         }
 
-        if (!_balance.TryDeduct(owner, amount, description: Loc.GetString("transaction-withdraw")))
+        if (!_balance.TryDeduct(owner, amount, balanceComp, Loc.GetString("transaction-withdraw")))
         {
             _popup.PopupEntity(Loc.GetString("id-card-withdraw-insufficient"), idCard, session, PopupType.MediumCaution);
             return;

--- a/Content.Server/RussStation/Economy/PaymentCollectionSystem.cs
+++ b/Content.Server/RussStation/Economy/PaymentCollectionSystem.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Access.Systems;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.RussStation.Economy.Components;
+using Content.Shared.Stacks;
+using Robust.Shared.Prototypes;
+using SharedEconomyConstants = Content.Shared.RussStation.Economy.EconomyConstants;
+
+namespace Content.Server.RussStation.Economy;
+
+/// <summary>
+/// Single seam for collecting payment from a buyer. Owns the account-resolution,
+/// account-debit, and physical-cash logic that vending and ID-card interactions
+/// previously each re-implemented against <see cref="PlayerBalanceSystem"/> directly.
+///
+/// Consumers (e.g. <see cref="VendingPaymentSystem"/>, <see cref="IdCardAccountSystem"/>)
+/// go through this system instead of reaching into the ledger's account index,
+/// keeping the "how do I find and charge an account" knowledge in one place.
+/// </summary>
+public sealed class PaymentCollectionSystem : EntitySystem
+{
+    [Dependency] private readonly PlayerBalanceSystem _balance = default!;
+    [Dependency] private readonly SharedIdCardSystem _idCard = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedStackSystem _stacks = default!;
+
+    /// <summary>
+    /// Resolve the balance account linked to an ID card. Returns false when the
+    /// card has no account number or the number does not map to a live account.
+    /// </summary>
+    public bool TryGetAccountByCard(EntityUid idCard, out EntityUid owner, [NotNullWhen(true)] out PlayerBalanceComponent? comp)
+    {
+        owner = default;
+        comp = null;
+
+        if (TryComp<BankLinkedCardComponent>(idCard, out var bankCard)
+            && !string.IsNullOrEmpty(bankCard.AccountNumber)
+            && _balance.TryGetByAccount(bankCard.AccountNumber, out owner))
+        {
+            return TryComp(owner, out comp);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolve the account a holder can spend from. Prefers the account linked to
+    /// the holder's ID card, falling back to a balance carried directly on the mob
+    /// (e.g. an ID-less NPC).
+    /// </summary>
+    public bool TryGetAccount(EntityUid holder, out EntityUid owner, [NotNullWhen(true)] out PlayerBalanceComponent? comp)
+    {
+        if (_idCard.TryFindIdCard(holder, out var idCard) && TryGetAccountByCard(idCard, out owner, out comp))
+            return true;
+
+        if (TryComp(holder, out comp))
+        {
+            owner = holder;
+            return true;
+        }
+
+        owner = default;
+        comp = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Try to charge a price to the buyer's bank account. Returns false if no
+    /// account is resolvable or it has insufficient funds.
+    /// </summary>
+    public bool TryPayByAccount(EntityUid buyer, int price, string? description = null)
+    {
+        if (TryGetAccount(buyer, out var owner, out var comp))
+            return _balance.TryDeduct(owner, price, comp, description);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to pay a price using physical spesos held in the buyer's hands.
+    /// Consumes stacks until the price is met. Returns false if not enough cash
+    /// is held (and leaves the partially-spent stacks as-is).
+    /// </summary>
+    public bool TryPayByCash(EntityUid buyer, int price)
+    {
+        var remaining = price;
+
+        foreach (var held in _hands.EnumerateHeld(buyer))
+        {
+            if (!TryComp<StackComponent>(held, out var stack) || stack.StackTypeId != SharedEconomyConstants.CreditStack)
+                continue;
+
+            var take = Math.Min(remaining, stack.Count);
+            _stacks.TryUse((held, stack), take);
+            remaining -= take;
+
+            if (remaining <= 0)
+                return true;
+        }
+
+        return remaining <= 0;
+    }
+
+    /// <summary>
+    /// Total spesos the buyer could spend right now: their account balance plus
+    /// any physical credits held in hand.
+    /// </summary>
+    public int GetAvailableFunds(EntityUid buyer)
+    {
+        var funds = 0;
+
+        // Account balance.
+        if (TryGetAccount(buyer, out var owner, out _))
+            funds += _balance.GetBalance(owner);
+
+        // Cash in hand.
+        foreach (var held in _hands.EnumerateHeld(buyer))
+        {
+            if (TryComp<StackComponent>(held, out var stack) && stack.StackTypeId == SharedEconomyConstants.CreditStack)
+                funds += stack.Count;
+        }
+
+        return funds;
+    }
+}

--- a/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
+++ b/Content.Server/RussStation/Economy/VendingPaymentSystem.cs
@@ -1,12 +1,9 @@
 using Content.Server.Cargo.Systems;
-using Content.Shared.Access.Systems;
-using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Materials;
 using Content.Shared.Popups;
 using Content.Shared.Research.Prototypes;
 using Content.Shared.RussStation.Economy;
 using Content.Shared.RussStation.Economy.Components;
-using Content.Shared.Stacks;
 using SharedEconomyConstants = Content.Shared.RussStation.Economy.EconomyConstants;
 using Content.Shared.VendingMachines;
 using Robust.Shared.Configuration;
@@ -26,10 +23,7 @@ public sealed class VendingPaymentSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly PricingSystem _pricing = default!;
-    [Dependency] private readonly PlayerBalanceSystem _balance = default!;
-    [Dependency] private readonly SharedIdCardSystem _idCard = default!;
-    [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly SharedStackSystem _stacks = default!;
+    [Dependency] private readonly PaymentCollectionSystem _payment = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private float _vendCargoMarkup;
@@ -144,86 +138,19 @@ public sealed class VendingPaymentSystem : EntitySystem
             return;
         }
 
-        // Try ID-based account payment first.
-        if (TryPayByAccount(args.User, price))
+        // Charge the buyer's account first, then physical spesos in hand.
+        if (_payment.TryPayByAccount(args.User, price, Loc.GetString("transaction-vending"))
+            || _payment.TryPayByCash(args.User, price))
+        {
             return;
-
-        // Try paying with physical spesos in hand.
-        if (TryPayByCash(args.User, price))
-            return;
+        }
 
         // Can't pay.
-        var currentBalance = GetAvailableFunds(args.User);
         _popup.PopupEntity(
-            Loc.GetString("vending-machine-insufficient-funds", ("cost", price), ("balance", currentBalance)),
+            Loc.GetString("vending-machine-insufficient-funds", ("cost", price), ("balance", _payment.GetAvailableFunds(args.User))),
             uid,
             args.User);
         args.Cancelled = true;
-    }
-
-    private int GetAvailableFunds(EntityUid buyer)
-    {
-        var funds = 0;
-
-        // Account balance.
-        if (_idCard.TryFindIdCard(buyer, out var idCard)
-            && TryComp<BankLinkedCardComponent>(idCard, out var bankCard)
-            && !string.IsNullOrEmpty(bankCard.AccountNumber)
-            && _balance.TryGetByAccount(bankCard.AccountNumber, out var owner))
-        {
-            funds += _balance.GetBalance(owner);
-        }
-        else if (TryComp<PlayerBalanceComponent>(buyer, out var directBalance))
-        {
-            funds += directBalance.Balance;
-        }
-
-        // Cash in hand.
-        foreach (var held in _hands.EnumerateHeld(buyer))
-        {
-            if (TryComp<StackComponent>(held, out var stack) && stack.StackTypeId == SharedEconomyConstants.CreditStack)
-                funds += stack.Count;
-        }
-
-        return funds;
-    }
-
-    private bool TryPayByAccount(EntityUid buyer, int price)
-    {
-        if (_idCard.TryFindIdCard(buyer, out var idCard)
-            && TryComp<BankLinkedCardComponent>(idCard, out var bankCard)
-            && !string.IsNullOrEmpty(bankCard.AccountNumber)
-            && _balance.TryGetByAccount(bankCard.AccountNumber, out var owner)
-            && TryComp<PlayerBalanceComponent>(owner, out var balanceComp))
-        {
-            return _balance.TryDeduct(owner, price, balanceComp, Loc.GetString("transaction-vending"));
-        }
-
-        // Fallback: direct mob lookup (mob has balance but no ID).
-        if (TryComp<PlayerBalanceComponent>(buyer, out var directBalance))
-            return _balance.TryDeduct(buyer, price, directBalance, Loc.GetString("transaction-vending"));
-
-        return false;
-    }
-
-    private bool TryPayByCash(EntityUid buyer, int price)
-    {
-        var remaining = price;
-
-        foreach (var held in _hands.EnumerateHeld(buyer))
-        {
-            if (!TryComp<StackComponent>(held, out var stack) || stack.StackTypeId != SharedEconomyConstants.CreditStack)
-                continue;
-
-            var take = Math.Min(remaining, stack.Count);
-            _stacks.TryUse((held, stack), take);
-            remaining -= take;
-
-            if (remaining <= 0)
-                return true;
-        }
-
-        return remaining <= 0;
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR

Adds a `PaymentCollectionSystem` that owns account lookup, account debit, and physical-cash handling. Vending and ID-card code now call it instead of each re-implementing that logic against `PlayerBalanceSystem`. `VendingPaymentSystem` goes from 263 to 188 lines and its `OnBeforeVend` shrinks to about five lines.

## Why / Balance

Part of the RussStation fork audit (#853). Closes #866. Payment collection was spread across three places: `PlayerBalanceSystem` owned the ledger, `VendingPaymentSystem.TryPayByAccount` re-did the account lookup and deduction inline, and `IdCardAccountSystem` reached into the ledger on its own. Moving that resolution into one system drops the duplication and gives both callers a single seam to go through.

## Technical details

- New `PaymentCollectionSystem` with `TryGetAccountByCard`, `TryGetAccount`, `TryPayByAccount`, `TryPayByCash`, and `GetAvailableFunds`. `TryGetAccount` resolves the account linked to a holder's ID card and falls back to a balance carried directly on the mob (an ID-less NPC, for example).
- `VendingPaymentSystem` delegates the payment step to the new system and keeps only the pricing logic. The four payment-related dependencies (`PlayerBalanceSystem`, `SharedIdCardSystem`, `SharedHandsSystem`, `SharedStackSystem`) moved with it.
- `IdCardAccountSystem` uses `TryGetAccountByCard` in its examine, deposit, withdraw, and withdraw-verb paths. The set-account path that takes a user-typed number keeps the direct ledger lookup, since that string does not come from a card.

Behavior matches the old code: the account-then-cash order, the account-versus-direct-mob fallback, the empty-versus-invalid account handling, and the transaction descriptions are all unchanged.

Tests:
- `PaymentCollectionSystemTest` covers card resolution, unlinked and stale cards, the direct-mob fallback, available funds, and account debit including the insufficient-funds no-op.
- `IdCardAccountInteractionTest` drives the real deposit interaction (cash used on a linked card), a stale-account deposit that should credit nobody, and the real withdraw verb with its quick-dialog reply.

One caveat for reviewers: the withdraw test reads a private field on `QuickDialogSystem` by reflection to learn the dialog id, because the server rejects a reply carrying the wrong id and there is no public way to read it. The read is guarded by an assertion that fails loudly if the field is renamed.

## Media

None. Code-only change with no in-game visual effect.

## Breaking changes

None. `PaymentCollectionSystem` is new and the existing public APIs are unchanged.