### PR TITLE
Split reagent-analysis engine out of HealthAnalyzerReagentSystem (#858)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/MedicalScanner/HealthAnalyzerReagentSystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/MedicalScanner/HealthAnalyzerReagentSystemTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.RussStation.MedicalScanner;
+using Content.Shared.Body;
 using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -120,6 +121,28 @@ public sealed class HealthAnalyzerReagentSystemTest
         - !type:ReagentCondition
           reagent: TestSelfDecayReagent
           min: 1
+
+# Mob dummy carrying a real stomach organ so the organ-aggregation path
+# (AddOrganSolutions) has something to walk. Bloodstream is required for
+# SolutionAggregator's mob branch to run at all; the stomach is filled into the
+# body_organs container so BuildState surfaces a stomach group.
+- type: entity
+  id: HealthAnalyzerReagentStomachDummy
+  components:
+  - type: SolutionContainerManager
+  - type: Body
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss: 1
+    bloodlossHealDamage:
+      types:
+        Bloodloss: -1
+  - type: EntityTableContainerFill
+    containers:
+      body_organs: !type:AllSelector
+        children:
+        - id: OrganHumanStomach
 ";
 
     private static readonly ProtoId<ReagentPrototype> Bicaridine = "Bicaridine";
@@ -355,6 +378,46 @@ public sealed class HealthAnalyzerReagentSystemTest
 
             var state = system.BuildState(notAMob);
             Assert.That(state.Groups, Is.Empty, "Entities without a bloodstream expose no reagent groups.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task StomachOrganSurfacesAsGroupWithoutDoseFlags()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entityManager.System<SharedSolutionContainerSystem>();
+        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entityManager.SpawnEntity("HealthAnalyzerReagentStomachDummy", mapData.GridCoords);
+
+            var bodyComp = entityManager.GetComponent<BodyComponent>(mob);
+            Assert.That(bodyComp.Organs, Is.Not.Null, "Body container should be initialized.");
+
+            var stomach = bodyComp.Organs!.ContainedEntities
+                .Single(organ => entityManager.HasComponent<StomachComponent>(organ));
+
+            Assert.That(containerSystem.TryGetSolution(stomach, "stomach", out var stomachHandle, out _),
+                "Stomach organ should have its 'stomach' solution from OrganBaseStomach.");
+
+            // 20u Bicaridine would overdose in BLOOD (15u threshold); organ solutions pass
+            // showDoseFlags: false, so the stomach group surfaces it with no OD/UD chrome.
+            containerSystem.TryAddSolution(stomachHandle!.Value, new Solution("Bicaridine", FixedPoint2.New(20)));
+
+            var state = system.BuildState(mob);
+            // A single organ uses the bare label (indexed labels only kick in with 2+ organs).
+            var stomachGroup = state.Groups.Single(g => g.Label == Loc.GetString("health-analyzer-reagent-group-stomach"));
+            var bicaridine = stomachGroup.Reagents.Single(r => r.ReagentId == "Bicaridine");
+
+            Assert.That(bicaridine.Quantity, Is.EqualTo(FixedPoint2.New(20)));
+            Assert.That(bicaridine.Overdose, Is.False, "Organ groups never carry dose flags.");
+            Assert.That(bicaridine.Underdose, Is.False);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/RussStation/MedicalScanner/HealthAnalyzerReagentSystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/MedicalScanner/HealthAnalyzerReagentSystemTest.cs
@@ -271,4 +271,92 @@ public sealed class HealthAnalyzerReagentSystemTest
 
         await pair.CleanReturnAsync();
     }
+
+    [Test]
+    public async Task MetabolitesGroupNeverShowsDoseFlags()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entityManager.System<SharedSolutionContainerSystem>();
+        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entityManager.SpawnEntity("HealthAnalyzerReagentMobDummy", mapData.GridCoords);
+            var bloodstream = entityManager.GetComponent<BloodstreamComponent>(mob);
+            Assert.That(containerSystem.TryGetSolution(mob, bloodstream.MetabolitesSolutionName,
+                out var metaboliteHandle, out _), "BloodstreamSystem should have created the metabolites solution on init.");
+
+            // 20u Bicaridine overdoses in BLOOD (15u threshold). Metabolites pass showDoseFlags: false,
+            // so the identical quantity must render with no OD/UD chrome — metabolites are the trickle
+            // of in-progress metabolism output and never reach whole-dose thresholds.
+            containerSystem.TryAddSolution(metaboliteHandle!.Value, new Solution("Bicaridine", FixedPoint2.New(20)));
+
+            var state = system.BuildState(mob);
+            var metabolitesGroup = state.Groups.Single(g => g.Label == Loc.GetString("health-analyzer-reagent-group-metabolites"));
+            var bicaridine = metabolitesGroup.Reagents.Single(r => r.ReagentId == "Bicaridine");
+
+            Assert.That(bicaridine.Quantity, Is.EqualTo(FixedPoint2.New(20)));
+            Assert.That(bicaridine.Overdose, Is.False, "Only the Blood group carries dose flags; metabolites must never overdose.");
+            Assert.That(bicaridine.Underdose, Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task BloodUnderdoseFlagsBelowBeneficialThreshold()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var containerSystem = entityManager.System<SharedSolutionContainerSystem>();
+        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entityManager.SpawnEntity("HealthAnalyzerReagentMobDummy", mapData.GridCoords);
+            var bloodstream = entityManager.GetComponent<BloodstreamComponent>(mob);
+            Assert.That(containerSystem.TryGetSolution(mob, bloodstream.BloodSolutionName,
+                out var bloodHandle, out _), "BloodstreamSystem should have created the blood solution on init.");
+
+            // TestUnderdoseReagent's healing effect only activates at 8u (BeneficialMin). 4u sits
+            // below that, so Blood should flag it underdosed and never overdosed.
+            containerSystem.TryAddSolution(bloodHandle!.Value, new Solution(TestUnderdoseReagent, FixedPoint2.New(4)));
+
+            var state = system.BuildState(mob);
+            var bloodGroup = state.Groups.Single(g => g.Label == Loc.GetString("health-analyzer-reagent-group-blood"));
+            var reagent = bloodGroup.Reagents.Single(r => r.ReagentId == TestUnderdoseReagent);
+
+            Assert.That(reagent.Underdose, Is.True, "4u is below the 8u beneficial activation threshold.");
+            Assert.That(reagent.Overdose, Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task MobWithoutBloodstreamYieldsNoGroups()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            // No BloodstreamComponent -> SolutionAggregator skips the mob branch entirely and
+            // BuildState returns an empty group list (just the display name).
+            var notAMob = entityManager.SpawnEntity(null, mapData.GridCoords);
+
+            var state = system.BuildState(notAMob);
+            Assert.That(state.Groups, Is.Empty, "Entities without a bloodstream expose no reagent groups.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
 }

--- a/Content.IntegrationTests/Tests/RussStation/MedicalScanner/HealthAnalyzerReagentSystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/MedicalScanner/HealthAnalyzerReagentSystemTest.cs
@@ -173,11 +173,11 @@ public sealed class HealthAnalyzerReagentSystemTest
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var analyzer = entityManager.System<ReagentDoseThresholdAnalyzer>();
 
         await server.WaitAssertion(() =>
         {
-            var thresholds = system.GetDoseThresholds(protoMan.Index(Bicaridine));
+            var thresholds = analyzer.GetDoseThresholds(protoMan.Index(Bicaridine));
             Assert.That(thresholds.HarmfulMin, Is.Not.Null,
                 "Bicaridine's metabolism gates harmful effects on a min threshold.");
             Assert.That(thresholds.HarmfulMin!.Value, Is.EqualTo(FixedPoint2.New(15)));
@@ -195,11 +195,11 @@ public sealed class HealthAnalyzerReagentSystemTest
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var analyzer = entityManager.System<ReagentDoseThresholdAnalyzer>();
 
         await server.WaitAssertion(() =>
         {
-            var thresholds = system.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestUnderdoseReagent));
+            var thresholds = analyzer.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestUnderdoseReagent));
             Assert.That(thresholds.BeneficialMin, Is.Not.Null,
                 "Healing-gated reagents should surface a beneficial activation threshold.");
             Assert.That(thresholds.BeneficialMin!.Value, Is.EqualTo(FixedPoint2.New(8)));
@@ -217,11 +217,11 @@ public sealed class HealthAnalyzerReagentSystemTest
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var analyzer = entityManager.System<ReagentDoseThresholdAnalyzer>();
 
         await server.WaitAssertion(() =>
         {
-            var thresholds = system.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestNeutralFlavorReagent));
+            var thresholds = analyzer.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestNeutralFlavorReagent));
             Assert.That(thresholds.HarmfulMin, Is.Null, "Emote/PopupMessage effects must not generate harmful thresholds.");
             Assert.That(thresholds.HarmfulMax, Is.Null);
             Assert.That(thresholds.BeneficialMin, Is.Null);
@@ -237,11 +237,11 @@ public sealed class HealthAnalyzerReagentSystemTest
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var analyzer = entityManager.System<ReagentDoseThresholdAnalyzer>();
 
         await server.WaitAssertion(() =>
         {
-            var thresholds = system.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestRangeHarmfulReagent));
+            var thresholds = analyzer.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestRangeHarmfulReagent));
             Assert.That(thresholds.HarmfulMax, Is.Not.Null, "max-gated slow effect should surface as HarmfulMax.");
             Assert.That(thresholds.HarmfulMax!.Value, Is.EqualTo(FixedPoint2.New(10)));
             Assert.That(thresholds.HarmfulMin, Is.Not.Null, "min-gated poison effect should surface as HarmfulMin.");
