### PR TITLE
refactor: tighten Surgery partials (orchestration / organs / healing)

### DIFF
--- a/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
@@ -8,9 +8,11 @@ using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.RussStation.Surgery;
+using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.RussStation.Surgery.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Tools;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.RussStation.Surgery;
@@ -540,7 +542,9 @@ public sealed partial class SurgerySystemTest : GameTest
         if (!entMan.TryGetComponent<DamageableComponent>(patient, out var dmg))
             return -1f;
 
-        return dmg.Damage.DamageDict.TryGetValue("Blunt", out var value) ? (float) value : 0f;
+        // Read damage through the system accessor; DamageableComponent.Damage is access-restricted.
+        var positive = entMan.System<DamageableSystem>().GetPositiveDamage((patient, dmg));
+        return positive.DamageDict.TryGetValue("Blunt", out var value) ? (float) value : 0f;
     }
 
     /// <summary>

--- a/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Surgery/SurgerySystemTest.cs
@@ -1,6 +1,15 @@
 using Content.IntegrationTests.Fixtures;
+using Content.Server.RussStation.Surgery;
+using Content.Shared.Buckle;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Systems;
+using Content.Shared.Standing;
 using Content.Shared.Tools;
 using Robust.Shared.Prototypes;
 
@@ -156,6 +165,53 @@ public sealed partial class SurgerySystemTest : GameTest
   - type: Tool
     qualities:
     - Slicing
+
+# A surgeon mob with a real hand slot, so surgery DoAfters (NeedHand) can run.
+- type: entity
+  id: SurgeryTestSurgeon
+  components:
+  - type: DoAfter
+  - type: Hands
+    hands:
+      hand_right:
+        location: Right
+    sortedHands:
+    - hand_right
+  - type: ComplexInteraction
+  - type: InputMover
+  - type: Physics
+    bodyType: KinematicController
+
+# A patient that can take and store damage, for testing healing steps.
+- type: entity
+  id: SurgeryTestHealPatient
+  components:
+  - type: Buckle
+  - type: Hands
+  - type: ComplexInteraction
+  - type: InputMover
+  - type: Physics
+    bodyType: KinematicController
+  - type: Body
+    prototype: Human
+  - type: StandingState
+  - type: Damageable
+    damageContainer: Biological
+
+# Single repeatable healing step: a flat budget that auto-repeats until damage is drained.
+- type: surgeryProcedure
+  id: SurgeryTestTendProcedure
+  name: Test Tend Procedure
+  description: A repeatable healing procedure.
+  steps:
+    - quality: Retracting
+      duration: 1.0
+      repeatable: true
+      popup: surgery-step-retract
+      healing:
+        types:
+          Blunt: 1
+      healingFlat: 6
 ";
 
     /// <summary>
@@ -295,5 +351,230 @@ public sealed partial class SurgerySystemTest : GameTest
                 }
             }
         });
