### PR TITLE
honksquad: ci: enforce REUSE compliance on PRs

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,26 @@
+name: REUSE compliance
+
+# Enforces the fork's per-file license map (ADR 0018). Fails a PR if any file is
+# not covered by a license, i.e. it falls through every glob in REUSE.toml. New
+# fork files under @RussStation / RussStation dirs are covered automatically; a
+# genuinely uncovered file (a new top-level file type, or a dir no glob matches)
+# is what this catches.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [release]
+  push:
+    branches: [release]
+
+jobs:
+  reuse:
+    name: REUSE lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: REUSE lint
+        uses: fsfe/reuse-action@v6.0.0
+        with:
+          args: lint


### PR DESCRIPTION
## About the PR

Adds a CI check that enforces the fork's per-file license map. It fails a PR when any file is not covered by a license in `REUSE.toml`. Phase 2 of the licensing migration, following the scaffolding in #902.

## Why / Balance

#902 established the license map but nothing keeps it honest. This makes coverage a merge gate: a new file that falls through every glob in `REUSE.toml` (a new top-level file type, or a directory no glob matches) fails the check instead of silently landing unlicensed. New fork files under the `RussStation` / `@RussStation` conventions are covered automatically, so the check is quiet in normal work and only speaks up when something genuinely needs a license decision.

## Technical details

One workflow, `.github/workflows/reuse.yml`, running the official `fsfe/reuse-action` (pinned to v6.0.0, which matches the REUSE 3.3 spec the map was built against). It runs `reuse lint` on pull requests to `release` and on push to `release`. The lint is fast and needs no build, so it runs on drafts too, catching coverage gaps early. Verified locally: `reuse lint` is compliant across all 43,569 files.

## Breaking changes

None. This adds a CI workflow only.