@@ -259,11 +259,11 @@ public sealed class HealthAnalyzerReagentSystemTest
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var system = entityManager.System<HealthAnalyzerReagentSystem>();
+        var analyzer = entityManager.System<ReagentDoseThresholdAnalyzer>();
 
         await server.WaitAssertion(() =>
         {
-            var thresholds = system.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestSelfDecayReagent));
+            var thresholds = analyzer.GetDoseThresholds(protoMan.Index<ReagentPrototype>(TestSelfDecayReagent));
             Assert.That(thresholds.HarmfulMin, Is.Null, "Self-decaying AdjustReagent (negative amount) must not be harmful.");
             Assert.That(thresholds.HarmfulMax, Is.Null);
             Assert.That(thresholds.BeneficialMin, Is.Null);

--- a/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
+++ b/Content.Server/RussStation/MedicalScanner/HealthAnalyzerReagentSystem.cs
@@ -1,24 +1,5 @@
-using System.Linq;
-using Content.Server.Body.Components;
-using Content.Server.Body.Systems;
 using Content.Server.Medical.Components;
-using Content.Shared.Body;
 using Content.Shared.Body.Components;
-using Content.Shared.Body.Systems;
-using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.EntitySystems;
-using Content.Shared.Chemistry.Reagent;
-using Content.Shared.Damage;
-using Content.Shared.Damage.Prototypes;
-using Content.Shared.EntityConditions;
-using Content.Shared.EntityConditions.Conditions;
-using Content.Shared.EntityEffects;
-using Content.Shared.EntityEffects.Effects;
-using Content.Shared.EntityEffects.Effects.Damage;
-using Content.Shared.EntityEffects.Effects.Solution;
-using Content.Shared.EntityEffects.Effects.StatusEffects;
-using Content.Shared.EntityEffects.Effects.Transform;
-using Content.Shared.FixedPoint;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item.ItemToggle.Components;
@@ -27,7 +8,6 @@ using Content.Shared.RussStation.MedicalScanner;
 using Content.Shared.RussStation.Scanner;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using UpstreamHealthAnalyzerSystem = Content.Server.Medical.HealthAnalyzerSystem;
 
