### PR TITLE
honksquad: fix: report only fork tests from the heisentest hunter

### DIFF
--- a/.github/workflows/heisendetector.yml
+++ b/.github/workflows/heisendetector.yml
@@ -67,7 +67,11 @@ jobs:
     strategy:
       matrix:
         value: ${{ fromJSON(needs.hunt.outputs.matrix) }}
-    if: ${{ always() && failure() && (needs.hunt.outputs.count < 5) }}
+    # HONK - added `count > 0`. Now that actions_extract_failures.py reports only
+    # fork tests, the usual outcome is a run that fails on an upstream heisentest
+    # and filters down to zero fork failures. Without this guard that produces an
+    # empty matrix, which is a workflow error rather than a skipped job.
+    if: ${{ always() && failure() && (needs.hunt.outputs.count > 0) && (needs.hunt.outputs.count < 5) }}
     name: Error for ${{ matrix.value.name }}
     steps:
       - name: Checkout Master

--- a/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRegenTest.cs
+++ b/Content.IntegrationTests/Tests/RussStation/Wounds/WoundRegenTest.cs
@@ -2,6 +2,7 @@ using Content.Server.RussStation.Wounds;
 using Content.Shared.RussStation.Wounds;
 using Content.Shared.RussStation.Wounds.Systems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests.RussStation.Wounds;
 
@@ -9,9 +10,15 @@ namespace Content.IntegrationTests.Tests.RussStation.Wounds;
 [TestOf(typeof(WoundRegenSystem))]
 public sealed class WoundRegenTest
 {
-    // Sentinel "well past any tick" time used where the test needs a wound
-    // entry that must not decay during the test window.
-    private static readonly TimeSpan FarFuture = TimeSpan.FromHours(1);
+    // Offset used where the test needs a wound entry that must not decay during
+    // the test window. It has to be added to the server's CurTime rather than
+    // used as a bare absolute TimeSpan: DecayWounds compares NextDecayTime
+    // against IGameTiming.CurTime, and PoolManager hands out reused server
+    // instances, so a pooled pair can arrive with hours of accumulated sim time
+    // already on the clock. A fixed TimeSpan.FromHours(1) then lands in the
+    // *past*, the wound decays, and the test fails depending on how much of the
+    // suite ran before it.
+    private static readonly TimeSpan FarFutureOffset = TimeSpan.FromHours(1);
 
 
     [Test]
@@ -47,20 +54,22 @@ public sealed class WoundRegenTest
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
         var mapData = await pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
             var entity = entityManager.SpawnEntity(null, mapData.GridCoords);
             var comp = entityManager.AddComponent<WoundComponent>(entity);
+            var farFuture = timing.CurTime + FarFutureOffset;
 
-            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 3) { NextDecayTime = FarFuture });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 3) { NextDecayTime = farFuture });
 
             entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
 
             Assert.That(comp.ActiveWounds[0].Tier, Is.EqualTo(3),
                 "Wound whose NextDecayTime is in the future should not decay.");
-            Assert.That(comp.ActiveWounds[0].NextDecayTime, Is.EqualTo(FarFuture));
+            Assert.That(comp.ActiveWounds[0].NextDecayTime, Is.EqualTo(farFuture));
         });
 
         await pair.CleanReturnAsync();
@@ -96,6 +105,7 @@ public sealed class WoundRegenTest
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
         var entityManager = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
         var mapData = await pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
@@ -105,7 +115,7 @@ public sealed class WoundRegenTest
 
             // One tier-1 Burn due to expire (will be removed) + one tier-3 Burn that stays.
             entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("HeatBurn", 1) { NextDecayTime = TimeSpan.Zero });
-            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("ColdBurn", 3) { NextDecayTime = FarFuture });
+            entityManager.System<SharedWoundSystem>().AddWound(comp, new WoundEntry("ColdBurn", 3) { NextDecayTime = timing.CurTime + FarFutureOffset });
 
             entityManager.System<WoundRegenSystem>().DecayWounds(entity, comp);
 

--- a/Tools/actions_extract_failures.py
+++ b/Tools/actions_extract_failures.py
@@ -49,6 +49,21 @@ all_fails = []
 all_fails.extend(extract('./test_results/logs/Content.Tests.xml'))
 all_fails.extend(extract('./test_results/logs/Content.IntegrationTests.xml'))
 
+# HONK START - upstream runs this on their own repo, where every failure is theirs
+# to action. The fork runs the same suite, so it also re-reports upstream
+# heisentests we can't fix here (NukeOpsTest and ExpireIdCardTest are both tracked
+# upstream and have been flaky there for over a year). Report only fork tests.
+#
+# This filters what gets *reported*, deliberately not what gets *run*: the full
+# suite still executes, so the PoolManager churn that surfaces order-dependent
+# fork flakes is preserved. Narrowing the test run instead would shrink that
+# churn and could hide exactly the kind of bug this is meant to catch.
+#
+# Fork tests all carry "RussStation" in their fully qualified name
+# (Content.IntegrationTests.Tests.RussStation.*, Content.Tests.*.RussStation.*).
+all_fails = [fail for fail in all_fails if 'RussStation' in fail['@fullname']]
+# HONK END
+
 # Create the list of processed failures to create a matrix for later jobs.
 matrix = []
 for fail in all_fails:


### PR DESCRIPTION
## About the PR

The scheduled heisentest hunter now files issues only for fork tests. It still runs the full suite, so upstream tests keep churning the test pool, but upstream failures stop landing in this tracker. Also fixes the one real fork bug it found.

## Why / Balance

The Hunt for Heisentests workflow arrived unmodified with the v283.1.3 sync (#905). Upstream runs it on their own repo, where every failure is theirs to act on. Here it also reported upstream flakes we cannot fix: #912 (NukeOpsTest) and #915 (ExpireIdCardTest) were both already tracked upstream, the latter since a week before it appeared here. Both are closed.

#914 was the exception, a real fork bug, and it is fixed here.

## Technical details

`Tools/actions_extract_failures.py` filters extracted failures to names containing `RussStation`. Fork tests all carry it, in both `Content.IntegrationTests.Tests.RussStation.*` and `Content.Tests.*.RussStation.*`.

This filters what gets reported, deliberately not what gets run. Upstream tests churn the PoolManager pool, and that churn is what exposed #914, so narrowing the run would have hidden the one bug worth finding.

`heisendetector.yml` gains a `count > 0` condition on the report job. With reporting filtered, the common outcome is a run that fails on an upstream flake and filters down to zero fork failures, and an empty matrix is a workflow error rather than a skipped job.

`WoundRegenTest` used a bare `TimeSpan.FromHours(1)` directly as a wound's `NextDecayTime`. That is an absolute point on the server clock, not an offset from now. `DecayWounds` compares `NextDecayTime` against `IGameTiming.CurTime`, and PoolManager hands out reused server instances, so a pooled pair can arrive with hours of accumulated sim time already on it. Past the one hour mark the sentinel lands in the past, the wound decays, and `NotDueWoundIsUntouched` fails with tier 2 where it expected 3. That is what made it a heisentest: it passes in isolation and fails depending on how much of the suite ran ahead of it. The sentinel is now resolved against `CurTime` at test time.

`ExpiredWoundCoexistsWithHealthySameCategoryWound` had the same latent flaw. It would not have failed, since a decayed ColdBurn still satisfies both of its assertions, but it had stopped testing what it claims.

Both the workflow and the extraction script are upstream files, so the changes there carry HONK markers.

## Media

CI and test changes only, nothing visible in game.

## Breaking changes

None.