+    }
+
+    /// <summary>
+    /// Drives a whole procedure end to end: a draping selection starts the surgery, each tool step
+    /// advances it, and a cautery closes the patient and tears the surgery state down. Exercises the
+    /// menu validator, the step handler, and the cautery-close path together.
+    /// </summary>
+    [Test]
+    public async Task FullSurgeryFlowTest()
+    {
+        var server = Server;
+        var sEntMan = server.EntMan;
+        var mapData = await Pair.CreateTestMap();
+
+        EntityUid surgeon = default;
+        EntityUid patient = default;
+        EntityUid scalpel = default;
+        EntityUid retractor = default;
+        EntityUid cautery = default;
+        NetEntity netPatient = default;
+        NetEntity netDrape = default;
+
+        await server.WaitPost(() =>
+        {
+            var standing = sEntMan.System<StandingStateSystem>();
+
+            surgeon = sEntMan.SpawnEntity("SurgeryTestSurgeon", mapData.GridCoords);
+            patient = sEntMan.SpawnEntity("SurgeryTestPatient", mapData.GridCoords);
+            scalpel = sEntMan.SpawnEntity("SurgeryTestScalpel", mapData.GridCoords);
+            retractor = sEntMan.SpawnEntity("SurgeryTestRetractor", mapData.GridCoords);
+            cautery = sEntMan.SpawnEntity("SurgeryTestCautery", mapData.GridCoords);
+            var drape = sEntMan.SpawnEntity("SurgeryTestSurgicalDrape", mapData.GridCoords);
+
+            // The session must drive the surgeon so the server sees them as the procedure sender.
+            server.PlayerMan.SetAttachedEntity(ServerSession, surgeon, force: true);
+            standing.Down(patient, force: true);
+
+            netPatient = sEntMan.GetNetEntity(patient);
+            netDrape = sEntMan.GetNetEntity(drape);
+        });
+
+        await Pair.RunTicksSync(5);
+
+        // Select the procedure: drapes the patient and starts the surgery.
+        await Client.WaitPost(() =>
+            Client.EntMan.EntityNetManager.SendSystemNetworkMessage(
+                new SelectSurgeryProcedureEvent(netPatient, netDrape, TestProcedureId)));
+
+        await RunUntil(() =>
+            sEntMan.HasComponent<ActiveSurgeryComponent>(patient) &&
+            sEntMan.HasComponent<SurgeryDrapedComponent>(patient));
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.TryGetComponent<ActiveSurgeryComponent>(patient, out var active), Is.True);
+            Assert.That(active!.CurrentStep, Is.EqualTo(0));
+        });
+
+        // Step 0 (Slicing) with the scalpel.
+        await UseToolOnPatient(sEntMan, surgeon, scalpel, patient);
+        await RunUntil(() => GetStep(sEntMan, patient) >= 1);
+
+        // Step 1 (Retracting) with the retractor: the final step.
+        await UseToolOnPatient(sEntMan, surgeon, retractor, patient);
+        await RunUntil(() => GetStep(sEntMan, patient) >= 2);
+
+        // Cautery universal close: removes the surgery and the drape.
+        await UseToolOnPatient(sEntMan, surgeon, cautery, patient);
+        await RunUntil(() => !sEntMan.HasComponent<ActiveSurgeryComponent>(patient));
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.HasComponent<ActiveSurgeryComponent>(patient), Is.False, "Surgery should be closed.");
+            Assert.That(sEntMan.HasComponent<SurgeryDrapedComponent>(patient), Is.False, "Drape should be removed.");
+        });
+    }
+
+    /// <summary>
+    /// The menu validator must refuse a selection when the patient is still standing: no drape,
+    /// no active surgery.
+    /// </summary>
+    [Test]
+    public async Task ProcedureSelectionRejectedWhenStandingTest()
+    {
+        var server = Server;
+        var sEntMan = server.EntMan;
+        var mapData = await Pair.CreateTestMap();
+
+        EntityUid patient = default;
+        NetEntity netPatient = default;
+        NetEntity netDrape = default;
+
+        await server.WaitPost(() =>
+        {
+            var surgeon = sEntMan.SpawnEntity("SurgeryTestSurgeon", mapData.GridCoords);
+            patient = sEntMan.SpawnEntity("SurgeryTestPatient", mapData.GridCoords);
+            var drape = sEntMan.SpawnEntity("SurgeryTestSurgicalDrape", mapData.GridCoords);
+
+            server.PlayerMan.SetAttachedEntity(ServerSession, surgeon, force: true);
+            // Patient is deliberately left standing.
+
+            netPatient = sEntMan.GetNetEntity(patient);
+            netDrape = sEntMan.GetNetEntity(drape);
+        });
+
+        await Pair.RunTicksSync(5);
+
+        await Client.WaitPost(() =>
+            Client.EntMan.EntityNetManager.SendSystemNetworkMessage(
+                new SelectSurgeryProcedureEvent(netPatient, netDrape, TestProcedureId)));
+
+        await Pair.RunTicksSync(15);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.HasComponent<ActiveSurgeryComponent>(patient), Is.False,
+                "A standing patient must not be draped into surgery.");
+            Assert.That(sEntMan.HasComponent<SurgeryDrapedComponent>(patient), Is.False);
+        });
+    }
+
+    /// <summary>
+    /// A repeatable healing step auto-repeats until the patient's matching damage is drained.
+    /// Exercises the step handler's repeat branch and the healing-budget application together.
+    /// </summary>
+    [Test]
+    public async Task RepeatableHealStepDrainsDamageTest()
+    {
+        var server = Server;
+        var sEntMan = server.EntMan;
+        var mapData = await Pair.CreateTestMap();
+
+        EntityUid surgeon = default;
+        EntityUid patient = default;
+        EntityUid retractor = default;
+        NetEntity netPatient = default;
+        NetEntity netDrape = default;
+
+        await server.WaitPost(() =>
+        {
+            var standing = sEntMan.System<StandingStateSystem>();
+            var damageable = sEntMan.System<DamageableSystem>();
+
+            surgeon = sEntMan.SpawnEntity("SurgeryTestSurgeon", mapData.GridCoords);
+            patient = sEntMan.SpawnEntity("SurgeryTestHealPatient", mapData.GridCoords);
+            retractor = sEntMan.SpawnEntity("SurgeryTestRetractor", mapData.GridCoords);
+            var drape = sEntMan.SpawnEntity("SurgeryTestSurgicalDrape", mapData.GridCoords);
+
+            server.PlayerMan.SetAttachedEntity(ServerSession, surgeon, force: true);
+            standing.Down(patient, force: true);
+
+            // Give the patient more Blunt damage than one heal budget (6) can clear, forcing a repeat.
+            var blunt = new DamageSpecifier();
+            blunt.DamageDict["Blunt"] = FixedPoint2.New(10);
+            damageable.TryChangeDamage(patient, blunt, ignoreResistances: true);
+
+            netPatient = sEntMan.GetNetEntity(patient);
+            netDrape = sEntMan.GetNetEntity(drape);
+        });
+
+        await Pair.RunTicksSync(5);
+
+        await Client.WaitPost(() =>
+            Client.EntMan.EntityNetManager.SendSystemNetworkMessage(
+                new SelectSurgeryProcedureEvent(netPatient, netDrape, "SurgeryTestTendProcedure")));
+
+        await RunUntil(() => sEntMan.HasComponent<ActiveSurgeryComponent>(patient));
+
+        // One retractor use kicks off the repeatable tend step; it auto-repeats to drain the damage.
+        await UseToolOnPatient(sEntMan, surgeon, retractor, patient);
+        await RunUntil(() => GetBlunt(sEntMan, patient) <= 0f);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(GetBlunt(sEntMan, patient), Is.EqualTo(0f).Within(0.01f),
+                "The repeatable tend step should drain Blunt damage to zero.");
+        });
+    }
+
+    private static int GetStep(IEntityManager entMan, EntityUid patient)
+    {
+        return entMan.TryGetComponent<ActiveSurgeryComponent>(patient, out var active) ? active.CurrentStep : -1;
+    }
+
+    private static float GetBlunt(IEntityManager entMan, EntityUid patient)
+    {
+        if (!entMan.TryGetComponent<DamageableComponent>(patient, out var dmg))
+            return -1f;
+
+        return dmg.Damage.DamageDict.TryGetValue("Blunt", out var value) ? (float) value : 0f;
+    }
+
+    /// <summary>
+    /// Simulates the surgeon using a tool on the patient by raising the interaction the surgery
+    /// system listens for. <c>canReach</c> is forced so the handler runs without spatial setup.
+    /// </summary>
+    private async Task UseToolOnPatient(IEntityManager entMan, EntityUid surgeon, EntityUid tool, EntityUid patient)
+    {
+        await Server.WaitPost(() =>
+        {
+            var coords = entMan.GetComponent<TransformComponent>(patient).Coordinates;
+            var ev = new AfterInteractUsingEvent(surgeon, tool, patient, coords, canReach: true);
+            entMan.EventBus.RaiseLocalEvent(patient, ev, false);
+        });
+    }
+
+    /// <summary>
+    /// Runs ticks in small batches until the server-evaluated <paramref name="condition"/> holds,
+    /// failing the test if it never does within the tick budget. Robust to the server tick rate.
+    /// </summary>
+    private async Task RunUntil(Func<bool> condition, int maxTicks = 800, int chunk = 5)
+    {
+        var elapsed = 0;
+        while (elapsed <= maxTicks)
+        {
+            var done = false;
+            await Server.WaitPost(() => done = condition());
+            if (done)
+                return;
+
+            await Pair.RunTicksSync(chunk);
+            elapsed += chunk;
+        }
+
+        Assert.Fail($"Condition not satisfied within {maxTicks} ticks.");
     }
 }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Healing.cs