@@ -46,19 +26,9 @@ namespace Content.Server.RussStation.MedicalScanner;
 public sealed class HealthAnalyzerReagentSystem : SharedHealthAnalyzerReagentSystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly SharedSolutionContainerSystem _solutions = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
-
-    private readonly Dictionary<string, ReagentDoseThresholds> _thresholdCache = new();
-
-    public readonly record struct ReagentDoseThresholds(
-        FixedPoint2? HarmfulMin,
-        FixedPoint2? HarmfulMax,
-        FixedPoint2? BeneficialMin);
-
-    private enum EffectClass { Harmful, Beneficial, Neutral }
+    [Dependency] private readonly SolutionAggregator _aggregator = default!;
 
     public override void Initialize()
     {
@@ -71,8 +41,6 @@ public sealed class HealthAnalyzerReagentSystem : SharedHealthAnalyzerReagentSys
         SubscribeLocalEvent<HealthAnalyzerReagentScannerComponent, DroppedEvent>(OnDropped);
         SubscribeLocalEvent<HealthAnalyzerReagentScannerComponent, EntGotInsertedIntoContainerMessage>(OnInsertedIntoContainer);
         SubscribeLocalEvent<HealthAnalyzerReagentScannerComponent, ItemToggledEvent>(OnToggled);
-
-        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
     }
 
     public override void Update(float frameTime)
@@ -110,12 +78,6 @@ public sealed class HealthAnalyzerReagentSystem : SharedHealthAnalyzerReagentSys
                     break;
             }
         }
-    }
-
-    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
-    {
-        if (args.WasModified<ReagentPrototype>())
-            _thresholdCache.Clear();
     }
 
     private void OnHealthDoAfter(Entity<HealthAnalyzerReagentScannerComponent> ent, ref HealthAnalyzerDoAfterEvent args)
@@ -201,233 +163,14 @@ public sealed class HealthAnalyzerReagentSystem : SharedHealthAnalyzerReagentSys
             StopReagentScan(ent);
     }
 
