### PR TITLE
config: enable replay auto-recording

### DIFF
--- a/server_config.toml
+++ b/server_config.toml
@@ -50,3 +50,6 @@ mode = 1
 
 [database]
 engine = "sqlite"
+
+[replay]
+auto_record = true


### PR DESCRIPTION
Enables server-side replay auto-recording by adding `replay.auto_record = true` to `server_config.toml`. Each round is recorded to the default `replays/` directory with a timestamped filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mz9M2hKC2z6XGi9daa1H48

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mz9M2hKC2z6XGi9daa1H48)_