@@ -6,7 +6,6 @@ using Content.Shared.RussStation.Damage;
 using Content.Shared.RussStation.Surgery;
 using Content.Shared.RussStation.Surgery.Components;
 using Content.Shared.RussStation.Surgery.Effects;
-using Content.Shared.RussStation.Wounds;
 
 namespace Content.Server.RussStation.Surgery;
 
@@ -26,33 +25,13 @@ public sealed partial class SurgerySystem
             if ((healingFlat > 0 || healingMultiplier > 0) &&
                 TryComp<DamageableComponent>(patient, out var damageable))
             {
-                // Calculate healing budget: flat + (total_eligible_damage * multiplier)
+                // Healing budget: flat + (total_eligible_damage * multiplier), distributed
+                // proportionally. Shared with implants/potions via HealingBudgetCalculator.
                 var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
-                var totalDamage = FixedPoint2.Zero;
+                var healSpec = HealingBudgetCalculator.Calculate(currentDamage, healing, healingFlat, healingMultiplier);
 
-                foreach (var type in healing.DamageDict.Keys)
-                {
-                    if (currentDamage.DamageDict.TryGetValue(type, out var current))
-                        totalDamage += current;
-                }
-
-                if (totalDamage > 0)
-                {
-                    var budget = FixedPoint2.New(healingFlat + (float) totalDamage * healingMultiplier);
-
-                    // Distribute proportionally across eligible damage types
-                    var healSpec = new DamageSpecifier();
-                    foreach (var type in healing.DamageDict.Keys)
-                    {
-                        if (currentDamage.DamageDict.TryGetValue(type, out var current) && current > 0)
-                        {
-                            var share = budget * current / totalDamage;
-                            healSpec.DamageDict[type] = -share;
-                        }
-                    }
-
+                if (healSpec != null)
                     _damageable.TryChangeDamage(patient, healSpec, true);
-                }
             }
             else
             {
@@ -126,70 +105,5 @@ public sealed partial class SurgerySystem
                 Log.Warning("Unhandled surgery effect type: {EffectType} on {Patient}", effect.GetType().Name, ToPrettyString(patient));
                 break;
         }
