### PR TITLE
honksquad: ci: give upstream sync a workflow-scoped PAT

### DIFF
--- a/.github/workflows/check-upstream-stable.yml
+++ b/.github/workflows/check-upstream-stable.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # GITHUB_TOKEN is refused by the push when the range creates or updates
+          # anything under .github/workflows/, which upstream ranges regularly do.
+          # UPSTREAM_SYNC_PAT must be a PAT carrying `workflow` scope.
+          token: ${{ secrets.UPSTREAM_SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Add wizden remote and fetch
         run: |
@@ -27,6 +31,8 @@ jobs:
 
       - name: Compare branches
         id: compare
+        env:
+          HAS_PAT: ${{ secrets.UPSTREAM_SYNC_PAT != '' }}
         run: |
           LOCAL_SHA=$(git rev-parse origin/upstream/stable)
           REMOTE_SHA=$(git rev-parse wizden/stable)
@@ -39,6 +45,19 @@ jobs:
             echo "behind_count=$BEHIND_COUNT" >> "$GITHUB_OUTPUT"
             echo "local_sha=$LOCAL_SHA" >> "$GITHUB_OUTPUT"
             echo "remote_sha=$REMOTE_SHA" >> "$GITHUB_OUTPUT"
+
+            # A range that touches .github/workflows/ is unpushable without a
+            # workflow-scoped PAT. Detect it up front so the job can report the
+            # missing secret instead of dying on an opaque remote rejection.
+            WORKFLOW_FILES=$(git diff --name-only "$LOCAL_SHA" "$REMOTE_SHA" -- .github/workflows/)
+            if [ -n "$WORKFLOW_FILES" ] && [ "$HAS_PAT" != "true" ]; then
+              echo "needs_pat=true" >> "$GITHUB_OUTPUT"
+              {
+                echo "workflow_files<<WORKFLOW_EOF"
+                echo "$WORKFLOW_FILES"
+                echo "WORKFLOW_EOF"
+              } >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "status=diverged" >> "$GITHUB_OUTPUT"
             echo "local_sha=$LOCAL_SHA" >> "$GITHUB_OUTPUT"
@@ -46,14 +65,73 @@ jobs:
           fi
 
       - name: Auto-advance mirror (fast-forward)
-        if: steps.compare.outputs.status == 'behind'
+        id: advance
+        if: steps.compare.outputs.status == 'behind' && steps.compare.outputs.needs_pat != 'true'
         run: |
           git push origin wizden/stable:upstream/stable
           echo "Advanced origin/upstream/stable by ${{ steps.compare.outputs.behind_count }} commits"
           echo "  ${{ steps.compare.outputs.local_sha }} -> ${{ steps.compare.outputs.remote_sha }}"
 
+      - name: Report missing workflow-scoped credentials
+        if: steps.compare.outputs.needs_pat == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEHIND_COUNT: ${{ steps.compare.outputs.behind_count }}
+          LOCAL_SHA: ${{ steps.compare.outputs.local_sha }}
+          REMOTE_SHA: ${{ steps.compare.outputs.remote_sha }}
+          WORKFLOW_FILES: ${{ steps.compare.outputs.workflow_files }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY="$(cat <<EOF
+          The mirror is $BEHIND_COUNT commits behind \`wizden/stable\`, but the pending
+          range modifies files under \`.github/workflows/\`. GitHub refuses such a push when it is
+          authenticated with the default \`GITHUB_TOKEN\`:
+
+          \`\`\`
+          ! [remote rejected] wizden/stable -> upstream/stable
+              (refusing to allow a GitHub App to create or update workflow ... without \`workflows\` permission)
+          \`\`\`
+
+          **Our SHA:** \`$LOCAL_SHA\`
+          **Wizden SHA:** \`$REMOTE_SHA\`
+
+          Workflow files in the pending range:
+
+          \`\`\`
+          $WORKFLOW_FILES
+          \`\`\`
+
+          **Fix:** add a repository secret named \`UPSTREAM_SYNC_PAT\` holding a PAT with
+          \`workflow\` scope (classic: \`repo\` + \`workflow\`; fine-grained: read/write on both
+          *Contents* and *Workflows*). This job picks it up automatically and falls back to
+          \`GITHUB_TOKEN\` when it is absent. Until then every upstream range touching a
+          workflow file will keep failing here.
+
+          A maintainer can also advance the mirror by hand:
+          \`\`\`bash
+          git fetch wizden stable
+          git push origin wizden/stable:upstream/stable
+          \`\`\`
+
+          Reported by the [Check Upstream Stable]($RUN_URL) workflow.
+          EOF
+          )"
+
+          EXISTING=$(gh issue list --label "upstream-sync" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create \
+              --title "Upstream mirror blocked: sync job needs a workflow-scoped PAT" \
+              --label "upstream-sync" \
+              --body "$BODY"
+          fi
+
+          echo "::error::Cannot advance upstream/stable: pending range touches .github/workflows/ and UPSTREAM_SYNC_PAT is not configured."
+          exit 1
+
       - name: Close resolved sync issues
-        if: steps.compare.outputs.status == 'behind' || steps.compare.outputs.status == 'current'
+        if: steps.compare.outputs.status == 'current' || steps.advance.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/check-upstream-stable.yml
+++ b/.github/workflows/check-upstream-stable.yml
@@ -34,6 +34,11 @@ jobs:
         env:
           HAS_PAT: ${{ secrets.UPSTREAM_SYNC_PAT != '' }}
         run: |
+          # Boolean only, never the secret itself. Without this the wiring is
+          # unobservable on a run that has nothing to push: the checkout falls
+          # back to GITHUB_TOKEN and succeeds either way.
+          echo "UPSTREAM_SYNC_PAT configured: $HAS_PAT"
+
           LOCAL_SHA=$(git rev-parse origin/upstream/stable)
           REMOTE_SHA=$(git rev-parse wizden/stable)
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -53,6 +53,18 @@ git remote add wizden https://github.com/space-wizards/space-station-14.git
 - **Who updates it:** Maintainers only.
 - **Protected:** Yes. No direct pushes except during sync (temporarily allow force-push).
 
+The `Check Upstream Stable` workflow (`.github/workflows/check-upstream-stable.yml`) runs daily at
+06:00 UTC and fast-forwards this mirror automatically whenever Wizden moves `stable` forward.
+
+**Required secret: `UPSTREAM_SYNC_PAT`.** GitHub refuses any push that creates or updates a file
+under `.github/workflows/` when the push is authenticated with the workflow's default
+`GITHUB_TOKEN`, and upstream ranges routinely carry workflow changes. The sync job therefore needs a
+PAT with `workflow` scope — classic tokens need `repo` + `workflow`, fine-grained tokens need
+read/write on both *Contents* and *Workflows*. The job falls back to `GITHUB_TOKEN` when the secret
+is unset, which still works for ranges that leave `.github/workflows/` alone; ranges that touch it
+are detected up front and reported as an `upstream-sync` issue instead of failing on an opaque
+remote rejection.
+
 ### `release`
 
 - **Purpose:** The primary deployable branch. Contains all tested fork additions on top of the upstream base.


### PR DESCRIPTION
## About the PR

The daily `Check Upstream Stable` job authenticates its push to `upstream/stable` with the default `GITHUB_TOKEN`, which GitHub refuses whenever the pending range creates or updates anything under `.github/workflows/`. This wires the job to a workflow-scoped PAT and makes the blocked case report itself instead of dying on an opaque remote rejection.

## Why / Balance

[Run 30332647509](https://github.com/HellWatcher/honksquad-ss14/actions/runs/30332647509) failed on a 597-commit range with:

```
! [remote rejected] wizden/stable -> upstream/stable (refusing to allow a GitHub App to
create or update workflow `.github/workflows/build-test-debug.yml` without `workflows` permission)
```

Upstream ranges carry workflow changes routinely — that range touched 16 files under `.github/workflows/` — so this is not a one-off. The preceding two weeks of scheduled runs were green only because those ranges happened to leave the workflow directory alone. Left as-is, every sync that touches a workflow file fails, and because the job is scheduled the failure is easy to miss.

## Technical details

`actions/checkout` now authenticates with `secrets.UPSTREAM_SYNC_PAT`, falling back to `GITHUB_TOKEN` when the secret is absent, so ranges that leave the workflow directory alone keep syncing unattended either way. The checkout persists those credentials, so the later `git push` picks them up.

The compare step additionally diffs the pending range against `.github/workflows/`. When that range touches a workflow file and no PAT is configured, the job skips the push and files the shortfall as an `upstream-sync` issue naming the secret and the scopes it needs, rather than surfacing a bare remote rejection.

Two smaller correctness points:

- "Close resolved sync issues" was gated on `status == 'behind'`, which describes an intent to push rather than a push that happened. It is now gated on the push step actually succeeding, so a blocked sync can no longer close its own tracking issue.
- The compare step logs whether the PAT is configured, as a boolean only. Without it the wiring is unobservable on any run that has nothing to push, since the checkout succeeds under either token.

Values interpolated into the issue body are passed through `env:` rather than expanded directly into the shell, since the file list is derived from upstream branch content.

**Deployment note:** this needs a repository secret named `UPSTREAM_SYNC_PAT` holding a PAT with `workflow` scope — classic tokens need `repo` + `workflow`, fine-grained tokens need read/write on both *Contents* and *Workflows*. The secret is already configured on this repository; runs [119](https://github.com/HellWatcher/honksquad-ss14/actions/runs/30340524282) and [120](https://github.com/HellWatcher/honksquad-ss14/actions/runs/30340706653) on this branch confirm it is picked up (`UPSTREAM_SYNC_PAT configured: true`) and that the checkout authenticates with it. The `workflow` scope itself is only exercised by a real push touching a workflow file, so the first genuine confirmation will be the next such upstream range.

`BRANCHING.md` documents the secret and its scopes under the `upstream/stable` section.

## Media

N/A — CI-only change, no in-game effect.

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZ4asn2sD5mRGu5uRzzgri

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ4asn2sD5mRGu5uRzzgri)_