### PR TITLE
deploy: add canonical server_config.toml

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,22 @@
+# Deploy assets
+
+Canonical server configuration kept in-repo so it can be copied into the
+server build output by the (external) codebase switcher / deploy script.
+
+## `server_config.toml`
+
+Drop this next to `Robust.Server` in the deployed server build (it is the
+file Robust looks for at startup).
+
+### Provenance
+
+This file was reconstructed from an older backup that **predated the Lowpop
+ruleset**. The only known config change made after that backup was:
+
+- **Lowpop ruleset** (PR #284): activate by setting
+  `game.secret_weight_prototype = "LowpopSecret"` (default is `"Secret"`).
+  This is included under `[game]`.
+
+If any other manual edits were made on the live server after the backup was
+taken, they could not be recovered here — diff this file against the running
+server's config and reconcile any differences before relying on it.

--- a/deploy/server_config.toml
+++ b/deploy/server_config.toml
@@ -1,0 +1,53 @@
+[log]
+path = "logs"
+format = "log_%(date)s-%(time)s.txt"
+level = 1
+enabled = false
+
+[net]
+tickrate = 60
+port = 1212
+bindto = "::,0.0.0.0"
+max_connections = 256
+
+[status]
+enabled = true
+
+[game]
+hostname = "Honk Squad"
+lobbyenabled = true
+maxplayers = 30
+lobbyduration = 420
+role_timers = false
+role_whitelist = false
+round_restart_time = 300
+map = "Packed"
+# Enables the Lowpop game ruleset (added in PR #284). Default is "Secret".
+secret_weight_prototype = "LowpopSecret"
+
+[shuttle]
+auto_call_time = 90
+
+[server]
+lobby_name = "Honk Squad"
+uptime_restart_minutes = 1440
+rules_file = "StandardRuleset"
+
+[vote]
+restart_not_allowed_when_admin_online = false
+
+[console]
+loginlocal = true
+login_host_user = "HellWatcher"
+
+[hub]
+advertise = false
+tags = ""
+server_url = ""
+hub_urls = "https://hub.spacestation14.com/"
+
+[auth]
+mode = 1
+
+[database]
+engine = "sqlite"

--- a/deploy/server_config.toml
+++ b/deploy/server_config.toml
@@ -22,7 +22,6 @@ role_timers = false
 role_whitelist = false
 round_restart_time = 300
 map = "Packed"
-# Enables the Lowpop game ruleset (added in PR #284). Default is "Secret".
 secret_weight_prototype = "LowpopSecret"
 
 [shuttle]


### PR DESCRIPTION
## Summary

Keeps a canonical copy of the Honk Squad server config in-repo so the external codebase switcher / deploy script can pull it. The previous live config was lost when the deploy tool overwrote it during testing; version-controlling it here makes any future overwrite recoverable.

The file was reconstructed from a pre-Lowpop backup plus the only known later change.

## Contents

- `deploy/server_config.toml` — canonical config. Drop next to `Robust.Server` in the deployed build.
- `deploy/README.md` — provenance notes.

## Reconstruction notes

- Based on an older backup that predated the Lowpop ruleset.
- Added the one known post-backup change: the **Lowpop ruleset** (PR #284), enabled via `game.secret_weight_prototype = "LowpopSecret"` under `[game]`.
- Intentionally **omitted** for a private server: `[build]` (works on defaults/ACZ — left untouched), `[hub]` advertising stays disabled, `[discord]` left blank (secrets injected at deploy), `[whitelist]` left at default (off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mz9M2hKC2z6XGi9daa1H48

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mz9M2hKC2z6XGi9daa1H48)_