-    }
-
-    /// <summary>
-    /// True if the procedure has at least one useful step whose target condition
-    /// is present on the patient: a healing step matching current damage above a
-    /// small epsilon, or a wound-clearing step matching an active wound category.
-    /// Procedures with no healing or wound-clearing steps (e.g. organ manipulation)
-    /// always pass.
-    /// </summary>
-    private bool ProcedureHasAnythingToTend(EntityUid patient, SurgeryProcedurePrototype proto)
-    {
-        var hasUsefulStep = false;
-        DamageSpecifier? currentDamage = null;
-        if (TryComp<DamageableComponent>(patient, out var damageable))
-            currentDamage = _damageable.GetPositiveDamage((patient, damageable));
-
-        TryComp<WoundComponent>(patient, out var wounds);
-
-        foreach (var step in proto.Steps)
-        {
-            var healing = step.GetHealing();
-            if (healing != null)
-            {
-                hasUsefulStep = true;
-
-                if (currentDamage != null)
-                {
-                    foreach (var type in healing.DamageDict.Keys)
-                    {
-                        if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > FixedPoint2.New(SurgeryConstants.HealingDamageEpsilon))
-                            return true;
-                    }
-                }
-            }
-
-            if (step.GetEffect() is ClearWoundCategoryEffect clear)
-            {
-                hasUsefulStep = true;
-
-                if (wounds != null && _wounds.GetWorstTier(wounds, clear.Category) > 0)
-                    return true;
-            }
-        }
-
-        return !hasUsefulStep;
-    }
-
-    private bool StepCanStillHeal(EntityUid patient, SurgeryStep step)
-    {
-        var healing = step.GetHealing();
-        if (healing == null || (step.GetHealingFlat() <= 0 && step.GetHealingMultiplier() <= 0))
-            return false;
-
-        if (!TryComp<DamageableComponent>(patient, out var damageable))
-            return false;
-
-        var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
-
-        foreach (var type in healing.DamageDict.Keys)
-        {
-            if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > 0)
-                return true;
-        }
-
-        return false;
     }
 }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Organs.cs
@@ -13,6 +13,20 @@ namespace Content.Server.RussStation.Surgery;
 
 public sealed partial class SurgerySystem
 {
+    // Organ category IDs that represent limbs rather than internal organs. Limbs are excluded from
+    // the organ-removal menu and from duplicate-by-category checks below.
+    private static readonly HashSet<string> LimbCategories = new()
+    {
+        "Torso", "Head",
+        "ArmLeft", "ArmRight",
+        "HandLeft", "HandRight",
+        "LegLeft", "LegRight",
+        "FootLeft", "FootRight",
+    };
+
+    // Tracks the tool held when the organ removal menu was opened, keyed by patient.
+    private readonly Dictionary<EntityUid, EntityUid> _pendingOrganRemovalTools = new();
+
     private void InitializeOrgans()
     {
         // Organ-specific subscriptions can go here if needed.
@@ -30,34 +44,13 @@ public sealed partial class SurgerySystem
         }
 
         // Block if the patient already has an equivalent organ.
-        // Categorized organs deduplicate by category (shared with the autosurgeon via
-        // OrganReplacementHelper); null-category organs deduplicate by prototype ID.
-        if (organComp.Category != null)
+        var organProtoId = MetaData(organ).EntityPrototype?.ID;
+        if (FindDuplicateOrgan(body, organComp, organProtoId) is { } existing)
         {
-            if (OrganReplacementHelper.TryFindOrganByCategory(EntityManager, body.Organs, organComp.Category, out var existing))
-            {
-                _popup.PopupEntity(
-                    Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
-                    patient, surgeon);
-                return;
-            }
-        }
-        else
-        {
-            var organProtoId = MetaData(organ).EntityPrototype?.ID;
-            foreach (var existing in body.Organs.ContainedEntities)
-            {
-                if (!TryComp<OrganComponent>(existing, out var existingOrgan) || existingOrgan.Category != null)
-                    continue;
-
-                if (organProtoId == null || organProtoId != MetaData(existing).EntityPrototype?.ID)
-                    continue;
-
-                _popup.PopupEntity(
-                    Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
-                    patient, surgeon);
-                return;
-            }
+            _popup.PopupEntity(
+                Loc.GetString("surgery-organ-already-exists", ("organ", MetaData(existing).EntityName)),
+                patient, surgeon);
+            return;
         }
 
         _container.Insert(organ, body.Organs, force: true);
@@ -208,14 +201,33 @@ public sealed partial class SurgerySystem
 
     private static bool IsLimbCategory(ProtoId<OrganCategoryPrototype>? category)
     {
-        if (category == null)
-            return false;
+        return category != null && LimbCategories.Contains(category.Value.Id);
+    }
 
-        return category.Value.Id is
-            "Torso" or "Head" or
-            "ArmLeft" or "ArmRight" or
-            "HandLeft" or "HandRight" or
-            "LegLeft" or "LegRight" or
-            "FootLeft" or "FootRight";
+    /// <summary>
+    /// Finds an organ already on the patient that the incoming organ would duplicate, or null if
+    /// there is none. Categorized organs deduplicate by category via the shared helper (also used by
+    /// the autosurgeon); null-category organs deduplicate by prototype ID.
+    /// </summary>
+    private EntityUid? FindDuplicateOrgan(BodyComponent body, OrganComponent organComp, string? organProtoId)
+    {
+        if (organComp.Category != null)
+        {
+            return OrganReplacementHelper.TryFindOrganByCategory(EntityManager, body.Organs!, organComp.Category, out var existing)
+                ? existing
+                : null;
+        }
+
+        // Null-category organs deduplicate by prototype ID.
+        foreach (var existing in body.Organs!.ContainedEntities)
+        {
+            if (!TryComp<OrganComponent>(existing, out var existingOrgan) || existingOrgan.Category != null)
+                continue;
+
+            if (organProtoId != null && organProtoId == MetaData(existing).EntityPrototype?.ID)
+                return existing;
+        }
+
+        return null;
     }
 }