+    /// <summary>
+    /// Builds the full reagent UI state for <paramref name="target"/>. Group construction is
+    /// delegated to <see cref="SolutionAggregator"/>; this wrapper just attaches the display name.
+    /// </summary>
     public HealthAnalyzerReagentState BuildState(EntityUid target)
     {
-        var groups = new List<HealthAnalyzerReagentGroup>();
-
-        if (TryComp<BloodstreamComponent>(target, out var bloodstream))
-        {
-            // Reagent OD/UD thresholds are calibrated against whole-reagent doses in the blood.
-            // Metabolites are the trickle of in-progress metabolism output — their quantities
-            // never reach those thresholds, so flagging them would be misleading noise. Only the
-            // Blood group gets dose flags; metabolites / stomach / lung / puddle / container
-            // entries pass false and render plain "{reagent}: Nu" without the dose chrome.
-            AddSolution(groups, target, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution,
-                Loc.GetString("health-analyzer-reagent-group-blood"), showDoseFlags: true);
-            AddSolution(groups, target, bloodstream.MetabolitesSolutionName, ref bloodstream.MetabolitesSolution,
-                Loc.GetString("health-analyzer-reagent-group-metabolites"));
-
-            AddOrganSolutions<StomachComponent>(groups, target,
-                "health-analyzer-reagent-group-stomach",
-                "health-analyzer-reagent-group-stomach-indexed",
-                (uid, stomach) =>
-                {
-                    var handle = stomach.Solution;
-                    return _solutions.ResolveSolution(uid, StomachSystem.DefaultSolutionName, ref handle, out var sol)
-                        ? sol : null;
-                });
-
-            AddOrganSolutions<LungComponent>(groups, target,
-                "health-analyzer-reagent-group-lung",
-                "health-analyzer-reagent-group-lung-indexed",
-                (uid, lung) =>
-                {
-                    // LungComponent is [Access]-locked to LungSystem; copy Solution into a local
-                    // so ResolveSolution's ref parameter doesn't write back through the locked field.
-                    var handle = lung.Solution;
-                    return _solutions.ResolveSolution(uid, lung.SolutionName, ref handle, out var sol)
-                        ? sol : null;
-                });
-        }
-
+        var groups = _aggregator.BuildGroups(target);
         var displayName = Identity.Name(target, EntityManager);
         return new HealthAnalyzerReagentState(GetNetEntity(target), displayName, groups);
-    }
-
-    private void AddOrganSolutions<TOrgan>(
-        List<HealthAnalyzerReagentGroup> groups,
-        EntityUid body,
-        string singleKey,
-        string indexedKey,
-        Func<EntityUid, TOrgan, Solution?> resolve)
-        where TOrgan : IComponent
-    {
-        if (!TryComp<BodyComponent>(body, out var bodyComp) || bodyComp.Organs is null)
-            return;
-
-        var organs = new List<(EntityUid Uid, TOrgan Comp)>();
-        foreach (var organ in bodyComp.Organs.ContainedEntities)
-        {
-            if (TryComp<TOrgan>(organ, out var comp))
-                organs.Add((organ, comp));
-        }
-
-        for (var i = 0; i < organs.Count; i++)
-        {
-            var (uid, comp) = organs[i];
-            var label = organs.Count > MedicalScannerConstants.MultiOrganLabelThreshold
-                ? Loc.GetString(indexedKey, ("index", i + MedicalScannerConstants.OrganIndexLabelOffset))
-                : Loc.GetString(singleKey);
-            if (resolve(uid, comp) is { } sol)
-                AddSolutionFromSolution(groups, sol, label);
-        }
-    }
-
-    private void AddSolution(List<HealthAnalyzerReagentGroup> groups, EntityUid owner, string name,
-        ref Entity<SolutionComponent>? handle, string label, bool showDoseFlags = false)
-    {
-        if (!_solutions.ResolveSolution(owner, name, ref handle, out var solution))
-            return;
-
-        AddSolutionFromSolution(groups, solution, label, showDoseFlags);
-    }
-
-    private void AddSolutionFromSolution(List<HealthAnalyzerReagentGroup> groups, Solution solution, string label, bool showDoseFlags = false)
-    {
-        var entries = new List<HealthAnalyzerReagentEntry>(solution.Contents.Count);
-        foreach (var (id, qty) in solution.Contents
-                     .Select(rq => (rq.Reagent.Prototype, rq.Quantity))
-                     .OrderByDescending(t => t.Quantity))
-        {
-            if (!_proto.TryIndex<ReagentPrototype>(id, out var protoData))
-                continue;
-
-            var od = false;
-            var ud = false;
-            if (showDoseFlags)
-            {
-                var thresholds = GetDoseThresholds(protoData);
-                od = (thresholds.HarmfulMin.HasValue && qty >= thresholds.HarmfulMin.Value)
-                     || (thresholds.HarmfulMax.HasValue && qty <= thresholds.HarmfulMax.Value);
-                ud = !od && thresholds.BeneficialMin.HasValue && qty < thresholds.BeneficialMin.Value;
-            }
-            entries.Add(new HealthAnalyzerReagentEntry(id, protoData.LocalizedName, protoData.SubstanceColor, qty, od, ud));
-        }
-
-        groups.Add(new HealthAnalyzerReagentGroup(label, solution.Volume, solution.MaxVolume, entries));
-    }
-
-    /// <summary>
-    /// Walks a reagent's metabolisms looking for self-referencing <see cref="ReagentCondition"/>s
-    /// and buckets the bounds into harmful or beneficial thresholds based on the effect type.
-    /// </summary>
-    public ReagentDoseThresholds GetDoseThresholds(ReagentPrototype proto)
-    {
-        if (_thresholdCache.TryGetValue(proto.ID, out var cached))
-            return cached;
-
-        FixedPoint2? harmfulMin = null;
-        FixedPoint2? harmfulMax = null;
-        FixedPoint2? beneficialMin = null;
-
-        if (proto.Metabolisms != null)
-        {
-            foreach (var (_, entry) in proto.Metabolisms.Metabolisms)
-            {
-                foreach (var effect in entry.Effects)
-                {
-                    if (effect.Conditions == null)
-                        continue;
-
-                    var cls = ClassifyEffect(effect, proto.ID);
-                    if (cls == EffectClass.Neutral)
-                        continue;
-
-                    var (selfMin, selfMax) = SelfBounds(proto.ID, effect.Conditions);
-                    if (selfMin is null && selfMax is null)
-                        continue;
-
-                    if (cls == EffectClass.Beneficial)
-                    {
-                        if (selfMin is { } bMin && (beneficialMin is null || bMin < beneficialMin.Value))
-                            beneficialMin = bMin;
-                    }
-                    else
-                    {
-                        if (selfMin is { } hMin && (harmfulMin is null || hMin < harmfulMin.Value))
-                            harmfulMin = hMin;
-                        if (selfMax is { } hMax && (harmfulMax is null || hMax > harmfulMax.Value))
-                            harmfulMax = hMax;
-                    }
-                }
-            }
-        }
-
-        var result = new ReagentDoseThresholds(harmfulMin, harmfulMax, beneficialMin);
-        _thresholdCache[proto.ID] = result;
-        return result;
-    }
-
-    private static (FixedPoint2? Min, FixedPoint2? Max) SelfBounds(string reagentId, EntityCondition[] conditions)
-    {
-        FixedPoint2? min = null;
-        FixedPoint2? max = null;
-        foreach (var cond in conditions)
-        {
-            if (cond is not ReagentCondition rc)
-                continue;
-            if (rc.Reagent != reagentId)
-                continue;
-            if (rc.Inverted)
-                continue;
-
-            if (rc.Min > FixedPoint2.Zero && (min is null || rc.Min < min.Value))
-                min = rc.Min;
-            if (rc.Max < FixedPoint2.MaxValue && (max is null || rc.Max > max.Value))
-                max = rc.Max;
-        }
-        return (min, max);
-    }
-
-    private static EffectClass ClassifyEffect(EntityEffect effect, string reagentId)
-    {
-        switch (effect)
-        {
-            case HealthChange hc:
-                return ClassifyDamageValues(hc.Damage.DamageDict.Values);
-            case EvenHealthChange ehc:
-                return ClassifyDamageValues(ehc.Damage.Values);
-
-            case AdjustReagent ar:
-                if (ar.Reagent == reagentId)
-                    return ar.Amount < FixedPoint2.Zero ? EffectClass.Neutral : EffectClass.Harmful;
-                return EffectClass.Neutral;
-
-            case MovementSpeedModifier msm:
-                if (msm.WalkSpeedModifier < MedicalScannerConstants.NeutralMovementSpeedModifier
-                    || msm.SprintSpeedModifier < MedicalScannerConstants.NeutralMovementSpeedModifier)
-                    return EffectClass.Harmful;
-                if (msm.WalkSpeedModifier > MedicalScannerConstants.NeutralMovementSpeedModifier
-                    || msm.SprintSpeedModifier > MedicalScannerConstants.NeutralMovementSpeedModifier)
-                    return EffectClass.Beneficial;
-                return EffectClass.Neutral;
-
-            case PopupMessage:
-            case Emote:
-            case GenericStatusEffect:
-            case ModifyStatusEffect:
-                return EffectClass.Neutral;
-
-            default:
-                return EffectClass.Harmful;
-        }
-    }
-
-    private static EffectClass ClassifyDamageValues(IEnumerable<FixedPoint2> values)
-    {
-        var anyPositive = false;
-        var anyNegative = false;
-        foreach (var v in values)
-        {
-            if (v > FixedPoint2.Zero)
-                anyPositive = true;
-            else if (v < FixedPoint2.Zero)
-                anyNegative = true;
-        }
-        if (anyPositive)
-            return EffectClass.Harmful;
-        if (anyNegative)
-            return EffectClass.Beneficial;
-        return EffectClass.Neutral;
     }
 }

