### PR TITLE
honksquad: fix: metrics host must be "*" not "0.0.0.0"

### DIFF
--- a/server_config.toml
+++ b/server_config.toml
@@ -55,10 +55,13 @@ engine = "sqlite"
 auto_record = true
 
 [metrics]
-# Prometheus metrics endpoint. host = 0.0.0.0 so it is reachable from a sibling
-# monitoring container over the internal Docker network (localhost would bind
-# the game container's own loopback only). Wings does not publish this port to
-# the host, so it is not exposed to the internet.
+# Prometheus metrics endpoint, scraped by a sibling monitoring container over
+# the internal Docker network (not published to the host, so off the internet).
+# host MUST be "*" (or "+"), NOT "0.0.0.0": the engine's SpaceWizards.HttpListener
+# rejects 0.0.0.0 with HttpListenerException 50. The port is intentionally
+# OMITTED: when deployed under Pelican/Wings, the egg's line-based config parser
+# rewrites every "port =" line to the game allocation, so a metrics port here
+# lands on the game port and crashes the listener. Omitting it uses the 44880
+# CVar default, which has no line for the parser to clobber.
 enabled = true
-host = "0.0.0.0"
-port = 44880
+host = "*"


### PR DESCRIPTION
## About the PR

Fixes the metrics endpoint added in #900, which crashed the metrics listener on the live server. Sets `host = "*"` and drops the explicit `port` line.

## Why / Balance

Two separate faults, both specific to running under Pelican/Wings:

- `host = "0.0.0.0"` threw `HttpListenerException 50`. The engine's `SpaceWizards.HttpListener` explicitly rejects `0.0.0.0`; the value for all interfaces is `"*"` (or `"+"`).
- The Pelican egg's config parser is line-based, so its `port` rule rewrote every `port =` line in the file, including the one under `[metrics]`, onto the game's allocation. That put metrics on the game port and crashed the listener. Dropping the line lets `metrics.port` fall back to its `44880` default, which the parser has no line to touch.

## Technical details

- `server_config.toml`: `[metrics] host` changed `"0.0.0.0"` to `"*"`, `port = 44880` line removed (default is already 44880). Comment updated to record both gotchas.

## Media

Config-only change, nothing in-game visible.

## Breaking changes

None.