--- a/Content.Server/RussStation/Surgery/SurgerySystem.Validation.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.Validation.cs
@@ -1,0 +1,124 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Surgery;
+using Content.Shared.RussStation.Surgery.Effects;
+using Content.Shared.RussStation.Wounds;
+
+namespace Content.Server.RussStation.Surgery;
+
+public sealed partial class SurgerySystem
+{
+    /// <summary>
+    /// Gate-keeps a procedure-menu selection. The entities are assumed already resolved; this checks
+    /// the surgeon/patient/drape state and that the procedure has something to do.
+    /// </summary>
+    /// <returns>
+    /// <c>Valid</c> is false when the selection should be rejected. <c>Error</c> is the localized
+    /// popup to show the surgeon, or <c>null</c> for a silent rejection (out of range / self-surgery).
+    /// </returns>
+    private (bool Valid, string? Error) ValidateProcedureSelection(
+        EntityUid surgeon,
+        EntityUid target,
+        EntityUid bedsheet,
+        SurgeryProcedurePrototype proto)
+    {
+        // Surgeon must be in range of patient.
+        if (!_interaction.InRangeUnobstructed(surgeon, target))
+            return (false, null);
+
+        // No self-surgery.
+        if (surgeon == target)
+            return (false, null);
+
+        // Patient must not already be draped.
+        if (_drapedQuery.HasComp(target))
+            return (false, Loc.GetString("surgery-already-draped"));
+
+        // Patient must still be down.
+        if (!_standing.IsDown(target))
+            return (false, Loc.GetString("surgery-patient-not-down"));
+
+        // Drape item must still exist and have Draping quality.
+        if (!Exists(bedsheet) || !_tool.HasQuality(bedsheet, DrapingQuality))
+            return (false, Loc.GetString("surgery-drape-missing"));
+
+        // If the procedure only heals and the patient has no matching damage, refuse.
+        if (!ProcedureHasAnythingToTend(target, proto))
+            return (false, Loc.GetString("surgery-nothing-to-tend", ("target", target)));
+
+        return (true, null);
+    }
+
+    /// <summary>
+    /// True if the procedure has at least one useful step whose target condition
+    /// is present on the patient: a healing step matching current damage above a
+    /// small epsilon, or a wound-clearing step matching an active wound category.
+    /// Procedures with no healing or wound-clearing steps (e.g. organ manipulation)
+    /// always pass.
+    /// </summary>
+    private bool ProcedureHasAnythingToTend(EntityUid patient, SurgeryProcedurePrototype proto)
+    {
+        var hasUsefulStep = false;
+        DamageSpecifier? currentDamage = null;
+        if (TryComp<DamageableComponent>(patient, out var damageable))
+            currentDamage = _damageable.GetPositiveDamage((patient, damageable));
+
+        TryComp<WoundComponent>(patient, out var wounds);
+
+        foreach (var step in proto.Steps)
+        {
+            var healing = step.GetHealing();
+            if (healing != null)
+            {
+                hasUsefulStep = true;
+
+                if (currentDamage != null &&
+                    HasTreatableDamage(currentDamage, healing, FixedPoint2.New(SurgeryConstants.HealingDamageEpsilon)))
+                    return true;
+            }
+
+            if (step.GetEffect() is ClearWoundCategoryEffect clear)
+            {
+                hasUsefulStep = true;
+
+                if (wounds != null && _wounds.GetWorstTier(wounds, clear.Category) > 0)
+                    return true;
+            }
+        }
+
+        return !hasUsefulStep;
+    }
+
+    /// <summary>
+    /// True if a repeatable healing step still has eligible damage left to heal, so the auto-repeat
+    /// loop should run another iteration.
+    /// </summary>
+    private bool StepCanStillHeal(EntityUid patient, SurgeryStep step)
+    {
+        var healing = step.GetHealing();
+        if (healing == null || (step.GetHealingFlat() <= 0 && step.GetHealingMultiplier() <= 0))
+            return false;
+
+        if (!TryComp<DamageableComponent>(patient, out var damageable))
+            return false;
+
+        var currentDamage = _damageable.GetPositiveDamage((patient, damageable));
+        return HasTreatableDamage(currentDamage, healing, FixedPoint2.Zero);
+    }
+
+    /// <summary>
+    /// True if any of the healing step's eligible damage types is present on the patient above
+    /// <paramref name="threshold"/>. Shared by the menu "anything to tend" gate and the repeat loop.
+    /// </summary>
+    private static bool HasTreatableDamage(DamageSpecifier currentDamage, DamageSpecifier healing, FixedPoint2 threshold)
+    {
+        foreach (var type in healing.DamageDict.Keys)
+        {
+            if (currentDamage.DamageDict.TryGetValue(type, out var amount) && amount > threshold)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/RussStation/Surgery/SurgerySystem.cs
+++ b/Content.Server/RussStation/Surgery/SurgerySystem.cs
@@ -52,9 +52,6 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
     private List<string> _cachedProcedureIds = new();
 
-    // Tracks the tool held when the organ removal menu was opened, keyed by patient.
-    private readonly Dictionary<EntityUid, EntityUid> _pendingOrganRemovalTools = new();
-
     public override void Initialize()
     {
         base.Initialize();
@@ -183,38 +180,11 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         if (!ProtoManager.TryIndex<SurgeryProcedurePrototype>(ev.ProcedureId, out var proto))
             return;
 
-        // Validate: surgeon must be in range of patient
-        if (!_interaction.InRangeUnobstructed(surgeon, target.Value))
-            return;
-
-        // No self-surgery
-        if (surgeon == target.Value)
-            return;
-
-        // Validate: patient must still be down and not already draped
-        if (_drapedQuery.HasComp(target.Value))
+        var (valid, error) = ValidateProcedureSelection(surgeon, target.Value, bedsheet.Value, proto);
+        if (!valid)
         {
-            _popup.PopupEntity(Loc.GetString("surgery-already-draped"), target.Value, surgeon);
-            return;
-        }
-
-        if (!_standing.IsDown(target.Value))
-        {
-            _popup.PopupEntity(Loc.GetString("surgery-patient-not-down"), target.Value, surgeon);
-            return;
-        }
-
-        // Validate: drape item must still exist and have Draping quality
-        if (!Exists(bedsheet.Value) || !_tool.HasQuality(bedsheet.Value, DrapingQuality))
-        {
-            _popup.PopupEntity(Loc.GetString("surgery-drape-missing"), target.Value, surgeon);
-            return;
-        }
-
-        // Validate: if the procedure only heals and the patient has no matching damage, refuse.
-        if (!ProcedureHasAnythingToTend(target.Value, proto))
-        {
-            _popup.PopupEntity(Loc.GetString("surgery-nothing-to-tend", ("target", target.Value)), target.Value, surgeon);
+            if (error != null)
+                _popup.PopupEntity(error, target.Value, surgeon);
             return;
         }
 
@@ -358,20 +328,27 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             return;
 
         args.Handled = true;
-        var patient = ent.Owner;
-        var active = ent.Comp;
+        args.Repeat = ProcessStepDoAfter(ent.Owner, ent.Comp, args.User);
+    }
 
+    /// <summary>
+    /// Runs a completed surgery step: applies its effects, advances or auto-repeats the procedure,
+    /// shows the step/completion popups, and dispatches any attached effect.
+    /// </summary>
+    /// <returns>True if the DoAfter should auto-repeat (effect-less repeatable step that still heals).</returns>
+    private bool ProcessStepDoAfter(EntityUid patient, ActiveSurgeryComponent active, EntityUid? user)
+    {
         if (active.ProcedureId == null ||
             !ProtoManager.TryIndex<SurgeryProcedurePrototype>(active.ProcedureId.Value, out var proto))
         {
             Log.Warning("Surgery step DoAfter completed but procedure {ProcedureId} is invalid on {Patient}", active.ProcedureId, ToPrettyString(patient));
-            return;
+            return false;
         }
 
         if (active.CurrentStep >= proto.Steps.Count)
         {
             _popup.PopupEntity(Loc.GetString("surgery-procedure-complete"), patient);
-            return;
+            return false;
         }
 
         var step = proto.Steps[active.CurrentStep];
@@ -382,6 +359,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         // Apply side effects
         ApplyStepEffects(patient, step);
 
+        var repeat = false;
         var suppressStepPopup = false;
         var repeatable = step.GetRepeatable();
         var effect = step.GetEffect();
@@ -401,9 +379,9 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             var healedSomething = damageAfter < damageBefore;
 
             // Auto-repeat only if healing actually reduced damage.
-            args.Repeat = healedSomething && StepCanStillHeal(patient, step);
+            repeat = healedSomething && StepCanStillHeal(patient, step);
 
-            if (!args.Repeat)
+            if (!repeat)
             {
                 // Swap the step popup for the completion popup so we don't double up.
                 suppressStepPopup = true;
@@ -412,16 +390,18 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
         }
 
         // Step popup (skipped on the terminal iteration of a repeatable step).
-        if (!suppressStepPopup && !string.IsNullOrEmpty(popup) && args.User is { } user)
-            _popup.PopupEntity(Loc.GetString(popup, ("user", user), ("target", patient)), patient);
+        if (!suppressStepPopup && !string.IsNullOrEmpty(popup) && user is { } popupUser)
+            _popup.PopupEntity(Loc.GetString(popup, ("user", popupUser), ("target", patient)), patient);
 
         // Trigger effect if this step has one
         if (effect != null)
-            HandleEffect(args.User, patient, effect);
+            HandleEffect(user, patient, effect);
 
         // Procedure steps exhausted, wait for cautery to close
         if (active.CurrentStep >= proto.Steps.Count)
             _popup.PopupEntity(Loc.GetString("surgery-procedure-complete"), patient);
+
+        return repeat;
     }
 
     private void OnCauteryDoAfter(Entity<ActiveSurgeryComponent> ent, ref SurgeryCauteryDoAfterEvent args)

--- a/Content.Shared/RussStation/Surgery/HealingBudgetCalculator.cs
+++ b/Content.Shared/RussStation/Surgery/HealingBudgetCalculator.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.RussStation.Surgery;
+
+/// <summary>
+/// Computes a "flat + (eligible damage × multiplier), distributed proportionally" healing budget
+/// and turns it into a negative <see cref="DamageSpecifier"/> ready to feed into the damageable
+/// system. Pure and standalone so implants, potions, and surgery tend-steps can all share the one
+/// formula instead of re-deriving it.
+/// </summary>
+public static class HealingBudgetCalculator
+{
+    /// <summary>
+    /// Builds the heal specifier for a tend-style effect.
+    /// </summary>
+    /// <param name="currentDamage">The patient's current (positive) damage by type.</param>
+    /// <param name="eligible">Damage types this effect is allowed to heal; only its keys are read.</param>
+    /// <param name="flat">Flat healing budget baseline.</param>
+    /// <param name="multiplier">Fraction of current eligible damage added to the budget.</param>
+    /// <returns>
+    /// A negative <see cref="DamageSpecifier"/> distributing the budget across the eligible damage
+    /// proportionally, or <c>null</c> when there is no eligible damage to heal.
+    /// </returns>
+    public static DamageSpecifier? Calculate(
+        DamageSpecifier currentDamage,
+        DamageSpecifier eligible,
+        float flat,
+        float multiplier)
+    {
+        var totalDamage = FixedPoint2.Zero;
+        foreach (var type in eligible.DamageDict.Keys)
+        {
+            if (currentDamage.DamageDict.TryGetValue(type, out var current))
+                totalDamage += current;
+        }
+
+        if (totalDamage <= 0)
+            return null;
+
+        var budget = FixedPoint2.New(flat + (float) totalDamage * multiplier);
+
+        // Distribute proportionally across eligible damage types.
+        var healSpec = new DamageSpecifier();
+        foreach (var type in eligible.DamageDict.Keys)
+        {
+            if (currentDamage.DamageDict.TryGetValue(type, out var current) && current > 0)
+            {
+                var share = budget * current / totalDamage;
+                healSpec.DamageDict[type] = -share;
+            }
+        }
+
+        return healSpec;
+    }
+}

--- a/Content.Tests/Server/RussStation/Surgery/HealingBudgetCalculatorTest.cs
+++ b/Content.Tests/Server/RussStation/Surgery/HealingBudgetCalculatorTest.cs
@@ -1,0 +1,118 @@
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Content.Shared.RussStation.Surgery;
+using NUnit.Framework;
+
+namespace Content.Tests.Server.RussStation.Surgery;
+
+[TestFixture, TestOf(typeof(HealingBudgetCalculator))]
+[Parallelizable(ParallelScope.All)]
+public sealed class HealingBudgetCalculatorTest
+{
+    private static DamageSpecifier Damage(params (string Type, float Amount)[] entries)
+    {
+        var spec = new DamageSpecifier();
+        foreach (var (type, amount) in entries)
+            spec.DamageDict[type] = FixedPoint2.New(amount);
+        return spec;
+    }
+
+    /// <summary>
+    /// budget = flat + total*multiplier, distributed proportionally across the eligible types
+    /// in proportion to each type's share of the current damage.
+    /// </summary>
+    [Test]
+    public void Calculate_DistributesBudgetProportionally()
+    {
+        var current = Damage(("Blunt", 80f), ("Slash", 20f));
+        var eligible = Damage(("Blunt", 1f), ("Slash", 1f)); // only the keys are read
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 5f, multiplier: 0.07f);
+
+        // total = 100, budget = 5 + 100*0.07 = 12 -> Blunt 12*0.8 = 9.6, Slash 12*0.2 = 2.4
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.DamageDict["Blunt"].Float(), Is.EqualTo(-9.6f).Within(0.001f));
+        Assert.That(result.DamageDict["Slash"].Float(), Is.EqualTo(-2.4f).Within(0.001f));
+    }
+
+    /// <summary>All produced entries heal (are negative), never aggravate.</summary>
+    [Test]
+    public void Calculate_ProducesOnlyNegativeAmounts()
+    {
+        var current = Damage(("Blunt", 50f), ("Slash", 50f));
+        var eligible = Damage(("Blunt", 1f), ("Slash", 1f));
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 10f, multiplier: 0.1f);
+
+        Assert.That(result, Is.Not.Null);
+        foreach (var amount in result!.DamageDict.Values)
+            Assert.That(amount, Is.LessThan(FixedPoint2.Zero));
+    }
+
+    /// <summary>A flat-only budget (multiplier 0) heals exactly the flat amount on one type.</summary>
+    [Test]
+    public void Calculate_FlatOnly_HealsFlatAmount()
+    {
+        var current = Damage(("Blunt", 40f));
+        var eligible = Damage(("Blunt", 1f));
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 10f, multiplier: 0f);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.DamageDict["Blunt"].Float(), Is.EqualTo(-10f).Within(0.001f));
+    }
+
+    /// <summary>A multiplier-only budget (flat 0) scales with current eligible damage.</summary>
+    [Test]
+    public void Calculate_MultiplierOnly_ScalesWithDamage()
+    {
+        var current = Damage(("Blunt", 100f));
+        var eligible = Damage(("Blunt", 1f));
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 0f, multiplier: 0.07f);
+
+        // budget = 0 + 100*0.07 = 7
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.DamageDict["Blunt"].Float(), Is.EqualTo(-7f).Within(0.001f));
+    }
+
+    /// <summary>Eligible types with no current damage are skipped, not zero-healed.</summary>
+    [Test]
+    public void Calculate_SkipsTypesWithNoCurrentDamage()
+    {
+        var current = Damage(("Blunt", 50f)); // no Slash present
+        var eligible = Damage(("Blunt", 1f), ("Slash", 1f));
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 5f, multiplier: 0.07f);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.DamageDict, Has.Count.EqualTo(1));
+        Assert.That(result.DamageDict.ContainsKey("Slash"), Is.False);
+        // budget = 5 + 50*0.07 = 8.5, all to Blunt
+        Assert.That(result.DamageDict["Blunt"].Float(), Is.EqualTo(-8.5f).Within(0.001f));
+    }
+
+    /// <summary>No eligible damage present (only a non-eligible type) yields no heal at all.</summary>
+    [Test]
+    public void Calculate_NoEligibleDamage_ReturnsNull()
+    {
+        var current = Damage(("Slash", 10f));
+        var eligible = Damage(("Blunt", 1f));
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 5f, multiplier: 0.07f);
+
+        Assert.That(result, Is.Null);
+    }
+
+    /// <summary>An empty current-damage set yields no heal.</summary>
+    [Test]
+    public void Calculate_NoDamageAtAll_ReturnsNull()
+    {
+        var current = new DamageSpecifier();
+        var eligible = Damage(("Blunt", 1f));
+
+        var result = HealingBudgetCalculator.Calculate(current, eligible, flat: 5f, multiplier: 0.07f);
+
+        Assert.That(result, Is.Null);
+    }
+}