--- a/Content.Server/RussStation/MedicalScanner/ReagentDoseThresholdAnalyzer.cs
+++ b/Content.Server/RussStation/MedicalScanner/ReagentDoseThresholdAnalyzer.cs
@@ -1,0 +1,172 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityConditions;
+using Content.Shared.EntityConditions.Conditions;
+using Content.Shared.EntityEffects;
+using Content.Shared.EntityEffects.Effects;
+using Content.Shared.EntityEffects.Effects.Damage;
+using Content.Shared.EntityEffects.Effects.Solution;
+using Content.Shared.EntityEffects.Effects.StatusEffects;
+using Content.Shared.EntityEffects.Effects.Transform;
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.MedicalScanner;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.MedicalScanner;
+
+/// <summary>
+/// Reagent-analysis engine pulled out of <see cref="HealthAnalyzerReagentSystem"/>. Walks a
+/// reagent's metabolisms, classifies each self-gated effect as harmful or beneficial, and
+/// buckets the gating bounds into overdose/underdose thresholds.
+///
+/// Living in its own system makes the classifier reusable by other tooling (chem scanners,
+/// pharmacist tools) and independently testable. Results are memoized per reagent in
+/// <see cref="_thresholdCache"/>, which is dropped whenever reagent prototypes reload.
+/// </summary>
+public sealed class ReagentDoseThresholdAnalyzer : EntitySystem
+{
+    private readonly Dictionary<string, ReagentDoseThresholds> _thresholdCache = new();
+
+    public readonly record struct ReagentDoseThresholds(
+        FixedPoint2? HarmfulMin,
+        FixedPoint2? HarmfulMax,
+        FixedPoint2? BeneficialMin);
+
+    private enum EffectClass { Harmful, Beneficial, Neutral }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (args.WasModified<ReagentPrototype>())
+            _thresholdCache.Clear();
+    }
+
+    /// <summary>
+    /// Walks a reagent's metabolisms looking for self-referencing <see cref="ReagentCondition"/>s
+    /// and buckets the bounds into harmful or beneficial thresholds based on the effect type.
+    /// </summary>
+    public ReagentDoseThresholds GetDoseThresholds(ReagentPrototype proto)
+    {
+        if (_thresholdCache.TryGetValue(proto.ID, out var cached))
+            return cached;
+
+        FixedPoint2? harmfulMin = null;
+        FixedPoint2? harmfulMax = null;
+        FixedPoint2? beneficialMin = null;
+
+        if (proto.Metabolisms != null)
+        {
+            foreach (var (_, entry) in proto.Metabolisms.Metabolisms)
+            {
+                foreach (var effect in entry.Effects)
+                {
+                    if (effect.Conditions == null)
+                        continue;
+
+                    var cls = ClassifyEffect(effect, proto.ID);
+                    if (cls == EffectClass.Neutral)
+                        continue;
+
+                    var (selfMin, selfMax) = SelfBounds(proto.ID, effect.Conditions);
+                    if (selfMin is null && selfMax is null)
+                        continue;
+
+                    if (cls == EffectClass.Beneficial)
+                    {
+                        if (selfMin is { } bMin && (beneficialMin is null || bMin < beneficialMin.Value))
+                            beneficialMin = bMin;
+                    }
+                    else
+                    {
+                        if (selfMin is { } hMin && (harmfulMin is null || hMin < harmfulMin.Value))
+                            harmfulMin = hMin;
+                        if (selfMax is { } hMax && (harmfulMax is null || hMax > harmfulMax.Value))
+                            harmfulMax = hMax;
+                    }
+                }
+            }
+        }
+
+        var result = new ReagentDoseThresholds(harmfulMin, harmfulMax, beneficialMin);
+        _thresholdCache[proto.ID] = result;
+        return result;
+    }
+
+    private static (FixedPoint2? Min, FixedPoint2? Max) SelfBounds(string reagentId, EntityCondition[] conditions)
+    {
+        FixedPoint2? min = null;
+        FixedPoint2? max = null;
+        foreach (var cond in conditions)
+        {
+            if (cond is not ReagentCondition rc)
+                continue;
+            if (rc.Reagent != reagentId)
+                continue;
+            if (rc.Inverted)
+                continue;
+
+            if (rc.Min > FixedPoint2.Zero && (min is null || rc.Min < min.Value))
+                min = rc.Min;
+            if (rc.Max < FixedPoint2.MaxValue && (max is null || rc.Max > max.Value))
+                max = rc.Max;
+        }
+        return (min, max);
+    }
+
+    private static EffectClass ClassifyEffect(EntityEffect effect, string reagentId)
+    {
+        switch (effect)
+        {
+            case HealthChange hc:
+                return ClassifyDamageValues(hc.Damage.DamageDict.Values);
+            case EvenHealthChange ehc:
+                return ClassifyDamageValues(ehc.Damage.Values);
+
+            case AdjustReagent ar:
+                if (ar.Reagent == reagentId)
+                    return ar.Amount < FixedPoint2.Zero ? EffectClass.Neutral : EffectClass.Harmful;
+                return EffectClass.Neutral;
+
+            case MovementSpeedModifier msm:
+                if (msm.WalkSpeedModifier < MedicalScannerConstants.NeutralMovementSpeedModifier
+                    || msm.SprintSpeedModifier < MedicalScannerConstants.NeutralMovementSpeedModifier)
+                    return EffectClass.Harmful;
+                if (msm.WalkSpeedModifier > MedicalScannerConstants.NeutralMovementSpeedModifier
+                    || msm.SprintSpeedModifier > MedicalScannerConstants.NeutralMovementSpeedModifier)
+                    return EffectClass.Beneficial;
+                return EffectClass.Neutral;
+
+            case PopupMessage:
+            case Emote:
+            case GenericStatusEffect:
+            case ModifyStatusEffect:
+                return EffectClass.Neutral;
+
+            default:
+                return EffectClass.Harmful;
+        }
+    }
+
+    private static EffectClass ClassifyDamageValues(IEnumerable<FixedPoint2> values)
+    {
+        var anyPositive = false;
+        var anyNegative = false;
+        foreach (var v in values)
+        {
+            if (v > FixedPoint2.Zero)
+                anyPositive = true;
+            else if (v < FixedPoint2.Zero)
+                anyNegative = true;
+        }
+        if (anyPositive)
+            return EffectClass.Harmful;
+        if (anyNegative)
+            return EffectClass.Beneficial;
+        return EffectClass.Neutral;
+    }
+}

