### PR TITLE
honksquad: fix: drop [skip ci] so changelog PRs can actually merge

### DIFF
--- a/.github/workflows/changelog-weekly.yml
+++ b/.github/workflows/changelog-weekly.yml
@@ -100,7 +100,14 @@ jobs:
                   Resources/Changelog/.changelog-watermark
           git diff --staged --quiet && echo "No new entries." && exit 0
 
-          git commit -m "honksquad: chore: weekly changelog update [skip ci]"
+          # No [skip ci] here. It suppresses push- and pull_request-triggered
+          # workflows, which is every required check in the release ruleset
+          # (build, YAML Linter, HONK audits, upstream-base and commit-prefix
+          # checks). A changelog PR whose head commit carries it can never go
+          # green, so auto-merge waits forever and the PR silently accumulates
+          # commits until someone admin-merges it. That is what stranded #836
+          # for two months.
+          git commit -m "honksquad: chore: weekly changelog update"
           git push origin "$BRANCH"
 
           if [ "$IS_NEW" = "true" ]; then


### PR DESCRIPTION
## About the PR

The weekly changelog job no longer puts `[skip ci]` in its commit message, so the PRs it opens can actually pass their own required checks.

## Why / Balance

`[skip ci]` suppresses push- and pull_request-triggered workflows. That covers every required check in the `release` ruleset: `build (ubuntu-latest)`, `YAML Linter`, `HONK C# audit`, `HONK YAML drift`, `Release is based on upstream/stable`, and `honksquad: prefix on fork commits`.

So the changelog PR could never go green. The only checks that reported were `labeler` and `size-label`, which are `pull_request_target` and therefore immune to the marker. Auto-merge sat waiting on six checks that were never going to arrive, and the job appended another commit to the same branch every week.

That is what happened to #836: seven commits over two months, unmergeable the whole time, and it took an admin merge to land.

## Technical details

One line in `.github/workflows/changelog-weekly.yml`, dropping the marker from the commit message, plus a comment recording why it must not come back.

The job triggers on `schedule` and `workflow_dispatch` only, with no `push` trigger, so the commit it makes cannot re-trigger it. There is no run loop risk.

The cost is one PR check run per weekly changelog update, which is precisely what has to pass for the PR to merge. `YAML Linter` is worth running on a change to `HonksquadChangelog.yml` regardless.

## Media

CI workflow change, nothing visible in game.

## Breaking changes

None.