### PR DESCRIPTION
## About the PR

Cleans up the `SurgerySystem` partial split so the orchestration, organs, and healing files stop leaking logic into each other. This is a behaviour-preserving extraction. Code moves into named, single-purpose helpers, and how surgery plays is unchanged.

## Why / Balance

Part of the RussStation fork audit. Closes #857 (P1).

The three-way split was the right idea, but pieces of each concern had drifted into the wrong file. The organ-removal bookkeeping sat in the orchestration file, the healing-budget maths lived only inside one private method, and `OnProcedureSelected` and `OnStepDoAfter` had each grown to roughly 50 to 70 lines that interleaved validation, step advancement, and effect dispatch. Splitting them lets each file do what its name says, and it makes the healing formula reusable by implants and potions later.

## Technical details

- Moved `_pendingOrganRemovalTools` out of `SurgerySystem.cs` into `.Organs.cs`, where it is actually used.
- Extracted `HealingBudgetCalculator` into Content.Shared. It holds the "flat + (damage * multiplier), distributed proportionally" formula that previously lived only inside `ApplyStepEffects`. It is pure and standalone now, so other systems can reuse it, and `ApplyStepEffects` just calls it.
- Added `SurgerySystem.Validation.cs`. `ValidateProcedureSelection` replaces the seven inline checks in `OnProcedureSelected` and returns `(bool Valid, string? Error)`. `ProcedureHasAnythingToTend` and `StepCanStillHeal` moved here too, and they now share one `HasTreatableDamage` scan instead of each duplicating the damage and wound check.
- Extracted `ProcessStepDoAfter` from `OnStepDoAfter`, so the event handler is a thin wrapper over the damage-snapshot, auto-repeat, and effect-dispatch logic.
- In organs, the hard-coded limb category IDs became a `LimbCategories` set and the nested duplicate-detection loop became `FindDuplicateOrgan`.

`FindDuplicateOrgan` overlaps with the shared organ-replacement helper proposed in the cross-cutting duplication issue. When that helper lands, this is the call site to redirect.

Testing:

- `HealingBudgetCalculatorTest` is a new pure unit test that pins the budget formula: proportional split, flat-only and multiplier-only budgets, skipping types with no current damage, and the null cases.
- `SurgerySystemTest` gains three integration tests that drive the real interaction and DoAfter path: a full flow (drape, select, two steps, cautery close), a validator rejection where a standing patient produces no surgery, and a repeatable heal step that auto-repeats until damage is drained. I wrote these against the existing harness patterns but did not run them locally, so CI is the first real execution and the surgery-flow ones may need a tweak.

## Media

N/A, code-only refactor.

## Breaking changes

None. No prototype, namespace, or public API changes. The new `HealingBudgetCalculator` is purely additive.