--- a/Content.Server/RussStation/MedicalScanner/SolutionAggregator.cs
+++ b/Content.Server/RussStation/MedicalScanner/SolutionAggregator.cs
@@ -1,0 +1,136 @@
+using System.Linq;
+using Content.Server.Body.Components;
+using Content.Server.Body.Systems;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.RussStation.MedicalScanner;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RussStation.MedicalScanner;
+
+/// <summary>
+/// Gathers the reagent solutions worth surfacing on a scanned mob — bloodstream, metabolites,
+/// stomach and lung contents — into the <see cref="HealthAnalyzerReagentGroup"/> list rendered
+/// by the Reagents tab. Pulled out of <see cref="HealthAnalyzerReagentSystem"/> so the
+/// solution-walking logic lives apart from the scanner lifecycle/UI plumbing, leaving
+/// <see cref="HealthAnalyzerReagentSystem.BuildState"/> as a thin wrapper.
+///
+/// Overdose/underdose flags are sourced from <see cref="ReagentDoseThresholdAnalyzer"/>.
+/// </summary>
+public sealed class SolutionAggregator : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutions = default!;
+    [Dependency] private readonly ReagentDoseThresholdAnalyzer _thresholds = default!;
+
+    /// <summary>
+    /// Builds the ordered reagent group list for <paramref name="target"/>. Mobs without a
+    /// <see cref="BloodstreamComponent"/> produce an empty list.
+    /// </summary>
+    public List<HealthAnalyzerReagentGroup> BuildGroups(EntityUid target)
+    {
+        var groups = new List<HealthAnalyzerReagentGroup>();
+
+        if (TryComp<BloodstreamComponent>(target, out var bloodstream))
+        {
+            // Reagent OD/UD thresholds are calibrated against whole-reagent doses in the blood.
+            // Metabolites are the trickle of in-progress metabolism output — their quantities
+            // never reach those thresholds, so flagging them would be misleading noise. Only the
+            // Blood group gets dose flags; metabolites / stomach / lung / puddle / container
+            // entries pass false and render plain "{reagent}: Nu" without the dose chrome.
+            AddSolution(groups, target, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution,
+                Loc.GetString("health-analyzer-reagent-group-blood"), showDoseFlags: true);
+            AddSolution(groups, target, bloodstream.MetabolitesSolutionName, ref bloodstream.MetabolitesSolution,
+                Loc.GetString("health-analyzer-reagent-group-metabolites"));
+
+            AddOrganSolutions<StomachComponent>(groups, target,
+                "health-analyzer-reagent-group-stomach",
+                "health-analyzer-reagent-group-stomach-indexed",
+                (uid, stomach) =>
+                {
+                    var handle = stomach.Solution;
+                    return _solutions.ResolveSolution(uid, StomachSystem.DefaultSolutionName, ref handle, out var sol)
+                        ? sol : null;
+                });
+
+            AddOrganSolutions<LungComponent>(groups, target,
+                "health-analyzer-reagent-group-lung",
+                "health-analyzer-reagent-group-lung-indexed",
+                (uid, lung) =>
+                {
+                    // LungComponent is [Access]-locked to LungSystem; copy Solution into a local
+                    // so ResolveSolution's ref parameter doesn't write back through the locked field.
+                    var handle = lung.Solution;
+                    return _solutions.ResolveSolution(uid, lung.SolutionName, ref handle, out var sol)
+                        ? sol : null;
+                });
+        }
+
+        return groups;
+    }
+
+    private void AddOrganSolutions<TOrgan>(
+        List<HealthAnalyzerReagentGroup> groups,
+        EntityUid body,
+        string singleKey,
+        string indexedKey,
+        Func<EntityUid, TOrgan, Solution?> resolve)
+        where TOrgan : IComponent
+    {
+        if (!TryComp<BodyComponent>(body, out var bodyComp) || bodyComp.Organs is null)
+            return;
+
+        var organs = new List<(EntityUid Uid, TOrgan Comp)>();
+        foreach (var organ in bodyComp.Organs.ContainedEntities)
+        {
+            if (TryComp<TOrgan>(organ, out var comp))
+                organs.Add((organ, comp));
+        }
+
+        for (var i = 0; i < organs.Count; i++)
+        {
+            var (uid, comp) = organs[i];
+            var label = organs.Count > MedicalScannerConstants.MultiOrganLabelThreshold
+                ? Loc.GetString(indexedKey, ("index", i + MedicalScannerConstants.OrganIndexLabelOffset))
+                : Loc.GetString(singleKey);
+            if (resolve(uid, comp) is { } sol)
+                AddSolutionFromSolution(groups, sol, label);
+        }
+    }
+
+    private void AddSolution(List<HealthAnalyzerReagentGroup> groups, EntityUid owner, string name,
+        ref Entity<SolutionComponent>? handle, string label, bool showDoseFlags = false)
+    {
+        if (!_solutions.ResolveSolution(owner, name, ref handle, out var solution))
+            return;
+
+        AddSolutionFromSolution(groups, solution, label, showDoseFlags);
+    }
+
+    private void AddSolutionFromSolution(List<HealthAnalyzerReagentGroup> groups, Solution solution, string label, bool showDoseFlags = false)
+    {
+        var entries = new List<HealthAnalyzerReagentEntry>(solution.Contents.Count);
+        foreach (var (id, qty) in solution.Contents
+                     .Select(rq => (rq.Reagent.Prototype, rq.Quantity))
+                     .OrderByDescending(t => t.Quantity))
+        {
+            if (!_proto.TryIndex<ReagentPrototype>(id, out var protoData))
+                continue;
+
+            var od = false;
+            var ud = false;
+            if (showDoseFlags)
+            {
+                var thresholds = _thresholds.GetDoseThresholds(protoData);
+                od = (thresholds.HarmfulMin.HasValue && qty >= thresholds.HarmfulMin.Value)
+                     || (thresholds.HarmfulMax.HasValue && qty <= thresholds.HarmfulMax.Value);
+                ud = !od && thresholds.BeneficialMin.HasValue && qty < thresholds.BeneficialMin.Value;
+            }
+            entries.Add(new HealthAnalyzerReagentEntry(id, protoData.LocalizedName, protoData.SubstanceColor, qty, od, ud));
+        }
+
+        groups.Add(new HealthAnalyzerReagentGroup(label, solution.Volume, solution.MaxVolume, entries));
+    }
+}

