### PR TITLE
honksquad: feat: enable Prometheus metrics endpoint

### DIFF
--- a/server_config.toml
+++ b/server_config.toml
@@ -53,3 +53,12 @@ engine = "sqlite"
 
 [replay]
 auto_record = true
+
+[metrics]
+# Prometheus metrics endpoint. host = 0.0.0.0 so it is reachable from a sibling
+# monitoring container over the internal Docker network (localhost would bind
+# the game container's own loopback only). Wings does not publish this port to
+# the host, so it is not exposed to the internet.
+enabled = true
+host = "0.0.0.0"
+port = 44880


### PR DESCRIPTION
## About the PR

Enables the engine's built-in Prometheus metrics endpoint. Adds a `[metrics]` block to `server_config.toml` that turns the metrics server on and binds it to `0.0.0.0:44880`.

## Why / Balance

We want hard numbers on round-start lag (which systems spike, GC pressure, tick frametime) rather than guessing. The endpoint lets an external Prometheus instance scrape per-system and game-loop timings. Binding `0.0.0.0` instead of the default `localhost` is required so a separate monitoring container can reach it over the internal Docker network. Wings does not publish the port to the host, so it stays off the public internet.

## Technical details

- `server_config.toml`: new `[metrics]` section with `enabled = true`, `host = "0.0.0.0"`, `port = 44880`. Config only, no code changes.

## Media

Config-only change, nothing in-game visible.

## Breaking changes

None.