--- a/Content.Server/RussStation/MedicalScanner/SolutionAggregator.cs
+++ b/Content.Server/RussStation/MedicalScanner/SolutionAggregator.cs
@@ -1,7 +1,7 @@
 using System.Linq;
-using Content.Server.Body.Components;
-using Content.Server.Body.Systems;
+using Content.Shared.Body;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;


### PR DESCRIPTION
## About the PR

Splits the 429-line `HealthAnalyzerReagentSystem.cs` into three focused systems without changing behavior. The scanner keeps its lifecycle and UI-state code, the dose-classification engine moves to its own system, and the solution-walking code moves to another. The scanner file ends up around 170 lines.

## Why / Balance

Closes #858, part of the RussStation fork audit (#853). The file was doing two unrelated jobs: scanner lifecycle plus UI building, and a self-contained engine that classifies reagent doses as harmful or beneficial. Pulling the engine out lets other tools reuse it (chem scanners, pharmacist tooling) and lets it be tested on its own. It also gets every file under the 300-line target.

## Technical details

- `ReagentDoseThresholdAnalyzer` (new system) holds the engine: `GetDoseThresholds`, the `ClassifyEffect` / `ClassifyDamageValues` / `SelfBounds` helpers, the `_thresholdCache`, and the cache invalidation on prototype reload. The logic is carried over unchanged.
- `SolutionAggregator` (new system) walks the bloodstream, metabolites, stomach, and lung solutions into the reagent group list, and reads the overdose/underdose flags from the analyzer. It exposes `BuildGroups`.
- `HealthAnalyzerReagentSystem` keeps only the DoAfter, Update, drop, and toggle handling plus the UI-state pushes. `BuildState` now just calls `SolutionAggregator` and attaches the display name.
- Tests: the five threshold tests resolve `ReagentDoseThresholdAnalyzer` directly now. Added four cases for `SolutionAggregator` paths that nothing covered before: metabolites never get dose flags, the underdose branch, the empty result for an entity with no bloodstream, and stomach-organ aggregation.

The Update range-check/pause/push loop still duplicates `PlantAnalyzerSystem`. That belongs to the separate `ScannerUpdateHelper` issue, so it is left alone here.

## Media

None. This is a code-only refactor with no in-game change.

## Breaking changes

`GetDoseThresholds` and `ReagentDoseThresholds` moved off `HealthAnalyzerReagentSystem` onto `ReagentDoseThresholdAnalyzer`. Nothing player-facing or prototype-related changes, and the only caller in the tree (the integration test) is updated here.